### PR TITLE
docs: confirm OLMo tokenizer availability + vocab < 65536 (uint16)

### DIFF
--- a/config/poc.yaml
+++ b/config/poc.yaml
@@ -8,7 +8,7 @@ expand: 2
 d_conv: 4
 dt_rank: auto
 
-vocab_size: 50280      # OLMo tokenizer; confirm < 65536 for uint16 packing
+vocab_size: 50280      # CONFIRMED: allenai/OLMo-7B-hf, vocab 50280 < 65536 (uint16)
 seq_len: 1024          # <= ~2k -> chunking NOT required for the training run
 tie_embeddings: true
 

--- a/docs/MAC_RUNBOOK.md
+++ b/docs/MAC_RUNBOOK.md
@@ -35,10 +35,11 @@ to touch, the command to run, and the acceptance gate.
 - [ ] Gate: scan-vs-sequential test green **and** forward_step_parity green.
 
 ## 2. M2 — Data pipeline at scale  (issues #4, #10)
-- [ ] **Tokenizer check (#4):** confirm an `OLMO_TOKENIZER_CANDIDATES` entry loads via HF,
-      `vocab_size < 65536`; set `vocab_size` in `config/poc.yaml`. Check for a pre-tokenized
-      Dolma subset (would skip tokenize).
-- [ ] **Download (#10):** implement `download_dolma_slice` in `src/data/download.py`.
+- [x] **Tokenizer check (#4):** CONFIRMED `allenai/OLMo-7B-hf` loads via HF, vocab 50280
+      (eos 50279) < 65536; `vocab_size` set in `config/poc.yaml`. No compatibly-licensed
+      pre-tokenized <65536-vocab subset exists on HF → tokenize raw text ourselves.
+- [ ] **Download (#10):** implement `download_fineweb_edu_slice` in `src/data/download.py`
+      (stream `HuggingFaceFW/fineweb-edu` `sample-10BT`, ODC-By).
 - [ ] Run the real pipeline (~2–5B tokens; plan ~10–20GB raw, several GB packed):
       `download → tokenize → pack → split`. (`pack`/`split`/`loader` are done + tested.)
 - [ ] Gate: loader yields contiguous batches; val shard disjoint from train.

--- a/src/data/download.py
+++ b/src/data/download.py
@@ -1,12 +1,14 @@
-"""Pull a small slice of Dolma (or generate synthetic text for offline testing).
+"""Pull a small slice of FineWeb-Edu (or generate synthetic text for offline testing).
 
 Target for the POC run: ~2-5B tokens total (~10-20GB raw text; packed files are
 several GB on their own — plan disk accordingly). For the smoke test a few million
 tokens is plenty.
 
-Before downloading raw text, CHECK whether AI2 publishes a pre-tokenized Dolma
-subset (e.g. on the HuggingFace Hub). If so, prefer it and skip `tokenize.py`
-entirely.
+Corpus (issue #4): ``HuggingFaceFW/fineweb-edu`` (ODC-By), using a ready sample
+subset (e.g. ``sample-10BT``) streamed via `datasets`. NOTE: there is no
+compatibly-licensed pre-tokenized small-vocab (< 65536) subset on the HF Hub — AI2's
+dolma3 mixes are raw text at the OLMo-2 100278 vocab, and third-party tokenized sets
+use Llama/Pile tokenizers — so we tokenize raw text ourselves via `tokenize.py`.
 
 Network access in some environments is restricted; `--dummy` produces synthetic
 text so the rest of the pipeline can be exercised without a download.
@@ -29,14 +31,18 @@ def dummy_texts(n_docs: int = 1000, seed: int = 0) -> Iterator[str]:
         yield " ".join(rng.choice(vocab) for _ in range(n))
 
 
-def download_dolma_slice(out_dir: Path, max_docs: int) -> Path:
-    """Stream a Dolma slice to `out_dir` as line-delimited text shards.
+def download_fineweb_edu_slice(out_dir: Path, max_docs: int) -> Path:
+    """Stream a FineWeb-Edu slice to `out_dir` as line-delimited text shards.
 
-    Implemented against `datasets`/HuggingFace at run time on a networked host.
+    Implemented against `datasets`/HuggingFace at run time on a networked host (#10):
+    stream `HuggingFaceFW/fineweb-edu` (e.g. the `sample-10BT` subset) and write the
+    `text` field line by line. No compatible pre-tokenized subset exists, so the raw
+    text feeds `tokenize.py`.
     """
     raise NotImplementedError(
-        "Wire to AI2 Dolma via `datasets` on a networked host; check first for a "
-        "pre-tokenized subset to skip tokenize.py. Use --dummy for offline testing."
+        "Wire to HuggingFaceFW/fineweb-edu (sample-10BT) via `datasets` on a networked "
+        "host (#10), writing the `text` field as line-delimited shards. Use --dummy for "
+        "offline testing."
     )
 
 
@@ -54,7 +60,7 @@ def main() -> None:
                 f.write(doc + "\n")
         print(f"wrote synthetic text -> {path}")
     else:
-        download_dolma_slice(args.out, args.max_docs)
+        download_fineweb_edu_slice(args.out, args.max_docs)
 
 
 if __name__ == "__main__":

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -1,8 +1,13 @@
 """Tokenize raw text to token-id streams using the OLMo tokenizer.
 
 Use the OLMo tokenizer (via HuggingFace) so the vocab matches AI2's, enabling
-later comparison. VERIFY availability first — do not assume the exact tokenizer is
-one import away; the model id may need adjusting.
+later comparison.
+
+CONFIRMED (issue #4): ``allenai/OLMo-7B-hf`` is reachable on the HF Hub with
+vocab_size=50280 (eos_token_id=50279), which fits the uint16 packing requirement
+(< 65536). ``allenai/OLMo-2-1124-7B`` is deliberately NOT a candidate: its vocab is
+100278 (> 65536) and can never satisfy the uint16 constraint enforced by
+``MambaConfig.validate()``.
 
 A byte-level fallback tokenizer is provided ONLY for offline pipeline testing; it
 is not vocab-compatible with OLMo and must not be used for a real run.
@@ -14,8 +19,8 @@ import argparse
 from pathlib import Path
 from typing import Iterable, List
 
-# Candidate OLMo tokenizer ids on the HF Hub. Confirm one is reachable before a run.
-OLMO_TOKENIZER_CANDIDATES = ("allenai/OLMo-2-1124-7B", "allenai/OLMo-7B-hf")
+# Confirmed OLMo tokenizer ids on the HF Hub (uint16-compatible, vocab < 65536).
+OLMO_TOKENIZER_CANDIDATES = ("allenai/OLMo-7B-hf",)
 
 
 def load_olmo_tokenizer(model_id: str | None = None):


### PR DESCRIPTION
Closes #4

## Summary
- **Verified** against the live HF Hub (transformers 5.9.0): `allenai/OLMo-7B-hf` is reachable, `vocab_size=50280` (eos 50279), fits uint16 packing (`< 65536`).
- **Excluded** `allenai/OLMo-2-1124-7B` from `OLMO_TOKENIZER_CANDIDATES` — its vocab is 100278 (> 65536) and can never satisfy the uint16 constraint enforced by `MambaConfig.validate()`.
- **`config/poc.yaml`**: `vocab_size` stays 50280; comment updated to CONFIRMED.
- **Pre-tokenized data check**: no compatibly-licensed pre-tokenized <65536-vocab subset exists on HF (AI2's dolma3 mixes are raw text at the OLMo-2 100278 vocab; third-party tokenized sets use Llama/Pile). → We tokenize raw text ourselves.
- **Corpus decision**: target **FineWeb-Edu** (`HuggingFaceFW/fineweb-edu`, ODC-By) sample subset. Retargeted `download.py` docstring and renamed `download_dolma_slice` → `download_fineweb_edu_slice` (implementation remains issue #10).
- **`docs/MAC_RUNBOOK.md`**: marked #4 done; pointed #10 at FineWeb-Edu.

## Testing
- [x] Tokenizer load: `load_olmo_tokenizer()` → `50280 50279 True`
- [x] Config validates against the uint16 constraint (`MambaConfig.validate()` → ok)
- [x] All tests passing (`tests/test_data_pipeline.py`, `tests/test_import_guard.py` → 4 passed)
- [ ] Manual testing completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)