### PR TITLE
perf(model): Mamba-2/SSD scalar-A scan + gradient checkpointing (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 data/
 runs/
 
+# Claude Code local/runtime artifacts (transient; not project config). Intentional
+# shared config (e.g. .claude/settings.json, .claude/commands/) can still be added.
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ do not import a backend — and add new portable modules to that test's
 Consequences of the seam that shape how code is written:
 - The training loop (`src/train/loop.py`) is backend-free and receives the
   backprop/optimizer primitive as an injected `train_step` callable
-  (`TrainStepFn = (model, inputs, targets, lr) -> {loss, grad_norm}`). The MLX
+  (`TrainStepFn = (model, micro_batches, lr) -> {loss, grad_norm, ...}`, where
+  `micro_batches` is a list of `(inputs, targets)` of length `grad_accum`). The MLX
   implementation is `make_train_step(...)` in `src/model/mlx_train_step.py`.
 - The data loader yields **numpy**; the backend converts to its own array type inside
   `forward`. Eval (`src/eval/val_loss.py`) takes a `to_numpy` converter at the seam.
@@ -70,21 +71,41 @@ are the decision record** — read them before changing values. Key locked decis
 - **toy.yaml** (smoke/correctness): tiny, `fp32` for bit-exact fixed-seed resume,
   `vocab_size 256` (byte-fallback tokenizer, offline).
 - **poc.yaml** (~100M scale run): `vocab_size 50280` (OLMo-7B-hf, confirmed `<65536`),
-  `precision fp16` + loss scaling (~18% faster than bf16 on Metal per the M1
+  `precision fp16` + (dynamic) loss scaling (~18% faster than bf16 on Metal per the M1
   micro-benchmark — **do not assume bf16**), tied embedding **mandatory** (~38M of
-  ~100M params).
+  ~100M params), `grad_checkpoint: true` (required at this depth — see below).
+- **`head_dim`** is the Mamba-2 head width: `d_inner` splits into
+  `n_heads = d_inner // head_dim` heads, each with a **scalar** decay A (the SSD
+  restriction that makes the scan a matmul). `validate()` requires `head_dim | d_inner`
+  (poc `head_dim 64` → 24 heads; toy `head_dim 16` → 8 heads).
 - **dt-bias init** (`dt_min`/`dt_max`/`dt_init_floor`) is **load-bearing** — without
   the inverse-softplus init in `SelectiveSSM._init_dt_bias` the model fails to learn
-  recall. These params are identical across both configs by design.
+  recall. Now **per-head** (shape `n_heads`). These params are identical across both
+  configs by design.
 
-## Two compute paths must agree
+## The SSM: Mamba-2 / SSD (scalar A)
 
-The model has two separate implementations of the SSM that must produce identical
-logits: `forward` (parallel chunked scan, training) and `step` (recurrence,
-inference). The selective scan **always chunks** (default 32) because a single-pass
-cumsum overflows fp32. Conformance (`src/conformance/`) guards this:
-`forward_step_parity` (train vs infer) and `backend_parity` (MLX vs CUDA, deferred)
-both compare in **fp32 at ~1e-4 rel** — bf16's epsilon is too coarse to be meaningful.
+The SSM is **Mamba-2 / SSD** (Dao & Gu, *State Space Duality*): scalar A **per head**,
+multi-head with one shared B/C group — migrated from the original diagonal-A Mamba-1
+for training throughput/memory (see `docs/design/02-model-ssm.md`). Two separate
+implementations must produce identical logits: `forward` (the SSD **chunked-matmul**
+scan, training) and `step` (the matching one-step recurrence, inference). The scan
+**always chunks** (length Q = `chunk_size`, default **64**) but, unlike the old
+diagonal-A cumsum scan, is **overflow-safe by construction** — every decay is `exp` of
+a non-positive sum (in `[0,1]`). Conformance (`src/conformance/`) guards train/infer
+equivalence: `forward_step_parity` and `backend_parity` (MLX vs CUDA, deferred) both
+compare in **fp32 at ~1e-4 rel** — bf16's epsilon is too coarse to be meaningful.
+
+## Training: the scale-run driver and its memory lever
+
+`scripts/train.py` is the real run driver (config → model → data → loop, with resume).
+It wires **gradient accumulation** (the loop pulls `grad_accum` micro-batches per step),
+**dynamic fp16 loss scaling** (`src/train/loss_scale.py`, a portable policy; the backend
+does the inf/nan check and skips overflowing steps), and **gradient checkpointing**
+(`grad_checkpoint` config — recompute each layer in backward instead of retaining its
+activations). Checkpointing is mandatory at poc depth: without it the 24-layer backward
+exceeds the 32 GB unified memory and swaps. Mamba-2/SSD + checkpointing took the poc
+step from ~180 s (diagonal-A, swapping) to ~3 s.
 
 ## Checkpointing: two deliberately separate concerns
 
@@ -97,8 +118,10 @@ The smoke gate stresses exactly this round-trip.
 ## Workflow
 
 - Milestones M1–M8 are tracked in **GitHub issue #2** (the milestone tracker); each
-  sub-issue references "Part of #2". M1–M4 are done and verified; M5 (scale run), and
-  M6–M8 (OLMES eval, serving/rewind, CUDA backend) are deferred.
+  sub-issue references "Part of #2". M1–M4 are done and verified; M2 data (#10) is done;
+  **M5 infrastructure is done** — the `scripts/train.py` driver (#22) and the Mamba-2/SSD
+  perf migration (#23, PR #25) — with the full 2–5B-token run + dataset generation still
+  pending (user-driven). M6–M8 (OLMES eval, serving/rewind, CUDA backend) are deferred.
 - `docs/design/` documents the design choices and rationale (start at
   `docs/design/README.md`). After completing a milestone, tick its box in issue #2.
 - After finishing a milestone or backend change, run the smoke gate, not just pytest.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ eval). Remaining work is the scale-up (M5–M8). Progress is tracked in
 | 4 Smoke test (gate) | passing — resume exact, eval runs |
 | 5–8 POC scale, OLMES, serve/rewind, CUDA | deferred stubs |
 
-**Locked decisions:** poc = d_model 768 / 24 layers / d_state 16 / seq 1024 /
+**Locked decisions:** SSM is **Mamba-2 / SSD** (scalar A per head; chunked-matmul
+scan) + gradient checkpointing — migrated from Mamba-1 for training throughput/memory.
+poc = d_model 768 / 24 layers / d_state 16 / head_dim 64 (24 heads) / seq 1024 /
 ~3B tokens (tied embedding mandatory). toy = d_model 64 / 2 layers / seq 128 /
 fp32. Precision for poc (fp16 vs bf16) **confirmed on MLX in M1** — not assumed.
 Conformance compares in **fp32** (~1e-4 rel). OLMES + serving/rewind deferred;

--- a/config/poc.yaml
+++ b/config/poc.yaml
@@ -3,20 +3,23 @@
 # budget -> tie_embeddings MUST stay true. d_model 768 x 24 layers lands near 100M.
 d_model: 768           # d_inner = expand*d_model = 1536
 n_layers: 24
-d_state: 16
+d_state: 16            # SSM state width N (per head, shared B/C group)
 expand: 2
 d_conv: 4
+head_dim: 64           # Mamba-2/SSD: 1536/64 = 24 heads (scalar A per head)
 dt_rank: auto
 
 vocab_size: 50280      # CONFIRMED: allenai/OLMo-7B-hf, vocab 50280 < 65536 (uint16)
-seq_len: 1024          # <= ~2k -> chunking NOT required for the training run
+seq_len: 1024
 tie_embeddings: true
 
 # CONFIRMED ON MLX (M1 micro-benchmark): fp16 ~3.96 TFLOP/s vs bf16 ~3.36 and
 # fp32 ~3.40 on this Metal GPU -> fp16 is ~18% faster; bf16 gives no speedup.
 # Use fp16 + loss scaling for the scale run (toy/smoke stay fp32 for exact resume).
 precision: fp16
-chunk_size: null       # set an int only for long-context inference
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: true  # REQUIRED at this depth: recompute layers in backward so the
+                       # 24-layer fp16 backward fits in unified memory (else it swaps).
 
 # dt-projection bias init (load-bearing)
 dt_min: 0.001

--- a/config/toy.yaml
+++ b/config/toy.yaml
@@ -2,9 +2,10 @@
 # Tiny + fp32 so fixed-seed resume is exactly reproducible.
 d_model: 64
 n_layers: 2
-d_state: 16
-expand: 2
+d_state: 16            # SSM state width N (per head)
+expand: 2              # d_inner = 128
 d_conv: 4
+head_dim: 16           # Mamba-2/SSD: 128/16 = 8 heads (scalar A per head)
 dt_rank: auto
 
 vocab_size: 256        # byte fallback tokenizer for offline smoke testing
@@ -12,7 +13,8 @@ seq_len: 128
 tie_embeddings: true
 
 precision: fp32        # correctness first; trivial exact resume
-chunk_size: null       # seq_len well under ~2k -> single-pass scan
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false # tiny model -> not needed; keep smoke exact-resume cheap
 
 # dt-projection bias init (load-bearing)
 dt_min: 0.001

--- a/docs/design/02-model-ssm.md
+++ b/docs/design/02-model-ssm.md
@@ -2,8 +2,11 @@
 
 [← Index](README.md)
 
-The model is the standard Mamba block (Gu & Dao): a diagonal selective state-space
-model with input-dependent B, C, and delta. Config lives in
+The model is a **Mamba-2 / SSD** block (Dao & Gu, *State Space Duality*): a
+**scalar-A** selective state-space model with input-dependent B, C, and delta,
+multi-head with one shared B/C group. Scalar A (one decay per head, not a per-state
+diagonal) is the restriction that turns the scan into matmuls — see [the migration
+note](#why-scalar-a-mamba-2). Config lives in
 [`src/model/blocks.py`](../../src/model/blocks.py); the MLX implementation in
 [`src/model/mlx_backend.py`](../../src/model/mlx_backend.py).
 
@@ -16,7 +19,8 @@ input projection
   -> split into `main` and `gate`
   -> short causal depthwise conv on `main` (width `d_conv`)
   -> SiLU
-  -> selective SSM (diagonal A; input-dependent B, C, delta; parallel scan)
+  -> selective SSM (Mamba-2 / SSD: scalar A per head; input-dependent B, C, delta;
+     chunked-matmul scan)
   -> multiply by SiLU(gate)
   -> output projection
 ```
@@ -34,46 +38,61 @@ LayerNorm to match the Mamba reference and for cheaper compute (no mean-subtract
 The SSM is implemented twice and the two must agree (see
 [conformance](03-conformance.md)). From the `mlx_backend.py` module docstring:
 
-> * `parallel(x)`: a chunked closed-form selective scan over the full sequence
->   (training path). Chunking keeps the per-chunk cumulative decay bounded so `exp`
->   does not overflow — a global single-pass cumsum overflows fp32 even at modest
->   seq_len, so we always chunk (default chunk 32).
+> * `parallel(x)`: the SSD chunked-matmul scan over the full sequence (training
+>   path). Intra-chunk via matmul, a short recurrence across chunk-states. All decays
+>   are exp of non-positive sums, so it is overflow-safe; chunk length Q comes from
+>   `chunk_size`.
 > * `recurrence(x, h)`: one-step state update (inference path).
 
-### Why always chunk
+### The SSD chunked-matmul scan
 
-The closed-form scan accumulates a log-decay `A_cum = cumsum(delta * A)`. Since
-`A = -exp(A_log)` is negative, `A_cum` is large-magnitude **negative** over a long
-sequence — so `exp(A_cum)` stays `<= 1` (safe), but the paired `exp(-A_cum)` term
-grows exponentially and **overflows fp32**. Chunking bounds the per-chunk decay so
-that `exp(-A_cum)` stays finite. The default chunk size is **32**; the per-chunk
-recurrence carries state across chunk boundaries.
-
-The closed-form per-chunk update (from `parallel`):
+`d_inner` is split into `n_heads = d_inner // head_dim` heads of width `P = head_dim`.
+Each head has a **scalar** decay `A = -exp(A_log)` (shape `(n_heads,)`); `B` and `C`
+are a single group of width `N = d_state`, shared across heads. The per-head log-decay
+is `g = delta * A` (`<= 0`). The scan ([Dao & Gu SSD, part 3](https://tridao.me/blog/2024/mamba2-part3-algorithm/))
+splits the sequence into chunks of length `Q` and runs four steps — three of them
+matmuls (tensor-core/Metal-friendly), one short recurrence:
 
 ```
-A_cum = cumsum(a_c)                              # inclusive log-decay (<= 0)
-# h_j = exp(A_cum_j) * (h_carry + sum_{i<=j} exp(-A_cum_i) * bu_i)
-inner = cumsum(exp(-A_cum) * bu_c)              # exp(-A_cum) is the term that can overflow
-h     = exp(A_cum) * (h_carry + inner)
+1. intra-chunk (diagonal): Lmask = exp(segsum(g));  Y_diag = (Lmask ∘ CBᵀ) · Xin
+2. chunk-final states:      states = Σ decay·Xin·B          (each chunk's end state)
+3. inter-chunk recurrence:  carry states across chunks (the only scan, length nc)
+4. off-diagonal:            Y_off = C · S_enter · exp(cumsum g)
+Y = Y_diag + Y_off
 ```
 
-`chunk_size` is also a `MambaConfig` field. From `blocks.py`:
+`segsum` builds the lower-triangular log-decay mask `seg[i,j] = Σ_{j<k≤i} g_k`; its
+`exp` is the within-chunk 1-semiseparable decay matrix (upper triangle `-inf → 0`,
+enforcing causality). **Overflow-safety is structural**: every decay is `exp` of a sum
+of non-positive `g`, so it lies in `[0, 1]` — no `exp(-A_cum)` term that can blow up
+(the failure mode of the old diagonal-A cumsum scan). The sequence is padded up to a
+multiple of `Q` (padded steps carry zero input, trimmed from the output). `chunk_size`
+(`MambaConfig`) sets `Q`; `null` → the backend default of **64**.
 
-> Chunked scan working-set bound. None => the backend's default chunk size (the MLX
-> backend uses 32) ... Set an int to tune the chunk for long-context.
+### Why scalar A (Mamba-2)
 
-So `chunk_size: null` does **not** mean a single unchunked pass — the MLX backend
-falls back to a default chunk of 32 (`chunk = self.config.chunk_size or min(L, 32)`).
-An explicit int is only needed to tune the chunk for long-context.
+The original POC used **Mamba-1** diagonal A (`A` shape `(d_inner, d_state)`). Its
+training backward retained the full `(B, L, d_inner, d_state)` scan intermediates for
+every layer at once — at poc scale (24 layers, seq 1024) ~76 GB, which swapped on a
+32 GB M4 and made a step take ~180 s. **SSD's matmul form requires scalar A** (`A =
+aI` per head) — that restriction is what collapses the per-`(channel,state)` decay
+into a shared matmul. Migrating to scalar-A Mamba-2 (plus [gradient
+checkpointing](#memory-gradient-checkpointing)) is what makes the scale run feasible.
 
-## Diagonal-A initialization
+## Scalar-A initialization
 
-`A = -exp(A_log)`, with `A_log` initialized so `A = -(1..d_state)` broadcast across
-channels — the standard **S4D-real** init. From `mlx_backend.py`:
+`A = -exp(A_log)`, with `A_log = log(1..n_heads)` — one decay per head, the **S4D-real**
+init carried to the Mamba-2 head layout. From `mlx_backend.py`:
 
-> A = -exp(A_log). Init A = -(1..d_state) broadcast across channels (the standard
-> "S4D-real" init).
+> Scalar decay A per head, stored as log: A = -exp(A_log). S4D-real init.
+
+## Memory: gradient checkpointing
+
+The training `forward` optionally wraps each layer in `mlx.nn.utils.checkpoint`
+(`grad_checkpoint` config), recomputing the layer in the backward pass instead of
+retaining its activations. Combined with the SSD scan this keeps the 24-layer poc
+backward within unified memory (without it, it swaps). Inference (`step`) is
+unaffected.
 
 ## The load-bearing dt-bias
 
@@ -81,16 +100,16 @@ The single most important initialization in the model. From
 `SelectiveSSM._init_dt_bias`:
 
 > LOAD-BEARING dt-projection bias init (inverse-softplus into a small positive
-> range). Without this the model fails to learn recall.
+> range). Without this the model fails to learn recall. Now PER-HEAD (shape n_heads).
 >
 > ```
 > dt   = uniform(log(dt_min), log(dt_max)).exp().clamp(min=dt_init_floor)
 > bias = dt + log(-expm1(-dt))          # inverse softplus
 > ```
 
-The `dt` projection passes through softplus at runtime; initializing its bias to the
-inverse-softplus of a log-uniform sample in `[dt_min, dt_max]` puts the initial
-timescales in a usable range. The parameters (`dt_min=1e-3`, `dt_max=1e-1`,
+The `dt` projection passes through softplus at runtime; initializing its bias (one
+value **per head** in Mamba-2) to the inverse-softplus of a log-uniform sample in
+`[dt_min, dt_max]` puts the initial timescales in a usable range. The parameters (`dt_min=1e-3`, `dt_max=1e-1`,
 `dt_init_floor=1e-4`) live in `MambaConfig` and are "carried into every backend" —
 this is a model decision, not an MLX detail. This was verified empirically (issue
 #5): on the toy model, loss decreases and long-range memory works.
@@ -111,7 +130,7 @@ the state, so single-token inference matches the full-sequence conv exactly.
 `init_state` returns a per-layer list of `(conv_state, ssm_state)` tuples:
 
 - `conv_state`: `(B, d_conv-1, d_inner)` — the rolling conv window
-- `ssm_state`: `(B, d_inner, d_state)` — the SSM hidden state
+- `ssm_state`: `(B, n_heads, head_dim, d_state)` — the per-head SSM hidden state
 
 This is the opaque blob the [seam](01-architecture-seam.md) snapshots and restores.
 

--- a/docs/design/07-configs-and-decisions.md
+++ b/docs/design/07-configs-and-decisions.md
@@ -14,9 +14,10 @@ decision record — reproduced verbatim below.
 # Tiny + fp32 so fixed-seed resume is exactly reproducible.
 d_model: 64
 n_layers: 2
-d_state: 16
-expand: 2
+d_state: 16            # SSM state width N (per head)
+expand: 2              # d_inner = 128
 d_conv: 4
+head_dim: 16           # Mamba-2/SSD: 128/16 = 8 heads (scalar A per head)
 dt_rank: auto
 
 vocab_size: 256        # byte fallback tokenizer for offline smoke testing
@@ -24,7 +25,8 @@ seq_len: 128
 tie_embeddings: true
 
 precision: fp32        # correctness first; trivial exact resume
-chunk_size: null       # seq_len well under ~2k -> single-pass scan
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false # tiny model -> not needed; keep smoke exact-resume cheap
 
 # dt-projection bias init (load-bearing)
 dt_min: 0.001
@@ -34,12 +36,12 @@ dt_init_floor: 0.0001
 
 The toy config exists to make the [smoke gate](06-smoke-gate-and-eval.md) fast and
 **bit-exact**: tiny dims, `fp32` (so fixed-seed resume is reproducible), and
-`vocab_size: 256` to run on the byte-fallback tokenizer with no network.
+`vocab_size: 256` to run on the byte-fallback tokenizer with no network. `head_dim 16`
+gives 8 heads — enough timescale spread for the dt-init recall test.
 
-> Note on `chunk_size: null`: the inline comments here predate the backend default
-> and read as "single-pass". In practice `null` means *the backend's default chunk
-> size* (the MLX backend uses 32) — the scan is always chunked. See
-> [why always chunk](02-model-ssm.md#why-always-chunk).
+> Note on `chunk_size: null`: it means *the backend's default chunk length* (the MLX
+> SSD scan uses **64**), not an unchunked pass. The SSD scan is overflow-safe by
+> construction — see [the SSD scan](02-model-ssm.md#the-ssd-chunked-matmul-scan).
 
 ## `config/poc.yaml`
 
@@ -49,20 +51,23 @@ The toy config exists to make the [smoke gate](06-smoke-gate-and-eval.md) fast a
 # budget -> tie_embeddings MUST stay true. d_model 768 x 24 layers lands near 100M.
 d_model: 768           # d_inner = expand*d_model = 1536
 n_layers: 24
-d_state: 16
+d_state: 16            # SSM state width N (per head, shared B/C group)
 expand: 2
 d_conv: 4
+head_dim: 64           # Mamba-2/SSD: 1536/64 = 24 heads (scalar A per head)
 dt_rank: auto
 
 vocab_size: 50280      # CONFIRMED: allenai/OLMo-7B-hf, vocab 50280 < 65536 (uint16)
-seq_len: 1024          # <= ~2k -> chunking NOT required for the training run
+seq_len: 1024
 tie_embeddings: true
 
 # CONFIRMED ON MLX (M1 micro-benchmark): fp16 ~3.96 TFLOP/s vs bf16 ~3.36 and
 # fp32 ~3.40 on this Metal GPU -> fp16 is ~18% faster; bf16 gives no speedup.
 # Use fp16 + loss scaling for the scale run (toy/smoke stay fp32 for exact resume).
 precision: fp16
-chunk_size: null       # set an int only for long-context inference
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: true  # REQUIRED at depth: recompute layers in backward so the
+                       # 24-layer fp16 backward fits in unified memory (else it swaps)
 
 # dt-projection bias init (load-bearing)
 dt_min: 0.001
@@ -70,20 +75,21 @@ dt_max: 0.1
 dt_init_floor: 0.0001
 ```
 
-> Note on `chunking NOT required` / `chunk_size: null`: as with the toy config, this
-> means the backend's default chunk size (the MLX backend uses 32), **not** an
-> unchunked single pass — the scan is always chunked. See
-> [why always chunk](02-model-ssm.md#why-always-chunk).
+> Note on `chunk_size: null`: it means the backend's default SSD chunk length (**64**),
+> not an unchunked pass. The migration to **Mamba-2 / SSD** (scalar A) plus
+> `grad_checkpoint` is what makes the poc step fit in memory and run fast — see
+> [the SSD scan](02-model-ssm.md#the-ssd-chunked-matmul-scan) and
+> [why scalar A](02-model-ssm.md#why-scalar-a-mamba-2).
 
 ## The decisions, distilled
 
 ### Sizing: ~100M params, ~3B tokens
 
 `d_model 768 × 24 layers` lands near 100M parameters; the target ~3B tokens is
-roughly Chinchilla-optimal for that size. `seq_len 1024` is comfortably under the ~2k
-limit, so `chunk_size` can stay `null` — meaning the backend's default chunk (32),
-not an unchunked pass; the scan is [always chunked](02-model-ssm.md#why-always-chunk).
-An explicit `chunk_size` is only needed to tune long-context behavior.
+roughly Chinchilla-optimal for that size. `seq_len 1024` runs the [SSD
+scan](02-model-ssm.md#the-ssd-chunked-matmul-scan) with the default chunk length
+`Q = 64`; an explicit `chunk_size` is only needed to tune that. `head_dim 64` splits
+`d_inner = 1536` into 24 scalar-A heads.
 
 ### Tied embedding is mandatory at scale
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2,7 +2,8 @@
 
 Why the Mamba POC is built the way it is. These files explain the **design
 choices and their rationale** — the *what* and *why*. M1–M4 are implemented and
-verified; the milestone tracking and remaining work (M5–M8) live in
+verified, and M5's infrastructure (training driver + Mamba-2/SSD perf migration) has
+landed; the milestone tracking and remaining work (the full M5 run, M6–M8) live in
 [GitHub issue #2](https://github.com/travisgalloway/monica/issues/2). For the
 project overview, see the root [`README.md`](../../README.md).
 
@@ -14,13 +15,15 @@ Every claim here is sourced from a docstring or config comment in the code, with
 1. [Architecture: the hardware seam](01-architecture-seam.md) — one abstraction
    (`ModelInterface`) isolates MLX/CUDA so everything above it stays portable.
 2. [Model: the Mamba block + selective SSM](02-model-ssm.md) — block dataflow,
-   diagonal-A init, load-bearing dt-bias, the chunked parallel scan, recurrence.
+   Mamba-2/SSD scalar-A (per-head) init, load-bearing per-head dt-bias, the SSD
+   chunked-matmul scan, recurrence, gradient checkpointing.
 3. [Conformance: fp32 parity](03-conformance.md) — forward-vs-step and
    backend-vs-backend equivalence checks, and why they run in fp32.
 4. [Data pipeline](04-data-pipeline.md) — uint16 packing, the OLMo tokenizer,
    disjoint val split, the mmap loader.
-5. [Training](05-training.md) — backend-free loop, LR schedule, grad clipping /
-   loss scaling, and the two-concern checkpoint split.
+5. [Training](05-training.md) — backend-free loop, the `scripts/train.py` driver,
+   LR schedule, gradient accumulation, grad clipping, dynamic fp16 loss scaling,
+   gradient checkpointing, and the two-concern checkpoint split.
 6. [Smoke gate & eval](06-smoke-gate-and-eval.md) — why resume-exactness is *the*
    gate, and val perplexity as the success metric.
 7. [Configs & locked decisions](07-configs-and-decisions.md) — `toy.yaml` /
@@ -34,8 +37,10 @@ Every claim here is sourced from a docstring or config comment in the code, with
 | Token storage | uint16 packing | compact; vocab must be < 65536 | `src/data/pack.py` |
 | Tokenizer | `allenai/OLMo-7B-hf` (vocab 50280) | fits uint16; matches AI2 for comparison | `src/data/tokenize.py` |
 | Embedding | tied (input = output) | ~38M of ~100M budget at POC scale | `config/poc.yaml` |
-| dt-bias init | inverse-softplus, log-uniform | **load-bearing** — model can't learn recall without it | `src/model/mlx_backend.py` |
-| Selective scan | chunked closed form (default 32) | the `exp(-A_cum)` term overflows fp32 unchunked | `src/model/mlx_backend.py` |
+| dt-bias init | inverse-softplus, log-uniform (per head) | **load-bearing** — model can't learn recall without it | `src/model/mlx_backend.py` |
+| Selective SSM | Mamba-2 / SSD, scalar A per head | matmul scan; ~62× faster than diagonal-A at poc scale | `src/model/mlx_backend.py` |
+| Selective scan | SSD chunked matmul (default 64) | scalar-A matmul form; overflow-safe by construction | `src/model/mlx_backend.py` |
+| Memory at depth | gradient checkpointing | recompute layers in backward; fits the 24-layer poc backward in 32 GB | `config/poc.yaml` |
 | Precision (poc) | fp16 + loss scaling | ~18% faster than bf16 on Metal (M1 benchmark) | `config/poc.yaml` |
 | Precision (toy/smoke) | fp32 | exact, reproducible resume | `config/toy.yaml` |
 | Conformance | compare in fp32, ~1e-4 rel | bf16 epsilon (~8e-3) too large to be meaningful | `src/conformance/` |

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -10,7 +10,8 @@ The Mamba block (described here textually; implemented in a backend):
       -> split into `main` and `gate`
       -> short causal depthwise conv on `main` (width `d_conv`)
       -> SiLU
-      -> selective SSM (diagonal A; input-dependent B, C, delta; parallel scan)
+      -> selective SSM (Mamba-2 / SSD: scalar A per head; input-dependent B, C,
+         delta; chunked-matmul parallel scan)
       -> multiply by SiLU(gate)
       -> output projection
 
@@ -40,9 +41,14 @@ class MambaConfig:
     # --- core dimensions ---
     d_model: int
     n_layers: int
-    d_state: int = 16
+    d_state: int = 16          # SSM state width N (per head, shared B/C group)
     expand: int = 2
     d_conv: int = 4
+    # Mamba-2 / SSD head dimension P. d_inner is split into n_heads = d_inner//head_dim
+    # heads, each with a SCALAR decay A (the SSD restriction that makes the scan a
+    # matmul). Must divide d_inner. 64 divides both toy (128->2 heads) and poc
+    # (1536->24 heads).
+    head_dim: int = 64
     # dt projection rank; "auto" -> ceil(d_model / 16)
     dt_rank: Union[int, str] = "auto"
 
@@ -58,10 +64,16 @@ class MambaConfig:
     # fp16 + loss scaling is the likely Metal-friendly choice).
     precision: str = "fp32"
 
-    # Chunked scan working-set bound. None => the backend's default chunk size (the
-    # MLX backend uses 32); fine for seq_len up to ~2k. Set an int to tune the chunk
-    # for long-context (keeps the per-chunk decay bounded so exp stays finite).
+    # SSD chunk length Q. None => the backend default (64). The chunked-matmul scan
+    # processes the sequence in chunks of Q; the sequence is padded up to a multiple
+    # of Q (padded steps carry zero input, trimmed from the output).
     chunk_size: Optional[int] = None
+
+    # Recompute each layer's forward in the backward pass instead of retaining its
+    # activations (mlx.nn.utils.checkpoint). Trades ~one extra forward for a large
+    # memory cut — required at poc scale (without it the 24-layer backward exceeds
+    # 32GB and swaps). Off for toy/smoke (tiny; keep exact-resume cheap).
+    grad_checkpoint: bool = False
 
     # --- dt-projection bias init (LOAD-BEARING) ---
     # Inverse-softplus of a sample in [dt_min, dt_max] initializes the dt bias.
@@ -73,6 +85,10 @@ class MambaConfig:
     @property
     def d_inner(self) -> int:
         return self.expand * self.d_model
+
+    @property
+    def n_heads(self) -> int:
+        return self.d_inner // self.head_dim
 
     @property
     def dt_rank_resolved(self) -> int:
@@ -92,6 +108,11 @@ class MambaConfig:
             raise ValueError("chunk_size must be positive or None")
         if self.d_conv < 1:
             raise ValueError("d_conv must be >= 1")
+        if self.head_dim <= 0 or self.d_inner % self.head_dim != 0:
+            raise ValueError(
+                f"head_dim={self.head_dim} must divide d_inner={self.d_inner} "
+                "(d_inner = expand*d_model)."
+            )
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -46,8 +46,8 @@ class MambaConfig:
     d_conv: int = 4
     # Mamba-2 / SSD head dimension P. d_inner is split into n_heads = d_inner//head_dim
     # heads, each with a SCALAR decay A (the SSD restriction that makes the scan a
-    # matmul). Must divide d_inner. 64 divides both toy (128->2 heads) and poc
-    # (1536->24 heads).
+    # matmul). Must divide d_inner. The configs override this: poc.yaml uses 64
+    # (d_inner 1536 -> 24 heads); toy.yaml uses 16 (d_inner 128 -> 8 heads).
     head_dim: int = 64
     # dt projection rank; "auto" -> ceil(d_model / 16)
     dt_rank: Union[int, str] = "auto"

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -156,7 +156,12 @@ class SelectiveSSM(nn.Module):
         # 2) each chunk's final state, from that chunk's inputs only
         decay_end = mx.exp(Acum[..., -1:] - Acum)            # (B,H,nc,Q)
         states = mx.einsum("bhcj,bcjhp,bcjn->bchpn", decay_end, Xc, Bc)
-        # 3) inter-chunk recurrence (the only scan, over nc chunk-states)
+        # 3) inter-chunk recurrence over the nc chunk-states. The canonical SSD form
+        # (Dao & Gu) does this as a matmul against an (nc+1, nc+1) decay matrix rather
+        # than a sequential scan: parallel/tensor-core-friendly, at the cost of O(nc^2).
+        # nc = ceil(L/Q) is small (16 at poc seq 1024 / Q 64), so the matrix is tiny vs
+        # the per-position activations; for very long contexts raise `chunk_size` (Q) to
+        # keep nc bounded. (A true O(nc) scan would be slower at these scales.)
         states = mx.concatenate(
             [mx.zeros((B_, 1, H, P, N), dtype=states.dtype), states], axis=1)
         chunk_tot = mx.pad(Acum[..., -1], [(0, 0), (0, 0), (1, 0)])   # (B,H,nc+1)

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -1,15 +1,18 @@
 """MLX backend for the Mamba POC (Apple Silicon).
 
-Implements `ModelInterface` with the standard Mamba block (Gu & Dao): a diagonal
-selective SSM with input-dependent B, C, delta. Two code paths must agree
+Implements `ModelInterface` with a Mamba-2 / SSD block: a SCALAR-A selective SSM
+(Dao & Gu, State Space Duality), multi-head with one shared B/C group. Scalar A is
+what lets the scan become a sequence of matmuls. Two code paths must agree
 (forward_step_parity, fp32 ~1e-4 rel):
 
-  * `parallel(x)`     : a chunked closed-form selective scan over the full
-                        sequence (training path). Chunking keeps the per-chunk
-                        cumulative decay bounded so `exp` does not overflow — a
-                        global single-pass cumsum overflows fp32 even at modest
-                        seq_len, so we always chunk (default chunk 32).
+  * `parallel(x)`     : the SSD chunked-matmul scan over the full sequence (training
+                        path). Intra-chunk via matmul, a short recurrence across
+                        chunk-states. All decays are exp of non-positive sums, so it
+                        is overflow-safe; chunk length Q comes from `chunk_size`.
   * `recurrence(x, h)`: one-step state update (inference path).
+
+Memory at depth is controlled with gradient checkpointing (recompute each layer's
+forward in backward); see `MLXMambaModel.__init__`.
 
 This file imports `mlx`, so it does NOT import on Linux/CUDA hosts — intentional
 and allowed: it lives below the seam and nothing portable imports it.
@@ -22,6 +25,7 @@ from typing import List, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
+from mlx.nn.utils import checkpoint as _checkpoint
 from mlx.utils import tree_flatten, tree_unflatten
 import numpy as np
 
@@ -52,30 +56,49 @@ class RMSNorm(nn.Module):
         return self.weight * (x * norm)
 
 
+def _segsum(x: Array) -> Array:
+    """Lower-triangular segment-sum. out[..., i, j] = sum_{j < k <= i} x_k for i >= j,
+    and -inf above the diagonal. `exp(_segsum(g))` is the within-window decay matrix
+    of a scalar SSM (a 1-semiseparable matrix); the -inf upper triangle exp's to 0,
+    enforcing causality."""
+    T = x.shape[-1]
+    xc = mx.cumsum(x, axis=-1)
+    seg = xc[..., :, None] - xc[..., None, :]
+    mask = mx.tril(mx.ones((T, T), dtype=mx.bool_))
+    return mx.where(mask, seg, mx.array(float("-inf"), dtype=seg.dtype))
+
+
 class SelectiveSSM(nn.Module):
-    """Diagonal-A selective state space with input-dependent B, C, delta."""
+    """Scalar-A Mamba-2 / SSD selective state space.
+
+    d_inner is split into `n_heads` heads of width `head_dim` (P); each head has a
+    SCALAR decay A (the SSD restriction that turns the scan into matmuls). B and C
+    are a single group of width `d_state` (N), shared across heads. The training
+    path (`parallel`) is the SSD chunked-matmul scan; the inference path
+    (`recurrence`) is the matching one-step recurrence. Both compute the same
+    function (forward_step_parity, fp32 ~1e-4)."""
 
     def __init__(self, config: MambaConfig):
         super().__init__()
         self.config = config
         d_inner, d_state = config.d_inner, config.d_state
-        dt_rank = config.dt_rank_resolved
+        dt_rank, H = config.dt_rank_resolved, config.n_heads
 
-        # x_proj produces (delta, B, C); dt_proj maps dt_rank -> d_inner.
+        # x_proj produces (dt_pre, B, C); B and C are one group, shared across heads.
         self.x_proj = nn.Linear(d_inner, dt_rank + 2 * d_state, bias=False)
-        self.dt_proj = nn.Linear(dt_rank, d_inner, bias=True)
+        # dt is PER-HEAD in Mamba-2: dt_proj maps dt_rank -> n_heads.
+        self.dt_proj = nn.Linear(dt_rank, H, bias=True)
 
-        # Diagonal A stored as log for stability: A = -exp(A_log). Init A = -(1..d_state)
-        # broadcast across channels (the standard "S4D-real" init).
-        a = mx.arange(1, d_state + 1, dtype=mx.float32)          # (d_state,)
-        self.A_log = mx.log(mx.ones((d_inner, d_state)) * a)     # (d_inner, d_state)
-        self.D = mx.ones((d_inner,))
+        # Scalar decay A per head, stored as log: A = -exp(A_log). S4D-real init.
+        self.A_log = mx.log(mx.arange(1, H + 1, dtype=mx.float32))   # (H,)
+        self.D = mx.ones((H,))                                       # (H,) skip per head
 
         self._init_dt_bias()
 
     def _init_dt_bias(self) -> None:
         """LOAD-BEARING dt-projection bias init (inverse-softplus into a small
-        positive range). Without this the model fails to learn recall.
+        positive range). Without this the model fails to learn recall. Now PER-HEAD
+        (shape n_heads), since Mamba-2 has one dt per head.
 
             dt   = uniform(log(dt_min), log(dt_max)).exp().clamp(min=dt_init_floor)
             bias = dt + log(-expm1(-dt))          # inverse softplus
@@ -83,57 +106,82 @@ class SelectiveSSM(nn.Module):
         c = self.config
         dt = mx.exp(mx.random.uniform(
             low=math.log(c.dt_min), high=math.log(c.dt_max),
-            shape=(c.d_inner,)))
+            shape=(c.n_heads,)))
         dt = mx.maximum(dt, c.dt_init_floor)
-        inv_softplus = dt + mx.log(-mx.expm1(-dt))
-        self.dt_proj.bias = inv_softplus
+        self.dt_proj.bias = dt + mx.log(-mx.expm1(-dt))             # (H,)
 
     # --- shared projections --------------------------------------------------
     def _project(self, x: Array):
+        """x: (..., d_inner) -> delta (..., H), a (H,), B (..., N), C (..., N)."""
         dt_rank, d_state = self.config.dt_rank_resolved, self.config.d_state
         proj = self.x_proj(x)
-        dt = proj[..., :dt_rank]
+        dt_pre = proj[..., :dt_rank]
         B = proj[..., dt_rank:dt_rank + d_state]
         C = proj[..., dt_rank + d_state:]
-        delta = _softplus(self.dt_proj(dt))     # (..., d_inner)
-        A = -mx.exp(self.A_log)                  # (d_inner, d_state)
-        return delta, A, B, C
+        delta = _softplus(self.dt_proj(dt_pre))   # (..., H) per head
+        a = -mx.exp(self.A_log)                    # (H,) scalar decay
+        return delta, a, B, C
 
     def parallel(self, x: Array) -> Array:
-        """Chunked closed-form selective scan. x: (B, L, d_inner) -> (B, L, d_inner)."""
+        """SSD chunked-matmul scan. x: (B, L, d_inner) -> (B, L, d_inner).
+
+        Pads L up to a multiple of the chunk length Q (padded steps carry zero
+        input and are trimmed). All decays are exp of non-positive sums, so the
+        scan is overflow-safe by construction."""
         B_, L, d_inner = x.shape
-        delta, A, Bmat, Cmat = self._project(x)
+        H, P, N = self.config.n_heads, self.config.head_dim, self.config.d_state
+        Q = self.config.chunk_size or 64
+        delta, a, Bm, Cm = self._project(x)        # delta (B,L,H); Bm,Cm (B,L,N)
+        X = x.reshape(B_, L, H, P)
 
-        # Discretized terms: a = delta*A (log-decay), deltaBu = delta*B*x.
-        a = delta[..., None] * A[None, None]                 # (B, L, di, ds)
-        deltaBu = delta[..., None] * Bmat[:, :, None, :] * x[..., None]  # (B,L,di,ds)
+        pad = (-L) % Q
+        if pad:
+            zc = lambda t, shp: mx.concatenate([t, mx.zeros(shp, dtype=t.dtype)], axis=1)
+            X, delta = zc(X, (B_, pad, H, P)), zc(delta, (B_, pad, H))
+            Bm, Cm = zc(Bm, (B_, pad, N)), zc(Cm, (B_, pad, N))
+        Lp, nc = L + pad, (L + pad) // Q
+        g = delta * a                              # (B,Lp,H) log-decay (<= 0)
+        Xin = delta[..., None] * X                 # (B,Lp,H,P) input = dt * X
 
-        chunk = self.config.chunk_size or min(L, 32)
-        d_state = self.config.d_state
-        h_carry = mx.zeros((B_, d_inner, d_state))
-        ys = []
-        for s in range(0, L, chunk):
-            e = min(s + chunk, L)
-            a_c = a[:, s:e]                                  # (B, lc, di, ds)
-            bu_c = deltaBu[:, s:e]
-            C_c = Cmat[:, s:e]                               # (B, lc, ds)
-            A_cum = mx.cumsum(a_c, axis=1)                   # inclusive log-decay
-            # h_j = exp(A_cum_j) * (h_carry + sum_{i<=j} exp(-A_cum_i) * bu_i)
-            inner = mx.cumsum(mx.exp(-A_cum) * bu_c, axis=1)
-            h = mx.exp(A_cum) * (h_carry[:, None] + inner)   # (B, lc, di, ds)
-            ys.append(mx.sum(h * C_c[:, :, None, :], axis=-1))  # (B, lc, di)
-            h_carry = h[:, -1]
-        y = mx.concatenate(ys, axis=1)                       # (B, L, di)
-        return y + x * self.D
+        gc = g.reshape(B_, nc, Q, H).transpose(0, 3, 1, 2)   # (B,H,nc,Q)
+        Xc = Xin.reshape(B_, nc, Q, H, P)
+        Bc = Bm.reshape(B_, nc, Q, N)
+        Cc = Cm.reshape(B_, nc, Q, N)
+        Acum = mx.cumsum(gc, axis=-1)                        # (B,H,nc,Q)
+
+        # 1) intra-chunk diagonal block (attention-like, within each chunk)
+        Lmask = mx.exp(_segsum(gc))                          # (B,H,nc,Q,Q)
+        CB = mx.einsum("bcin,bcjn->bcij", Cc, Bc)            # (B,nc,Q,Q)
+        Ydiag = mx.einsum("bhcij,bcij,bcjhp->bcihp", Lmask, CB, Xc)
+        # 2) each chunk's final state, from that chunk's inputs only
+        decay_end = mx.exp(Acum[..., -1:] - Acum)            # (B,H,nc,Q)
+        states = mx.einsum("bhcj,bcjhp,bcjn->bchpn", decay_end, Xc, Bc)
+        # 3) inter-chunk recurrence (the only scan, over nc chunk-states)
+        states = mx.concatenate(
+            [mx.zeros((B_, 1, H, P, N), dtype=states.dtype), states], axis=1)
+        chunk_tot = mx.pad(Acum[..., -1], [(0, 0), (0, 0), (1, 0)])   # (B,H,nc+1)
+        decay_chunk = mx.exp(_segsum(chunk_tot))                      # (B,H,nc+1,nc+1)
+        new_states = mx.einsum("bhzc,bchpn->bzhpn", decay_chunk, states)
+        S_enter = new_states[:, :-1]                                  # (B,nc,H,P,N)
+        # 4) off-diagonal output: entering state decayed to each position
+        out_decay = mx.exp(Acum)                                      # (B,H,nc,Q)
+        Yoff = mx.einsum("bcin,bchpn,bhci->bcihp", Cc, S_enter, out_decay)
+
+        Y = (Ydiag + Yoff).reshape(B_, Lp, H, P)[:, :L]             # (B,L,H,P)
+        Y = Y + X[:, :L] * self.D[None, None, :, None]             # skip
+        return Y.reshape(B_, L, d_inner)
 
     def recurrence(self, x: Array, state: State) -> Tuple[Array, State]:
-        """Single timestep. x: (B, d_inner), state h: (B, d_inner, d_state)."""
-        delta, A, Bmat, Cmat = self._project(x)
-        dA = mx.exp(delta[..., None] * A[None])              # (B, di, ds)
-        dBu = delta[..., None] * Bmat[:, None, :] * x[..., None]
-        h = dA * state + dBu                                 # (B, di, ds)
-        y = mx.sum(h * Cmat[:, None, :], axis=-1) + x * self.D
-        return y, h
+        """One timestep. x: (B, d_inner), state h: (B, H, P, N) -> y: (B, d_inner)."""
+        B_ = x.shape[0]
+        H, P = self.config.n_heads, self.config.head_dim
+        delta, a, Bm, Cm = self._project(x)        # delta (B,H); Bm,Cm (B,N)
+        Xh = x.reshape(B_, H, P)
+        dA = mx.exp(delta * a)                      # (B,H)
+        dBx = (delta[..., None] * Xh)[..., None] * Bm[:, None, None, :]  # (B,H,P,N)
+        h = dA[:, :, None, None] * state + dBx      # (B,H,P,N)
+        y = mx.sum(h * Cm[:, None, None, :], axis=-1) + Xh * self.D[None, :, None]
+        return y.reshape(B_, -1), h
 
 
 class MambaBlock(nn.Module):
@@ -192,6 +240,13 @@ class MLXMambaModel(ModelInterface, nn.Module):
         if not config.tie_embeddings:
             self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
         self._state = None
+        # Gradient checkpointing: recompute each layer's forward in the backward pass
+        # instead of retaining its activations. Essential at poc scale — without it the
+        # 24-layer backward exceeds 32GB and swaps. `step` (inference) is unaffected.
+        if config.grad_checkpoint:
+            self._layer_fns = [_checkpoint(l, l.forward_seq) for l in self.layers]
+        else:
+            self._layer_fns = [l.forward_seq for l in self.layers]
 
     def _head(self, h: Array) -> Array:
         if self._tie_embeddings:
@@ -201,8 +256,8 @@ class MLXMambaModel(ModelInterface, nn.Module):
     # --- ModelInterface ---
     def forward(self, token_batch: Array) -> Array:
         h = self.embedding(mx.array(token_batch))
-        for layer in self.layers:
-            h = layer.forward_seq(h)
+        for layer_fn in self._layer_fns:
+            h = layer_fn(h)
         return self._head(self.norm_f(h))
 
     def step(self, token: Array, state: State) -> Tuple[Array, State]:
@@ -214,8 +269,11 @@ class MLXMambaModel(ModelInterface, nn.Module):
         return self._head(self.norm_f(h)), new_state
 
     def init_state(self, batch_size: int) -> State:
-        di, ds, k = self.config.d_inner, self.config.d_state, self.config.d_conv
-        return [(mx.zeros((batch_size, k - 1, di)), mx.zeros((batch_size, di, ds)))
+        c = self.config
+        di, k = c.d_inner, c.d_conv
+        H, P, N = c.n_heads, c.head_dim, c.d_state
+        # Per layer: (conv window (B,k-1,di), SSM state (B,H,P,N)).
+        return [(mx.zeros((batch_size, k - 1, di)), mx.zeros((batch_size, H, P, N)))
                 for _ in range(self.config.n_layers)]
 
     def get_state(self) -> State:

--- a/tests/test_dt_bias.py
+++ b/tests/test_dt_bias.py
@@ -73,7 +73,7 @@ def test_dt_bias_timescales_in_range():
     bias = ssm.dt_proj.bias
     dt = _np(_softplus(bias))
 
-    assert bias.shape == (cfg.d_inner,)
+    assert bias.shape == (cfg.n_heads,)        # Mamba-2: one dt per head
     assert np.all(dt > 0.0)
     # log-uniform in [dt_min, dt_max], clamped up to dt_init_floor. The floor
     # (1e-4) is below dt_min (1e-3) here, so the effective range is [dt_min, dt_max].

--- a/tests/test_mlx_parity.py
+++ b/tests/test_mlx_parity.py
@@ -26,44 +26,45 @@ def _np(a):
 
 
 def _seq_reference_numpy(ssm, x_np):
-    """Fully independent fp64 sequential selective scan.
+    """Fully independent fp64 sequential scan of the scalar-A Mamba-2 / SSD SSM.
 
-    Computes the projections, softplus, diagonal-A discretization and the
+    Computes the projections, softplus, scalar-A (per-head) discretization and the
     recurrence FROM SCRATCH in numpy using only the SSM's raw parameters — it
-    shares no code with `SelectiveSSM.parallel` or `.recurrence`, so a bug living
-    identically in their shared `_project`/discretization cannot hide here.
+    shares no code with `SelectiveSSM.parallel` (SSD matmul) or `.recurrence`, so a
+    bug living identically in their shared `_project`/discretization cannot hide here.
 
     x_np: (B, L, d_inner) float -> (B, L, d_inner) float64.
     """
     cfg = ssm.config
-    dt_rank, d_state = cfg.dt_rank_resolved, cfg.d_state
+    dt_rank, N = cfg.dt_rank_resolved, cfg.d_state
+    H, P = cfg.n_heads, cfg.head_dim
 
-    # Raw params -> fp64. MLX nn.Linear stores weight as (out, in) and computes
-    # `x @ W.T + b`, so we project with W.T.
-    Wx = _np(ssm.x_proj.weight).astype(np.float64)    # (dt_rank+2*ds, di)
-    Wdt = _np(ssm.dt_proj.weight).astype(np.float64)  # (di, dt_rank)
-    bdt = _np(ssm.dt_proj.bias).astype(np.float64)    # (di,)
-    A = -np.exp(_np(ssm.A_log).astype(np.float64))    # (di, ds)
-    D = _np(ssm.D).astype(np.float64)                 # (di,)
+    # Raw params -> fp64. MLX nn.Linear stores weight as (out, in), computes x @ W.T + b.
+    Wx = _np(ssm.x_proj.weight).astype(np.float64)    # (dt_rank+2N, d_inner)
+    Wdt = _np(ssm.dt_proj.weight).astype(np.float64)  # (H, dt_rank)
+    bdt = _np(ssm.dt_proj.bias).astype(np.float64)    # (H,)
+    a = -np.exp(_np(ssm.A_log).astype(np.float64))    # (H,) scalar decay per head
+    D = _np(ssm.D).astype(np.float64)                 # (H,)
 
     x = x_np.astype(np.float64)
     B_, L, di = x.shape
 
-    proj = x @ Wx.T                                   # (B, L, dt_rank+2*ds)
-    dt = proj[..., :dt_rank]
-    Bm = proj[..., dt_rank:dt_rank + d_state]         # (B, L, ds)
-    Cm = proj[..., dt_rank + d_state:]                # (B, L, ds)
-    delta = np.logaddexp(dt @ Wdt.T + bdt, 0.0)       # softplus -> (B, L, di)
+    proj = x @ Wx.T                                   # (B, L, dt_rank+2N)
+    Bm = proj[..., dt_rank:dt_rank + N]               # (B, L, N) shared across heads
+    Cm = proj[..., dt_rank + N:]                      # (B, L, N)
+    delta = np.logaddexp(proj[..., :dt_rank] @ Wdt.T + bdt, 0.0)  # softplus -> (B, L, H)
 
-    y = np.zeros((B_, L, di), np.float64)
-    h = np.zeros((B_, di, d_state), np.float64)
+    X = x.reshape(B_, L, H, P)
+    y = np.zeros((B_, L, H, P), np.float64)
+    h = np.zeros((B_, H, P, N), np.float64)           # per-head state (P, N)
     for t in range(L):
-        dlt = delta[:, t][..., None]                  # (B, di, 1)
-        dA = np.exp(dlt * A[None])                     # (B, di, ds)
-        dBu = dlt * Bm[:, t][:, None, :] * x[:, t][..., None]
-        h = dA * h + dBu
-        y[:, t] = np.sum(h * Cm[:, t][:, None, :], axis=-1) + x[:, t] * D
-    return y
+        dA = np.exp(delta[:, t] * a)                  # (B, H)
+        Xin = delta[:, t][..., None] * X[:, t]        # (B, H, P) input = dt * X
+        dBx = Xin[..., None] * Bm[:, t][:, None, None, :]    # (B, H, P, N)
+        h = dA[:, :, None, None] * h + dBx
+        y[:, t] = np.sum(h * Cm[:, t][:, None, None, :], axis=-1)  # (B, H, P)
+    y = y + X * D[None, None, :, None]
+    return y.reshape(B_, L, di)
 
 
 def test_ssm_parallel_matches_sequential():
@@ -75,8 +76,8 @@ def test_ssm_parallel_matches_sequential():
 
     y_par = _np(ssm.parallel(x))
 
-    # Sequential reference from the one-step recurrence.
-    h = mx.zeros((B, di, cfg.d_state))
+    # Sequential reference from the one-step recurrence. State is per-head (B,H,P,N).
+    h = mx.zeros((B, cfg.n_heads, cfg.head_dim, cfg.d_state))
     ys = []
     for t in range(L):
         y_t, h = ssm.recurrence(x[:, t], h)

--- a/tests/test_mlx_train_step.py
+++ b/tests/test_mlx_train_step.py
@@ -56,8 +56,9 @@ def test_fp16_overflow_skips_update_and_backs_off():
     mx.random.seed(0)
     model = MLXMambaModel(cfg)
     opt = optim.AdamW(learning_rate=1e-3)
-    # A huge scale forces loss*scale -> inf, so the unscaled grads are non-finite.
-    scaler = DynamicLossScaler(init_scale=1e38, backoff=0.5, min_scale=1.0)
+    # A scale above fp32-max makes loss*scale -> inf, so the gradients are
+    # non-finite regardless of the per-element grad magnitude (robust trigger).
+    scaler = DynamicLossScaler(init_scale=1e40, backoff=0.5, min_scale=1.0)
     step_fn = make_train_step(model, opt, grad_clip=1.0, scaler=scaler)
 
     before = [np.array(v) for _, v in tree_flatten(model.parameters())]
@@ -65,7 +66,7 @@ def test_fp16_overflow_skips_update_and_backs_off():
     after = [np.array(v) for _, v in tree_flatten(model.parameters())]
 
     assert out["skipped"] is True
-    assert scaler.scale == 0.5e38                 # backed off on overflow
+    assert scaler.scale == 0.5e40                 # backed off on overflow
     for b, a in zip(before, after):
         assert np.array_equal(b, a)               # weights untouched on a skipped step
 


### PR DESCRIPTION
Part of #2. Closes #23. (Supersedes #24, which GitHub auto-closed when the stacked base branch was deleted on #22's merge; now rebased directly onto `main`.)

## Why
The poc training step was **~180 s** — not the forward (1.1 s), but the backward: the diagonal-A Mamba-1 scan retained the full `(B, L, d_inner, d_state)` intermediates for all 24 layers at once (~76 GB → swap on the 32 GB M4; OOM-kill at batch 32). `mx.compile` didn't help (intrinsic memory pressure). This blocked the M5 scale run.

## What
- **Replace Mamba-1 (diagonal A) with Mamba-2 / SSD (scalar A)** — `d_inner` splits into `n_heads` heads of width `head_dim`, each with a **scalar** decay `A`; `B`/`C` are one shared group. Training uses the [SSD](https://tridao.me/blog/2024/mamba2-part3-algorithm/) chunked-matmul scan (a `segsum` decay mask + 3 matmuls + 1 short inter-chunk recurrence); the `step` recurrence matches. All decays are `exp` of non-positive sums → **overflow-safe by construction**.
- **Gradient checkpointing** (`mlx.nn.utils.checkpoint`) recomputes each layer in backward instead of retaining activations (`grad_checkpoint` config).
- **Config**: add `head_dim` (`n_heads = d_inner // head_dim`) and `grad_checkpoint`; validate `head_dim | d_inner`. toy `head_dim 16` (8 heads), poc `head_dim 64` (24 heads, checkpointing on). `chunk_size` is now the SSD chunk length Q (default 64). dt-bias init is now per-head.

## Performance (poc scale, seq 1024, batch 4)
| variant | step | peak mem | tok/s |
|---|---|---|---|
| Mamba-1 (orig) | ~180 s | >32 GB (swap/OOM) | ~11 |
| Mamba-1 + checkpoint | 22.5 s | 14 GB | ~182 |
| **Mamba-2 SSD + checkpoint** | **2.9 s** | **5.6 GB** | **~1,400** |

**~62× faster** than the original; **~7.7×** the checkpointed-Mamba-1 throughput.

## Verification
- **pytest: 36 passed** (on the combined tree post-#22) — SSD `parallel` == sequential `recurrence` == a rewritten, fully-independent numpy reference; long-context; whole-model forward/step parity (all fp32 ~1e-4).
- **Smoke gate**: resume still **bit-exact** (2.4e-7) with the new model.
- **Dry run** (50M-token OLMo slice, poc.yaml, 200 steps): smoothly decreasing `val_perplexity` 3350 → 2869 → 2543 → **2318**, bounded `grad_norm`, no NaN.
- SSD algorithm de-risked in a standalone prototype before integration (matched the recurrence to ~1e-16).

The seam (`ModelInterface`), conformance contracts, and portable-weights format are unchanged. The full 2–5B-token run + dataset generation remain user-driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)