### PR TITLE
feat(data): FineWeb-Edu download + streaming tokenize at scale (#10)

### DIFF
--- a/docs/design/04-data-pipeline.md
+++ b/docs/design/04-data-pipeline.md
@@ -103,6 +103,31 @@ The pipeline runs end to end offline today on the byte-fallback path. The remain
   norm too); benchmark scores are not required — see
   [smoke gate & eval](06-smoke-gate-and-eval.md).
 
+### Full-scale run (M2) — commands
+
+```bash
+pip install -e ".[data]"          # datasets + transformers
+
+# 1. Stream raw text to a single line-delimited file (one normalized doc per line).
+#    Over-provision docs; step 2's --max-tokens trims to target. ~3B OLMo tokens is a
+#    few million docs / ~10–15GB raw text. Re-run with a larger --max-docs if short.
+python -m src.data.download --out data/raw --max-docs 3500000 --subset sample-10BT
+
+# 2. Tokenize + pack in one streamed pass (bounded memory), capped at ~3B tokens.
+#    A .bin output streams straight through pack_ids and writes the .meta.json sidecar,
+#    so it feeds `split` directly — no separate `pack` step at scale.
+python -m src.data.tokenize --in data/raw/fineweb-edu.txt --out data/packed.bin \
+    --max-tokens 3000000000
+
+# 3. Cut a disjoint held-out val shard (contiguous tail).
+python -m src.data.split --packed data/packed.bin --out data/split --val-tokens 10000000
+```
+
+Disk: ~10–15GB raw + ~6GB packed + ~6GB train/val copies (`split` duplicates). Delete
+`data/raw/` after step 2 and `data/packed.bin` after step 3 to reclaim space. (The
+offline byte-fallback smoke in [CLAUDE.md](../../CLAUDE.md) still uses the `.npy` path
++ a separate `pack` step; the `.bin` fold-in above is the scale path.)
+
 ## Related
 
 - [Architecture: the hardware seam](01-architecture-seam.md) — why the loader yields numpy.

