### PR TITLE
feat: [M6] OLMES / lm-eval custom-model adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ data = ["datasets>=2.0", "transformers>=4.40"]
 mlx = ["mlx>=0.18"]
 # Experiment logging.
 logging = ["wandb>=0.16"]
-# Tier-2 OLMES/lm-eval benchmark harness. lm-eval hard-depends on torch (CPU
-# wheels on macOS arm64) — install only where benchmarks run; above the seam it
-# may only ever be imported lazily (inside functions), never at module level.
+# Tier-2 OLMES/lm-eval benchmark harness. A heavy optional dependency (some
+# versions pull in torch) — install only where benchmarks run; above the seam
+# it may only ever be imported lazily (inside functions), never at module level.
 eval = ["lm-eval>=0.4.5,<0.5"]
 dev = ["pytest>=8.0"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ data = ["datasets>=2.0", "transformers>=4.40"]
 mlx = ["mlx>=0.18"]
 # Experiment logging.
 logging = ["wandb>=0.16"]
+# Tier-2 OLMES/lm-eval benchmark harness. lm-eval hard-depends on torch (CPU
+# wheels on macOS arm64) — install only where benchmarks run; above the seam it
+# may only ever be imported lazily (inside functions), never at module level.
+eval = ["lm-eval>=0.4.5,<0.5"]
 dev = ["pytest>=8.0"]
 
 [tool.setuptools.packages.find]

--- a/scripts/eval_olmes.py
+++ b/scripts/eval_olmes.py
@@ -1,0 +1,95 @@
+"""Tier-2 OLMES / lm-eval benchmark run over the MLX backend (issue #14).
+
+Wires config -> MLXMambaModel -> tokenizer -> the lm-eval adapter
+(src/eval/olmes_adapter.py) -> lm_eval.simple_evaluate. Judge by "runs end to
+end": with random-init or 100M-scale weights the accuracies will sit near
+chance — that is expected and fine for the POC.
+
+Needs the eval extra (pip install -e ".[eval]"; pulls torch, CPU wheels on
+macOS) and network for the HF datasets + OLMo tokenizer. If `datasets` refuses
+piqa's script-based loader, set HF_DATASETS_TRUST_REMOTE_CODE=1 or drop piqa.
+
+    .venv/bin/python scripts/eval_olmes.py --config config/poc.yaml --tasks piqa --limit 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
+    ap.add_argument("--weights", type=Path, default=None,
+                    help="portable .safetensors checkpoint; RANDOM INIT if omitted")
+    ap.add_argument("--tasks", default="hellaswag,arc_easy,arc_challenge,piqa")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="examples per task (small values for smoke runs)")
+    ap.add_argument("--output", type=Path, default=None, help="write results JSON here")
+    ap.add_argument("--byte-fallback", action="store_true",
+                    help="offline ByteTokenizer (toy config only; not OLMo-compatible)")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    # MLX-only imports kept local so the seam stays clean for portable hosts.
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/eval_olmes.py ...\n"
+            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
+            "`python` likely points at a different interpreter.)"
+        ) from e
+    try:
+        import lm_eval
+    except ModuleNotFoundError as e:
+        raise SystemExit(
+            "lm-eval not found — install the eval extra (pulls torch, CPU "
+            "wheels on macOS):\n    .venv/bin/pip install -e \".[eval]\""
+        ) from e
+    from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
+    from src.eval.olmes_adapter import make_lm_eval_adapter
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+
+    cfg = load_config(str(args.config))
+    mx.random.seed(args.seed)
+    model = MLXMambaModel(cfg)
+    if args.weights:
+        model.load(str(args.weights))
+        print(f"loaded weights: {args.weights}")
+    else:
+        print("=" * 70)
+        print("RANDOM INIT — no --weights given; scores will be chance level.")
+        print("=" * 70)
+
+    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer()
+    # A tokenizer that can emit ids >= the model vocab would crash deep in the
+    # embedding lookup; fail here with a clear message instead.
+    if tok.vocab_size > cfg.vocab_size:
+        raise SystemExit(
+            f"tokenizer vocab {tok.vocab_size} exceeds model vocab "
+            f"{cfg.vocab_size} ({args.config}) — use a matching config, or "
+            f"--byte-fallback only with toy-scale configs.")
+
+    lm = make_lm_eval_adapter(model, tok, to_numpy=lambda a: np.array(a))
+    results = lm_eval.simple_evaluate(
+        model=lm, tasks=args.tasks.split(","), limit=args.limit)
+
+    print(lm_eval.utils.make_table(results))
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w") as f:
+            json.dump(results["results"], f, indent=2, default=str)
+        print(f"results -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_olmes.py
+++ b/scripts/eval_olmes.py
@@ -5,8 +5,8 @@ Wires config -> MLXMambaModel -> tokenizer -> the lm-eval adapter
 end": with random-init or 100M-scale weights the accuracies will sit near
 chance — that is expected and fine for the POC.
 
-Needs the eval extra (pip install -e ".[eval]"; pulls torch, CPU wheels on
-macOS) and network for the HF datasets + OLMo tokenizer. If `datasets` refuses
+Needs the eval extra (pip install -e ".[eval]") and network for the HF
+datasets + OLMo tokenizer. If `datasets` refuses
 piqa's script-based loader, set HF_DATASETS_TRUST_REMOTE_CODE=1 or drop piqa.
 
     .venv/bin/python scripts/eval_olmes.py --config config/poc.yaml --tasks piqa --limit 10
@@ -51,8 +51,8 @@ def main() -> None:
         import lm_eval
     except ModuleNotFoundError as e:
         raise SystemExit(
-            "lm-eval not found — install the eval extra (pulls torch, CPU "
-            "wheels on macOS):\n    .venv/bin/pip install -e \".[eval]\""
+            "lm-eval not found — install the eval extra:\n"
+            "    .venv/bin/pip install -e \".[eval]\""
         ) from e
     from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
     from src.eval.olmes_adapter import make_lm_eval_adapter

--- a/scripts/eval_olmes.py
+++ b/scripts/eval_olmes.py
@@ -50,6 +50,8 @@ def main() -> None:
     try:
         import lm_eval
     except ModuleNotFoundError as e:
+        if e.name != "lm_eval":
+            raise
         raise SystemExit(
             "lm-eval not found — install the eval extra:\n"
             "    .venv/bin/pip install -e \".[eval]\""
@@ -80,8 +82,8 @@ def main() -> None:
             f"--byte-fallback only with toy-scale configs.")
 
     lm = make_lm_eval_adapter(model, tok, to_numpy=lambda a: np.array(a))
-    results = lm_eval.simple_evaluate(
-        model=lm, tasks=args.tasks.split(","), limit=args.limit)
+    tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+    results = lm_eval.simple_evaluate(model=lm, tasks=tasks, limit=args.limit)
 
     print(lm_eval.utils.make_table(results))
     if args.output:

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -82,7 +82,8 @@ def disjoint_rolling_windows(
     Matches lm-eval's make_disjoint_window(get_rolling_token_windows(...,
     context_len=1)): the first window is conditioned on the prefix (EOT) token,
     full windows on the single preceding token, and the final short window on
-    as many preceding tokens as fit (ctx + cont always spans max_length + 1).
+    as many preceding tokens as fit — once the document exceeds one window,
+    every window's ctx + cont spans exactly max_length + 1 tokens.
     """
     tokens = list(tokens)
     windows = []

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -1,27 +1,154 @@
-"""Tier-2 evaluation: OLMES / lm-evaluation-harness adapter — STUB (deferred).
+"""Tier-2 evaluation: OLMES / lm-evaluation-harness adapter.
 
-OLMES inherits its model abstraction from EleutherAI's lm-evaluation-harness and is
-built around HuggingFace-loadable models. Evaluating a custom MLX Mamba requires
-implementing the harness's model class (the loglikelihood-style methods), using its
-`huggingface.py` as reference. This is its own milestone-sized task, NOT wiring.
+OLMES inherits its model abstraction from EleutherAI's lm-evaluation-harness.
+This module implements the harness's model class (the loglikelihood-style
+methods) over `ModelInterface.forward`, with the same split as `val_loss`: a
+pure-numpy scoring core (`score_continuation`, `disjoint_rolling_windows`) that
+is testable anywhere, and a thin lm-eval shell built by `make_lm_eval_adapter`.
 
