### PR TITLE
test: independent reference for MLX selective scan (#7)

### DIFF
--- a/tests/test_mlx_parity.py
+++ b/tests/test_mlx_parity.py
@@ -1,8 +1,13 @@
 """MLX-only parity tests (Milestone 1). Skipped where mlx is unavailable.
 
-Two independent checks, both in fp32 (~1e-4 rel):
+Checks, all in fp32 (~1e-4 rel):
   * SSM scan parity: the chunked closed-form `parallel` must match a sequential
     reference built from one-step `recurrence`.
+  * SSM scan vs an INDEPENDENT reference: `parallel` must also match a
+    from-scratch numpy sequential scan computed from the SSM's raw parameters
+    (shares no code with `parallel` or `recurrence`). This catches a bug that
+    would live identically in the discretization shared by the MLX paths, plus a
+    long-context case guarding the chunked scan's fp32 overflow-safety.
   * forward/step parity: whole-model `forward` (parallel) vs `step` (recurrence).
 """
 
@@ -18,6 +23,47 @@ from src.conformance.forward_step_parity import check_forward_step_parity
 
 def _np(a):
     return np.array(a)
+
+
+def _seq_reference_numpy(ssm, x_np):
+    """Fully independent fp64 sequential selective scan.
+
+    Computes the projections, softplus, diagonal-A discretization and the
+    recurrence FROM SCRATCH in numpy using only the SSM's raw parameters — it
+    shares no code with `SelectiveSSM.parallel` or `.recurrence`, so a bug living
+    identically in their shared `_project`/discretization cannot hide here.
+
+    x_np: (B, L, d_inner) float -> (B, L, d_inner) float64.
+    """
+    cfg = ssm.config
+    dt_rank, d_state = cfg.dt_rank_resolved, cfg.d_state
+
+    # Raw params -> fp64. MLX nn.Linear stores weight as (out, in) and computes
+    # `x @ W.T + b`, so we project with W.T.
+    Wx = _np(ssm.x_proj.weight).astype(np.float64)    # (dt_rank+2*ds, di)
+    Wdt = _np(ssm.dt_proj.weight).astype(np.float64)  # (di, dt_rank)
+    bdt = _np(ssm.dt_proj.bias).astype(np.float64)    # (di,)
+    A = -np.exp(_np(ssm.A_log).astype(np.float64))    # (di, ds)
+    D = _np(ssm.D).astype(np.float64)                 # (di,)
+
+    x = x_np.astype(np.float64)
+    B_, L, di = x.shape
+
+    proj = x @ Wx.T                                   # (B, L, dt_rank+2*ds)
+    dt = proj[..., :dt_rank]
+    Bm = proj[..., dt_rank:dt_rank + d_state]         # (B, L, ds)
+    Cm = proj[..., dt_rank + d_state:]                # (B, L, ds)
+    delta = np.logaddexp(dt @ Wdt.T + bdt, 0.0)       # softplus -> (B, L, di)
+
+    y = np.zeros((B_, L, di), np.float64)
+    h = np.zeros((B_, di, d_state), np.float64)
+    for t in range(L):
+        dlt = delta[:, t][..., None]                  # (B, di, 1)
+        dA = np.exp(dlt * A[None])                     # (B, di, ds)
+        dBu = dlt * Bm[:, t][:, None, :] * x[:, t][..., None]
+        h = dA * h + dBu
+        y[:, t] = np.sum(h * Cm[:, t][:, None, :], axis=-1) + x[:, t] * D
+    return y
 
 
 def test_ssm_parallel_matches_sequential():
@@ -39,6 +85,39 @@ def test_ssm_parallel_matches_sequential():
 
     max_abs = float(np.abs(y_par.astype(np.float64) - y_seq.astype(np.float64)).max())
     assert np.allclose(y_par, y_seq, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
+
+
+def test_ssm_parallel_matches_independent_reference():
+    """`parallel` vs a from-scratch numpy scan (no shared code) at toy seq_len."""
+    mx.random.seed(0)
+    cfg = load_config("config/toy.yaml")
+    ssm = SelectiveSSM(cfg)
+    B, L, di = 2, cfg.seq_len, cfg.d_inner
+    x = mx.random.normal((B, L, di)) * 0.1
+
+    y_par = _np(ssm.parallel(x)).astype(np.float64)
+    y_ref = _seq_reference_numpy(ssm, _np(x))
+
+    max_abs = float(np.abs(y_par - y_ref).max())
+    assert np.allclose(y_par, y_ref, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
+
+
+def test_ssm_parallel_overflow_safe_long_context():
+    """Long context (L=512 -> 16 chunks of 32): the chunked scan must stay finite
+    (the docstring's fp32 overflow-safety claim) and still match the independent
+    reference."""
+    mx.random.seed(0)
+    cfg = load_config("config/toy.yaml")
+    ssm = SelectiveSSM(cfg)
+    B, L, di = 2, 512, cfg.d_inner
+    x = mx.random.normal((B, L, di)) * 0.1
+
+    y_par = _np(ssm.parallel(x)).astype(np.float64)
+    assert np.isfinite(y_par).all(), "chunked scan produced NaN/Inf at long context"
+
+    y_ref = _seq_reference_numpy(ssm, _np(x))
+    max_abs = float(np.abs(y_par - y_ref).max())
+    assert np.allclose(y_par, y_ref, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
 
 
 def test_forward_step_parity_toy():


### PR DESCRIPTION
Closes #7

## Summary
The chunked closed-form selective scan (`SelectiveSSM.parallel`, `src/model/mlx_backend.py:102`) and a parallel-vs-sequential parity test (`tests/test_mlx_parity.py::test_ssm_parallel_matches_sequential`) were **already implemented in the M1 scaffold** and pass on Apple Silicon — the `blocked-on-mac` label predated Mac access (same situation as #5 / PR #18). This verifies them and strengthens the verification.

The existing reference is built from `ssm.recurrence`, which shares `_project()` (projections, softplus, `A=-exp(A_log)`) with `parallel`. The two scan *formulas* differ — a real cross-check — but a bug living identically in that shared discretization would pass undetected. So this adds a **genuinely independent** reference and a long-context case.

## Changes (test-only — no production code)
- **`_seq_reference_numpy`** — a from-scratch fp64 sequential scan computed from the SSM's raw parameters (`x_proj.weight`, `dt_proj.weight/.bias`, `A_log`, `D`), re-deriving the projections, softplus, diagonal-A discretization and recurrence in numpy. Shares no code with `parallel` or `recurrence`.
- **`test_ssm_parallel_matches_independent_reference`** — `parallel` vs the independent reference at toy `seq_len=128` (4 chunks), `rtol=1e-4, atol=1e-5`.
- **`test_ssm_parallel_overflow_safe_long_context`** — `L=512` (16 chunks of 32): asserts the chunked scan stays finite (guards the docstring's fp32 overflow-safety claim) and still matches the independent reference.

Both new tests sit under the existing module-level `pytest.importorskip("mlx.core")`, so they auto-skip off Apple Silicon.

## Testing
- [x] `pytest tests/test_mlx_parity.py` — **4 passed** (2 existing + 2 new)
- [x] Full suite — **20 passed** (was 18)
- [x] Teeth check: genuine fp32-vs-fp64 gap is **1.5e-8** at L=128 (well under 1e-4, confirms a real independent computation); a 0.1% perturbation to `D` breaks `allclose` (max|diff| 4.2e-4), confirming the reference detects scan errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)