--- a/src/data/download.py
+++ b/src/data/download.py
@@ -5,7 +5,8 @@ several GB on their own — plan disk accordingly). For the smoke test a few mil
 tokens is plenty.
 
 Corpus (issue #4): ``HuggingFaceFW/fineweb-edu`` (ODC-By), using a ready sample
-subset (e.g. ``sample-10BT``) streamed via `datasets`. NOTE: there is no
+subset (e.g. ``sample-10BT``) streamed via `datasets` to a single line-delimited
+text file (one normalized document per line). NOTE: there is no
 compatibly-licensed pre-tokenized small-vocab (< 65536) subset on the HF Hub — AI2's
 dolma3 mixes are raw text at the OLMo-2 100278 vocab, and third-party tokenized sets
 use Llama/Pile tokenizers — so we tokenize raw text ourselves via `tokenize.py`.
@@ -31,25 +32,56 @@ def dummy_texts(n_docs: int = 1000, seed: int = 0) -> Iterator[str]:
         yield " ".join(rng.choice(vocab) for _ in range(n))
 
 
-def download_fineweb_edu_slice(out_dir: Path, max_docs: int) -> Path:
-    """Stream a FineWeb-Edu slice to `out_dir` as line-delimited text shards.
+def _normalize_doc(text: str) -> str:
+    """Collapse all whitespace (incl. internal newlines) so each doc is one line.
 
-    Implemented against `datasets`/HuggingFace at run time on a networked host (#10):
-    stream `HuggingFaceFW/fineweb-edu` (e.g. the `sample-10BT` subset) and write the
-    `text` field line by line. No compatible pre-tokenized subset exists, so the raw
-    text feeds `tokenize.py`.
+    The pipeline is one-doc-per-line and `tokenize.py` appends EOS *per line*; a raw
+    document's internal newlines would otherwise inject spurious EOS boundaries
+    mid-document. Collapsing runs of whitespace to single spaces is lossy on layout
+    but correct for the perplexity-curve POC.
     """
-    raise NotImplementedError(
-        "Wire to HuggingFaceFW/fineweb-edu (sample-10BT) via `datasets` on a networked "
-        "host (#10), writing the `text` field as line-delimited shards. Use --dummy for "
-        "offline testing."
+    return " ".join(text.split())
+
+
+def download_fineweb_edu_slice(
+    out_dir: Path, max_docs: int, subset: str = "sample-10BT"
+) -> Path:
+    """Stream a FineWeb-Edu slice to a single line-delimited text file. Returns its path.
+
+    Streams `HuggingFaceFW/fineweb-edu` (the `subset` config, default `sample-10BT`)
+    via `datasets`, writing each document's normalized `text` field as one line to
+    `out_dir / "fineweb-edu.txt"`. No compatible pre-tokenized small-vocab subset
+    exists, so the raw text feeds `tokenize.py` (OLMo tokenizer). Stops after
+    `max_docs` non-empty documents.
+    """
+    from datasets import load_dataset  # imported lazily (optional `data` extra)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "fineweb-edu.txt"
+    ds = load_dataset(
+        "HuggingFaceFW/fineweb-edu", name=subset, split="train", streaming=True
     )
+    written = 0
+    with open(path, "w") as f:
+        for ex in ds:
+            doc = _normalize_doc(ex.get("text", ""))
+            if not doc:
+                continue
+            f.write(doc + "\n")
+            written += 1
+            if written % 100_000 == 0:
+                print(f"  ... {written} docs")
+            if written >= max_docs:
+                break
+    print(f"wrote {written} docs -> {path}")
+    return path
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--out", type=Path, default=Path("data/raw"))
     ap.add_argument("--max-docs", type=int, default=10000)
+    ap.add_argument("--subset", default="sample-10BT", help="FineWeb-Edu config name")
     ap.add_argument("--dummy", action="store_true", help="synthetic text, no network")
     args = ap.parse_args()
     args.out.mkdir(parents=True, exist_ok=True)
@@ -60,7 +92,7 @@ def main() -> None:
                 f.write(doc + "\n")
         print(f"wrote synthetic text -> {path}")
     else:
-        download_fineweb_edu_slice(args.out, args.max_docs)
+        download_fineweb_edu_slice(args.out, args.max_docs, args.subset)
 
 
 if __name__ == "__main__":

--- a/src/data/download.py
+++ b/src/data/download.py
@@ -62,7 +62,10 @@ def download_fineweb_edu_slice(
         "HuggingFaceFW/fineweb-edu", name=subset, split="train", streaming=True
     )
     written = 0
-    with open(path, "w") as f:
+    # Explicit UTF-8 + "\n" newlines: the corpus is UTF-8, and forcing the line
+    # terminator avoids Windows \r\n translation that downstream tokenization would
+    # otherwise mis-strip.
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
         for ex in ds:
             doc = _normalize_doc(ex.get("text", ""))
             if not doc:

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, Iterator, List
 
 # Confirmed OLMo tokenizer ids on the HF Hub (uint16-compatible, vocab < 65536).
 OLMO_TOKENIZER_CANDIDATES = ("allenai/OLMo-7B-hf",)
@@ -60,22 +60,46 @@ def tokenize_texts(texts: Iterable[str], tokenizer) -> Iterable[int]:
             yield eos
 
 
+def _capped(stream: Iterable[int], max_tokens: int | None) -> Iterator[int]:
+    """Truncate an id stream at `max_tokens` (pass-through when None)."""
+    if max_tokens is None:
+        yield from stream
+        return
+    for n, tid in enumerate(stream):
+        if n >= max_tokens:
+            break
+        yield tid
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--in", dest="inp", type=Path, required=True)
-    ap.add_argument("--out", type=Path, required=True, help="raw .npy/.bin uint16 ids")
+    ap.add_argument("--out", type=Path, required=True, help="uint16 ids; .bin streams "
+                    "straight into the packed format, .npy goes through `pack` separately")
     ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
     ap.add_argument("--model-id", default=None)
+    ap.add_argument("--max-tokens", type=int, default=None,
+                    help="stop after this many tokens (caps the scale run)")
     args = ap.parse_args()
-
-    import numpy as np
 
     tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
     with open(args.inp) as f:
         texts = (line.rstrip("\n") for line in f)
-        ids = np.fromiter(tokenize_texts(texts, tok), dtype=np.uint16)
-    np.save(args.out, ids)
-    print(f"tokenized {ids.size} ids (vocab {tok.vocab_size}) -> {args.out}")
+        stream = _capped(tokenize_texts(texts, tok), args.max_tokens)
+        if args.out.suffix == ".bin":
+            # Stream straight into the packed format (chunked, bounded memory) — this
+            # folds the `pack` stage in for the scale run and writes the .meta.json
+            # sidecar, so `split` can consume the output directly.
+            from .pack import pack_ids
+
+            n = pack_ids(stream, args.out)
+            print(f"tokenized+packed {n} ids (vocab {tok.vocab_size}) -> {args.out}")
+        else:
+            import numpy as np
+
+            ids = np.fromiter(stream, dtype=np.uint16)
+            np.save(args.out, ids)
+            print(f"tokenized {ids.size} ids (vocab {tok.vocab_size}) -> {args.out}")
 
 
 if __name__ == "__main__":

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -81,10 +81,14 @@ def main() -> None:
     ap.add_argument("--max-tokens", type=int, default=None,
                     help="stop after this many tokens (caps the scale run)")
     args = ap.parse_args()
+    if args.max_tokens is not None and args.max_tokens <= 0:
+        ap.error("--max-tokens must be positive (a value <= 0 silently yields 0 tokens)")
 
     tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
-    with open(args.inp) as f:
-        texts = (line.rstrip("\n") for line in f)
+    # Explicit UTF-8 (corpus is UTF-8; avoids locale-dependent decoding) and strip any
+    # trailing \r so \r\n-terminated input doesn't leak a stray carriage return into a doc.
+    with open(args.inp, encoding="utf-8") as f:
+        texts = (line.rstrip("\r\n") for line in f)
         stream = _capped(tokenize_texts(texts, tok), args.max_tokens)
         if args.out.suffix == ".bin":
             # Stream straight into the packed format (chunked, bounded memory) — this

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -7,9 +7,11 @@ Exercises pack -> split -> loader and asserts the two invariants that matter mos
 
 import numpy as np
 
+from src.data.download import _normalize_doc
 from src.data.pack import pack_ids, open_packed
 from src.data.split import split_packed
 from src.data.loader import PackedLoader
+from src.data.tokenize import ByteTokenizer, tokenize_texts, _capped
 
 
 def test_pack_roundtrip(tmp_path):
@@ -32,6 +34,33 @@ def test_split_is_disjoint(tmp_path):
     assert train.size == 1800 and val.size == 200
     assert set(train.tolist()).isdisjoint(val.tolist())
     assert np.array_equal(np.concatenate([train, val]), ids)
+
+
+def test_normalize_doc_collapses_internal_newlines():
+    # Internal newlines/tabs/runs must collapse so each doc stays a single line --
+    # tokenize.py appends EOS per line, so a multi-line doc would inject stray EOS.
+    out = _normalize_doc("  a\nb\t c\r\n\nd  ")
+    assert out == "a b c d"
+    assert "\n" not in out
+
+
+def test_tokenize_streams_to_bin(tmp_path):
+    # The .bin path streams straight through pack_ids: it writes the packed file AND
+    # its meta sidecar, so split/open_packed can consume it without a separate pack.
+    tok = ByteTokenizer()
+    texts = ["abc", "de"]  # byte ids; ByteTokenizer has no eos -> no separators
+    out = tmp_path / "packed.bin"
+    n = pack_ids(_capped(tokenize_texts(texts, tok), None), out)
+    expected = list(b"abc") + list(b"de")
+    assert n == len(expected)
+    assert (tmp_path / "packed.meta.json").exists()
+    assert np.array_equal(np.asarray(open_packed(out)), np.asarray(expected, np.uint16))
+
+
+def test_capped_truncates_stream():
+    assert list(_capped(iter(range(100)), 5)) == [0, 1, 2, 3, 4]
+    assert list(_capped(iter(range(3)), 10)) == [0, 1, 2]  # cap above length
+    assert list(_capped(iter(range(10)), None)) == list(range(10))  # pass-through
 
 
 def test_loader_contiguous_windows(tmp_path):

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -5,6 +5,9 @@ Exercises pack -> split -> loader and asserts the two invariants that matter mos
   * the validation shard does not overlap the training stream
 """
 
+import subprocess
+import sys
+
 import numpy as np
 
 from src.data.download import _normalize_doc
@@ -61,6 +64,18 @@ def test_capped_truncates_stream():
     assert list(_capped(iter(range(100)), 5)) == [0, 1, 2, 3, 4]
     assert list(_capped(iter(range(3)), 10)) == [0, 1, 2]  # cap above length
     assert list(_capped(iter(range(10)), None)) == list(range(10))  # pass-through
+
+
+def test_nonpositive_max_tokens_rejected(tmp_path):
+    # A value <= 0 would silently yield 0 tokens (enumerate starts at 0); the CLI must
+    # reject it at parse time rather than produce a surprising "successful" empty run.
+    inp = tmp_path / "in.txt"
+    inp.write_text("abc\n")
+    cmd = [sys.executable, "-m", "src.data.tokenize", "--in", str(inp),
+           "--out", str(tmp_path / "o.bin"), "--byte-fallback", "--max-tokens", "-1"]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    assert res.returncode != 0
+    assert "must be positive" in res.stderr
 
 
 def test_loader_contiguous_windows(tmp_path):


### PR DESCRIPTION
Closes #10. Part of #2 (M2).

## What

Wire the real M2 data pipeline so it can produce the ~3B-token POC corpus. The only stub was `download_fineweb_edu_slice`; the pack/split/loader were already done. This also hardens `tokenize` for the 2–5B-token scale.

## Changes

- **`src/data/download.py`** — implement `download_fineweb_edu_slice` (stream `HuggingFaceFW/fineweb-edu` via `datasets` to a single line-delimited file). New `_normalize_doc` collapses internal newlines so each doc is exactly one line, preventing **spurious per-line EOS** (`tokenize` appends EOS per line). Add `--subset` flag (default `sample-10BT`).
- **`src/data/tokenize.py`** — add `--max-tokens` cap (`_capped` generator) to hit the target exactly; a `.bin` output **streams straight through `pack_ids`** (bounded memory, folds in the `pack` stage, writes the `.meta.json` sidecar so `split` consumes it directly). The `.npy` path is kept for the offline byte-fallback smoke.
- **`tests/test_data_pipeline.py`** — 3 offline tests: newline normalization, tokenize→`.bin` streaming, token cap.
- **`docs/design/04-data-pipeline.md`** — "Full-scale run (M2)" runbook + disk budget.

## Why these two scale fixes

- **EOS-per-line corruption:** real FineWeb-Edu docs contain internal newlines → naive write injects EOS mid-document. Fixed by `_normalize_doc`.
- **Whole-array-in-RAM:** old flow was `np.fromiter` → `.npy` → `np.load`, holding ~6 GB twice for ~3B tokens. The `.bin` streaming path keeps only a 1 MiB chunk buffered.

## Verification

- `pytest -q` → **23 passed** (was 20).
- M4 smoke gate → **PASSED** (resume exact, max diff 2.4e-7; val_ppl 4.67) — data-stage changes don't touch the model.
- **Real path end-to-end** on a 2000-doc slice: ~2.1M real OLMo tokens (vocab 50280) → packed `.bin` → disjoint split → loader yields valid `(input, target)` batches with the +1 shift and ids in `[0, 50280)`. ~1059 tokens/doc, so ~3M docs ≈ 3B tokens.

## Not in this PR

The actual multi-hour ~3B-token production run — kicked off via the documented runbook. M2 is **not** ticked in #2 until that run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)