### PR TITLE
test(train): reproducible fp16-vs-bf16 precision bench + scaler wiring (#3)

### DIFF
--- a/config/poc.yaml
+++ b/config/poc.yaml
@@ -13,9 +13,10 @@ vocab_size: 50280      # CONFIRMED: allenai/OLMo-7B-hf, vocab 50280 < 65536 (uin
 seq_len: 1024
 tie_embeddings: true
 
-# CONFIRMED ON MLX (M1 micro-benchmark): fp16 ~3.96 TFLOP/s vs bf16 ~3.36 and
-# fp32 ~3.40 on this Metal GPU -> fp16 is ~18% faster; bf16 gives no speedup.
-# Use fp16 + loss scaling for the scale run (toy/smoke stay fp32 for exact resume).
+# CONFIRMED ON MLX (issue #3, reproduce: `python scripts/bench_precision.py`):
+# fp16 ~4.37 TFLOP/s vs bf16 ~3.78 vs fp32 ~3.33 on this Metal GPU -> fp16 is ~16%
+# faster than bf16 (and ~31% over fp32). Do NOT assume bf16. Use fp16 + loss scaling
+# for the scale run (toy/smoke stay fp32 for exact resume).
 precision: fp16
 chunk_size: null       # SSD chunk length Q (null -> backend default 64)
 grad_checkpoint: true  # REQUIRED at this depth: recompute layers in backward so the

--- a/docs/design/07-configs-and-decisions.md
+++ b/docs/design/07-configs-and-decisions.md
@@ -101,11 +101,15 @@ separate LM head) is therefore not a tuning knob but a requirement; see
 ### Precision: fp16 for poc, fp32 for toy/smoke
 
 The fp16-vs-bf16 question was settled empirically on MLX in M1 (issue #3), not
-assumed. The micro-benchmark on this Metal GPU: **fp16 ~3.96 TFLOP/s vs bf16 ~3.36
-and fp32 ~3.40** — fp16 is ~18% faster and bf16 gives no speedup. So the scale run
-uses **fp16 + loss scaling** (the loss-scaling machinery lives in
-[training](05-training.md)), while toy/smoke stay **fp32** for exact resume. Note this
-contradicts the common assumption that bf16 is the safe default — on Metal it isn't.
+assumed. The benchmark — reproducible in-repo via `scripts/bench_precision.py`, which
+times the poc forward GEMM workload (per-layer in/x/out projections + the tied head)
+in each dtype — on this Metal GPU: **fp16 ~4.37 TFLOP/s vs bf16 ~3.78 and fp32 ~3.33**.
+fp16 is **~16% faster than bf16** (and ~31% over fp32); bf16 buys only a small edge on
+fp32. So the scale run uses **fp16 + loss scaling** (the loss-scaling machinery lives
+in [training](05-training.md); the precision→scaler wiring is `scaler_for_precision`
+in `src/train/loss_scale.py`), while toy/smoke stay **fp32** for exact resume. Note
+this contradicts the common assumption that bf16 is the safe default — on Metal it
+isn't. Re-run `python scripts/bench_precision.py` on new hardware to re-confirm.
 
 ### Vocab is locked to uint16
 

--- a/scripts/bench_precision.py
+++ b/scripts/bench_precision.py
@@ -34,7 +34,18 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--iters", type=int, default=50, help="timed iterations per dtype")
     ap.add_argument("--warmup", type=int, default=10, help="untimed warmup iterations per dtype")
     ap.add_argument("--seed", type=int, default=0)
-    return ap.parse_args()
+    args = ap.parse_args()
+    # Fail fast on inputs that would crash or report nonsense (e.g. --iters 0 leaves
+    # `last` unset and divides by ~0; non-positive batch/seq/warmup are meaningless).
+    if args.iters < 1:
+        ap.error("--iters must be >= 1")
+    if args.warmup < 0:
+        ap.error("--warmup must be >= 0")
+    if args.batch < 1:
+        ap.error("--batch must be >= 1")
+    if args.seq is not None and args.seq < 1:
+        ap.error("--seq must be >= 1")
+    return args
 
 
 def _gemm_shapes(cfg, tokens: int):
@@ -108,7 +119,9 @@ def main() -> None:
             last = run_iter()
         elapsed = time.perf_counter() - t0
 
-        if not bool(mx.all(mx.isfinite(last[0])).item()):
+        # Check every GEMM output, not just the first — the widest one (the LM head,
+        # last in the list) is the most likely to overflow in low precision.
+        if not all(bool(mx.all(mx.isfinite(o)).item()) for o in last):
             raise RuntimeError(f"{name}: non-finite GEMM output — benchmark is degenerate")
 
         tflops = (flops_per_iter * args.iters) / elapsed / 1e12

--- a/scripts/bench_precision.py
+++ b/scripts/bench_precision.py
@@ -1,0 +1,132 @@
+"""Precision micro-benchmark (Apple Silicon / MLX) — the reproducer for issue #3.
+
+Settles the poc training precision *empirically* on this Metal GPU rather than
+assuming bf16. It times the matmul (GEMM) workload that dominates a Mamba-2 forward
+pass — the per-layer in/x/out projections plus the tied LM head — in fp32, fp16, and
+bf16, and reports achieved TFLOP/s and a tokens/sec-equivalent for each. The shapes
+come from the model config (default `config/poc.yaml`), so the numbers are
+representative of the real run, not a generic square GEMM.
+
+This is op-level on purpose: it reproduces the kind of measurement the precision
+decision rests on (see config/poc.yaml + docs/design/07-configs-and-decisions.md)
+without requiring the model itself to compute in low precision. The model still runs
+fp32; `precision` only toggles the fp16 loss scaler.
+
+    .venv/bin/python scripts/bench_precision.py                       # config/poc.yaml
+    .venv/bin/python scripts/bench_precision.py --batch 8 --iters 100
+
+MLX imports are kept local so the module stays importable for `--help` on any host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
+    ap.add_argument("--batch", type=int, default=4, help="sequences per GEMM (rows = batch*seq)")
+    ap.add_argument("--seq", type=int, default=None, help="sequence length (default: config seq_len)")
+    ap.add_argument("--iters", type=int, default=50, help="timed iterations per dtype")
+    ap.add_argument("--warmup", type=int, default=10, help="untimed warmup iterations per dtype")
+    ap.add_argument("--seed", type=int, default=0)
+    return ap.parse_args()
+
+
+def _gemm_shapes(cfg, tokens: int):
+    """Unique (K, N, count) GEMMs of one Mamba-2 forward, weighted by multiplicity.
+
+    Per layer: in_proj (d_model -> 2*d_inner), x_proj (d_inner -> dt_rank+2*d_state),
+    out_proj (d_inner -> d_model). Once for the whole model: the tied head
+    (d_model -> vocab). The selective-scan einsums are not GEMMs against a weight and
+    are a small share of FLOPs at poc dims, so the projections + head are the
+    representative throughput workload."""
+    dm, di = cfg.d_model, cfg.d_inner
+    nL = cfg.n_layers
+    x_out = cfg.dt_rank_resolved + 2 * cfg.d_state
+    return [
+        ("in_proj",  dm, 2 * di, nL),
+        ("x_proj",   di, x_out,  nL),
+        ("out_proj", di, dm,     nL),
+        ("lm_head",  dm, cfg.vocab_size, 1),
+    ]
+
+
+def main() -> None:
+    args = _parse_args()
+    import mlx.core as mx
+
+    from src.model.blocks import load_config
+
+    cfg = load_config(str(args.config))
+    seq = args.seq if args.seq is not None else cfg.seq_len
+    tokens = args.batch * seq                       # rows M of every GEMM
+    shapes = _gemm_shapes(cfg, tokens)
+
+    # FLOPs of one full forward pass over `tokens` rows: 2*M*K*N per GEMM, x count.
+    flops_per_iter = sum(2 * tokens * K * N * count for _, K, N, count in shapes)
+
+    dtypes = [("fp32", mx.float32), ("fp16", mx.float16), ("bf16", mx.bfloat16)]
+    print(f"[bench] config={args.config}  d_model={cfg.d_model}  d_inner={cfg.d_inner}  "
+          f"n_layers={cfg.n_layers}  vocab={cfg.vocab_size}")
+    print(f"[bench] rows(M)={tokens} (batch {args.batch} x seq {seq})  "
+          f"iters={args.iters} (+{args.warmup} warmup)  "
+          f"FLOPs/iter={flops_per_iter / 1e9:.2f} GFLOP\n")
+
+    results = []
+    for name, dt in dtypes:
+        mx.random.seed(args.seed)
+        # One A and W per unique GEMM, reused across its `count` calls (throughput is
+        # what we measure, not a dimensionally-chained activation). Scaled small so
+        # fp16 accumulation stays well inside its range — this is a speed test, the
+        # finiteness assert below guards against a degenerate (overflowed) run.
+        ops = []
+        for _, K, N, count in shapes:
+            A = (mx.random.uniform(shape=(tokens, K)) * 0.2 - 0.1).astype(dt)
+            W = (mx.random.uniform(shape=(K, N)) * 0.2 - 0.1).astype(dt)
+            ops.append((A, W, count))
+        mx.eval([A for A, _, _ in ops] + [W for _, W, _ in ops])
+
+        def run_iter():
+            outs = []
+            for A, W, count in ops:
+                for _ in range(count):
+                    outs.append(A @ W)
+            mx.eval(outs)
+            return outs
+
+        for _ in range(args.warmup):
+            run_iter()
+
+        t0 = time.perf_counter()
+        last = None
+        for _ in range(args.iters):
+            last = run_iter()
+        elapsed = time.perf_counter() - t0
+
+        if not bool(mx.all(mx.isfinite(last[0])).item()):
+            raise RuntimeError(f"{name}: non-finite GEMM output — benchmark is degenerate")
+
+        tflops = (flops_per_iter * args.iters) / elapsed / 1e12
+        tok_per_s = (tokens * args.iters) / elapsed
+        results.append((name, tflops, tok_per_s))
+
+    fp32_tflops = next(t for n, t, _ in results if n == "fp32")
+    print(f"{'dtype':<6} {'TFLOP/s':>9} {'tokens/s':>12} {'vs fp32':>9}")
+    print("-" * 40)
+    for name, tflops, tok in results:
+        print(f"{name:<6} {tflops:>9.2f} {tok:>12,.0f} {tflops / fp32_tflops:>8.2f}x")
+
+    best = max(results, key=lambda r: r[1])
+    fp16_t = next(t for n, t, _ in results if n == "fp16")
+    bf16_t = next(t for n, t, _ in results if n == "bf16")
+    print(f"\n[verdict] fastest: {best[0]} ({best[1]:.2f} TFLOP/s).  "
+          f"fp16 is {fp16_t / bf16_t:.2f}x bf16 and {fp16_t / fp32_tflops:.2f}x fp32.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -101,7 +101,8 @@ def main() -> None:
     opt = optim.AdamW(learning_rate=args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
     if scaler is None and cfg.precision != "fp32":
-        print(f"[warn] precision={cfg.precision!r}: training without loss scaling")
+        print(f"[info] precision={cfg.precision!r}: training unscaled "
+              "(loss scaling is fp16-only; expected for bf16)")
     train_step = make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler)
 
     # --- data ------------------------------------------------------------------

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -82,7 +82,7 @@ def main() -> None:
         make_train_step, save_optimizer, load_optimizer,
     )
     from src.data.loader import PackedLoader
-    from src.train.loss_scale import DynamicLossScaler
+    from src.train.loss_scale import scaler_for_precision
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
     from src.train.checkpoint import save_resume, load_resume
@@ -99,7 +99,7 @@ def main() -> None:
     mx.random.seed(args.seed)
     model = MLXMambaModel(cfg)
     opt = optim.AdamW(learning_rate=args.base_lr)
-    scaler = DynamicLossScaler(args.init_loss_scale) if cfg.precision == "fp16" else None
+    scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
     if scaler is None and cfg.precision != "fp32":
         print(f"[warn] precision={cfg.precision!r}: training without loss scaling")
     train_step = make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler)

--- a/src/train/loss_scale.py
+++ b/src/train/loss_scale.py
@@ -52,3 +52,14 @@ class DynamicLossScaler:
             return
         self.scale = float(state["scale"])
         self._good_steps = int(state.get("good_steps", 0))
+
+
+def scaler_for_precision(precision: str, init_scale: float = 2.0 ** 13):
+    """Map a config `precision` to the loss scaler the train step needs.
+
+    Only fp16 needs dynamic loss scaling (its narrow exponent range under/overflows);
+    fp32 and bf16 train unscaled, so they get `None`. This is the single source of
+    truth for the precision->scaler wiring, kept here (above the seam) so it is
+    unit-testable without a backend. See `scripts/train.py` for how it is consumed.
+    """
+    return DynamicLossScaler(init_scale) if precision == "fp16" else None

--- a/src/train/loss_scale.py
+++ b/src/train/loss_scale.py
@@ -54,7 +54,7 @@ class DynamicLossScaler:
         self._good_steps = int(state.get("good_steps", 0))
 
 
-def scaler_for_precision(precision: str, init_scale: float = 2.0 ** 13):
+def scaler_for_precision(precision: str, init_scale: float = 2.0 ** 13) -> "DynamicLossScaler | None":
     """Map a config `precision` to the loss scaler the train step needs.
 
     Only fp16 needs dynamic loss scaling (its narrow exponent range under/overflows);

--- a/tests/test_loss_scale.py
+++ b/tests/test_loss_scale.py
@@ -1,6 +1,6 @@
 """DynamicLossScaler policy — portable (no backend); just the number machine."""
 
-from src.train.loss_scale import DynamicLossScaler
+from src.train.loss_scale import DynamicLossScaler, scaler_for_precision
 
 
 def test_overflow_backs_off_and_resets_counter():
@@ -57,3 +57,22 @@ def test_load_empty_state_is_noop():
     assert s.scale == 512.0
     s.load_state_dict(None)             # resume with no scaler bundle
     assert s.scale == 512.0
+
+
+# --- precision -> scaler wiring (issue #3, acceptance criterion 3) --------------
+def test_scaler_for_precision_fp16_enables_scaling():
+    s = scaler_for_precision("fp16", init_scale=4096.0)
+    assert isinstance(s, DynamicLossScaler)
+    assert s.scale == 4096.0             # the requested init scale is honored
+
+
+def test_scaler_for_precision_fp16_default_init():
+    s = scaler_for_precision("fp16")
+    assert isinstance(s, DynamicLossScaler)
+    assert s.scale == 2.0 ** 13          # matches DynamicLossScaler's default
+
+
+def test_scaler_for_precision_skips_scaling_for_fp32_and_bf16():
+    # bf16's wide exponent range and fp32 don't need (and must not get) loss scaling.
+    assert scaler_for_precision("fp32") is None
+    assert scaler_for_precision("bf16") is None


### PR DESCRIPTION
## Summary

Closes #3 — settles the poc training precision **empirically and reproducibly** on MLX/Metal. The decision (`fp16`) was already documented as "confirmed", but rested on a matmul micro-benchmark that wasn't in the repo, and the precision→loss-scaler wiring was inline in a script (untested). This closes both loose ends.

Scope is **reproducible bench + verify wiring** — it does *not* change the model to actually compute in fp16/bf16 (the model still runs fp32; `precision` only toggles the fp16 loss scaler). That larger refactor is tracked separately as follow-up.

## Findings

`scripts/bench_precision.py` times the dominant poc forward GEMM workload (per-layer in/x/out projections + the 50280-wide tied head) in each dtype. On this Metal GPU:

| dtype | TFLOP/s | vs fp32 |
|-------|--------:|--------:|
| fp32  | ~3.33   | 1.00×   |
| fp16  | **4.37**| 1.31×   |
| bf16  | ~3.78   | 1.14×   |

**fp16 is ~16% faster than bf16** (and ~31% over fp32) → `precision: fp16` confirmed. This contradicts the common "bf16 is the safe default" assumption — on Metal it isn't. (Nuance corrected vs the old comment: bf16 does edge fp32 slightly; fp16 still wins clearly.)

## Changes

- **`scripts/bench_precision.py`** (new) — the reproducible micro-benchmark; MLX imported locally so it stays `--help`-able on any host.
- **`scaler_for_precision()`** in `src/train/loss_scale.py` — the precision→loss-scaler mapping, extracted from `scripts/train.py` so it's unit-testable above the seam (acceptance criterion 3). `train.py` now calls it.
- **`tests/test_loss_scale.py`** — 3 wiring tests (fp16→scaler, fp32/bf16→None).
- **`config/poc.yaml`** + **`docs/design/07-configs-and-decisions.md`** — rationale refreshed with the measured numbers and a pointer to the bench script.

## Verification

- `pytest`: **39 passed** (36 + 3 new wiring tests)
- `scripts/bench_precision.py`: fp16 fastest, reproducible across runs
- M4 smoke gate: **PASSED** — resume exact (diff 2.4e-7), eval runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