-Known trap: off-by-one errors in loglikelihood token indexing. Run a small set
-(HellaSwag, ARC, PIQA). For a 100M model, absolute scores will be poor — judge the
-harness by whether it runs end to end, not by leaderboard position.
+lm-eval hard-depends on torch, so it is imported ONLY inside the factory — this
+module stays above the seam (guarded by tests/test_import_guard.py).
 
-Deferred for the POC (success = Tier-1 val perplexity). Implement here when
-comparable benchmark numbers are wanted.
+The classic trap here is the loglikelihood token-indexing off-by-one:
+`forward` logits at position i predict the token at position i+1, so the model
+input is `(ctx + cont)[:-1]` and the continuation is scored by the LAST
+`len(cont)` logit rows. See `score_continuation`.
+
+For a 100M model, absolute scores will be poor — judge the harness by whether
+it runs end to end (scripts/eval_olmes.py), not by leaderboard position.
 """
 
 from __future__ import annotations
 
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
 from ..model.interface import ModelInterface
 
 
-class OlmesMambaAdapter:  # pragma: no cover - deferred
-    def __init__(self, model: ModelInterface):
-        raise NotImplementedError(
-            "OLMES adapter is a deferred, milestone-sized task. Implement the "
-            "lm-eval model class (loglikelihood + loglikelihood_rolling) over "
-            "ModelInterface.forward; mind loglikelihood token indexing off-by-one."
-        )
+def _log_softmax(logits: np.ndarray) -> np.ndarray:
+    """Stable log-softmax over the last axis (float64 internally)."""
+    x = np.asarray(logits, dtype=np.float64)
+    m = x.max(axis=-1, keepdims=True)
+    return x - m - np.log(np.exp(x - m).sum(axis=-1, keepdims=True))
+
+
+def score_continuation(
+    model: ModelInterface,
+    ctx_tokens: Sequence[int],
+    cont_tokens: Sequence[int],
+    *,
+    max_length: int,
+    to_numpy=np.asarray,
+) -> Tuple[float, bool]:
+    """Return (sum log P(cont | ctx), is_greedy) for one context/continuation pair.
+
+    Indexing: with `whole = ctx + cont`, the model sees `whole[:-1]` (the final
+    continuation token is never fed — its logit comes from the position before
+    it), and `logits[i]` predicts `whole[i + 1]`, so the continuation is scored
+    by `logits[-len(cont):]` against targets `whole[-len(cont):]`.
+
+    Inputs longer than `max_length` are left-truncated, always keeping the full
+    continuation and at least one context token. Requests run one at a time
+    (batch=1); right-padded batching would be a safe future optimization since
+    the model is causal, but the POC bar is "runs end to end".
+    """
+    ctx, cont = list(ctx_tokens), list(cont_tokens)
+    if not ctx or not cont:
+        raise ValueError("context and continuation must each be non-empty")
+    if len(cont) > max_length:
+        raise ValueError(f"continuation length {len(cont)} exceeds max_length {max_length}")
+
+    # Keep max_length + 1 tokens so the model input whole[:-1] is <= max_length
+    # and the token preceding the first continuation token survives truncation.
+    whole = (ctx + cont)[-(max_length + 1):]
+    inp = np.asarray(whole[:-1], dtype=np.int64)[None, :]
+    logits = to_numpy(model.forward(inp))[0]  # (len(whole)-1, V)
+
+    cont_logits = np.asarray(logits[-len(cont):], dtype=np.float64)
+    targets = np.asarray(whole[-len(cont):])
+    logprob = float(_log_softmax(cont_logits)[np.arange(len(targets)), targets].sum())
+    is_greedy = bool((cont_logits.argmax(axis=-1) == targets).all())
+    return logprob, is_greedy
+
+
+def disjoint_rolling_windows(
+    tokens: Sequence[int], prefix_token: int, max_length: int,
+) -> List[Tuple[List[int], List[int]]]:
+    """Disjoint (ctx, cont) windows covering `tokens`; each token scored once.
+
+    Matches lm-eval's make_disjoint_window(get_rolling_token_windows(...,
+    context_len=1)): the first window is conditioned on the prefix (EOT) token,
+    full windows on the single preceding token, and the final short window on
+    as many preceding tokens as fit (ctx + cont always spans max_length + 1).
+    """
+    tokens = list(tokens)
+    windows = []
+    for start in range(0, len(tokens), max_length):
+        cont = tokens[start:start + max_length]
+        ctx = ([prefix_token] if start == 0
+               else tokens[start - (max_length + 1 - len(cont)):start])
+        windows.append((ctx, cont))
+    return windows
+
+
+def make_lm_eval_adapter(
+    model: ModelInterface,
+    tokenizer,
+    *,
+    max_length: int | None = None,
+    to_numpy=np.asarray,
+):
+    """Build an lm-eval `LM` over `ModelInterface.forward`.
+
+    `tokenizer` is an HF tokenizer (or ByteTokenizer-like: anything with
+    `.encode`). `to_numpy` converts backend logits to numpy, as in
+    `val_loss.evaluate`. Imports lm_eval (and transitively torch) lazily.
+    """
+    from lm_eval.api.model import TemplateLM  # lazy: pulls torch
+
+    seq_limit = max_length or model.config.seq_len
+
+    class _MonicaLM(TemplateLM):
+        @property
+        def eot_token_id(self) -> int:
+            eos = getattr(tokenizer, "eos_token_id", None)
+            return 0 if eos is None else int(eos)  # ByteTokenizer: NUL byte
+
+        @property
+        def max_length(self) -> int:
+            return seq_limit
+
+        def tok_encode(self, string: str, **kwargs) -> List[int]:
+            try:
+                return tokenizer.encode(string, add_special_tokens=False)
+            except TypeError:  # ByteTokenizer takes no kwargs
+                return tokenizer.encode(string)
+
+        def _loglikelihood_tokens(self, requests, **kwargs):
+            return [
+                score_continuation(model, ctx_toks, cont_toks,
+                                   max_length=seq_limit, to_numpy=to_numpy)
+                for _key, ctx_toks, cont_toks in requests
+            ]
+
+        def loglikelihood_rolling(self, requests, **kwargs):
+            results = []
+            for (string,) in (req.args for req in requests):
+                results.append(sum(
+                    score_continuation(model, ctx, cont,
+                                       max_length=seq_limit, to_numpy=to_numpy)[0]
+                    for ctx, cont in disjoint_rolling_windows(
+                        self.tok_encode(string), self.eot_token_id, seq_limit)
+                ))
+            return results
+
+        def generate_until(self, requests, **kwargs):
+            raise NotImplementedError(
+                "generate_until is not implemented: HellaSwag/ARC/PIQA are "
+                "loglikelihood (multiple-choice) tasks and never call it. "
+                "Implement over ModelInterface.step when generative tasks are "
+                "needed.")
+
+    return _MonicaLM()

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -6,8 +6,9 @@ methods) over `ModelInterface.forward`, with the same split as `val_loss`: a
 pure-numpy scoring core (`score_continuation`, `disjoint_rolling_windows`) that
 is testable anywhere, and a thin lm-eval shell built by `make_lm_eval_adapter`.
 
-lm-eval hard-depends on torch, so it is imported ONLY inside the factory — this
-module stays above the seam (guarded by tests/test_import_guard.py).
+lm-eval is a heavy optional dependency (and some versions of it pull in torch),
+so it is imported ONLY inside the factory — this module stays above the seam
+(guarded by tests/test_import_guard.py).
 
 The classic trap here is the loglikelihood token-indexing off-by-one:
 `forward` logits at position i predict the token at position i+1, so the model

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -20,6 +20,7 @@ PORTABLE_MODULES = [
     "src.train.loss_scale",
     "src.train.loop",
     "src.eval.val_loss",
+    "src.eval.olmes_adapter",
     "src.conformance.forward_step_parity",
 ]
 

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -1,12 +1,32 @@
 """Seam guard: nothing portable may import a hardware backend.
 
 If importing the interface or any above-the-seam package pulls in `mlx` or torch's
