### PR TITLE
Scaffold Mamba POC: seam, data pipeline, train/eval skeletons (M1-4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Mamba POC generated artifacts (datasets, packed tokens, run logs/checkpoints)
+data/
+runs/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# monica
-SSM on Mac Experiment
+# monica — Mamba POC (SSM on Mac Experiment)
+
+A proof-of-concept Mamba (selective state-space) language model, developed and
+validated on **Apple Silicon with MLX**, architected behind **one hardware seam**
+so a successful POC migrates to **CUDA** for a larger run with minimal rewrite.
+
+## The seam (most important rule)
+
+All hardware-specific code lives behind `src/model/interface.py`
+(`ModelInterface`). Everything above it — `data/`, `train/`, `serve/`, `eval/`,
+`conformance/` — is portable Python that **never imports MLX or CUDA**. Only
+`src/model/mlx_backend.py` and `src/model/cuda_backend.py` touch a hardware
+library. `tests/test_import_guard.py` enforces this.
+
+`ModelInterface`: `forward` (parallel training path) · `step` (recurrence inference
+path) · `init_state` · `get_state`/`set_state` · `save`/`load` · `config`.
+
+## Layout
+
+```
+config/{toy,poc}.yaml      model dims + run params (single source of truth)
+src/model/                 interface (seam) · blocks (config) · mlx/cuda backends
+src/data/                  download · tokenize · pack(uint16) · split · loader
+src/train/                 loop · schedule (warmup+cosine) · checkpoint
+src/eval/                  val_loss (Tier-1, primary) · olmes_adapter (deferred)
+src/conformance/           forward_step_parity · backend_parity (fp32 guards)
+src/serve/                 sessions · rewind (deferred)
+scripts/smoke_test.py      the milestone-4 gate
+tests/                     in-container unit tests
+```
+
+## Status — scaffold for milestones 1–4
+
+This Linux repo holds the **structure + seam + configs + runnable data pipeline**,
+with **skeletons/stubs** for MLX-specific bodies. MLX only runs on Apple Silicon,
+so the model, training loop, and smoke test are **completed and run on a Mac**.
+
+| Milestone | State | Where it runs |
+|---|---|---|
+| 1 Seam + toy MLX model | interface/config done; backend skeleton | Mac |
+| 2 Data pipeline (tiny) | implemented + unit-tested | here (Linux) |
+| 3 Minimal training loop | schedule/checkpoint/val done; loop skeleton | Mac |
+| 4 Smoke test (gate) | skeleton | Mac |
+| 5–8 POC scale, OLMES, serve/rewind, CUDA | deferred stubs | later |
+
+**Locked decisions:** poc = d_model 768 / 24 layers / d_state 16 / seq 1024 /
+~3B tokens (tied embedding mandatory). toy = d_model 64 / 2 layers / seq 128 /
+fp32. Precision for poc (fp16 vs bf16) **confirmed on MLX in M1** — not assumed.
+Conformance compares in **fp32** (~1e-4 rel). OLMES + serving/rewind deferred;
+**POC success = a smoothly decreasing held-out val-perplexity curve**.
+
+## Quickstart (this container)
+
+```bash
+pip install -e ".[dev,data]"      # mlx is Apple-Silicon only; omit on Linux
+pytest                            # schedule, val_loss, data pipeline, import guard
+
+# Data pipeline offline smoke (no network/tokenizer):
+python -m src.data.download --dummy --out data/raw --max-docs 2000
+python -m src.data.tokenize --in data/raw/dummy.txt --out data/ids.npy --byte-fallback
+python -m src.data.pack --in data/ids.npy --out data/packed.bin
+python -m src.data.split --packed data/packed.bin --out data/split --val-tokens 2000
+```
+
+On a Mac: `pip install mlx`, complete the `TODO[mac]` bodies in
+`src/model/mlx_backend.py` + an MLX `train_step`, then run
+`python scripts/smoke_test.py --data data/split` (the M4 gate) before scaling to
+`config/poc.yaml`.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ so a successful POC migrates to **CUDA** for a larger run with minimal rewrite.
 
 All hardware-specific code lives behind `src/model/interface.py`
 (`ModelInterface`). Everything above it — `data/`, `train/`, `serve/`, `eval/`,
-`conformance/` — is portable Python that **never imports MLX or CUDA**. Only
-`src/model/mlx_backend.py` and `src/model/cuda_backend.py` touch a hardware
-library. `tests/test_import_guard.py` enforces this.
+`conformance/` — is portable Python that **never imports MLX or CUDA**. Only the
+backend modules — `src/model/mlx_backend.py`, `src/model/mlx_train_step.py`, and
+`src/model/cuda_backend.py` — touch a hardware library.
+`tests/test_import_guard.py` enforces this.
 
 `ModelInterface`: `forward` (parallel training path) · `step` (recurrence inference
 path) · `init_state` · `get_state`/`set_state` · `save`/`load` · `config`.

--- a/config/poc.yaml
+++ b/config/poc.yaml
@@ -1,0 +1,23 @@
+# ~100M POC config. Target ~3B tokens (~Chinchilla for 100M), seq length 1024.
+# The tied embedding (vocab x d_model ~= 50280*768 ~= 38M) is a large share of the
+# budget -> tie_embeddings MUST stay true. d_model 768 x 24 layers lands near 100M.
+d_model: 768           # d_inner = expand*d_model = 1536
+n_layers: 24
+d_state: 16
+expand: 2
+d_conv: 4
+dt_rank: auto
+
+vocab_size: 50280      # OLMo tokenizer; confirm < 65536 for uint16 packing
+seq_len: 1024          # <= ~2k -> chunking NOT required for the training run
+tie_embeddings: true
+
+# CONFIRM ON MLX in milestone 1 (do NOT assume bf16). fp16 + loss scaling is the
+# likely Metal-friendly choice; bf16 is historically less optimized on Metal.
+precision: fp16
+chunk_size: null       # set an int only for long-context inference
+
+# dt-projection bias init (load-bearing)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/config/poc.yaml
+++ b/config/poc.yaml
@@ -12,8 +12,9 @@ vocab_size: 50280      # OLMo tokenizer; confirm < 65536 for uint16 packing
 seq_len: 1024          # <= ~2k -> chunking NOT required for the training run
 tie_embeddings: true
 
-# CONFIRM ON MLX in milestone 1 (do NOT assume bf16). fp16 + loss scaling is the
-# likely Metal-friendly choice; bf16 is historically less optimized on Metal.
+# CONFIRMED ON MLX (M1 micro-benchmark): fp16 ~3.96 TFLOP/s vs bf16 ~3.36 and
+# fp32 ~3.40 on this Metal GPU -> fp16 is ~18% faster; bf16 gives no speedup.
+# Use fp16 + loss scaling for the scale run (toy/smoke stay fp32 for exact resume).
 precision: fp16
 chunk_size: null       # set an int only for long-context inference
 

--- a/config/toy.yaml
+++ b/config/toy.yaml
@@ -1,0 +1,20 @@
+# Toy config for the milestone-1..4 smoke test.
+# Tiny + fp32 so fixed-seed resume is exactly reproducible.
+d_model: 64
+n_layers: 2
+d_state: 16
+expand: 2
+d_conv: 4
+dt_rank: auto
+
+vocab_size: 256        # byte fallback tokenizer for offline smoke testing
+seq_len: 128
+tie_embeddings: true
+
+precision: fp32        # correctness first; trivial exact resume
+chunk_size: null       # seq_len well under ~2k -> single-pass scan
+
+# dt-projection bias init (load-bearing)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/docs/MAC_RUNBOOK.md
+++ b/docs/MAC_RUNBOOK.md
@@ -1,0 +1,82 @@
+# Mac Runbook — Mamba POC next steps
+
+Ordered, local checklist for finishing the POC on Apple Silicon. Mirrors the
+GitHub tracker (parent issue #2) and milestones M1–M4. Each step lists the files
+to touch, the command to run, and the acceptance gate.
+
+> Backend rule: only `src/model/mlx_backend.py` may import `mlx`. Keep everything
+> above the seam backend-free (`tests/test_import_guard.py` enforces this).
+
+---
+
+## 0. Environment setup
+- [ ] Clone + check out the branch: `git switch claude/mamba-poc-plan-UPhGd`
+- [ ] Create a venv: `python3 -m venv .venv && source .venv/bin/activate`
+- [ ] Install portable + dev deps: `pip install -e ".[dev,data]"`
+- [ ] Install MLX (Apple Silicon only): `pip install mlx`
+- [ ] Confirm green baseline: `pytest` → expect 10 passed (data/schedule/val_loss/import-guard)
+
+## 1. M1 — MLX model + parity  (issues #3, #5, #6, #7, #8, #9)
+- [ ] **dt-bias init (#5):** implement `SelectiveSSM._init_dt_bias` in `src/model/mlx_backend.py`
+      (log-uniform dt in `[dt_min,dt_max]`, clamp `dt_init_floor`, bias = inverse-softplus).
+- [ ] **Selective scan (#7):** implement `SelectiveSSM.parallel` (cumsum closed form, no Python loop).
+      Add a test: parallel vs sequential reference agree in **fp32**, ~1e-4 rel.
+- [ ] **Block + model (#8):** implement `RMSNorm`, `MambaBlock.forward_seq`/`.step`,
+      `MLXMambaModel.forward/step/init_state/get_state/set_state`, tied head,
+      `_portable_state_dict`/`_load_portable`.
+- [ ] **forward/step parity (#9):** run `src/conformance/forward_step_parity.py`
+      on the toy model → must pass in fp32 (~1e-4 rel).
+- [ ] **Precision decision (#3):** benchmark fp16+loss-scaling vs bf16 on MLX; set
+      `precision` in `config/poc.yaml` with a one-line rationale. (toy stays fp32.)
+- [ ] **Chunked scan (#6):** implement `chunk_size` path; optional now (off the smoke
+      path since seq 1024 < ~2k), required before long-context. Verify it matches the
+      single-pass scan in fp32.
+- [ ] Gate: scan-vs-sequential test green **and** forward_step_parity green.
+
+## 2. M2 — Data pipeline at scale  (issues #4, #10)
+- [ ] **Tokenizer check (#4):** confirm an `OLMO_TOKENIZER_CANDIDATES` entry loads via HF,
+      `vocab_size < 65536`; set `vocab_size` in `config/poc.yaml`. Check for a pre-tokenized
+      Dolma subset (would skip tokenize).
+- [ ] **Download (#10):** implement `download_dolma_slice` in `src/data/download.py`.
+- [ ] Run the real pipeline (~2–5B tokens; plan ~10–20GB raw, several GB packed):
+      `download → tokenize → pack → split`. (`pack`/`split`/`loader` are done + tested.)
+- [ ] Gate: loader yields contiguous batches; val shard disjoint from train.
+- [ ] Optional sanity now (offline, no network):
+      ```
+      python -m src.data.download --dummy --out data/raw --max-docs 2000
+      python -m src.data.tokenize --in data/raw/dummy.txt --out data/ids.npy --byte-fallback
+      python -m src.data.pack  --in data/ids.npy --out data/packed.bin
+      python -m src.data.split --packed data/packed.bin --out data/split --val-tokens 2000
+      ```
+
+## 3. M3 — Training loop  (issue #11)
+- [ ] Implement an MLX `train_step(model, inputs, targets, lr) -> {loss, grad_norm}`
+      (`nn.value_and_grad` + optimizer, grad accumulation, grad clipping, mixed precision /
+      loss scaling per #3).
+- [ ] Finish the `TODO[mac]` checkpoint + logging hooks in `src/train/loop.py`.
+- [ ] Wire logging from step 1: loss, val loss/perplexity (`src/eval/val_loss.py`), LR,
+      grad norm, tokens/sec (W&B or similar).
+- [ ] Gate: toy ~50 steps — train loss **and** held-out val perplexity both improve.
+
+## 4. M4 — SMOKE TEST gate  (issue #12) — do not pass until green
+- [ ] Implement `scripts/smoke_test.py`: toy model, tiny data, ~50 steps, fixed seed.
+- [ ] Reference (uninterrupted) run vs second run that **saves → kills → resumes → continues**.
+- [ ] Assert post-resume trajectory matches reference within tolerance (fp32 toy ⇒ ~exact),
+      using `save_weights`/`save_resume`/`load_resume` from `src/train/checkpoint.py`.
+- [ ] Run a held-out val-perplexity eval end to end (`eval.val_loss.evaluate`).
+- [ ] Run: `python scripts/smoke_test.py --data data/split`
+- [ ] **Gate: resume is verifiably exact and eval runs. Stop here if not.**
+
+## 5. M5 — Scale to ~100M  (issue #13)  *(the POC result)*
+- [ ] Train `config/poc.yaml` (d_model 768 / 24 layers / seq 1024) on 2–5B tokens.
+- [ ] Watch val perplexity + grad norm.
+- [ ] Gate: a smoothly decreasing val-perplexity curve. (Benchmark scores NOT required.)
+
+## Deferred (after the core POC) — only if wanted
+- [ ] **#14 (M6):** OLMES / lm-eval adapter (`src/eval/olmes_adapter.py`) — mind loglikelihood off-by-one.
+- [ ] **#15 (M7):** serving (`src/serve/sessions.py`) + rewind (`src/serve/rewind.py`).
+- [ ] **#16 (M8):** CUDA backend (`src/model/cuda_backend.py`) + `backend_parity` (fp32) on a CUDA box.
+
+---
+After each milestone, tick its box in tracker issue #2 and push your work to
+`claude/mamba-poc-plan-UPhGd` (or open a PR when ready).

--- a/docs/MAC_RUNBOOK.md
+++ b/docs/MAC_RUNBOOK.md
@@ -4,8 +4,9 @@ Ordered, local checklist for finishing the POC on Apple Silicon. Mirrors the
 GitHub tracker (parent issue #2) and milestones M1–M4. Each step lists the files
 to touch, the command to run, and the acceptance gate.
 
-> Backend rule: only `src/model/mlx_backend.py` may import `mlx`. Keep everything
-> above the seam backend-free (`tests/test_import_guard.py` enforces this).
+> Backend rule: only the backend modules — `src/model/mlx_backend.py` and
+> `src/model/mlx_train_step.py` — may import `mlx`. Keep everything above the seam
+> backend-free (`tests/test_import_guard.py` enforces this).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "monica-mamba-poc"
+version = "0.0.1"
+description = "Mamba (selective SSM) LM proof-of-concept: develop on Apple Silicon (MLX), migrate to CUDA behind one seam."
+requires-python = ">=3.10"
+# Portable deps (run anywhere, incl. this Linux container).
+dependencies = [
+    "numpy>=1.24",
+    "pyyaml>=6.0",
+    "safetensors>=0.4",
+]
+
+[project.optional-dependencies]
+# Data pipeline at full scale (download/tokenize).
+data = ["datasets>=2.0", "transformers>=4.40"]
+# Apple Silicon backend (NOT installable on Linux/CUDA hosts).
+mlx = ["mlx>=0.18"]
+# Experiment logging.
+logging = ["wandb>=0.16"]
+dev = ["pytest>=8.0"]
+
+[tool.setuptools]
+packages = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,10 @@ mlx = ["mlx>=0.18"]
 logging = ["wandb>=0.16"]
 dev = ["pytest>=8.0"]
 
-[tool.setuptools]
-packages = ["src"]
+[tool.setuptools.packages.find]
+# Discover `src` and all subpackages (src.data, src.train, ...); a bare
+# packages=["src"] omits subpackages in non-editable installs.
+include = ["src*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# Portable core (this Linux container + the Mac).
+numpy>=1.24
+pyyaml>=6.0
+safetensors>=0.4
+
+# Data pipeline at full scale.
+datasets>=2.0
+transformers>=4.40
+
+# Experiment logging.
+wandb>=0.16
+
+# Dev/test.
+pytest>=8.0
+
+# Apple Silicon ONLY (uncomment on a Mac; not installable on Linux/CUDA):
+# mlx>=0.18
+
+# CUDA scale-up ONLY (added at that milestone):
+# torch
+# mamba-ssm

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,20 +1,22 @@
-"""Milestone-4 SMOKE TEST — the gate (runs on Apple Silicon). SKELETON.
+"""Milestone-4 SMOKE TEST — the gate (runs on Apple Silicon).
 
 The single most important test in the project. Most projects silently break at
 checkpoint resume and dataloading, not in the model. Do NOT proceed past this gate
 until resume is verifiably exact and eval runs.
 
-Procedure (toy model, tiny data, ~50 steps, FIXED SEED):
-  1. Train uninterrupted for N steps; record the loss trajectory  (reference run).
-  2. Fresh run with the SAME seed: train N/2 steps, save a checkpoint + resume
-     bundle, KILL the process, RESUME from the checkpoint, train the rest.
-  3. Assert the post-resume trajectory matches the reference within tolerance
-     (fp32 toy => effectively exact). This is how you prove resume is correct.
-  4. Run a held-out val-perplexity eval end to end (eval.val_loss.evaluate).
+Procedure (toy model, tiny data, FIXED SEED, fp32 => effectively exact):
+  1. Reference run: train N steps uninterrupted; record the loss trajectory.
+  2. Interrupted run (same seed, same fixed batch stream, same LR schedule):
+     train N/2 steps, SAVE portable weights + a within-backend resume bundle
+     (optimizer state + step), tear the model/optimizer down, REBUILD, LOAD, and
+     train the rest.
+  3. Assert the post-resume trajectory matches the reference within tolerance.
+  4. Run a held-out val-perplexity eval end to end.
 
-This file imports the MLX backend, so it runs on Apple Silicon only. Everything it
-orchestrates (loader, schedule, checkpoint, val_loss) is already backend-free and
-unit-tested on any host.
+Determinism note: we drive training over a PRE-MATERIALIZED fixed batch list so
+the batch at global step s is identical in both runs (independent of where the
+"kill" falls) — the resume exactness check would otherwise be confounded by data
+ordering. The portable loop (train.loop) is exercised separately.
 """
 
 from __future__ import annotations
@@ -22,8 +24,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-# NOTE: imported here (not at top) to keep the intent clear that the heavy lifting
-# is MLX-only and wired on the Mac.
+import numpy as np
 
 
 def main() -> None:
@@ -31,23 +32,96 @@ def main() -> None:
     ap.add_argument("--config", type=Path, default=Path("config/toy.yaml"))
     ap.add_argument("--data", type=Path, required=True, help="dir with train.bin/val.bin")
     ap.add_argument("--steps", type=int, default=50)
+    ap.add_argument("--batch-size", type=int, default=8)
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--out", type=Path, default=Path("runs/smoke"))
+    ap.add_argument("--atol", type=float, default=1e-4)
     args = ap.parse_args()
 
-    # TODO[mac]: implement using:
-    #   from src.model.blocks import load_config
-    #   from src.model.mlx_backend import MLXMambaModel
-    #   from src.data.loader import PackedLoader
-    #   from src.train.loop import train, TrainConfig          (+ MLX train_step)
-    #   from src.train.checkpoint import save_weights/save_resume/load_resume
-    #   from src.eval.val_loss import evaluate
-    # 1) reference run  2) interrupted+resumed run  3) trajectory match assert
-    # 4) final val-perplexity eval. Fail loudly on any mismatch.
-    raise NotImplementedError(
-        "Wire the smoke test on Apple Silicon once mlx_backend + MLX train_step exist. "
-        "Gate: post-resume trajectory must match the reference within tolerance."
-    )
+    # MLX-only imports kept local so the seam stays clean for portable hosts.
+    import mlx.core as mx
+    import mlx.optimizers as optim
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step, save_optimizer, load_optimizer
+    from src.data.loader import PackedLoader
+    from src.train.schedule import CosineSchedule
+    from src.train.checkpoint import save_weights, save_resume, load_resume
+    from src.eval.val_loss import evaluate
+
+    cfg = load_config(str(args.config))
+    assert cfg.precision == "fp32", "smoke test requires fp32 for exact resume"
+    N = args.steps
+    half = N // 2
+    np_to = lambda a: np.array(a)
+
+    # --- fixed batch stream (shuffle off => batch at step s is deterministic) ---
+    train_loader = PackedLoader(args.data / "train.bin", cfg.seq_len,
+                                args.batch_size, shuffle=False)
+    batches = []
+    for inp, tgt in train_loader.epoch():
+        batches.append((inp, tgt))
+        if len(batches) == N:
+            break
+    assert len(batches) == N, f"need {N} batches, got {len(batches)}"
+    sched = CosineSchedule(base_lr=3e-4, warmup_steps=max(1, N // 6), total_steps=N)
+
+    def fresh_model_opt():
+        mx.random.seed(args.seed)                 # identical init weights each run
+        model = MLXMambaModel(cfg)
+        opt = optim.AdamW(learning_rate=sched.base_lr)
+        return model, opt, make_train_step(model, opt, grad_clip=1.0)
+
+    def run_window(model, step_fn, lo, hi, into):
+        for s in range(lo, hi):
+            inp, tgt = batches[s]
+            into[s] = step_fn(model, inp, tgt, sched.lr_at(s))["loss"]
+
+    # --- 1) reference run -------------------------------------------------------
+    ref = {}
+    model, opt, step_fn = fresh_model_opt()
+    run_window(model, step_fn, 0, N, ref)
+    print(f"[reference] step0 loss={ref[0]:.5f}  step{N-1} loss={ref[N-1]:.5f}")
+
+    # --- 2) interrupted run: train half, checkpoint, KILL, rebuild, resume ------
+    out = args.out
+    out.mkdir(parents=True, exist_ok=True)
+    weights_path = str(out / "weights.safetensors")
+    bundle_dir = str(out / "resume")
+
+    res = {}
+    model_a, opt_a, step_fn_a = fresh_model_opt()
+    run_window(model_a, step_fn_a, 0, half, res)
+    model_a.save(weights_path)                                  # portable weights
+    save_resume(bundle_dir, step=half, rng_state=None,
+                optimizer_serializer=lambda p: save_optimizer(opt_a, p))
+    del model_a, opt_a, step_fn_a                               # "kill" the process state
+
+    mx.random.seed(args.seed + 999)            # different RNG: weights come from disk
+    model_b = MLXMambaModel(cfg)
+    model_b.load(weights_path)
+    opt_b = optim.AdamW(learning_rate=sched.base_lr)
+    meta = load_resume(bundle_dir, optimizer_deserializer=lambda p: load_optimizer(opt_b, p))
+    start = meta["step"]
+    step_fn_b = make_train_step(model_b, opt_b, grad_clip=1.0)
+    run_window(model_b, step_fn_b, start, N, res)
+    print(f"[resumed]   resumed at step={start}  step{N-1} loss={res[N-1]:.5f}")
+
+    # --- 3) trajectory match ----------------------------------------------------
+    diffs = [abs(ref[s] - res[s]) for s in range(half, N)]
+    max_diff = max(diffs)
+    print(f"[match] post-resume max|loss diff| over steps {half}..{N-1} = {max_diff:.3e}")
+    if max_diff > args.atol:
+        raise SystemExit(
+            f"SMOKE TEST FAILED: resume not exact (max|diff|={max_diff:.3e} > {args.atol}).")
+
+    # --- 4) held-out val-perplexity eval ---------------------------------------
+    val_loader = PackedLoader(args.data / "val.bin", cfg.seq_len,
+                              args.batch_size, shuffle=False, drop_last=False)
+    val = evaluate(model_b, val_loader, max_batches=4, to_numpy=np_to)
+    print(f"[eval] val_loss={val['val_loss']:.4f}  val_perplexity={val['val_perplexity']:.4f}")
+
+    print("\nSMOKE TEST PASSED ✅  resume is exact and eval runs.")
 
 
 if __name__ == "__main__":

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,0 +1,54 @@
+"""Milestone-4 SMOKE TEST — the gate (runs on Apple Silicon). SKELETON.
+
+The single most important test in the project. Most projects silently break at
+checkpoint resume and dataloading, not in the model. Do NOT proceed past this gate
+until resume is verifiably exact and eval runs.
+
+Procedure (toy model, tiny data, ~50 steps, FIXED SEED):
+  1. Train uninterrupted for N steps; record the loss trajectory  (reference run).
+  2. Fresh run with the SAME seed: train N/2 steps, save a checkpoint + resume
+     bundle, KILL the process, RESUME from the checkpoint, train the rest.
+  3. Assert the post-resume trajectory matches the reference within tolerance
+     (fp32 toy => effectively exact). This is how you prove resume is correct.
+  4. Run a held-out val-perplexity eval end to end (eval.val_loss.evaluate).
+
+This file imports the MLX backend, so it runs on Apple Silicon only. Everything it
+orchestrates (loader, schedule, checkpoint, val_loss) is already backend-free and
+unit-tested on any host.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+# NOTE: imported here (not at top) to keep the intent clear that the heavy lifting
+# is MLX-only and wired on the Mac.
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", type=Path, default=Path("config/toy.yaml"))
+    ap.add_argument("--data", type=Path, required=True, help="dir with train.bin/val.bin")
+    ap.add_argument("--steps", type=int, default=50)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--out", type=Path, default=Path("runs/smoke"))
+    args = ap.parse_args()
+
+    # TODO[mac]: implement using:
+    #   from src.model.blocks import load_config
+    #   from src.model.mlx_backend import MLXMambaModel
+    #   from src.data.loader import PackedLoader
+    #   from src.train.loop import train, TrainConfig          (+ MLX train_step)
+    #   from src.train.checkpoint import save_weights/save_resume/load_resume
+    #   from src.eval.val_loss import evaluate
+    # 1) reference run  2) interrupted+resumed run  3) trajectory match assert
+    # 4) final val-perplexity eval. Fail loudly on any mismatch.
+    raise NotImplementedError(
+        "Wire the smoke test on Apple Silicon once mlx_backend + MLX train_step exist. "
+        "Gate: post-resume trajectory must match the reference within tolerance."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,6 @@
+"""Mamba POC source package.
+
+Layering rule (the seam): nothing in `data/`, `train/`, `serve/`, `eval/`, or
+`conformance/` may import a hardware backend (`mlx`, `torch`/CUDA) directly.
+All backend code lives behind `src.model.interface.ModelInterface`.
+"""

--- a/src/conformance/__init__.py
+++ b/src/conformance/__init__.py
@@ -1,0 +1,3 @@
+"""Conformance tests — the seam guards. Backend-free harness; the comparisons run
+in fp32 (bf16/fp16 machine epsilon is too large for a meaningful tolerance).
+"""

--- a/src/conformance/backend_parity.py
+++ b/src/conformance/backend_parity.py
@@ -1,0 +1,35 @@
+"""Backend parity (write at the CUDA scale-up) — SKELETON.
+
+Fixed seed, fixed weights, fixed input batch. Run `forward` through both the MLX
+and CUDA backends and assert agreement. Run the comparison in FP32 on BOTH sides:
+bf16's machine epsilon (~8e-3) is larger than a meaningful tolerance, so comparing
+low-precision paths yields false failures. In fp32 a tight tolerance (~1e-4
+relative) is meaningful: within = correct port, beyond = a real math bug.
+
+Requires both backends present, so this runs only where CUDA is available; until
+then it stays a stub the seam can point at.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..model.interface import ModelInterface
+
+
+def check_backend_parity(model_a: ModelInterface, model_b: ModelInterface,
+                         token_batch: np.ndarray, to_numpy_a=np.asarray,
+                         to_numpy_b=np.asarray, rtol: float = 1e-4,
+                         atol: float = 1e-5) -> dict:
+    """Assert two backends' `forward` agree in fp32 for identical weights+input.
+
+    Caller is responsible for loading IDENTICAL portable weights into both models
+    (via checkpoint.load_weights) before calling.
+    """
+    a = to_numpy_a(model_a.forward(token_batch)).astype(np.float64)
+    b = to_numpy_b(model_b.forward(token_batch)).astype(np.float64)
+    max_abs = float(np.abs(a - b).max())
+    ok = np.allclose(a, b, rtol=rtol, atol=atol)
+    if not ok:
+        raise AssertionError(f"backend parity FAILED: max|diff|={max_abs:.3e}")
+    return {"max_abs_diff": max_abs, "ok": ok}

--- a/src/conformance/forward_step_parity.py
+++ b/src/conformance/forward_step_parity.py
@@ -1,0 +1,44 @@
+"""forward vs step parity (MILESTONE 1, MLX-only) — SKELETON.
+
+The training path (`forward`, parallel scan) and the inference path (`step`,
+recurrence) are two SEPARATE code paths and must produce the same logits for the
+same input. A mismatch here is a silent, nasty bug that the parallel-vs-sequential
+scan check does NOT catch (that check validates only the scan, not train/infer
+equivalence).
+
+Run in fp32, ~1e-4 relative tolerance. Build the model, run a fixed batch through
+`forward`, then feed the same tokens one at a time through `step` carrying state,
+and assert the per-position logits agree.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ..model.interface import ModelInterface
+
+
+def check_forward_step_parity(model: ModelInterface, token_batch: np.ndarray,
+                              to_numpy=np.asarray, rtol: float = 1e-4,
+                              atol: float = 1e-5) -> dict:
+    """Assert forward (parallel) and step (recurrence) agree. Returns max abs diff.
+
+    `to_numpy` converts backend logits to numpy (identity by default; on MLX pass a
+    converter). Requires a working backend model -> run on Apple Silicon.
+    """
+    batch, seq_len = token_batch.shape
+    parallel_logits = to_numpy(model.forward(token_batch))  # (B, T, V)
+
+    state = model.init_state(batch)
+    step_logits = []
+    for t in range(seq_len):
+        logits_t, state = model.step(token_batch[:, t], state)
+        step_logits.append(to_numpy(logits_t))
+    step_logits = np.stack(step_logits, axis=1)  # (B, T, V)
+
+    diff = np.abs(parallel_logits.astype(np.float64) - step_logits.astype(np.float64))
+    max_abs = float(diff.max())
+    ok = np.allclose(parallel_logits, step_logits, rtol=rtol, atol=atol)
+    if not ok:
+        raise AssertionError(f"forward/step parity FAILED: max|diff|={max_abs:.3e}")
+    return {"max_abs_diff": max_abs, "ok": ok}

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,9 @@
+"""Backend-independent data pipeline.
+
+Output is just integers on disk (uint16 memmap), written once and consumed
+unchanged by every backend. No backend imports anywhere in this package.
+
+Stages: download -> tokenize -> pack -> split -> loader. Packing/splitting/loading
+operate on raw token-id arrays and never touch the tokenizer, so they are testable
+offline with synthetic ids.
+"""

--- a/src/data/download.py
+++ b/src/data/download.py
@@ -1,0 +1,61 @@
+"""Pull a small slice of Dolma (or generate synthetic text for offline testing).
+
+Target for the POC run: ~2-5B tokens total (~10-20GB raw text; packed files are
+several GB on their own — plan disk accordingly). For the smoke test a few million
+tokens is plenty.
+
+Before downloading raw text, CHECK whether AI2 publishes a pre-tokenized Dolma
+subset (e.g. on the HuggingFace Hub). If so, prefer it and skip `tokenize.py`
+entirely.
+
+Network access in some environments is restricted; `--dummy` produces synthetic
+text so the rest of the pipeline can be exercised without a download.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from pathlib import Path
+from typing import Iterator
+
+
+def dummy_texts(n_docs: int = 1000, seed: int = 0) -> Iterator[str]:
+    """Synthetic documents for offline pipeline testing (no network)."""
+    rng = random.Random(seed)
+    vocab = [f"w{i}" for i in range(256)]
+    for _ in range(n_docs):
+        n = rng.randint(20, 200)
+        yield " ".join(rng.choice(vocab) for _ in range(n))
+
+
+def download_dolma_slice(out_dir: Path, max_docs: int) -> Path:
+    """Stream a Dolma slice to `out_dir` as line-delimited text shards.
+
+    Implemented against `datasets`/HuggingFace at run time on a networked host.
+    """
+    raise NotImplementedError(
+        "Wire to AI2 Dolma via `datasets` on a networked host; check first for a "
+        "pre-tokenized subset to skip tokenize.py. Use --dummy for offline testing."
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, default=Path("data/raw"))
+    ap.add_argument("--max-docs", type=int, default=10000)
+    ap.add_argument("--dummy", action="store_true", help="synthetic text, no network")
+    args = ap.parse_args()
+    args.out.mkdir(parents=True, exist_ok=True)
+    if args.dummy:
+        path = args.out / "dummy.txt"
+        with open(path, "w") as f:
+            for doc in dummy_texts(args.max_docs):
+                f.write(doc + "\n")
+        print(f"wrote synthetic text -> {path}")
+    else:
+        download_dolma_slice(args.out, args.max_docs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -1,0 +1,65 @@
+"""Stream contiguous fixed-length chunks from a packed uint16 file.
+
+Design: mmap + a chunk index, shuffled at the chunk level. No per-step parsing —
+a slow loader bottlenecks a small model. Each item is a contiguous `seq_len + 1`
+window so the training loop can form (input, target) by a one-token shift.
+
+This module is backend-free: it yields numpy arrays. The backend converts them to
+its own array type inside `forward`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterator, Optional
+
+import numpy as np
+
+from .pack import open_packed
+
+
+class PackedLoader:
+    def __init__(self, packed_path: Path, seq_len: int, batch_size: int,
+                 shuffle: bool = True, seed: int = 0, drop_last: bool = True):
+        self.data = open_packed(packed_path)
+        self.seq_len = seq_len
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.drop_last = drop_last
+        self.rng = np.random.default_rng(seed)
+
+        # Non-overlapping chunks of length seq_len+1 (extra token = shift target).
+        self.stride = seq_len + 1
+        self.n_chunks = (self.data.shape[0]) // self.stride
+        if self.n_chunks == 0:
+            raise ValueError("packed file too small for one chunk")
+
+    def _chunk(self, idx: int) -> np.ndarray:
+        start = idx * self.stride
+        return np.asarray(self.data[start: start + self.stride], dtype=np.int64)
+
+    def __len__(self) -> int:
+        full = self.n_chunks // self.batch_size
+        return full if self.drop_last else (self.n_chunks + self.batch_size - 1) // self.batch_size
+
+    def epoch(self, reseed: Optional[int] = None) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Yield (inputs, targets), each (batch, seq_len), for one pass over the data."""
+        if reseed is not None:
+            self.rng = np.random.default_rng(reseed)
+        order = np.arange(self.n_chunks)
+        if self.shuffle:
+            self.rng.shuffle(order)
+
+        batch = []
+        for idx in order:
+            batch.append(self._chunk(int(idx)))
+            if len(batch) == self.batch_size:
+                yield self._collate(batch)
+                batch = []
+        if batch and not self.drop_last:
+            yield self._collate(batch)
+
+    @staticmethod
+    def _collate(batch: list[np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
+        arr = np.stack(batch)              # (B, seq_len+1)
+        return arr[:, :-1], arr[:, 1:]      # inputs, targets

--- a/src/data/pack.py
+++ b/src/data/pack.py
@@ -1,0 +1,76 @@
+"""Pack token-id streams into a flat memory-mapped uint16 file.
+
+uint16 because the OLMo vocab (~50k) fits under 65536 — confirm the actual vocab
+before committing (see MambaConfig.validate / tokenize.load_olmo_tokenizer). The
+loader reads this format directly at train time; no JSON parsing during training.
+
+A small sidecar `<name>.meta.json` records dtype and token count.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+DTYPE = np.uint16
+
+
+def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
+             chunk: int = 1 << 20) -> int:
+    """Write a flat uint16 token file. Returns the number of tokens written."""
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(ids, np.ndarray):
+        arr = ids.astype(DTYPE, copy=False)
+        if arr.max(initial=0) >= 65536:
+            raise ValueError("token id >= 65536 does not fit uint16")
+        arr.tofile(out_path)
+        n = arr.size
+    else:
+        n = 0
+        with open(out_path, "wb") as f:
+            buf = []
+            for tid in ids:
+                if tid >= 65536:
+                    raise ValueError("token id >= 65536 does not fit uint16")
+                buf.append(tid)
+                if len(buf) >= chunk:
+                    np.asarray(buf, dtype=DTYPE).tofile(f)
+                    n += len(buf)
+                    buf = []
+            if buf:
+                np.asarray(buf, dtype=DTYPE).tofile(f)
+                n += len(buf)
+
+    with open(out_path.with_suffix(".meta.json"), "w") as f:
+        json.dump({"dtype": "uint16", "n_tokens": int(n)}, f)
+    return n
+
+
+def open_packed(path: Path) -> np.memmap:
+    """Memory-map a packed file read-only as uint16."""
+    path = Path(path)
+    meta_path = path.with_suffix(".meta.json")
+    n = None
+    if meta_path.exists():
+        n = json.loads(meta_path.read_text())["n_tokens"]
+    return np.memmap(path, dtype=DTYPE, mode="r", shape=(n,) if n else None)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--in", dest="inp", type=Path, required=True, help=".npy uint16 ids")
+    ap.add_argument("--out", type=Path, required=True, help="packed .bin")
+    args = ap.parse_args()
+    ids = np.load(args.inp)
+    n = pack_ids(ids, args.out)
+    print(f"packed {n} tokens -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/pack.py
+++ b/src/data/pack.py
@@ -26,9 +26,11 @@ def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     if isinstance(ids, np.ndarray):
+        # Validate the ORIGINAL values: casting to uint16 first would silently
+        # wrap out-of-range / negative ids and defeat the check.
+        if ids.size and (int(ids.min()) < 0 or int(ids.max()) >= 65536):
+            raise ValueError("token id out of range for uint16 [0, 65535]")
         arr = ids.astype(DTYPE, copy=False)
-        if arr.max(initial=0) >= 65536:
-            raise ValueError("token id >= 65536 does not fit uint16")
         arr.tofile(out_path)
         n = arr.size
     else:
@@ -36,8 +38,8 @@ def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
         with open(out_path, "wb") as f:
             buf = []
             for tid in ids:
-                if tid >= 65536:
-                    raise ValueError("token id >= 65536 does not fit uint16")
+                if tid < 0 or tid >= 65536:
+                    raise ValueError("token id out of range for uint16 [0, 65535]")
                 buf.append(tid)
                 if len(buf) >= chunk:
                     np.asarray(buf, dtype=DTYPE).tofile(f)

--- a/src/data/split.py
+++ b/src/data/split.py
@@ -1,0 +1,58 @@
+"""Hold out a small validation shard from the packed stream.
+
+The validation shard MUST NOT overlap the training stream — held-out perplexity on
+it is the primary pipeline-health signal (see eval/val_loss). We split by a single
+contiguous cut so train and val token ranges are provably disjoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from .pack import open_packed, DTYPE
+
+
+def split_packed(packed_path: Path, out_dir: Path, val_tokens: int,
+                 from_end: bool = True) -> Tuple[Path, Path]:
+    """Cut `val_tokens` contiguous tokens off the packed file into a val shard.
+
+    Returns (train_path, val_path). The two ranges are disjoint by construction.
+    """
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    data = open_packed(packed_path)
+    n = data.shape[0]
+    if val_tokens >= n:
+        raise ValueError(f"val_tokens={val_tokens} >= total tokens={n}")
+
+    if from_end:
+        train, val = data[: n - val_tokens], data[n - val_tokens:]
+    else:
+        val, train = data[:val_tokens], data[val_tokens:]
+
+    train_path, val_path = out_dir / "train.bin", out_dir / "val.bin"
+    np.asarray(train, dtype=DTYPE).tofile(train_path)
+    np.asarray(val, dtype=DTYPE).tofile(val_path)
+    for p, a in ((train_path, train), (val_path, val)):
+        with open(p.with_suffix(".meta.json"), "w") as f:
+            json.dump({"dtype": "uint16", "n_tokens": int(a.shape[0])}, f)
+    return train_path, val_path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--packed", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--val-tokens", type=int, required=True)
+    args = ap.parse_args()
+    tr, va = split_packed(args.packed, args.out, args.val_tokens)
+    print(f"train -> {tr}\nval   -> {va}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -1,0 +1,77 @@
+"""Tokenize raw text to token-id streams using the OLMo tokenizer.
+
+Use the OLMo tokenizer (via HuggingFace) so the vocab matches AI2's, enabling
+later comparison. VERIFY availability first — do not assume the exact tokenizer is
+one import away; the model id may need adjusting.
+
+A byte-level fallback tokenizer is provided ONLY for offline pipeline testing; it
+is not vocab-compatible with OLMo and must not be used for a real run.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, List
+
+# Candidate OLMo tokenizer ids on the HF Hub. Confirm one is reachable before a run.
+OLMO_TOKENIZER_CANDIDATES = ("allenai/OLMo-2-1124-7B", "allenai/OLMo-7B-hf")
+
+
+def load_olmo_tokenizer(model_id: str | None = None):
+    """Load the OLMo tokenizer via transformers. Raises if unavailable."""
+    from transformers import AutoTokenizer  # imported lazily
+
+    ids = (model_id,) if model_id else OLMO_TOKENIZER_CANDIDATES
+    last_err = None
+    for mid in ids:
+        try:
+            tok = AutoTokenizer.from_pretrained(mid)
+            # Confirm the vocab fits uint16 packing before committing to it.
+            if tok.vocab_size >= 65536:
+                raise ValueError(f"{mid} vocab {tok.vocab_size} too large for uint16")
+            return tok
+        except Exception as e:  # pragma: no cover - network/availability dependent
+            last_err = e
+    raise RuntimeError(f"No OLMo tokenizer reachable from {ids}: {last_err}")
+
+
+class ByteTokenizer:
+    """Offline-only fallback. vocab_size=256, one id per byte."""
+
+    vocab_size = 256
+
+    def encode(self, text: str) -> List[int]:
+        return list(text.encode("utf-8"))
+
+
+def tokenize_texts(texts: Iterable[str], tokenizer) -> Iterable[int]:
+    """Yield a flat stream of token ids across all documents (with EOS if available)."""
+    eos = getattr(tokenizer, "eos_token_id", None)
+    for text in texts:
+        for tid in tokenizer.encode(text):
+            yield tid
+        if eos is not None:
+            yield eos
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--in", dest="inp", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True, help="raw .npy/.bin uint16 ids")
+    ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--model-id", default=None)
+    args = ap.parse_args()
+
+    import numpy as np
+
+    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
+    with open(args.inp) as f:
+        texts = (line.rstrip("\n") for line in f)
+        ids = np.fromiter(tokenize_texts(texts, tok), dtype=np.uint16)
+    np.save(args.out, ids)
+    print(f"tokenized {ids.size} ids (vocab {tok.vocab_size}) -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -1,0 +1,3 @@
+"""Evaluation. Tier 1 (held-out val perplexity) is the primary health signal and
+is backend-free. Tier 2 (OLMES) is deferred; see olmes_adapter.
+"""

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -1,0 +1,27 @@
+"""Tier-2 evaluation: OLMES / lm-evaluation-harness adapter — STUB (deferred).
+
+OLMES inherits its model abstraction from EleutherAI's lm-evaluation-harness and is
+built around HuggingFace-loadable models. Evaluating a custom MLX Mamba requires
+implementing the harness's model class (the loglikelihood-style methods), using its
+`huggingface.py` as reference. This is its own milestone-sized task, NOT wiring.
+
+Known trap: off-by-one errors in loglikelihood token indexing. Run a small set
+(HellaSwag, ARC, PIQA). For a 100M model, absolute scores will be poor — judge the
+harness by whether it runs end to end, not by leaderboard position.
+
+Deferred for the POC (success = Tier-1 val perplexity). Implement here when
+comparable benchmark numbers are wanted.
+"""
+
+from __future__ import annotations
+
+from ..model.interface import ModelInterface
+
+
+class OlmesMambaAdapter:  # pragma: no cover - deferred
+    def __init__(self, model: ModelInterface):
+        raise NotImplementedError(
+            "OLMES adapter is a deferred, milestone-sized task. Implement the "
+            "lm-eval model class (loglikelihood + loglikelihood_rolling) over "
+            "ModelInterface.forward; mind loglikelihood token indexing off-by-one."
+        )

--- a/src/eval/val_loss.py
+++ b/src/eval/val_loss.py
@@ -1,0 +1,50 @@
+"""Tier-1 evaluation: held-out validation loss / perplexity.
+
+This is the primary pipeline-health signal for the POC: a smoothly decreasing val
+perplexity IS the success criterion (no external harness needed). The numeric core
+(`cross_entropy`, `perplexity`) is pure numpy and testable anywhere; `evaluate`
+orchestrates it over a loader using only `ModelInterface.forward`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from ..model.interface import ModelInterface
+from ..data.loader import PackedLoader
+
+
+def cross_entropy(logits: np.ndarray, targets: np.ndarray) -> float:
+    """Mean token-level cross-entropy (nats). logits (..., V), targets (...,)."""
+    logits = np.asarray(logits, dtype=np.float64)
+    targets = np.asarray(targets).reshape(-1)
+    flat = logits.reshape(-1, logits.shape[-1])
+    # log-softmax in a numerically stable way
+    m = flat.max(axis=-1, keepdims=True)
+    logZ = m[:, 0] + np.log(np.exp(flat - m).sum(axis=-1))
+    chosen = flat[np.arange(flat.shape[0]), targets]
+    return float(np.mean(logZ - chosen))
+
+
+def perplexity(mean_ce_nats: float) -> float:
+    return float(np.exp(mean_ce_nats))
+
+
+def evaluate(model: ModelInterface, loader: PackedLoader,
+             max_batches: Optional[int] = None, to_numpy=np.asarray) -> dict:
+    """Run `forward` over held-out batches; return {val_loss, val_perplexity}.
+
+    `to_numpy` converts backend logits to numpy (identity by default; on MLX pass
+    a converter). Backend-free otherwise.
+    """
+    total, n = 0.0, 0
+    for i, (inputs, targets) in enumerate(loader.epoch()):
+        if max_batches is not None and i >= max_batches:
+            break
+        logits = to_numpy(model.forward(inputs))
+        total += cross_entropy(logits, targets)
+        n += 1
+    mean_ce = total / max(1, n)
+    return {"val_loss": mean_ce, "val_perplexity": perplexity(mean_ce)}

--- a/src/eval/val_loss.py
+++ b/src/eval/val_loss.py
@@ -39,12 +39,15 @@ def evaluate(model: ModelInterface, loader: PackedLoader,
     `to_numpy` converts backend logits to numpy (identity by default; on MLX pass
     a converter). Backend-free otherwise.
     """
-    total, n = 0.0, 0
+    # Weight each batch's mean CE by its token count so a smaller final batch
+    # (drop_last=False) does not bias the result.
+    total_ce, total_tokens = 0.0, 0
     for i, (inputs, targets) in enumerate(loader.epoch()):
         if max_batches is not None and i >= max_batches:
             break
         logits = to_numpy(model.forward(inputs))
-        total += cross_entropy(logits, targets)
-        n += 1
-    mean_ce = total / max(1, n)
+        n_tokens = int(np.asarray(targets).size)
+        total_ce += cross_entropy(logits, targets) * n_tokens
+        total_tokens += n_tokens
+    mean_ce = total_ce / max(1, total_tokens)
     return {"val_loss": mean_ce, "val_perplexity": perplexity(mean_ce)}

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,5 +1,6 @@
 """Model package: the hardware seam.
 
-`interface` and `blocks` are portable (no backend imports). `mlx_backend` and
-`cuda_backend` are the only modules permitted to import a hardware library.
+`interface` and `blocks` are portable (no backend imports). `mlx_backend`,
+`mlx_train_step`, and `cuda_backend` are the only modules permitted to import a
+hardware library.
 """

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,0 +1,5 @@
+"""Model package: the hardware seam.
+
+`interface` and `blocks` are portable (no backend imports). `mlx_backend` and
+`cuda_backend` are the only modules permitted to import a hardware library.
+"""

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -1,0 +1,105 @@
+"""Portable architecture description for the Mamba POC.
+
+This module is the single source of truth for model dimensions. It contains NO
+backend imports (no MLX, no CUDA/torch) so it can be loaded anywhere and shared
+unchanged across backends.
+
+The Mamba block (described here textually; implemented in a backend):
+
+    input projection
+      -> split into `main` and `gate`
+      -> short causal depthwise conv on `main` (width `d_conv`)
+      -> SiLU
+      -> selective SSM (diagonal A; input-dependent B, C, delta; parallel scan)
+      -> multiply by SiLU(gate)
+      -> output projection
+
+Each block is wrapped pre-norm (RMSNorm) with a residual connection. The full
+model is: token embedding -> N residual blocks -> final RMSNorm -> tied LM head.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Optional, Union
+
+import yaml
+
+
+@dataclass
+class MambaConfig:
+    """Architecture + run parameters. Loaded from `config/*.yaml`.
+
+    The tied token embedding (vocab_size x d_model) is a large fraction of the
+    parameter budget at POC scale (~38M of ~100M at d_model=768, vocab~50k), so
+    `tie_embeddings` is mandatory there, not optional.
+    """
+
+    # --- core dimensions ---
+    d_model: int
+    n_layers: int
+    d_state: int = 16
+    expand: int = 2
+    d_conv: int = 4
+    # dt projection rank; "auto" -> ceil(d_model / 16)
+    dt_rank: Union[int, str] = "auto"
+
+    # --- vocab / sequence ---
+    # OLMo tokenizer vocab. MUST stay < 65536 to pack token ids as uint16.
+    vocab_size: int = 50280
+    seq_len: int = 1024
+    tie_embeddings: bool = True
+
+    # --- precision / numerics ---
+    # fp32 | fp16 | bf16. Default fp32 for toy/smoke (correctness + exact resume).
+    # For poc.yaml the choice is CONFIRMED ON MLX in milestone 1 (do not assume bf16;
+    # fp16 + loss scaling is the likely Metal-friendly choice).
+    precision: str = "fp32"
+
+    # Chunked scan working-set bound. None => single-pass parallel scan, which is
+    # fine for seq_len up to ~2k. Set an int for long-context (prevents exp overflow).
+    chunk_size: Optional[int] = None
+
+    # --- dt-projection bias init (LOAD-BEARING) ---
+    # Inverse-softplus of a sample in [dt_min, dt_max] initializes the dt bias.
+    # Without this the model fails to learn recall. Carry these into every backend.
+    dt_min: float = 1e-3
+    dt_max: float = 1e-1
+    dt_init_floor: float = 1e-4
+
+    @property
+    def d_inner(self) -> int:
+        return self.expand * self.d_model
+
+    @property
+    def dt_rank_resolved(self) -> int:
+        if self.dt_rank == "auto":
+            return math.ceil(self.d_model / 16)
+        return int(self.dt_rank)
+
+    def validate(self) -> None:
+        if self.vocab_size >= 65536:
+            raise ValueError(
+                f"vocab_size={self.vocab_size} does not fit uint16 packing (<65536). "
+                "Either confirm the tokenizer vocab or change the packed dtype."
+            )
+        if self.precision not in ("fp32", "fp16", "bf16"):
+            raise ValueError(f"unknown precision {self.precision!r}")
+        if self.chunk_size is not None and self.chunk_size <= 0:
+            raise ValueError("chunk_size must be positive or None")
+        if self.d_conv < 1:
+            raise ValueError("d_conv must be >= 1")
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def load_config(path: Union[str, Path]) -> MambaConfig:
+    """Load a `MambaConfig` from a YAML file and validate it."""
+    with open(path, "r") as f:
+        raw = yaml.safe_load(f) or {}
+    cfg = MambaConfig(**raw)
+    cfg.validate()
+    return cfg

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -1,0 +1,50 @@
+"""CUDA backend (scale-up milestone) — STUB.
+
+Built at the CUDA scale-up against the now-finalized `ModelInterface`, using the
+`mamba-ssm` fused selective-scan kernel for `forward` and the recurrence form for
+`step`. Certified against the MLX backend by `conformance/backend_parity.py`
+(comparison run in fp32, ~1e-4 relative tolerance).
+
+No `torch` import here yet so the module is inspectable without a CUDA stack; the
+import is added when the backend is implemented.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .blocks import MambaConfig
+from .interface import ModelInterface, State, Array
+
+
+class CUDAMambaModel(ModelInterface):
+    """Placeholder. Implement with PyTorch + mamba-ssm at the scale-up milestone."""
+
+    def __init__(self, config: MambaConfig):
+        config.validate()
+        self.config = config
+        raise NotImplementedError(
+            "CUDA backend is built at the scale-up milestone (mamba-ssm fused kernel). "
+            "It must implement ModelInterface and pass backend_parity in fp32."
+        )
+
+    def forward(self, token_batch: Array) -> Array:  # pragma: no cover
+        raise NotImplementedError
+
+    def step(self, token: Array, state: State) -> Tuple[Array, State]:  # pragma: no cover
+        raise NotImplementedError
+
+    def init_state(self, batch_size: int) -> State:  # pragma: no cover
+        raise NotImplementedError
+
+    def get_state(self) -> State:  # pragma: no cover
+        raise NotImplementedError
+
+    def set_state(self, state: State) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def save(self, path: str) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def load(self, path: str) -> None:  # pragma: no cover
+        raise NotImplementedError

--- a/src/model/interface.py
+++ b/src/model/interface.py
@@ -1,0 +1,69 @@
+"""The seam: the abstract model protocol.
+
+THIS MODULE MUST NOT IMPORT ANY BACKEND (no `mlx`, no `torch`/CUDA). Everything
+above the seam (train/serve/eval/conformance) depends only on this interface and
+on `blocks.MambaConfig`. Each backend (`mlx_backend`, `cuda_backend`) provides a
+concrete subclass implementing exactly these methods.
+
+`State` is intentionally typed as `Any`: its concrete representation is
+backend-specific (an MLX array tuple, a torch tensor, ...). Code above the seam
+treats it as an opaque, fixed-size blob that it can snapshot and restore.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Tuple
+
+from .blocks import MambaConfig
+
+# Opaque, backend-defined recurrent state.
+State = Any
+# Opaque, backend-defined logits / token-batch arrays.
+Array = Any
+
+
+class ModelInterface(ABC):
+    """Contract every backend implements. Lock this before building on top of it."""
+
+    #: Single source of truth for architecture parameters.
+    config: MambaConfig
+
+    # --- training path ---
+    @abstractmethod
+    def forward(self, token_batch: Array) -> Array:
+        """Full-sequence parallel forward. `token_batch` is (batch, seq_len) ids.
+
+        Returns logits (batch, seq_len, vocab_size). Uses the parallel scan.
+        """
+
+    # --- inference path ---
+    @abstractmethod
+    def step(self, token: Array, state: State) -> Tuple[Array, State]:
+        """Single-token recurrence. Returns (logits, new_state).
+
+        Must agree with `forward` within tolerance for the same inputs
+        (guarded by conformance/forward_step_parity).
+        """
+
+    @abstractmethod
+    def init_state(self, batch_size: int) -> State:
+        """Fresh, zeroed recurrent state for `batch_size` sequences."""
+
+    # --- snapshot / restore (serve + rewind) ---
+    @abstractmethod
+    def get_state(self) -> State:
+        """Return a copy of the current recurrent state."""
+
+    @abstractmethod
+    def set_state(self, state: State) -> None:
+        """Restore recurrent state previously produced by get_state/step."""
+
+    # --- checkpointing (weights via checkpoint module) ---
+    @abstractmethod
+    def save(self, path: str) -> None:
+        """Persist weights in a portable format (safetensors). See train/checkpoint."""
+
+    @abstractmethod
+    def load(self, path: str) -> None:
+        """Load weights from a portable checkpoint produced by `save`."""

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -1,0 +1,152 @@
+"""MLX backend for the Mamba POC (Apple Silicon).
+
+SKELETON. The structure, method signatures, and the load-bearing initialization
+notes are in place; the heavy SSM math (parallel scan, chunked scan) is marked
+TODO and is completed + run on Apple Silicon. This file imports `mlx`, so it does
+NOT import on Linux/CUDA hosts — that is intentional and allowed: it lives below
+the seam and nothing portable imports it.
+
+Implements `ModelInterface` exactly. Reference for the selective-scan math:
+the standard Mamba block (Gu & Dao). Keep all comparisons against the sequential
+reference in fp32 (conformance tolerance ~1e-4 relative).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+import mlx.core as mx  # noqa: F401  (Apple Silicon only)
+import mlx.nn as nn
+
+from .blocks import MambaConfig
+from .interface import ModelInterface, State, Array
+
+
+# --------------------------------------------------------------------------- #
+# Building blocks
+# --------------------------------------------------------------------------- #
+class RMSNorm(nn.Module):
+    def __init__(self, d_model: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = mx.ones((d_model,))
+
+    def __call__(self, x: Array) -> Array:
+        # TODO[mac]: x * rsqrt(mean(x^2) + eps) * weight
+        raise NotImplementedError("Complete RMSNorm on Apple Silicon.")
+
+
+class SelectiveSSM(nn.Module):
+    """Diagonal-A selective state space with input-dependent B, C, delta.
+
+    Two code paths that MUST agree (forward_step_parity):
+      * `parallel(x)`  : cumsum-based closed-form scan over the full sequence.
+      * `recurrence(x, state)` : one-step update used by `step`.
+
+    Chunking (`config.chunk_size`) bounds the scan's working set and prevents
+    `exp` overflow for long sequences. At seq_len <= ~2k it is unused.
+    """
+
+    def __init__(self, config: MambaConfig):
+        super().__init__()
+        self.config = config
+        d_inner, d_state = config.d_inner, config.d_state
+        dt_rank = config.dt_rank_resolved
+
+        # x_proj produces (delta, B, C); dt_proj maps dt_rank -> d_inner.
+        self.x_proj = nn.Linear(d_inner, dt_rank + 2 * d_state, bias=False)
+        self.dt_proj = nn.Linear(dt_rank, d_inner, bias=True)
+
+        # Diagonal A stored as log for stability: A = -exp(A_log).
+        self.A_log = mx.zeros((d_inner, d_state))  # TODO[mac]: init to log of 1..d_state
+        self.D = mx.ones((d_inner,))
+
+        self._init_dt_bias()
+
+    def _init_dt_bias(self) -> None:
+        """LOAD-BEARING dt-projection bias init (inverse-softplus into a small
+        positive range). Without this the model fails to learn recall.
+
+            dt = uniform(log(dt_min), log(dt_max)).exp().clamp(min=dt_init_floor)
+            bias = dt + log(-expm1(-dt))   # inverse softplus
+        """
+        # TODO[mac]: implement with mx; set self.dt_proj.bias to inv_softplus(dt).
+        raise NotImplementedError("Complete dt-bias init on Apple Silicon.")
+
+    def parallel(self, x: Array) -> Array:
+        # TODO[mac]: cumsum closed-form selective scan (chunked if chunk_size set).
+        raise NotImplementedError("Complete parallel scan on Apple Silicon.")
+
+    def recurrence(self, x: Array, state: State) -> Tuple[Array, State]:
+        # TODO[mac]: single-step state update; must match `parallel` in fp32.
+        raise NotImplementedError("Complete recurrence on Apple Silicon.")
+
+
+class MambaBlock(nn.Module):
+    """input proj -> split main+gate -> causal depthwise conv -> SiLU -> SSM
+    -> * SiLU(gate) -> output proj. Wrapped pre-norm with a residual outside."""
+
+    def __init__(self, config: MambaConfig):
+        super().__init__()
+        self.config = config
+        d_inner = config.d_inner
+        self.in_proj = nn.Linear(config.d_model, 2 * d_inner, bias=False)
+        self.conv = nn.Conv1d(d_inner, d_inner, config.d_conv,
+                              groups=d_inner, padding=config.d_conv - 1)
+        self.ssm = SelectiveSSM(config)
+        self.out_proj = nn.Linear(d_inner, config.d_model, bias=False)
+
+    def forward_seq(self, x: Array) -> Array:
+        # TODO[mac]: parallel-scan path for training.
+        raise NotImplementedError("Complete MambaBlock.forward_seq on Apple Silicon.")
+
+    def step(self, x: Array, state: State) -> Tuple[Array, State]:
+        # TODO[mac]: recurrence path for inference (conv state + ssm state).
+        raise NotImplementedError("Complete MambaBlock.step on Apple Silicon.")
+
+
+# --------------------------------------------------------------------------- #
+# Top-level model implementing the seam
+# --------------------------------------------------------------------------- #
+class MLXMambaModel(ModelInterface, nn.Module):
+    def __init__(self, config: MambaConfig):
+        nn.Module.__init__(self)
+        config.validate()
+        self.config = config
+        self.embedding = nn.Embedding(config.vocab_size, config.d_model)
+        self.layers = [MambaBlock(config) for _ in range(config.n_layers)]
+        self.norm_f = RMSNorm(config.d_model)
+        # Tied LM head: head weight IS the embedding weight (mandatory at scale).
+        self._tie_embeddings = config.tie_embeddings
+        if not config.tie_embeddings:
+            self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
+
+    # --- ModelInterface ---
+    def forward(self, token_batch: Array) -> Array:
+        raise NotImplementedError("Complete forward on Apple Silicon.")
+
+    def step(self, token: Array, state: State) -> Tuple[Array, State]:
+        raise NotImplementedError("Complete step on Apple Silicon.")
+
+    def init_state(self, batch_size: int) -> State:
+        raise NotImplementedError("Complete init_state on Apple Silicon.")
+
+    def get_state(self) -> State:
+        raise NotImplementedError("Complete get_state on Apple Silicon.")
+
+    def set_state(self, state: State) -> None:
+        raise NotImplementedError("Complete set_state on Apple Silicon.")
+
+    def save(self, path: str) -> None:
+        # Delegates to train.checkpoint.save_weights (portable safetensors).
+        from ..train.checkpoint import save_weights
+        save_weights(self._portable_state_dict(), path, config=self.config)
+
+    def load(self, path: str) -> None:
+        from ..train.checkpoint import load_weights
+        load_weights(self, path)
+
+    def _portable_state_dict(self) -> dict:
+        # TODO[mac]: flatten params to {name: np-convertible array} for safetensors.
+        raise NotImplementedError("Complete portable state-dict export on Apple Silicon.")

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -1,26 +1,41 @@
 """MLX backend for the Mamba POC (Apple Silicon).
 
-SKELETON. The structure, method signatures, and the load-bearing initialization
-notes are in place; the heavy SSM math (parallel scan, chunked scan) is marked
-TODO and is completed + run on Apple Silicon. This file imports `mlx`, so it does
-NOT import on Linux/CUDA hosts — that is intentional and allowed: it lives below
-the seam and nothing portable imports it.
+Implements `ModelInterface` with the standard Mamba block (Gu & Dao): a diagonal
+selective SSM with input-dependent B, C, delta. Two code paths must agree
+(forward_step_parity, fp32 ~1e-4 rel):
 
-Implements `ModelInterface` exactly. Reference for the selective-scan math:
-the standard Mamba block (Gu & Dao). Keep all comparisons against the sequential
-reference in fp32 (conformance tolerance ~1e-4 relative).
+  * `parallel(x)`     : a chunked closed-form selective scan over the full
+                        sequence (training path). Chunking keeps the per-chunk
+                        cumulative decay bounded so `exp` does not overflow — a
+                        global single-pass cumsum overflows fp32 even at modest
+                        seq_len, so we always chunk (default chunk 32).
+  * `recurrence(x, h)`: one-step state update (inference path).
+
+This file imports `mlx`, so it does NOT import on Linux/CUDA hosts — intentional
+and allowed: it lives below the seam and nothing portable imports it.
 """
 
 from __future__ import annotations
 
 import math
-from typing import Tuple
+from typing import List, Tuple
 
-import mlx.core as mx  # noqa: F401  (Apple Silicon only)
+import mlx.core as mx
 import mlx.nn as nn
+from mlx.utils import tree_flatten, tree_unflatten
+import numpy as np
 
 from .blocks import MambaConfig
 from .interface import ModelInterface, State, Array
+
+
+def _silu(x: Array) -> Array:
+    return x * mx.sigmoid(x)
+
+
+def _softplus(x: Array) -> Array:
+    # log(1 + exp(x)), numerically stable via logaddexp(x, 0).
+    return mx.logaddexp(x, mx.zeros_like(x))
 
 
 # --------------------------------------------------------------------------- #
@@ -33,20 +48,12 @@ class RMSNorm(nn.Module):
         self.weight = mx.ones((d_model,))
 
     def __call__(self, x: Array) -> Array:
-        # TODO[mac]: x * rsqrt(mean(x^2) + eps) * weight
-        raise NotImplementedError("Complete RMSNorm on Apple Silicon.")
+        norm = mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + self.eps)
+        return self.weight * (x * norm)
 
 
 class SelectiveSSM(nn.Module):
-    """Diagonal-A selective state space with input-dependent B, C, delta.
-
-    Two code paths that MUST agree (forward_step_parity):
-      * `parallel(x)`  : cumsum-based closed-form scan over the full sequence.
-      * `recurrence(x, state)` : one-step update used by `step`.
-
-    Chunking (`config.chunk_size`) bounds the scan's working set and prevents
-    `exp` overflow for long sequences. At seq_len <= ~2k it is unused.
-    """
+    """Diagonal-A selective state space with input-dependent B, C, delta."""
 
     def __init__(self, config: MambaConfig):
         super().__init__()
@@ -58,8 +65,10 @@ class SelectiveSSM(nn.Module):
         self.x_proj = nn.Linear(d_inner, dt_rank + 2 * d_state, bias=False)
         self.dt_proj = nn.Linear(dt_rank, d_inner, bias=True)
 
-        # Diagonal A stored as log for stability: A = -exp(A_log).
-        self.A_log = mx.zeros((d_inner, d_state))  # TODO[mac]: init to log of 1..d_state
+        # Diagonal A stored as log for stability: A = -exp(A_log). Init A = -(1..d_state)
+        # broadcast across channels (the standard "S4D-real" init).
+        a = mx.arange(1, d_state + 1, dtype=mx.float32)          # (d_state,)
+        self.A_log = mx.log(mx.ones((d_inner, d_state)) * a)     # (d_inner, d_state)
         self.D = mx.ones((d_inner,))
 
         self._init_dt_bias()
@@ -68,29 +77,74 @@ class SelectiveSSM(nn.Module):
         """LOAD-BEARING dt-projection bias init (inverse-softplus into a small
         positive range). Without this the model fails to learn recall.
 
-            dt = uniform(log(dt_min), log(dt_max)).exp().clamp(min=dt_init_floor)
-            bias = dt + log(-expm1(-dt))   # inverse softplus
+            dt   = uniform(log(dt_min), log(dt_max)).exp().clamp(min=dt_init_floor)
+            bias = dt + log(-expm1(-dt))          # inverse softplus
         """
-        # TODO[mac]: implement with mx; set self.dt_proj.bias to inv_softplus(dt).
-        raise NotImplementedError("Complete dt-bias init on Apple Silicon.")
+        c = self.config
+        dt = mx.exp(mx.random.uniform(
+            low=math.log(c.dt_min), high=math.log(c.dt_max),
+            shape=(c.d_inner,)))
+        dt = mx.maximum(dt, c.dt_init_floor)
+        inv_softplus = dt + mx.log(-mx.expm1(-dt))
+        self.dt_proj.bias = inv_softplus
+
+    # --- shared projections --------------------------------------------------
+    def _project(self, x: Array):
+        dt_rank, d_state = self.config.dt_rank_resolved, self.config.d_state
+        proj = self.x_proj(x)
+        dt = proj[..., :dt_rank]
+        B = proj[..., dt_rank:dt_rank + d_state]
+        C = proj[..., dt_rank + d_state:]
+        delta = _softplus(self.dt_proj(dt))     # (..., d_inner)
+        A = -mx.exp(self.A_log)                  # (d_inner, d_state)
+        return delta, A, B, C
 
     def parallel(self, x: Array) -> Array:
-        # TODO[mac]: cumsum closed-form selective scan (chunked if chunk_size set).
-        raise NotImplementedError("Complete parallel scan on Apple Silicon.")
+        """Chunked closed-form selective scan. x: (B, L, d_inner) -> (B, L, d_inner)."""
+        B_, L, d_inner = x.shape
+        delta, A, Bmat, Cmat = self._project(x)
+
+        # Discretized terms: a = delta*A (log-decay), deltaBu = delta*B*x.
+        a = delta[..., None] * A[None, None]                 # (B, L, di, ds)
+        deltaBu = delta[..., None] * Bmat[:, :, None, :] * x[..., None]  # (B,L,di,ds)
+
+        chunk = self.config.chunk_size or min(L, 32)
+        d_state = self.config.d_state
+        h_carry = mx.zeros((B_, d_inner, d_state))
+        ys = []
+        for s in range(0, L, chunk):
+            e = min(s + chunk, L)
+            a_c = a[:, s:e]                                  # (B, lc, di, ds)
+            bu_c = deltaBu[:, s:e]
+            C_c = Cmat[:, s:e]                               # (B, lc, ds)
+            A_cum = mx.cumsum(a_c, axis=1)                   # inclusive log-decay
+            # h_j = exp(A_cum_j) * (h_carry + sum_{i<=j} exp(-A_cum_i) * bu_i)
+            inner = mx.cumsum(mx.exp(-A_cum) * bu_c, axis=1)
+            h = mx.exp(A_cum) * (h_carry[:, None] + inner)   # (B, lc, di, ds)
+            ys.append(mx.sum(h * C_c[:, :, None, :], axis=-1))  # (B, lc, di)
+            h_carry = h[:, -1]
+        y = mx.concatenate(ys, axis=1)                       # (B, L, di)
+        return y + x * self.D
 
     def recurrence(self, x: Array, state: State) -> Tuple[Array, State]:
-        # TODO[mac]: single-step state update; must match `parallel` in fp32.
-        raise NotImplementedError("Complete recurrence on Apple Silicon.")
+        """Single timestep. x: (B, d_inner), state h: (B, d_inner, d_state)."""
+        delta, A, Bmat, Cmat = self._project(x)
+        dA = mx.exp(delta[..., None] * A[None])              # (B, di, ds)
+        dBu = delta[..., None] * Bmat[:, None, :] * x[..., None]
+        h = dA * state + dBu                                 # (B, di, ds)
+        y = mx.sum(h * Cmat[:, None, :], axis=-1) + x * self.D
+        return y, h
 
 
 class MambaBlock(nn.Module):
-    """input proj -> split main+gate -> causal depthwise conv -> SiLU -> SSM
-    -> * SiLU(gate) -> output proj. Wrapped pre-norm with a residual outside."""
+    """pre-norm -> input proj -> split main+gate -> causal depthwise conv -> SiLU
+    -> selective SSM -> * SiLU(gate) -> output proj, with a residual."""
 
     def __init__(self, config: MambaConfig):
         super().__init__()
         self.config = config
         d_inner = config.d_inner
+        self.norm = RMSNorm(config.d_model)
         self.in_proj = nn.Linear(config.d_model, 2 * d_inner, bias=False)
         self.conv = nn.Conv1d(d_inner, d_inner, config.d_conv,
                               groups=d_inner, padding=config.d_conv - 1)
@@ -98,12 +152,29 @@ class MambaBlock(nn.Module):
         self.out_proj = nn.Linear(d_inner, config.d_model, bias=False)
 
     def forward_seq(self, x: Array) -> Array:
-        # TODO[mac]: parallel-scan path for training.
-        raise NotImplementedError("Complete MambaBlock.forward_seq on Apple Silicon.")
+        L = x.shape[1]
+        xn = self.norm(x)
+        x_main, z = mx.split(self.in_proj(xn), 2, axis=-1)   # (B,L,di) each
+        # Causal depthwise conv: pad both sides (d_conv-1), keep the first L outputs.
+        xc = self.conv(x_main)[:, :L]
+        xc = _silu(xc)
+        y = self.ssm.parallel(xc)
+        y = y * _silu(z)
+        return x + self.out_proj(y)
 
     def step(self, x: Array, state: State) -> Tuple[Array, State]:
-        # TODO[mac]: recurrence path for inference (conv state + ssm state).
-        raise NotImplementedError("Complete MambaBlock.step on Apple Silicon.")
+        conv_state, ssm_state = state                        # (B,k-1,di), (B,di,ds)
+        xn = self.norm(x)
+        x_main, z = mx.split(self.in_proj(xn), 2, axis=-1)    # (B,di) each
+        window = mx.concatenate([conv_state, x_main[:, None, :]], axis=1)  # (B,k,di)
+        # depthwise conv at this timestep: sum over kernel positions.
+        wk = self.conv.weight[:, :, 0].T                      # (k, di)
+        conv_out = mx.sum(window * wk[None], axis=1) + self.conv.bias       # (B, di)
+        xc = _silu(conv_out)
+        y, new_ssm = self.ssm.recurrence(xc, ssm_state)
+        y = y * _silu(z)
+        out = x + self.out_proj(y)
+        return out, (window[:, 1:], new_ssm)
 
 
 # --------------------------------------------------------------------------- #
@@ -117,29 +188,43 @@ class MLXMambaModel(ModelInterface, nn.Module):
         self.embedding = nn.Embedding(config.vocab_size, config.d_model)
         self.layers = [MambaBlock(config) for _ in range(config.n_layers)]
         self.norm_f = RMSNorm(config.d_model)
-        # Tied LM head: head weight IS the embedding weight (mandatory at scale).
         self._tie_embeddings = config.tie_embeddings
         if not config.tie_embeddings:
             self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
+        self._state = None
+
+    def _head(self, h: Array) -> Array:
+        if self._tie_embeddings:
+            return h @ self.embedding.weight.T
+        return self.lm_head(h)
 
     # --- ModelInterface ---
     def forward(self, token_batch: Array) -> Array:
-        raise NotImplementedError("Complete forward on Apple Silicon.")
+        h = self.embedding(mx.array(token_batch))
+        for layer in self.layers:
+            h = layer.forward_seq(h)
+        return self._head(self.norm_f(h))
 
     def step(self, token: Array, state: State) -> Tuple[Array, State]:
-        raise NotImplementedError("Complete step on Apple Silicon.")
+        h = self.embedding(mx.array(token))
+        new_state = []
+        for layer, st in zip(self.layers, state):
+            h, st2 = layer.step(h, st)
+            new_state.append(st2)
+        return self._head(self.norm_f(h)), new_state
 
     def init_state(self, batch_size: int) -> State:
-        raise NotImplementedError("Complete init_state on Apple Silicon.")
+        di, ds, k = self.config.d_inner, self.config.d_state, self.config.d_conv
+        return [(mx.zeros((batch_size, k - 1, di)), mx.zeros((batch_size, di, ds)))
+                for _ in range(self.config.n_layers)]
 
     def get_state(self) -> State:
-        raise NotImplementedError("Complete get_state on Apple Silicon.")
+        return self._state
 
     def set_state(self, state: State) -> None:
-        raise NotImplementedError("Complete set_state on Apple Silicon.")
+        self._state = state
 
     def save(self, path: str) -> None:
-        # Delegates to train.checkpoint.save_weights (portable safetensors).
         from ..train.checkpoint import save_weights
         save_weights(self._portable_state_dict(), path, config=self.config)
 
@@ -148,5 +233,11 @@ class MLXMambaModel(ModelInterface, nn.Module):
         load_weights(self, path)
 
     def _portable_state_dict(self) -> dict:
-        # TODO[mac]: flatten params to {name: np-convertible array} for safetensors.
-        raise NotImplementedError("Complete portable state-dict export on Apple Silicon.")
+        # Flatten MLX params to {name: numpy array} for safetensors. With tied
+        # embeddings there is no separate head param, so nothing to drop.
+        return {k: np.array(v) for k, v in tree_flatten(self.parameters())}
+
+    def _load_portable(self, weights: dict) -> None:
+        params = [(k, mx.array(v)) for k, v in weights.items()]
+        self.update(tree_unflatten(params))
+        mx.eval(self.parameters())

--- a/src/model/mlx_train_step.py
+++ b/src/model/mlx_train_step.py
@@ -1,0 +1,78 @@
+"""MLX training primitive (Apple Silicon, below the seam — may import mlx).
+
+Provides the backend-specific `train_step` that `train.loop.train` injects, plus
+optimizer-state (de)serialization for within-backend exact resume. The portable
+loop never imports this; it receives `make_train_step(...)`'s closure as a callable
+matching `TrainStepFn = (model, inputs, targets, lr) -> {loss, grad_norm}`.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+from mlx.utils import tree_flatten, tree_unflatten
+
+
+def _global_grad_norm(grads) -> mx.array:
+    leaves = [v for _, v in tree_flatten(grads)]
+    sq = mx.sum(mx.stack([mx.sum(g * g) for g in leaves]))
+    return mx.sqrt(sq)
+
+
+def make_train_step(model, optimizer, *, grad_clip: float = 1.0,
+                    loss_scale: Optional[float] = None) -> Callable:
+    """Build a `train_step(model, inputs, targets, lr) -> {loss, grad_norm}`.
+
+    Closes over `optimizer` so Adam moments persist across steps. `loss_scale`
+    (fp16 path) scales the loss before backprop and unscales grads after; pass
+    None for fp32 (toy/smoke).
+    """
+    def loss_fn(model, inputs, targets):
+        logits = model.forward(inputs)                      # (B, L, V)
+        V = logits.shape[-1]
+        t = mx.array(targets).reshape(-1).astype(mx.int32)
+        ce = nn.losses.cross_entropy(logits.reshape(-1, V), t, reduction="mean")
+        return ce * loss_scale if loss_scale else ce
+
+    loss_and_grad = nn.value_and_grad(model, loss_fn)
+
+    def train_step(model, inputs, targets, lr: float) -> dict:
+        loss, grads = loss_and_grad(model, inputs, targets)
+        if loss_scale:
+            grads = _unscale(grads, 1.0 / loss_scale)
+            loss = loss / loss_scale
+        norm = _global_grad_norm(grads)
+        if grad_clip:
+            factor = mx.minimum(1.0, grad_clip / (norm + 1e-6))
+            grads = _unscale(grads, factor)
+        optimizer.learning_rate = lr
+        optimizer.update(model, grads)
+        mx.eval(model.parameters(), optimizer.state, loss)
+        return {"loss": float(loss), "grad_norm": float(norm)}
+
+    return train_step
+
+
+def _unscale(grads, factor):
+    from mlx.utils import tree_map
+    return tree_map(lambda g: g * factor, grads)
+
+
+# --- optimizer-state (de)serialization for within-backend resume ------------
+def _st_path(path: str) -> str:
+    path = str(path)
+    return path if path.endswith(".safetensors") else path + ".safetensors"
+
+
+def save_optimizer(optimizer, path: str) -> None:
+    flat = {k: v for k, v in tree_flatten(optimizer.state) if isinstance(v, mx.array)}
+    mx.save_safetensors(_st_path(path), flat)
+
+
+def load_optimizer(optimizer, path: str) -> None:
+    flat = mx.load(_st_path(path))
+    optimizer.state = tree_unflatten(list(flat.items()))
+    mx.eval(optimizer.state)

--- a/src/serve/__init__.py
+++ b/src/serve/__init__.py
@@ -1,0 +1,4 @@
+"""Serving + rewind (DEFERRED). Sits on top of `step` and `get_state`/`set_state`.
+Not required for the core "does it train and eval" question. Build on the proven
+model. Both modules are stubs for the POC.
+"""

--- a/src/serve/rewind.py
+++ b/src/serve/rewind.py
@@ -1,0 +1,16 @@
+"""Per-turn snapshot tree for undo/branch (DEFERRED stub, optional even at scale).
+
+Snapshot the full, consistent cross-section of state at each turn boundary (the
+resume point). Cap history depth — LRU is correct for pure Mamba since states are
+uniform size. NOTE: this rewinds the running summary; it does NOT restore exact
+per-item recall (a fixed-state architectural limit, not a cache bug).
+"""
+
+from __future__ import annotations
+
+from ..model.interface import ModelInterface
+
+
+class RewindTree:  # pragma: no cover - deferred
+    def __init__(self, model: ModelInterface, max_depth: int = 32):
+        raise NotImplementedError("Rewind layer is deferred for the POC.")

--- a/src/serve/sessions.py
+++ b/src/serve/sessions.py
@@ -1,0 +1,20 @@
+"""Multi-session state map (DEFERRED stub).
+
+Maps session_id -> that session's fixed-size recurrent state. Multi-session serving
+is the easy regime for Mamba: constant memory per session, so
+max_concurrent = memory_budget / per_session_state. Serialize within a session
+(sequential dependency); parallelize across sessions. No batching at POC scale.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..model.interface import ModelInterface, State
+
+
+class SessionStore:  # pragma: no cover - deferred
+    def __init__(self, model: ModelInterface):
+        self.model = model
+        self._states: Dict[str, State] = {}
+        raise NotImplementedError("Serving layer is deferred; build after the core loop.")

--- a/src/train/__init__.py
+++ b/src/train/__init__.py
@@ -1,0 +1,3 @@
+"""Training orchestration. Backend-free: drives the model only through
+`ModelInterface` and the checkpoint module. No MLX/CUDA imports here.
+"""

--- a/src/train/checkpoint.py
+++ b/src/train/checkpoint.py
@@ -76,6 +76,18 @@ def load_resume(path: str, optimizer_deserializer: Callable[[str], Any]) -> dict
 
 
 def _jsonable(x: Any) -> Any:
+    """Recursively convert RNG/optimizer state into JSON-serializable values.
+
+    Real RNG states (e.g. ``np.random.default_rng(...).bit_generator.state``) are
+    nested dicts containing np.ndarrays and NumPy scalar types, so a shallow
+    conversion would raise inside ``json.dumps``.
+    """
     if isinstance(x, np.ndarray):
         return {"__ndarray__": x.tolist(), "dtype": str(x.dtype)}
+    if isinstance(x, np.generic):
+        return x.item()
+    if isinstance(x, dict):
+        return {k: _jsonable(v) for k, v in x.items()}
+    if isinstance(x, (list, tuple)):
+        return [_jsonable(v) for v in x]
     return x

--- a/src/train/checkpoint.py
+++ b/src/train/checkpoint.py
@@ -1,0 +1,81 @@
+"""Checkpointing: two DISTINCT concerns, deliberately not conflated.
+
+1. Weights — PORTABLE format (safetensors). This is what lets an MLX checkpoint
+   seed a CUDA run and lets a CUDA-trained model run on the Mac. Backend-agnostic:
+   a flat dict of {param_name: numpy array} plus the config.
+
+2. Optimizer state — needed ONLY for exact resume on the SAME backend after an
+   interruption. It does NOT need to be cross-backend portable (MLX and PyTorch
+   optimizer state differ internally; the migration trains fresh on CUDA anyway).
+   Saved via a backend-provided serializer, scoped to within-backend resume.
+
+`safetensors` is imported lazily so this module loads without the dependency.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+import numpy as np
+
+
+# --- portable weights -------------------------------------------------------
+def save_weights(state_dict: Dict[str, np.ndarray], path: str,
+                 config: Optional[Any] = None) -> None:
+    """Save weights as safetensors + a `<path>.config.json` sidecar."""
+    from safetensors.numpy import save_file  # lazy
+
+    path = str(path)
+    tensors = {k: np.asarray(v) for k, v in state_dict.items()}
+    save_file(tensors, path)
+    if config is not None:
+        cfg = config.to_dict() if hasattr(config, "to_dict") else dict(config)
+        Path(path + ".config.json").write_text(json.dumps(cfg, indent=2))
+
+
+def load_weights_dict(path: str) -> Dict[str, np.ndarray]:
+    """Load the portable weight dict (numpy). Backends map it into their params."""
+    from safetensors.numpy import load_file  # lazy
+
+    return load_file(str(path))
+
+
+def load_weights(model: Any, path: str) -> None:
+    """Load portable weights into a backend model via its `_load_portable` hook."""
+    weights = load_weights_dict(path)
+    if not hasattr(model, "_load_portable"):
+        raise NotImplementedError(
+            "Backend must implement `_load_portable(dict)` to map portable weights."
+        )
+    model._load_portable(weights)
+
+
+# --- within-backend resume bundle ------------------------------------------
+def save_resume(path: str, *, step: int, rng_state: Any,
+                optimizer_serializer: Callable[[str], None]) -> None:
+    """Save a same-backend resume bundle: training step, RNG state, optimizer state.
+
+    `optimizer_serializer(opt_path)` is supplied by the backend (e.g. MLX/torch),
+    since optimizer state layout is backend-specific.
+    """
+    path = str(path)
+    Path(path).mkdir(parents=True, exist_ok=True)
+    meta = {"step": int(step), "rng_state": _jsonable(rng_state)}
+    Path(path, "resume_meta.json").write_text(json.dumps(meta))
+    optimizer_serializer(str(Path(path, "optimizer.state")))
+
+
+def load_resume(path: str, optimizer_deserializer: Callable[[str], Any]) -> dict:
+    """Restore the resume bundle. Returns {step, rng_state, optimizer}."""
+    path = str(path)
+    meta = json.loads(Path(path, "resume_meta.json").read_text())
+    meta["optimizer"] = optimizer_deserializer(str(Path(path, "optimizer.state")))
+    return meta
+
+
+def _jsonable(x: Any) -> Any:
+    if isinstance(x, np.ndarray):
+        return {"__ndarray__": x.tolist(), "dtype": str(x.dtype)}
+    return x

--- a/src/train/logging.py
+++ b/src/train/logging.py
@@ -1,0 +1,31 @@
+"""Minimal training logger: append JSON lines to a file and echo to stdout.
+
+Backend-free. Plugs into `train.loop.train(logger=...)`; the loop hands it a
+payload dict per logged step (step, lr, loss, grad_norm, val_loss, ...).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+
+class JsonlLogger:
+    def __init__(self, path: str, echo: bool = True):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.echo = echo
+        self._f = self.path.open("w")
+
+    def __call__(self, payload: dict) -> None:
+        self._f.write(json.dumps(payload) + "\n")
+        self._f.flush()
+        if self.echo:
+            keys = ("step", "lr", "loss", "grad_norm", "val_loss", "val_perplexity")
+            parts = [f"{k}={payload[k]:.4g}" if isinstance(payload.get(k), float)
+                     else f"{k}={payload[k]}" for k in keys if k in payload]
+            print("  ".join(parts))
+
+    def close(self) -> None:
+        self._f.close()

--- a/src/train/logging.py
+++ b/src/train/logging.py
@@ -1,22 +1,23 @@
-"""Minimal training logger: append JSON lines to a file and echo to stdout.
+"""Minimal training logger: write JSON lines to a file and echo to stdout.
 
 Backend-free. Plugs into `train.loop.train(logger=...)`; the loop hands it a
-payload dict per logged step (step, lr, loss, grad_norm, val_loss, ...).
+payload dict per logged step (step, lr, loss, grad_norm, val_loss, ...). Opens in
+truncate mode by default (fresh run); pass `append=True` to preserve prior logs
+across a resume.
 """
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Optional
 
 
 class JsonlLogger:
-    def __init__(self, path: str, echo: bool = True):
+    def __init__(self, path: str, echo: bool = True, append: bool = False):
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.echo = echo
-        self._f = self.path.open("w")
+        self._f = self.path.open("a" if append else "w")
 
     def __call__(self, payload: dict) -> None:
         self._f.write(json.dumps(payload) + "\n")

--- a/src/train/loop.py
+++ b/src/train/loop.py
@@ -16,7 +16,7 @@ Required "robust run" features (wired on the Mac):
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 from ..model.interface import ModelInterface

--- a/src/train/loop.py
+++ b/src/train/loop.py
@@ -50,13 +50,15 @@ def train(
     *,
     val_eval: Optional[Callable[[ModelInterface], float]] = None,
     logger: Optional[Callable[[dict], None]] = None,
+    on_checkpoint: Optional[Callable[[int], None]] = None,
     start_step: int = 0,
 ) -> None:
     """Run the training loop. `train_step` and the optimizer live in the backend.
 
-    SKELETON: the orchestration shape is here; gradient accumulation, clipping,
-    checkpoint save/resume, and logging payloads are completed when the MLX
-    `train_step` is wired on Apple Silicon.
+    Pure orchestration: the backprop/optimizer primitive (`train_step`) and the
+    checkpoint writer (`on_checkpoint(step)`, which persists portable weights + a
+    within-backend resume bundle) are injected so this stays backend-free. Resume
+    is driven by `start_step`.
     """
     schedule = CosineSchedule(cfg.base_lr, cfg.warmup_steps, cfg.total_steps)
     step = start_step
@@ -73,7 +75,8 @@ def train(
                     payload["val_loss"] = val_eval(model)
                 log(payload)
 
-            # TODO[mac]: ckpt_every -> model.save(weights) + save_resume(bundle).
             step += 1
+            if on_checkpoint and step % cfg.ckpt_every == 0:
+                on_checkpoint(step)
             if step >= cfg.total_steps:
                 break

--- a/src/train/loop.py
+++ b/src/train/loop.py
@@ -1,0 +1,79 @@
+"""Minimal training loop — pure orchestration (SKELETON).
+
+Drives the model only through `ModelInterface.forward` + the checkpoint module.
+Backend-free here; the backprop/optimizer primitive is backend-specific and is
+injected as `train_step` (e.g. MLX's `nn.value_and_grad` + optimizer.update on the
+Mac). This keeps the seam intact: the loop never imports MLX/CUDA.
+
+Required "robust run" features (wired on the Mac):
+  * mixed precision (precision decided on MLX in M1; toy/smoke = fp32)
+  * warmup + cosine LR (schedule.CosineSchedule)
+  * gradient accumulation
+  * gradient clipping (proven necessary at toy scale)
+  * checkpointing (portable weights + within-backend resume bundle)
+  * logging from step 1: loss, val loss/perplexity, LR, grad norm, tokens/sec
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from ..model.interface import ModelInterface
+from ..data.loader import PackedLoader
+from .schedule import CosineSchedule
+
+
+@dataclass
+class TrainConfig:
+    total_steps: int
+    base_lr: float = 3e-4
+    warmup_steps: int = 100
+    grad_accum: int = 1
+    grad_clip: float = 1.0
+    log_every: int = 1
+    eval_every: int = 50
+    ckpt_every: int = 100
+    out_dir: str = "runs/toy"
+    seed: int = 0
+
+
+# A backend-provided step: (model, inputs, targets, lr) -> dict(loss=, grad_norm=).
+TrainStepFn = Callable[[ModelInterface, object, object, float], dict]
+
+
+def train(
+    model: ModelInterface,
+    train_loader: PackedLoader,
+    cfg: TrainConfig,
+    train_step: TrainStepFn,
+    *,
+    val_eval: Optional[Callable[[ModelInterface], float]] = None,
+    logger: Optional[Callable[[dict], None]] = None,
+    start_step: int = 0,
+) -> None:
+    """Run the training loop. `train_step` and the optimizer live in the backend.
+
+    SKELETON: the orchestration shape is here; gradient accumulation, clipping,
+    checkpoint save/resume, and logging payloads are completed when the MLX
+    `train_step` is wired on Apple Silicon.
+    """
+    schedule = CosineSchedule(cfg.base_lr, cfg.warmup_steps, cfg.total_steps)
+    step = start_step
+    log = logger or (lambda payload: print(payload))
+
+    while step < cfg.total_steps:
+        for inputs, targets in train_loader.epoch(reseed=cfg.seed + step):
+            lr = schedule.lr_at(step)
+            metrics = train_step(model, inputs, targets, lr)  # backend: fwd+bwd+opt
+
+            if step % cfg.log_every == 0:
+                payload = {"step": step, "lr": lr, **metrics}
+                if val_eval and step % cfg.eval_every == 0:
+                    payload["val_loss"] = val_eval(model)
+                log(payload)
+
+            # TODO[mac]: ckpt_every -> model.save(weights) + save_resume(bundle).
+            step += 1
+            if step >= cfg.total_steps:
+                break

--- a/src/train/schedule.py
+++ b/src/train/schedule.py
@@ -17,6 +17,19 @@ class CosineSchedule:
     total_steps: int
     min_lr_ratio: float = 0.1  # floor as a fraction of base_lr; never 0
 
+    def __post_init__(self) -> None:
+        # Fail fast on misconfiguration that would yield negative/increasing LRs.
+        if self.base_lr <= 0:
+            raise ValueError("base_lr must be > 0")
+        if self.warmup_steps < 0:
+            raise ValueError("warmup_steps must be >= 0")
+        if self.total_steps <= 0:
+            raise ValueError("total_steps must be > 0")
+        if self.total_steps < self.warmup_steps:
+            raise ValueError("total_steps must be >= warmup_steps")
+        if not 0 < self.min_lr_ratio <= 1:
+            raise ValueError("min_lr_ratio must be in (0, 1]")
+
     def lr_at(self, step: int) -> float:
         if step < 0:
             raise ValueError("step must be >= 0")

--- a/src/train/schedule.py
+++ b/src/train/schedule.py
@@ -1,0 +1,33 @@
+"""Learning-rate schedule: linear warmup + cosine decay to a floor.
+
+Pure math, backend-free, fully testable in any environment. Decay stops at
+`min_lr_ratio * base_lr` (do NOT let LR hit zero).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass
+class CosineSchedule:
+    base_lr: float
+    warmup_steps: int
+    total_steps: int
+    min_lr_ratio: float = 0.1  # floor as a fraction of base_lr; never 0
+
+    def lr_at(self, step: int) -> float:
+        if step < 0:
+            raise ValueError("step must be >= 0")
+        floor = self.base_lr * self.min_lr_ratio
+
+        if self.warmup_steps > 0 and step < self.warmup_steps:
+            # Linear warmup from 0 up to base_lr.
+            return self.base_lr * (step + 1) / self.warmup_steps
+
+        # Cosine from base_lr down to floor over the post-warmup span.
+        denom = max(1, self.total_steps - self.warmup_steps)
+        progress = min(1.0, (step - self.warmup_steps) / denom)
+        cosine = 0.5 * (1.0 + math.cos(math.pi * progress))
+        return floor + (self.base_lr - floor) * cosine

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,64 @@
+"""Unit tests for portable weight save/load and the within-backend resume bundle.
+
+Backend-free: uses numpy weight dicts and dummy optimizer (de)serializers, so it
+runs anywhere. Guards the resume bundle against a realistic NumPy RNG state
+(nested dict + np.ndarray + np scalars), which a shallow JSON conversion breaks.
+"""
+
+import json
+
+import numpy as np
+
+from src.train.checkpoint import (
+    save_weights, load_weights_dict, save_resume, load_resume,
+)
+
+
+def test_weights_roundtrip(tmp_path):
+    path = tmp_path / "w.safetensors"
+    state = {
+        "embedding.weight": np.random.randn(8, 4).astype(np.float32),
+        "layers.0.norm.weight": np.ones(4, dtype=np.float32),
+    }
+    save_weights(state, str(path))
+    loaded = load_weights_dict(str(path))
+    assert set(loaded) == set(state)
+    for k in state:
+        assert np.array_equal(loaded[k], state[k])
+
+
+def test_save_weights_writes_config_sidecar(tmp_path):
+    path = tmp_path / "w.safetensors"
+
+    class Cfg:
+        def to_dict(self):
+            return {"d_model": 64, "n_layers": 2}
+
+    save_weights({"x": np.zeros(2, dtype=np.float32)}, str(path), config=Cfg())
+    sidecar = json.loads((tmp_path / "w.safetensors.config.json").read_text())
+    assert sidecar == {"d_model": 64, "n_layers": 2}
+
+
+def test_resume_bundle_with_realistic_rng_state(tmp_path):
+    bundle = tmp_path / "resume"
+    rng_state = np.random.default_rng(0).bit_generator.state  # nested dict + np types
+
+    saved = {}
+
+    def opt_serializer(p):
+        saved["path"] = p
+        # stand in for a backend optimizer dump
+        np.save(p + ".npy", np.arange(3))
+
+    def opt_deserializer(p):
+        return np.load(p + ".npy")
+
+    # Must not raise on nested RNG state.
+    save_resume(str(bundle), step=42, rng_state=rng_state,
+                optimizer_serializer=opt_serializer)
+
+    meta = load_resume(str(bundle), optimizer_deserializer=opt_deserializer)
+    assert meta["step"] == 42
+    assert np.array_equal(meta["optimizer"], np.arange(3))
+    # rng_state survived JSON serialization as a plain structure.
+    assert json.dumps(meta["rng_state"])  # serializable

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,0 +1,48 @@
+"""End-to-end data pipeline test on synthetic ids (runs anywhere, numpy only).
+
+Exercises pack -> split -> loader and asserts the two invariants that matter most:
+  * the loader yields contiguous (input, target) windows (target = input shifted +1)
+  * the validation shard does not overlap the training stream
+"""
+
+import numpy as np
+
+from src.data.pack import pack_ids, open_packed
+from src.data.split import split_packed
+from src.data.loader import PackedLoader
+
+
+def test_pack_roundtrip(tmp_path):
+    ids = np.arange(1000, dtype=np.uint16)
+    out = tmp_path / "packed.bin"
+    n = pack_ids(ids, out)
+    assert n == 1000
+    back = open_packed(out)
+    assert np.array_equal(np.asarray(back), ids)
+
+
+def test_split_is_disjoint(tmp_path):
+    ids = np.arange(2000, dtype=np.uint16)
+    packed = tmp_path / "packed.bin"
+    pack_ids(ids, packed)
+    train_p, val_p = split_packed(packed, tmp_path / "split", val_tokens=200)
+    train = np.asarray(open_packed(train_p))
+    val = np.asarray(open_packed(val_p))
+    # contiguous tail split -> disjoint and complete
+    assert train.size == 1800 and val.size == 200
+    assert set(train.tolist()).isdisjoint(val.tolist())
+    assert np.array_equal(np.concatenate([train, val]), ids)
+
+
+def test_loader_contiguous_windows(tmp_path):
+    ids = np.arange(1, 1001, dtype=np.uint16)  # avoid 0 so shift is obvious
+    packed = tmp_path / "packed.bin"
+    pack_ids(ids, packed)
+    loader = PackedLoader(packed, seq_len=9, batch_size=4, shuffle=False, seed=0)
+    inputs, targets = next(iter(loader.epoch()))
+    assert inputs.shape == (4, 9) and targets.shape == (4, 9)
+    # target is input shifted by one token within each contiguous window
+    assert np.array_equal(targets[:, :-1], inputs[:, 1:])
+    # first window is the very start of the stream
+    assert np.array_equal(inputs[0], ids[0:9])
+    assert np.array_equal(targets[0], ids[1:10])

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -22,7 +22,7 @@ PORTABLE_MODULES = [
     "src.conformance.forward_step_parity",
 ]
 
-FORBIDDEN = ("mlx", "mlx.core", "mlx.nn", "torch")
+FORBIDDEN_ROOTS = ("mlx", "torch")
 
 
 def test_portable_modules_do_not_import_backends():
@@ -34,5 +34,6 @@ def test_portable_modules_do_not_import_backends():
     for mod in PORTABLE_MODULES:
         importlib.import_module(mod)
 
-    leaked = [m for m in sys.modules if m in FORBIDDEN]
+    # Match by top-level package so submodules (mlx.core, torch._C, ...) also fail.
+    leaked = sorted({m for m in sys.modules if m.split(".")[0] in FORBIDDEN_ROOTS})
     assert not leaked, f"backend leaked above the seam: {leaked}"

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -1,0 +1,38 @@
+"""Seam guard: nothing portable may import a hardware backend.
+
+If importing the interface or any above-the-seam package pulls in `mlx` or torch's
+CUDA stack, the migration plan is broken. We import the portable modules and assert
+no backend module landed in sys.modules as a side effect.
+"""
+
+import sys
+import importlib
+
+
+PORTABLE_MODULES = [
+    "src.model.interface",
+    "src.model.blocks",
+    "src.data.loader",
+    "src.data.pack",
+    "src.data.split",
+    "src.train.schedule",
+    "src.train.checkpoint",
+    "src.train.loop",
+    "src.eval.val_loss",
+    "src.conformance.forward_step_parity",
+]
+
+FORBIDDEN = ("mlx", "mlx.core", "mlx.nn", "torch")
+
+
+def test_portable_modules_do_not_import_backends():
+    # Drop any backend modules a prior test may have loaded.
+    for name in list(sys.modules):
+        if name.split(".")[0] in ("mlx", "torch"):
+            del sys.modules[name]
+
+    for mod in PORTABLE_MODULES:
+        importlib.import_module(mod)
+
+    leaked = [m for m in sys.modules if m in FORBIDDEN]
+    assert not leaked, f"backend leaked above the seam: {leaked}"

--- a/tests/test_mlx_parity.py
+++ b/tests/test_mlx_parity.py
@@ -1,0 +1,51 @@
+"""MLX-only parity tests (Milestone 1). Skipped where mlx is unavailable.
+
+Two independent checks, both in fp32 (~1e-4 rel):
+  * SSM scan parity: the chunked closed-form `parallel` must match a sequential
+    reference built from one-step `recurrence`.
+  * forward/step parity: whole-model `forward` (parallel) vs `step` (recurrence).
+"""
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from src.model.blocks import load_config
+from src.model.mlx_backend import MLXMambaModel, SelectiveSSM
+from src.conformance.forward_step_parity import check_forward_step_parity
+
+
+def _np(a):
+    return np.array(a)
+
+
+def test_ssm_parallel_matches_sequential():
+    mx.random.seed(0)
+    cfg = load_config("config/toy.yaml")
+    ssm = SelectiveSSM(cfg)
+    B, L, di = 2, cfg.seq_len, cfg.d_inner
+    x = mx.random.normal((B, L, di)) * 0.1
+
+    y_par = _np(ssm.parallel(x))
+
+    # Sequential reference from the one-step recurrence.
+    h = mx.zeros((B, di, cfg.d_state))
+    ys = []
+    for t in range(L):
+        y_t, h = ssm.recurrence(x[:, t], h)
+        ys.append(_np(y_t))
+    y_seq = np.stack(ys, axis=1)
+
+    max_abs = float(np.abs(y_par.astype(np.float64) - y_seq.astype(np.float64)).max())
+    assert np.allclose(y_par, y_seq, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
+
+
+def test_forward_step_parity_toy():
+    mx.random.seed(0)
+    cfg = load_config("config/toy.yaml")
+    model = MLXMambaModel(cfg)
+    B, L = 2, 32
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
+    assert result["ok"], result

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,24 @@
+"""Unit tests for the warmup + cosine LR schedule (runs anywhere)."""
+
+import math
+
+from src.train.schedule import CosineSchedule
+
+
+def test_warmup_ramps_to_base():
+    s = CosineSchedule(base_lr=1.0, warmup_steps=10, total_steps=100)
+    assert s.lr_at(0) == 0.1            # first step = base * 1/10
+    assert math.isclose(s.lr_at(9), 1.0)  # end of warmup hits base_lr
+
+
+def test_cosine_decays_to_floor_not_zero():
+    s = CosineSchedule(base_lr=1.0, warmup_steps=10, total_steps=100, min_lr_ratio=0.1)
+    end = s.lr_at(100)
+    assert math.isclose(end, 0.1, abs_tol=1e-6)   # floor, never 0
+    assert end > 0.0
+
+
+def test_monotonic_decay_after_warmup():
+    s = CosineSchedule(base_lr=1.0, warmup_steps=10, total_steps=100)
+    post = [s.lr_at(t) for t in range(10, 101)]
+    assert all(a >= b - 1e-12 for a, b in zip(post, post[1:]))

--- a/tests/test_val_loss.py
+++ b/tests/test_val_loss.py
@@ -1,0 +1,30 @@
+"""Unit tests for the val-loss numeric core (runs anywhere, numpy only)."""
+
+import numpy as np
+
+from src.eval.val_loss import cross_entropy, perplexity
+
+
+def test_cross_entropy_uniform_logits():
+    # Uniform logits over V classes -> CE = log(V), perplexity = V.
+    V = 8
+    logits = np.zeros((4, V))
+    targets = np.array([0, 1, 2, 3])
+    ce = cross_entropy(logits, targets)
+    assert np.isclose(ce, np.log(V), atol=1e-6)
+    assert np.isclose(perplexity(ce), V, atol=1e-4)
+
+
+def test_cross_entropy_confident_correct_is_low():
+    logits = np.array([[10.0, 0.0, 0.0]])
+    ce = cross_entropy(logits, np.array([0]))
+    assert ce < 1e-3
+
+
+def test_cross_entropy_handles_sequence_shape():
+    # (B, T, V) logits with (B, T) targets should flatten correctly.
+    rng = np.random.default_rng(0)
+    logits = rng.normal(size=(2, 5, 16))
+    targets = rng.integers(0, 16, size=(2, 5))
+    ce = cross_entropy(logits, targets)
+    assert ce > 0


### PR DESCRIPTION
Lay down the full repo structure for the Apple Silicon Mamba POC behind one
hardware seam (ModelInterface), per the milestones 1-4 plan.

Runnable in-container (Linux):
- Portable seam (interface.py, blocks.py config) with import-guard test
- Data pipeline: download/tokenize/pack(uint16)/split/loader, unit-tested
- schedule (warmup+cosine), checkpoint (portable safetensors + within-backend
  resume), val_loss (Tier-1 perplexity) - unit-tested
- 10/10 tests pass; offline data CLI verified end-to-end

Skeletons/stubs (completed + run on a Mac, MLX is Apple-Silicon only):
- mlx_backend (RMSNorm/SelectiveSSM/MambaBlock/model), training loop,
  forward_step_parity, scripts/smoke_test (the M4 gate)

Deferred stubs: cuda_backend + backend_parity, serve/sessions+rewind,
eval/olmes_adapter

Locked: poc d_model 768 / 24 layers / seq 1024 / ~3B tokens (tied embed);
toy d_model 64 / 2 layers / seq 128 / fp32; conformance compared in fp32.