-CUDA stack, the migration plan is broken. We import the portable modules and assert
-no backend module landed in sys.modules as a side effect.
+CUDA stack, the migration plan is broken. The check runs in a FRESH subprocess,
+not in-process, for two reasons:
+
+  * pytest imports every test module at collection, and the test files already
+    import nearly all the portable modules — an in-process re-import is a
+    sys.modules cache hit that re-triggers nothing, so a real module-level
+    backend import would be invisible (a false pass).
+  * the old design deleted mlx/torch from sys.modules to compensate, which made
+    any later fresh import of a native backend inside a test body abort the
+    interpreter.
+
+A fresh interpreter makes every import genuinely fresh and leaves this process's
+sys.modules untouched.
 """
 
+import subprocess
 import sys
-import importlib
+from pathlib import Path
+
+try:
+    import mlx.core  # noqa: F401 — presence probe for the mechanism self-test
+    HAVE_MLX = True
+except ImportError:
+    HAVE_MLX = False
+
+import pytest
 
 
 PORTABLE_MODULES = [
@@ -27,15 +47,30 @@ PORTABLE_MODULES = [
 FORBIDDEN_ROOTS = ("mlx", "torch")
 
 
+def _run_guard(modules):
+    """Import `modules` in a fresh interpreter; fail if a backend lands in sys.modules."""
+    code = (
+        "import sys, importlib\n"
+        f"for mod in {modules!r}:\n"
+        "    importlib.import_module(mod)\n"
+        # Match by top-level package so submodules (mlx.core, torch._C, ...) also fail.
+        f"leaked = sorted({{m for m in sys.modules if m.split('.')[0] in {FORBIDDEN_ROOTS!r}}})\n"
+        "assert not leaked, f'backend leaked above the seam: {leaked}'\n"
+    )
+    repo_root = Path(__file__).resolve().parents[1]
+    return subprocess.run([sys.executable, "-c", code],
+                          cwd=repo_root, capture_output=True, text=True)
+
+
 def test_portable_modules_do_not_import_backends():
-    # Drop any backend modules a prior test may have loaded.
-    for name in list(sys.modules):
-        if name.split(".")[0] in ("mlx", "torch"):
-            del sys.modules[name]
+    res = _run_guard(PORTABLE_MODULES)
+    assert res.returncode == 0, f"seam guard failed:\n{res.stderr}"
 
-    for mod in PORTABLE_MODULES:
-        importlib.import_module(mod)
 
-    # Match by top-level package so submodules (mlx.core, torch._C, ...) also fail.
-    leaked = sorted({m for m in sys.modules if m.split(".")[0] in FORBIDDEN_ROOTS})
-    assert not leaked, f"backend leaked above the seam: {leaked}"
+@pytest.mark.skipif(not HAVE_MLX, reason="mlx unavailable")
+def test_guard_mechanism_detects_leaks():
+    # The MLX backend legitimately imports mlx; the guard must flag it, proving
+    # the check is not vacuously green.
+    res = _run_guard(["src.model.mlx_backend"])
+    assert res.returncode != 0, "guard failed to detect a known backend import"
+    assert "backend leaked above the seam" in res.stderr

--- a/tests/test_olmes_adapter.py
+++ b/tests/test_olmes_adapter.py
@@ -15,11 +15,8 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-# Optional backends imported at collection time (module level), matching the
-# repo convention: tests/test_import_guard.py deletes mlx/torch from
-# sys.modules mid-run, and re-importing a native extension afterwards aborts
-# the process — so grab the references before the guard runs and never
-# importorskip these inside a test body.
+# Optional backends imported at module level so only the tests that need them
+# skip (a module-level importorskip would skip the offline numpy tests too).
 try:
     import mlx.core as mx
 except ImportError:  # non-Apple-Silicon host

--- a/tests/test_olmes_adapter.py
+++ b/tests/test_olmes_adapter.py
@@ -39,8 +39,8 @@ class FakeModel:
     """Successor model: logits[b, t] = BIG * one_hot((input[b, t] + 1) % V).
 
     The greedy prediction after token t is exactly t+1 (mod V), so a continuation
-    is is_greedy iff every token is its predecessor + 1 — which makes the correct
-    off-by-one slice the only one that scores it as greedy.
+    is flagged greedy iff every token is its predecessor + 1 — which makes the
+    correct off-by-one slice the only one that scores it as greedy.
     """
 
     def __init__(self, vocab_size=8, seq_len=64):
@@ -93,7 +93,7 @@ def test_single_token_continuation():
 
 def test_left_truncation_keeps_continuation():
     m = FakeModel()
-    ctx = list(range(8, 18)) * 0 + [0, 1, 2, 3, 4, 5, 6, 7, 0, 1]  # length 10
+    ctx = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1]  # length 10
     lp, greedy = score_continuation(m, ctx, [2, 3], max_length=4)
     assert m.last_input.shape == (1, 4)
     # Identical to scoring with the pre-truncated context (last 3 ctx tokens).

--- a/tests/test_olmes_adapter.py
+++ b/tests/test_olmes_adapter.py
@@ -1,0 +1,207 @@
+"""OLMES adapter tests (Milestone 6).
+
+The numpy scoring core is exercised offline with a deterministic FakeModel — in
+particular the loglikelihood token-indexing off-by-one (logits[i] predicts
+token[i+1]), left-truncation, and the rolling disjoint windows. An MLX
+cross-check (skipped where mlx is unavailable) verifies the core against a
+naive independent computation on the real backend, and a light lm-eval
+integration test (skipped where lm_eval is unavailable) exercises the
+TemplateLM shell.
+"""
+
+import math
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+# Optional backends imported at collection time (module level), matching the
+# repo convention: tests/test_import_guard.py deletes mlx/torch from
+# sys.modules mid-run, and re-importing a native extension afterwards aborts
+# the process — so grab the references before the guard runs and never
+# importorskip these inside a test body.
+try:
+    import mlx.core as mx
+except ImportError:  # non-Apple-Silicon host
+    mx = None
+try:
+    import lm_eval
+except ImportError:  # eval extra not installed
+    lm_eval = None
+
+from src.eval.olmes_adapter import (
+    disjoint_rolling_windows,
+    make_lm_eval_adapter,
+    score_continuation,
+)
+
+BIG = 10.0
+
+
+class FakeModel:
+    """Successor model: logits[b, t] = BIG * one_hot((input[b, t] + 1) % V).
+
+    The greedy prediction after token t is exactly t+1 (mod V), so a continuation
+    is is_greedy iff every token is its predecessor + 1 — which makes the correct
+    off-by-one slice the only one that scores it as greedy.
+    """
+
+    def __init__(self, vocab_size=8, seq_len=64):
+        self.config = SimpleNamespace(vocab_size=vocab_size, seq_len=seq_len)
+        self.last_input = None
+
+    def forward(self, token_batch):
+        self.last_input = np.asarray(token_batch)
+        succ = (self.last_input + 1) % self.config.vocab_size
+        eye = np.eye(self.config.vocab_size, dtype=np.float32)
+        return BIG * eye[succ]
+
+
+def _lp_match(v):
+    """log P of the peaked (matching) token: BIG - log(e^BIG + (V-1))."""
+    return BIG - math.log(math.exp(BIG) + (v - 1))
+
+
+def _lp_miss(v):
+    """log P of a non-peaked token: 0 - log(e^BIG + (V-1))."""
+    return -math.log(math.exp(BIG) + (v - 1))
+
+
+def test_off_by_one_greedy_continuation():
+    m = FakeModel()
+    lp, greedy = score_continuation(m, [1, 2, 3], [4, 5], max_length=64)
+    # Input must be whole[:-1]: the final continuation token is never fed.
+    np.testing.assert_array_equal(m.last_input, [[1, 2, 3, 4]])
+    assert greedy is True
+    assert np.isclose(lp, 2 * _lp_match(8))
+
+
+def test_off_by_one_non_greedy():
+    m = FakeModel()
+    lp, greedy = score_continuation(m, [1, 2, 3], [5, 5], max_length=64)
+    assert greedy is False
+    # Position 1 predicts 4 (target 5 misses); position 2 then predicts 6 (miss).
+    assert np.isclose(lp, 2 * _lp_miss(8))
+
+
+def test_single_token_continuation():
+    m = FakeModel()
+    lp, greedy = score_continuation(m, [6], [7], max_length=64)
+    np.testing.assert_array_equal(m.last_input, [[6]])
+    assert greedy is True
+    assert np.isclose(lp, _lp_match(8))
+    _, greedy = score_continuation(m, [7], [0], max_length=64)  # wraps mod 8
+    assert greedy is True
+
+
+def test_left_truncation_keeps_continuation():
+    m = FakeModel()
+    ctx = list(range(8, 18)) * 0 + [0, 1, 2, 3, 4, 5, 6, 7, 0, 1]  # length 10
+    lp, greedy = score_continuation(m, ctx, [2, 3], max_length=4)
+    assert m.last_input.shape == (1, 4)
+    # Identical to scoring with the pre-truncated context (last 3 ctx tokens).
+    m2 = FakeModel()
+    lp2, greedy2 = score_continuation(m2, ctx[-3:], [2, 3], max_length=4)
+    assert (lp, greedy) == (lp2, greedy2)
+    assert greedy is True
+
+
+def test_continuation_fills_max_length():
+    # len(cont) == max_length: exactly one context token must survive.
+    m = FakeModel()
+    lp, greedy = score_continuation(m, [1], [2, 3, 4, 5], max_length=4)
+    np.testing.assert_array_equal(m.last_input, [[1, 2, 3, 4]])
+    assert greedy is True
+    assert np.isclose(lp, 4 * _lp_match(8))
+
+
+def test_invalid_inputs_raise():
+    m = FakeModel()
+    with pytest.raises(ValueError):
+        score_continuation(m, [], [1], max_length=4)
+    with pytest.raises(ValueError):
+        score_continuation(m, [1], [], max_length=4)
+    with pytest.raises(ValueError):
+        score_continuation(m, [1], [2, 3, 4, 5, 6], max_length=4)
+
+
+def test_disjoint_rolling_windows():
+    assert disjoint_rolling_windows(list(range(10)), prefix_token=99, max_length=4) == [
+        ([99], [0, 1, 2, 3]),
+        ([3], [4, 5, 6, 7]),
+        ([5, 6, 7], [8, 9]),  # final short window: context fills to max_length+1
+    ]
+    # A doc that fits one window: rolling sum == direct prefix-conditioned score.
+    m = FakeModel()
+    windows = disjoint_rolling_windows([1, 2, 3], prefix_token=0, max_length=8)
+    assert windows == [([0], [1, 2, 3])]
+    lp_roll = sum(score_continuation(m, c, t, max_length=8)[0] for c, t in windows)
+    lp_direct, _ = score_continuation(m, [0], [1, 2, 3], max_length=8)
+    assert np.isclose(lp_roll, lp_direct)
+
+
+@pytest.mark.skipif(mx is None, reason="mlx unavailable")
+def test_score_continuation_mlx_cross_check():
+    """Core vs a naive independent computation on the real MLX backend."""
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+
+    mx.random.seed(0)
+    cfg = load_config("config/toy.yaml")
+    model = MLXMambaModel(cfg)
+    np_to = lambda a: np.array(a)
+
+    rng = np.random.default_rng(0)
+    ctx = rng.integers(0, cfg.vocab_size, size=12).tolist()
+    cont = rng.integers(0, cfg.vocab_size, size=5).tolist()
+    lp, greedy = score_continuation(model, ctx, cont,
+                                    max_length=cfg.seq_len, to_numpy=np_to)
+
+    # Naive reference: full forward, log-softmax everywhere, explicit indexing.
+    whole = ctx + cont
+    logits = np_to(model.forward(np.asarray(whole[:-1])[None, :]))[0].astype(np.float64)
+    m = logits.max(axis=-1, keepdims=True)
+    lsm = logits - m - np.log(np.exp(logits - m).sum(axis=-1, keepdims=True))
+    ref = sum(lsm[len(ctx) - 1 + j, whole[len(ctx) + j]] for j in range(len(cont)))
+    ref_greedy = all(int(logits[len(ctx) - 1 + j].argmax()) == whole[len(ctx) + j]
+                     for j in range(len(cont)))
+    assert np.isclose(lp, ref, rtol=1e-5, atol=1e-5)
+    assert greedy == ref_greedy
+
+
+@pytest.mark.skipif(lm_eval is None, reason="lm_eval unavailable")
+def test_lm_eval_adapter_integration():
+    """TemplateLM shell over FakeModel + ByteTokenizer (skipped without lm_eval)."""
+    from lm_eval.api.instance import Instance
+
+    from src.data.tokenize import ByteTokenizer
+
+    model = FakeModel(vocab_size=256, seq_len=32)
+    lm = make_lm_eval_adapter(model, ByteTokenizer())
+    assert lm.max_length == 32
+    assert lm.eot_token_id == 0  # ByteTokenizer has no eos -> NUL byte
+
+    reqs = [Instance(request_type="loglikelihood", doc={}, arguments=(c, t), idx=i)
+            for i, (c, t) in enumerate([("ab", "c"), ("ab", " longer cont")])]
+    out = lm.loglikelihood(reqs, disable_tqdm=True)
+    assert len(out) == 2
+    assert all(isinstance(lp, float) and isinstance(g, bool) for lp, g in out)
+
+    rolling = lm.loglikelihood_rolling(
+        [Instance(request_type="loglikelihood_rolling", doc={},
+                  arguments=("hello rolling world, longer than one window",),
+                  idx=0)],
+        disable_tqdm=True)
+    assert len(rolling) == 1 and isinstance(rolling[0], float)
+
+    with pytest.raises(NotImplementedError):
+        lm.generate_until([], disable_tqdm=True)
+
+    # Our hand-rolled windows match lm_eval's reference utilities.
+    from lm_eval.utils import get_rolling_token_windows, make_disjoint_window
+
+    toks = list(range(10))
+    ref = [make_disjoint_window(w) for w in get_rolling_token_windows(
+        toks, prefix_token=99, max_seq_len=4, context_len=1)]
+    ref = [(list(c), list(t)) for c, t in ref]
+    assert disjoint_rolling_windows(toks, prefix_token=99, max_length=4) == ref


### PR DESCRIPTION
Closes #14. Part of #2.

## Summary
- Replace the `src/eval/olmes_adapter.py` stub with a two-layer implementation: a **pure-numpy scoring core** (`score_continuation`, `disjoint_rolling_windows`) and a **lazy factory** `make_lm_eval_adapter` that subclasses lm-eval's `TemplateLM` without importing `lm_eval` at module level — the module stays above the hardware seam and is registered in the import guard.
- The loglikelihood **token-indexing off-by-one** is handled explicitly: the model input is `(ctx + cont)[:-1]` and the continuation is scored by the last `len(cont)` logit rows (`logits[i]` predicts `token[i+1]`), with left-truncation that always preserves the continuation plus ≥1 context token.
- `loglikelihood_rolling` uses hand-rolled disjoint windows verified equal to lm-eval's `make_disjoint_window(get_rolling_token_windows(..., context_len=1))`, including the fuller-context final window. `generate_until` raises `NotImplementedError` (HellaSwag/ARC/PIQA are multiple-choice and never call it).
- New `scripts/eval_olmes.py` runner: config → `MLXMambaModel` → OLMo (or `--byte-fallback`) tokenizer → `lm_eval.simple_evaluate`, with a tokenizer-vocab-vs-config sanity check and `--weights/--tasks/--limit/--output` args.
- New optional dependency group `eval = ["lm-eval>=0.4.5,<0.5"]` (heavy/optional; lm-eval 0.4.12 turns out not to depend on torch, but the lazy-import rule stands).
- **Hardened the seam guard** (`tests/test_import_guard.py`): the old in-process check deleted mlx/torch from `sys.modules` (aborting any later fresh native import inside a test body) and, because pytest's collection pre-imports nearly every portable module, its re-imports were cache hits — a real module-level backend import would have passed silently. The check now runs in a fresh subprocess (genuinely fresh imports, no `sys.modules` surgery), plus a mechanism self-test proving the guard flags a known backend import.

## Testing
- [x] Tests added/updated — `tests/test_olmes_adapter.py`: deterministic FakeModel off-by-one/greedy/truncation/boundary tests, rolling-window equivalence, MLX cross-check vs a naive independent computation, and an lm-eval `TemplateLM` integration test; `tests/test_import_guard.py`: subprocess guard + leak-detection self-test (verified against a deliberately planted module-level import)
- [x] All tests passing — 53/53
- [x] Manual testing completed — `scripts/eval_olmes.py --config config/poc.yaml --tasks hellaswag,arc_easy,arc_challenge,piqa --limit 50` runs end to end on a random-init poc model with chance-level scores (ARC/HellaSwag acc 0.16–0.34 four-way, PIQA 0.50–0.56 two-way), per the issue's "judge by runs end to end" bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)