### PR TITLE
feat(serve): generation core (CLI + eval generate_until) + Wikipedia/instruction data sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-# Mamba POC generated artifacts (datasets, packed tokens, run logs/checkpoints)
-data/
-runs/
+# Mamba POC generated artifacts (datasets, packed tokens, run logs/checkpoints).
+# Anchored to the repo root so they don't also match the tracked `src/data/` package.
+/data/
+/runs/
 
 # Claude Code local/runtime artifacts (transient; not project config). Intentional
 # shared config (e.g. .claude/settings.json, .claude/commands/) can still be added.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A proof-of-concept Mamba (selective state-space) language model, developed and
 validated on **Apple Silicon with MLX**, architected behind **one hardware seam**
 so a successful POC migrates to **CUDA** for a larger run with minimal rewrite.
 
+**Usage:** [`docs/usage.md`](docs/usage.md) has end-to-end commands —
+install → data → train → serve/chat → eval.
+
 ## The seam (most important rule)
 
 All hardware-specific code lives behind `src/model/interface.py`
@@ -21,32 +24,37 @@ path) · `init_state` · `get_state`/`set_state` · `save`/`load` · `config`.
 ```
 config/{toy,poc}.yaml      model dims + run params (single source of truth)
 src/model/                 interface (seam) · blocks (config) · mlx/cuda backends
-src/data/                  download · tokenize · pack(uint16) · split · loader
+src/data/                  download (fineweb/wikipedia/instruct) · tokenize · pack(uint16) · split · loader
 src/train/                 loop · schedule (warmup+cosine) · checkpoint
-src/eval/                  val_loss (Tier-1, primary) · olmes_adapter (deferred)
+src/eval/                  val_loss (Tier-1) · olmes_adapter (Tier-2 lm-eval)
 src/conformance/           forward_step_parity · backend_parity (fp32 guards)
-src/serve/                 sessions · rewind (deferred)
-scripts/smoke_test.py      the milestone-4 gate
-tests/                     in-container unit tests
-docs/design/               design choices + rationale (start at docs/design/README.md)
+src/serve/                 sessions · rewind · sampling · generate (generation core)
+scripts/train.py           training driver         scripts/generate.py   serve + chat CLI
+scripts/smoke_test.py      milestone-4 gate        scripts/eval_olmes.py  lm-eval harness
+tests/                     unit tests
+docs/usage.md              usage guide             docs/design/           design + rationale
 ```
 
-## Status — M1–M4 done (verified on Apple Silicon)
+## Status — M1–M7 implemented; M8 (CUDA) deferred
 
-The seam, configs, data pipeline, MLX model/backend, training loop, and smoke test
-are **implemented and verified on Apple Silicon** — `pytest` → 20 passing on a Mac
-(incl. the real MLX paths; on Linux the MLX-only tests skip and the rest pass) and
-the M4 smoke gate passes end to end (exact save/kill/resume + held-out perplexity
-eval). Remaining work is the scale-up (M5–M8). Progress is tracked in
+The seam, configs, data pipeline, MLX model/backend, training loop, smoke gate,
+serving/chat, and the Tier-2 eval harness are **implemented and verified on Apple
+Silicon** — the full suite (~97 tests) runs on a Mac (incl. the real MLX paths; on
+Linux the MLX-only tests skip and the rest pass), and the M4 smoke gate passes end to
+end (exact save/kill/resume + held-out perplexity eval). A reference **~100M-param run
+on ~100M tokens** reached held-out val-perplexity ~77. Progress is tracked in
 [issue #2](https://github.com/travisgalloway/monica/issues/2).
 
 | Milestone | State |
 |---|---|
 | 1 Seam + toy MLX model | done; MLX backend + forward/step parity verified |
-| 2 Data pipeline (tiny) | done; unit-tested |
+| 2 Data pipeline | done; FineWeb-Edu / Wikipedia / instruction sources, unit-tested |
 | 3 Minimal training loop | done; `train_step` + loop exercised by the smoke gate |
 | 4 Smoke test (gate) | passing — resume exact, eval runs |
-| 5–8 POC scale, OLMES, serve/rewind, CUDA | deferred stubs |
+| 5 POC scale run | infra done; short ~100M-token run completed (val-ppl ~77); full 2–5B deferred |
+| 6 OLMES / lm-eval | working — loglikelihood + generative (`generate_until`) tasks |
+| 7 Serving + chat | working — CLI generate/chat over `SessionStore` + `RewindTree` |
+| 8 CUDA backend | deferred |
 
 **Locked decisions:** SSM is **Mamba-2 / SSD** (scalar A per head; chunked-matmul
 scan) + gradient checkpointing — migrated from Mamba-1 for training throughput/memory.
@@ -65,9 +73,9 @@ pip install -e ".[dev,data,mlx]"  # the mlx extra installs only on Apple Silicon
 # Linux / CUDA host (portable layers only — omit the mlx extra):
 pip install -e ".[dev,data]"
 
-pytest                            # Mac: 36 passed. Linux: MLX-only tests
-                                  # (pytest.importorskip("mlx.core")) are skipped,
-                                  # not failed — the portable suite still runs.
+pytest                            # Mac: full suite (~97 tests, MLX paths included).
+                                  # Linux: MLX-only tests (pytest.importorskip(
+                                  # "mlx.core")) skip, not fail — portable suite runs.
 
 # Data pipeline offline smoke (no network/tokenizer):
 python -m src.data.download --dummy --out data/raw --max-docs 2000
@@ -75,6 +83,9 @@ python -m src.data.tokenize --in data/raw/dummy.txt --out data/ids.npy --byte-fa
 python -m src.data.pack --in data/ids.npy --out data/packed.bin
 python -m src.data.split --packed data/packed.bin --out data/split --val-tokens 2000
 ```
+
+For a **real corpus** (Wikipedia + instruction data) and the full
+train → serve → eval flow, see [`docs/usage.md`](docs/usage.md).
 
 Run the smoke gate (the M4 gate) to confirm the MLX backend, training loop, and
 exact-resume all pass before scaling to `config/poc.yaml`:
@@ -101,3 +112,33 @@ python scripts/train.py --config config/poc.yaml --data data/split --out runs/po
 
 **POC success = a smoothly decreasing `val_perplexity` in `runs/poc/metrics.jsonl`**
 with a stable `grad_norm` — not a benchmark score.
+
+### Serve & chat (M7)
+
+[`scripts/generate.py`](scripts/generate.py) is the CLI front-end over the trained
+weights — completion and an instruction-template chat REPL:
+
+```bash
+# completion
+python scripts/generate.py --config config/poc.yaml --weights runs/poc/weights.safetensors \
+    --prompt "Water is a chemical compound that " --max-new-tokens 80 --temperature 0.7 --top-p 0.9
+# chat REPL (Ctrl-D to exit)
+python scripts/generate.py --config config/poc.yaml --weights runs/poc/weights.safetensors --chat
+```
+
+At ~100M params expect roughly grammatical English, weak semantics — the goal is the
+learning curve, not answer quality. See [`docs/usage.md`](docs/usage.md) for flags,
+sampling tips, and embedding the generation core in an app.
+
+### Eval (M6, Tier-2)
+
+[`scripts/eval_olmes.py`](scripts/eval_olmes.py) runs the lm-evaluation-harness
+(`pip install -e ".[eval]"`) over loglikelihood and generative tasks:
+
+```bash
+HF_DATASETS_TRUST_REMOTE_CODE=1 python scripts/eval_olmes.py \
+    --config config/poc.yaml --weights runs/poc/weights.safetensors \
+    --tasks hellaswag,arc_easy,arc_challenge,piqa --limit 500
+```
+
+Scores sit near chance at this scale — judge by "the harness runs end-to-end."

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -5,7 +5,7 @@ choices and their rationale** — the *what* and *why*. M1–M4 are implemented 
 verified, and M5's infrastructure (training driver + Mamba-2/SSD perf migration) has
 landed; the milestone tracking and remaining work (the full M5 run, M6–M8) live in
 [GitHub issue #2](https://github.com/travisgalloway/monica/issues/2). For the
-project overview see the root [`README.md`](../../README.md); for end-to-end commands
+project overview, see the root [`README.md`](../../README.md); for end-to-end commands
 (install → data → train → serve/chat → eval) see [`../usage.md`](../usage.md).
 
 Every claim here is sourced from a docstring or config comment in the code, with a

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -5,7 +5,8 @@ choices and their rationale** — the *what* and *why*. M1–M4 are implemented 
 verified, and M5's infrastructure (training driver + Mamba-2/SSD perf migration) has
 landed; the milestone tracking and remaining work (the full M5 run, M6–M8) live in
 [GitHub issue #2](https://github.com/travisgalloway/monica/issues/2). For the
-project overview, see the root [`README.md`](../../README.md).
+project overview see the root [`README.md`](../../README.md); for end-to-end commands
+(install → data → train → serve/chat → eval) see [`../usage.md`](../usage.md).
 
 Every claim here is sourced from a docstring or config comment in the code, with a
 `src/...` or `config/...` path so you can jump to the source of truth.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,223 @@
+# Usage guide
+
+End-to-end commands for the Mamba POC: **install → data → train → serve/chat →
+eval**. For *why* the project is built this way, see [`design/`](design/README.md).
+
+Everything runs on **Apple Silicon via MLX**. Commands use the project venv
+(`.venv/bin/python`); from a fresh shell you can substitute `python` once the venv is
+activated. All paths are relative to the repo root.
+
+---
+
+## 1. Install
+
+```bash
+# Apple Silicon (full backend — required for training/serving/eval):
+pip install -e ".[dev,data,mlx]"     # the mlx extra installs only on Apple Silicon
+
+# Linux / CUDA host (portable layers only; no MLX runtime):
+pip install -e ".[dev,data]"
+
+# Optional, for the Tier-2 benchmark harness:
+pip install -e ".[eval]"             # pulls lm-eval (and transitively torch)
+```
+
+The **OLMo tokenizer** (`allenai/OLMo-7B-hf`, vocab 50280) auto-downloads from the
+HF Hub on first use and is cached under `~/.cache/huggingface` (needs network once).
+
+Run the tests to confirm the install (on Linux the MLX-only tests skip, not fail):
+
+```bash
+.venv/bin/python -m pytest -q
+```
+
+---
+
+## 2. Build a training corpus
+
+The pipeline is **one document per line → tokenize (uint16) → pack → split**. Three
+sources are available via `--source`; mix them by concatenating the text files.
+
+```bash
+# English Wikipedia (clean encyclopedic prose) — the bulk of the corpus
+.venv/bin/python -m src.data.download --source wikipedia --out data/raw/wiki.txt --max-docs 420000
+
+# Instruction pairs (Dolly-15k), oversampled so the chat format is learned
+.venv/bin/python -m src.data.download --source instruct --out data/raw/instruct.txt --repeat 4
+
+# Concatenate INSTRUCT FIRST so the token cap / val split only ever trims Wikipedia
+cat data/raw/instruct.txt data/raw/wiki.txt > data/raw/corpus.txt
+
+# Tokenize + pack (OLMo tokenizer, EOS per line), capped near a target token count
+.venv/bin/python -m src.data.tokenize --in data/raw/corpus.txt --out data/packed.bin --max-tokens 110000000
+
+# Split off a held-out validation shard (disjoint tail)
+.venv/bin/python -m src.data.split --packed data/packed.bin --out data/split --val-tokens 5000000
+```
+
+This yields `data/split/{train.bin,val.bin}` (+ `.meta.json` sidecars). `--source
+fineweb` (FineWeb-Edu web text) is also available; `--dummy` produces synthetic
+offline text for pipeline smoke tests.
+
+> **Tip — sizing:** ~257 OLMo tokens/Wikipedia article, so ~420k docs ≈ ~108M tokens.
+> Pick `--max-docs` and `--max-tokens` for your token budget. At ~99 s/step the M1 Pro
+> does ~114M tokens/day, so a ~100M-token run is ~1 day.
+
+---
+
+## 3. Train
+
+[`scripts/train.py`](../scripts/train.py) wires config → model → data → loop, with
+fp16 dynamic loss scaling, gradient accumulation, JSONL metrics, periodic
+checkpoints, and held-out perplexity. Run it under `caffeinate`/`nohup` for a long
+unattended run.
+
+```bash
+caffeinate -i nohup .venv/bin/python scripts/train.py \
+    --config config/poc.yaml --data data/split --out runs/poc \
+    --total-tokens 100000000 --batch-size 8 --grad-accum 16 \
+    --base-lr 3e-4 --warmup-steps 40 --grad-clip 1.0 \
+    --log-every 10 --eval-every 50 --ckpt-every 100 --seed 0 \
+    > runs/poc/train.log 2>&1 &
+```
+
+- **Effective batch = `batch-size × grad-accum × seq_len` tokens/step** (here
+  8 × 16 × 1024 = 131,072). `batch 8 / accum 16` keeps peak RAM ~12–17 GB; `batch
+  32 / accum 4` is faster (~25 GB peak) — use the smaller batch if you're also using
+  the machine, the larger if it's dedicated.
+- **Resume** after any interruption (auto-detects `runs/poc/resume`): re-run the same
+  command, optionally adding `--resume runs/poc/resume`.
+- **Checkpoints overwrite a single path** (`runs/poc/weights.safetensors` +
+  `runs/poc/resume/`). To keep a good checkpoint, `cp` it aside at a val-perplexity low.
+
+**Monitor:**
+
+```bash
+tail -f runs/poc/metrics.jsonl     # {step, lr, loss, grad_norm, val_perplexity, tokens_per_sec, ...}
+```
+
+**POC success = a smoothly decreasing `val_perplexity`** with stable `grad_norm`.
+(A reference ~100M-param run on ~100M tokens reached val-perplexity ~77.)
+
+The smaller `config/toy.yaml` (vocab 256, fp32) is for the exact-resume smoke gate:
+
+```bash
+.venv/bin/python scripts/smoke_test.py --data data/split    # use a byte-fallback split
+```
+
+---
+
+## 4. Serve & chat
+
+[`scripts/generate.py`](../scripts/generate.py) is the CLI front-end (completion +
+interactive chat). It needs trained `--weights`; without them it random-inits and
+emits gibberish.
+
+**Completion** — continue a prompt (streams token-by-token):
+
+```bash
+.venv/bin/python scripts/generate.py \
+    --config config/poc.yaml --weights runs/poc/weights.safetensors \
+    --prompt "Water is a chemical compound that " \
+    --max-new-tokens 80 --temperature 0.7 --top-p 0.9
+```
+
+**Chat** — an instruction-template REPL (type a line, Enter to send, Ctrl-D to exit):
+
+```bash
+.venv/bin/python scripts/generate.py \
+    --config config/poc.yaml --weights runs/poc/weights.safetensors --chat --temperature 0.7
+```
+
+Each chat line is wrapped in the **same instruction template the model was trained on**
+([`src/data/instruct_format.py`](../src/data/instruct_format.py)), and generation stops
+at the next `### Instruction:` marker or end-of-text.
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--config` | `config/poc.yaml` | Model config (must match the weights) |
+| `--weights` | — (random init) | Path to a `.safetensors` checkpoint |
+| `--prompt "…"` / `--chat` | — | Completion prompt **or** chat REPL (one required) |
+| `--max-new-tokens` | 100 | Max tokens to generate |
+| `--temperature` | 0.8 | 0 = greedy/deterministic; higher = more random |
+| `--top-k` / `--top-p` | none | Top-k / nucleus filtering (e.g. `--top-p 0.9`) |
+| `--seed` | 0 | RNG seed for reproducible sampling |
+| `--byte-fallback` | off | Offline byte tokenizer — **toy configs only** |
+
+**Sampling tips:** deterministic → `--temperature 0`; most coherent → `--temperature
+0.6 --top-p 0.9`; more varied → higher temp + `--top-k 40`.
+
+> **Expectation:** at ~100M params output is roughly grammatical English with weak
+> semantics, and chat replies are *template-shaped but not reliably correct*. The POC
+> goal is the learning curve, not answer quality.
+
+### Embedding it in an app
+
+The CLI is thin glue over portable primitives in [`src/serve/`](../src/serve/) (no
+MLX/torch). Use them directly for multi-session serving:
+
+```python
+import numpy as np
+from functools import partial
+from src.model.blocks import load_config
+from src.model.mlx_backend import MLXMambaModel
+from src.data.tokenize import load_olmo_tokenizer
+from src.serve.sessions import SessionStore
+from src.serve.sampling import sample
+from src.serve.generate import generate
+
+cfg = load_config("config/poc.yaml")
+model = MLXMambaModel(cfg); model.load("runs/poc/weights.safetensors")
+tok = load_olmo_tokenizer()
+store = SessionStore(model, max_concurrent=8)          # LRU-evicted, constant RAM/session
+
+store.create("user1")
+ids = tok.encode("The history of ", add_special_tokens=False)
+out = generate(store, "user1", ids,
+               sampler=partial(sample, temperature=0.8, top_p=0.9, rng=np.random.default_rng(0)),
+               to_numpy=lambda a: np.array(a),
+               max_new_tokens=80, eos_id=tok.eos_token_id)
+print(tok.decode(out))
+```
+
+`SessionStore` holds each conversation's recurrent state with bounded memory;
+`RewindTree` ([`src/serve/rewind.py`](../src/serve/rewind.py)) snapshots/undoes turns.
+Both are portable, so the same code runs unchanged on a future CUDA backend.
+
+---
+
+## 5. Evaluate (Tier-2 benchmarks)
+
+Beyond the Tier-1 held-out perplexity (logged during training),
+[`scripts/eval_olmes.py`](../scripts/eval_olmes.py) runs the **lm-evaluation-harness**
+(needs the `[eval]` extra). It supports loglikelihood (multiple-choice) tasks and
+generative tasks (via `generate_until`).
+
+```bash
+# Multiple-choice (set HF_DATASETS_TRUST_REMOTE_CODE=1 for piqa's loader)
+HF_DATASETS_TRUST_REMOTE_CODE=1 .venv/bin/python scripts/eval_olmes.py \
+    --config config/poc.yaml --weights runs/poc/weights.safetensors \
+    --tasks hellaswag,arc_easy,arc_challenge,piqa --limit 500 --output runs/poc/eval_mc.json
+
+# Generative (exercises the generate_until path)
+HF_DATASETS_TRUST_REMOTE_CODE=1 .venv/bin/python scripts/eval_olmes.py \
+    --config config/poc.yaml --weights runs/poc/weights.safetensors \
+    --tasks gsm8k --limit 50 --output runs/poc/eval_gsm8k.json
+```
+
+`--limit N` caps examples per task (each is a batch-1 forward, so full sets are slow);
+omit for a full run. At ~100M params scores sit near chance — **judge by "the harness
+runs end-to-end and returns numbers,"** not leaderboard position.
+
+---
+
+## Troubleshooting
+
+- **`mlx not found`** — you're not on Apple Silicon, or not using the venv interpreter.
+  Use `.venv/bin/python` (the `[mlx]` extra installs only on Apple Silicon).
+- **Empty / immediate-EOS generation** — ensure prompts are encoded with
+  `add_special_tokens=False` (the CLI does this); appending EOS makes the model stop at once.
+- **Swapping / slow steps near the RAM ceiling** — drop to `--batch-size 8 --grad-accum 16`
+  (or lower); the run is resume-safe, so stop and resume if it thrashes.
+- **`transformers`/HF warnings** ("PyTorch not found", "clean_up_tokenization_spaces",
+  unauthenticated Hub) — harmless; only the tokenizer is needed.

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -93,7 +93,13 @@ def main() -> None:
         prints once: the stop marker is only detectable *after* its tokens are produced,
         so streaming would leak the marker to stdout before it could be truncated.
         """
-        ids = tok.encode(text)
+        # add_special_tokens=False: the HF tokenizer otherwise appends EOS to the
+        # prompt, which makes the model immediately predict end-of-text and emit
+        # nothing. ByteTokenizer.encode takes no kwargs, hence the fallback.
+        try:
+            ids = tok.encode(text, add_special_tokens=False)
+        except TypeError:
+            ids = tok.encode(text)
         if not ids:
             return
         sid = "cli"

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -87,21 +87,34 @@ def main() -> None:
     to_numpy = lambda a: np.array(a)
 
     def run(text: str, *, stop_marker: str | None) -> None:
-        """Encode `text`, stream the continuation to stdout, on one fresh session."""
+        """Encode `text`, emit the continuation to stdout, on one fresh session.
+
+        Completion mode (no stop marker) streams token-by-token. Chat mode buffers and
+        prints once: the stop marker is only detectable *after* its tokens are produced,
+        so streaming would leak the marker to stdout before it could be truncated.
+        """
         ids = tok.encode(text)
         if not ids:
             return
         sid = "cli"
         store.create(sid)
         try:
-            stop_fn = None
-            if stop_marker is not None:
-                stop_fn = lambda gen: stop_marker in tok.decode(gen)
-            generate(
-                store, sid, ids, sampler=sampler, to_numpy=to_numpy,
-                max_new_tokens=args.max_new_tokens, eos_id=eos_id, stop_fn=stop_fn,
-                on_token=lambda t: (sys.stdout.write(tok.decode([t])), sys.stdout.flush()),
-            )
+            if stop_marker is None:
+                generate(
+                    store, sid, ids, sampler=sampler, to_numpy=to_numpy,
+                    max_new_tokens=args.max_new_tokens, eos_id=eos_id,
+                    on_token=lambda t: (sys.stdout.write(tok.decode([t])),
+                                        sys.stdout.flush()),
+                )
+            else:
+                out_ids = generate(
+                    store, sid, ids, sampler=sampler, to_numpy=to_numpy,
+                    max_new_tokens=args.max_new_tokens, eos_id=eos_id,
+                    stop_fn=lambda gen: stop_marker in tok.decode(gen),
+                )
+                out = tok.decode(out_ids)
+                cut = out.find(stop_marker)
+                sys.stdout.write(out if cut == -1 else out[:cut])
         finally:
             store.remove(sid)
         print()

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,0 +1,126 @@
+"""Generate text from a trained Mamba-2/SSD checkpoint (MLX backend).
+
+Wires the seam to the shared generation core: tokenizer encode -> SessionStore.step
+-> sampler -> tokenizer decode, streaming tokens to stdout. Two modes:
+
+  * completion (``--prompt "..."``): continue the raw prompt verbatim.
+  * chat (``--chat``): a REPL that wraps each line in the SAME instruction template
+    Dolly was formatted with at train time (``src.data.instruct_format``), so the
+    model is prompted in the shape it learned. Generation stops at the next
+    ``### Instruction:`` marker or EOS.
+
+mlx is imported inside ``main`` (local backend import, like ``scripts/smoke_test.py``)
+so the file stays runnable to parse on non-Mac hosts.
+
+    .venv/bin/python scripts/generate.py --config config/poc.yaml \\
+        --weights runs/poc/weights.safetensors --prompt "The history of"
+    .venv/bin/python scripts/generate.py --config config/poc.yaml \\
+        --weights runs/poc/weights.safetensors --chat
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+
+from src.data.instruct_format import INSTRUCTION_MARKER, format_prompt
+from src.serve import sampling
+from src.serve.generate import generate
+from src.serve.sessions import SessionStore
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
+    ap.add_argument("--weights", type=Path, default=None,
+                    help="portable .safetensors checkpoint; RANDOM INIT if omitted")
+    ap.add_argument("--prompt", default=None, help="completion-mode prompt")
+    ap.add_argument("--chat", action="store_true", help="instruction-template REPL")
+    ap.add_argument("--max-new-tokens", type=int, default=100)
+    ap.add_argument("--temperature", type=float, default=0.8)
+    ap.add_argument("--top-k", type=int, default=None)
+    ap.add_argument("--top-p", type=float, default=None)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--byte-fallback", action="store_true",
+                    help="offline ByteTokenizer (toy config only; not OLMo-compatible)")
+    args = ap.parse_args()
+    if not args.chat and args.prompt is None:
+        ap.error("provide --prompt for completion mode, or --chat for the REPL")
+
+    try:
+        import mlx.core as mx  # noqa: F401  (seeded below; import proves availability)
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/generate.py ...")
+    from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+
+    cfg = load_config(str(args.config))
+    mx.random.seed(args.seed)
+    model = MLXMambaModel(cfg)
+    if args.weights:
+        model.load(str(args.weights))
+        print(f"loaded weights: {args.weights}", file=sys.stderr)
+    else:
+        print("RANDOM INIT — no --weights; output will be gibberish.", file=sys.stderr)
+
+    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer()
+    if tok.vocab_size > cfg.vocab_size:
+        raise SystemExit(
+            f"tokenizer vocab {tok.vocab_size} exceeds model vocab {cfg.vocab_size} "
+            f"({args.config}) — use --byte-fallback only with toy-scale configs.")
+
+    eos_id = getattr(tok, "eos_token_id", None)
+    rng = np.random.default_rng(args.seed)
+    sampler = partial(sampling.sample, temperature=args.temperature,
+                      top_k=args.top_k, top_p=args.top_p, rng=rng)
+    store = SessionStore(model, max_concurrent=1)
+    to_numpy = lambda a: np.array(a)
+
+    def run(text: str, *, stop_marker: str | None) -> None:
+        """Encode `text`, stream the continuation to stdout, on one fresh session."""
+        ids = tok.encode(text)
+        if not ids:
+            return
+        sid = "cli"
+        store.create(sid)
+        try:
+            stop_fn = None
+            if stop_marker is not None:
+                stop_fn = lambda gen: stop_marker in tok.decode(gen)
+            generate(
+                store, sid, ids, sampler=sampler, to_numpy=to_numpy,
+                max_new_tokens=args.max_new_tokens, eos_id=eos_id, stop_fn=stop_fn,
+                on_token=lambda t: (sys.stdout.write(tok.decode([t])), sys.stdout.flush()),
+            )
+        finally:
+            store.remove(sid)
+        print()
+
+    if args.chat:
+        print("chat mode — type a message (Ctrl-D / Ctrl-C to exit).", file=sys.stderr)
+        while True:
+            try:
+                line = input(">>> ")
+            except (EOFError, KeyboardInterrupt):
+                print(file=sys.stderr)
+                break
+            if not line.strip():
+                continue
+            run(format_prompt(line), stop_marker=INSTRUCTION_MARKER)
+    else:
+        sys.stdout.write(args.prompt)
+        run(args.prompt, stop_marker=None)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/download.py
+++ b/src/data/download.py
@@ -1,26 +1,33 @@
-"""Pull a small slice of FineWeb-Edu (or generate synthetic text for offline testing).
+"""Pull a slice of an English corpus (or generate synthetic text for offline testing).
 
-Target for the POC run: ~2-5B tokens total (~10-20GB raw text; packed files are
-several GB on their own — plan disk accordingly). For the smoke test a few million
-tokens is plenty.
+Sources (`--source`):
 
-Corpus (issue #4): ``HuggingFaceFW/fineweb-edu`` (ODC-By), using a ready sample
-subset (e.g. ``sample-10BT``) streamed via `datasets` to a single line-delimited
-text file (one normalized document per line). NOTE: there is no
-compatibly-licensed pre-tokenized small-vocab (< 65536) subset on the HF Hub — AI2's
-dolma3 mixes are raw text at the OLMo-2 100278 vocab, and third-party tokenized sets
-use Llama/Pile tokenizers — so we tokenize raw text ourselves via `tokenize.py`.
+  * ``fineweb``   — ``HuggingFaceFW/fineweb-edu`` (ODC-By), the original web-text path.
+  * ``wikipedia`` — ``wikimedia/structured-wikipedia`` (``enwiki_namespace_0``,
+    CC BY-SA 4.0): clean encyclopedic English. Records are structured; we extract
+    ``name`` + ``abstract`` + section prose into one normalized line per article.
+  * ``instruct``  — ``databricks/databricks-dolly-15k`` (CC BY-SA 3.0): human
+    prompt/response pairs, formatted with the shared instruction template
+    (``src.data.instruct_format``) so the model learns a prompt->response shape. Tiny
+    relative to the pretraining corpus, so ``--repeat`` oversamples it.
 
-Network access in some environments is restricted; `--dummy` produces synthetic
+All sources write one normalized document per line (``tokenize.py`` appends EOS per
+line). The text extractors are pure functions over an injected record iterable, so the
+parsing logic is unit-testable without any network or `datasets` dependency.
+
+Network access in some environments is restricted; ``--dummy`` produces synthetic
 text so the rest of the pipeline can be exercised without a download.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import random
 from pathlib import Path
-from typing import Iterator
+from typing import Iterable, Iterator
+
+from .instruct_format import format_example
 
 
 def dummy_texts(n_docs: int = 1000, seed: int = 0) -> Iterator[str]:
@@ -43,59 +50,176 @@ def _normalize_doc(text: str) -> str:
     return " ".join(text.split())
 
 
-def download_fineweb_edu_slice(
-    out_dir: Path, max_docs: int, subset: str = "sample-10BT"
-) -> Path:
-    """Stream a FineWeb-Edu slice to a single line-delimited text file. Returns its path.
+# --- FineWeb-Edu (web text) ---------------------------------------------------------
 
-    Streams `HuggingFaceFW/fineweb-edu` (the `subset` config, default `sample-10BT`)
-    via `datasets`, writing each document's normalized `text` field as one line to
-    `out_dir / "fineweb-edu.txt"`. No compatible pre-tokenized small-vocab subset
-    exists, so the raw text feeds `tokenize.py` (OLMo tokenizer). Stops after
-    `max_docs` non-empty documents.
-    """
+def download_fineweb_edu_slice(
+    out: Path, max_docs: int, subset: str = "sample-10BT"
+) -> Path:
+    """Stream a FineWeb-Edu slice to a single line-delimited text file. Returns its path."""
     from datasets import load_dataset  # imported lazily (optional `data` extra)
 
-    out_dir.mkdir(parents=True, exist_ok=True)
-    path = out_dir / "fineweb-edu.txt"
     ds = load_dataset(
         "HuggingFaceFW/fineweb-edu", name=subset, split="train", streaming=True
     )
+    texts = (_normalize_doc(ex.get("text", "")) for ex in ds)
+    return _write_lines(texts, out, max_docs)
+
+
+# --- Wikipedia (structured) ---------------------------------------------------------
+
+def _walk_section_prose(node: object) -> Iterator[str]:
+    """Yield paragraph text from a structured-wikipedia section tree.
+
+    Records store ``sections`` as a tree of nodes; prose lives in nodes typed
+    ``"paragraph"`` with a string ``value``. We recurse ``has_parts`` and skip
+    everything else (tables, references, infoboxes, images) by simply not collecting
+    their values. Tolerant of schema drift: any unrecognized node is just recursed.
+    """
+    if isinstance(node, dict):
+        if node.get("type") == "paragraph" and isinstance(node.get("value"), str):
+            yield node["value"]
+        parts = node.get("has_parts")
+        if isinstance(parts, (list, tuple)):
+            for part in parts:
+                yield from _walk_section_prose(part)
+    elif isinstance(node, (list, tuple)):
+        for item in node:
+            yield from _walk_section_prose(item)
+
+
+def wikipedia_doc_text(record: dict) -> str:
+    """Extract one normalized prose line from a structured-wikipedia record.
+
+    Uses ``name`` (title) + ``abstract`` (clean lead summary) + section paragraph
+    prose. ``sections`` is a JSON-encoded string on the real dataset; we accept either
+    a string (decoded here) or an already-parsed list (for tests). Falls back to title
+    + abstract alone when section parsing yields nothing or errors.
+    """
+    title = (record.get("name") or "").strip()
+    abstract = (record.get("abstract") or "").strip()
+
+    sections = record.get("sections")
+    if isinstance(sections, str):
+        try:
+            sections = json.loads(sections)
+        except (ValueError, TypeError):
+            sections = None
+    body = " ".join(_walk_section_prose(sections)) if sections is not None else ""
+
+    return _normalize_doc(" ".join(p for p in (title, abstract, body) if p))
+
+
+def iter_wikipedia_texts(records: Iterable[dict]) -> Iterator[str]:
+    """Yield normalized non-empty prose lines from structured-wikipedia records."""
+    for rec in records:
+        doc = wikipedia_doc_text(rec)
+        if doc:
+            yield doc
+
+
+def download_wikipedia_slice(out: Path, max_docs: int) -> Path:
+    """Stream English structured-wikipedia prose to a line-delimited text file."""
+    from datasets import load_dataset  # imported lazily (optional `data` extra)
+
+    ds = load_dataset(
+        "wikimedia/structured-wikipedia", "enwiki_namespace_0",
+        split="train", streaming=True,
+    )
+    return _write_lines(iter_wikipedia_texts(ds), out, max_docs)
+
+
+# --- Dolly (instruction pairs) ------------------------------------------------------
+
+def iter_instruct_texts(records: Iterable[dict], repeat: int = 1) -> Iterator[str]:
+    """Yield template-formatted instruction docs, each repeated `repeat` times.
+
+    Dolly fields: ``instruction``, ``response``, optional ``context``. Repeating
+    oversamples the tiny instruction set so its format is actually learned; emitting
+    the copies adjacently is fine since the loader chunk-shuffles at train time.
+    """
+    if repeat < 1:
+        raise ValueError(f"repeat={repeat} must be >= 1")
+    for rec in records:
+        instruction = (rec.get("instruction") or "").strip()
+        response = (rec.get("response") or "").strip()
+        if not instruction or not response:
+            continue
+        doc = _normalize_doc(
+            format_example(instruction, response, rec.get("context") or "")
+        )
+        for _ in range(repeat):
+            yield doc
+
+
+def download_instruct(out: Path, repeat: int = 1) -> Path:
+    """Stream Dolly-15k, formatted with the instruction template, to a text file."""
+    from datasets import load_dataset  # imported lazily (optional `data` extra)
+
+    ds = load_dataset("databricks/databricks-dolly-15k", split="train", streaming=True)
+    # No doc cap: the full 15k (times `repeat`) is the point.
+    return _write_lines(iter_instruct_texts(ds, repeat), out, max_docs=None)
+
+
+# --- shared writer ------------------------------------------------------------------
+
+def _write_lines(texts: Iterable[str], out: Path, max_docs: int | None) -> Path:
+    """Write non-empty normalized lines to `out`, stopping after `max_docs` (or all).
+
+    Explicit UTF-8 + "\\n" newlines: the corpus is UTF-8, and forcing the line
+    terminator avoids Windows \\r\\n translation that downstream tokenization would
+    otherwise mis-strip.
+    """
+    out.parent.mkdir(parents=True, exist_ok=True)
     written = 0
-    # Explicit UTF-8 + "\n" newlines: the corpus is UTF-8, and forcing the line
-    # terminator avoids Windows \r\n translation that downstream tokenization would
-    # otherwise mis-strip.
-    with open(path, "w", encoding="utf-8", newline="\n") as f:
-        for ex in ds:
-            doc = _normalize_doc(ex.get("text", ""))
+    with open(out, "w", encoding="utf-8", newline="\n") as f:
+        for doc in texts:
             if not doc:
                 continue
             f.write(doc + "\n")
             written += 1
             if written % 100_000 == 0:
                 print(f"  ... {written} docs")
-            if written >= max_docs:
+            if max_docs is not None and written >= max_docs:
                 break
-    print(f"wrote {written} docs -> {path}")
-    return path
+    print(f"wrote {written} docs -> {out}")
+    return out
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--out", type=Path, default=Path("data/raw"))
-    ap.add_argument("--max-docs", type=int, default=10000)
+    ap.add_argument("--source", choices=("fineweb", "wikipedia", "instruct"),
+                    default="fineweb", help="corpus source (ignored with --dummy)")
+    ap.add_argument("--out", type=Path, default=Path("data/raw"),
+                    help="output file (or directory for --dummy/legacy default)")
+    ap.add_argument("--max-docs", type=int, default=10000,
+                    help="cap documents (ignored for --source instruct)")
     ap.add_argument("--subset", default="sample-10BT", help="FineWeb-Edu config name")
+    ap.add_argument("--repeat", type=int, default=1,
+                    help="oversample factor for --source instruct")
     ap.add_argument("--dummy", action="store_true", help="synthetic text, no network")
     args = ap.parse_args()
-    args.out.mkdir(parents=True, exist_ok=True)
+
     if args.dummy:
+        args.out.mkdir(parents=True, exist_ok=True)
         path = args.out / "dummy.txt"
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
             for doc in dummy_texts(args.max_docs):
                 f.write(doc + "\n")
         print(f"wrote synthetic text -> {path}")
+        return
+
+    # If --out is an existing dir (or the legacy default), pick a source-named file in it.
+    out = args.out
+    if out.is_dir() or out.suffix == "":
+        out = out / {"fineweb": "fineweb-edu.txt", "wikipedia": "wiki.txt",
+                     "instruct": "instruct.txt"}[args.source]
+
+    if args.source == "fineweb":
+        download_fineweb_edu_slice(out, args.max_docs, args.subset)
+    elif args.source == "wikipedia":
+        download_wikipedia_slice(out, args.max_docs)
     else:
-        download_fineweb_edu_slice(args.out, args.max_docs, args.subset)
+        download_instruct(out, args.repeat)
 
 
 if __name__ == "__main__":

--- a/src/data/download.py
+++ b/src/data/download.py
@@ -200,12 +200,14 @@ def main() -> None:
     args = ap.parse_args()
 
     if args.dummy:
-        args.out.mkdir(parents=True, exist_ok=True)
-        path = args.out / "dummy.txt"
-        with open(path, "w", encoding="utf-8", newline="\n") as f:
+        out = args.out
+        if out.is_dir() or out.suffix == "":   # --out may be a dir (legacy) or a file
+            out = out / "dummy.txt"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with open(out, "w", encoding="utf-8", newline="\n") as f:
             for doc in dummy_texts(args.max_docs):
                 f.write(doc + "\n")
-        print(f"wrote synthetic text -> {path}")
+        print(f"wrote synthetic text -> {out}")
         return
 
     # If --out is an existing dir (or the legacy default), pick a source-named file in it.

--- a/src/data/instruct_format.py
+++ b/src/data/instruct_format.py
@@ -1,0 +1,36 @@
+"""Single source of truth for the instruction template.
+
+The model only learns a prompt->response behavior if the format it is *trained* on
+(instruction examples baked into the corpus) is the same format it is *prompted* with
+at inference (`scripts/generate.py --chat`). Both sides import from here so they can
+never drift.
+
+The template is the classic Alpaca/Dolly-style block. `format_example` produces the
+full instruction+response text used as a training document; `format_prompt` produces
+everything up to and including the response marker, so the model continues from there
+at inference. `RESPONSE_MARKER` is the boundary used to split the response off the
+prompt, and `INSTRUCTION_MARKER` is the natural stop string for a single turn (the
+model starting a new "### Instruction:" means the turn is done).
+
+Portable: pure string formatting, no dependencies, lives above the seam.
+"""
+
+from __future__ import annotations
+
+INSTRUCTION_MARKER = "### Instruction:\n"
+CONTEXT_MARKER = "### Input:\n"
+RESPONSE_MARKER = "### Response:\n"
+
+
+def format_prompt(instruction: str, context: str = "") -> str:
+    """The instruction block up to the response marker (model continues from here)."""
+    parts = [f"{INSTRUCTION_MARKER}{instruction.strip()}\n"]
+    if context and context.strip():
+        parts.append(f"\n{CONTEXT_MARKER}{context.strip()}\n")
+    parts.append(f"\n{RESPONSE_MARKER}")
+    return "".join(parts)
+
+
+def format_example(instruction: str, response: str, context: str = "") -> str:
+    """A full training document: the prompt block followed by the response text."""
+    return f"{format_prompt(instruction, context)}{response.strip()}"

--- a/src/data/instruct_format.py
+++ b/src/data/instruct_format.py
@@ -5,32 +5,46 @@ The model only learns a prompt->response behavior if the format it is *trained* 
 at inference (`scripts/generate.py --chat`). Both sides import from here so they can
 never drift.
 
-The template is the classic Alpaca/Dolly-style block. `format_example` produces the
-full instruction+response text used as a training document; `format_prompt` produces
-everything up to and including the response marker, so the model continues from there
-at inference. `RESPONSE_MARKER` is the boundary used to split the response off the
-prompt, and `INSTRUCTION_MARKER` is the natural stop string for a single turn (the
-model starting a new "### Instruction:" means the turn is done).
+**Single line, deliberately.** The data pipeline is one-document-per-line and
+`tokenize.py` appends EOS per line, so a training document cannot contain raw newlines
+(each would become a spurious document boundary). The corpus builder also runs every
+instruction doc through `download._normalize_doc` (whitespace-collapse). A multi-line
+Alpaca block would therefore be flattened to spaces at train time while
+`format_prompt` kept its newlines at inference — a silent train/inference mismatch.
+Keeping the template newline-free makes `format_example` collapse-idempotent and
+byte-identical to the prompt the model is later given.
+
+`format_example` is the full instruction+response training document; `format_prompt`
+is everything up to the response marker (the model continues from there).
+`RESPONSE_MARKER` splits the response off the prompt; `INSTRUCTION_MARKER` is the
+natural stop string for a single turn (the model emitting a new "### Instruction:"
+means the turn is done — though with one example per training doc the primary stop is
+EOS).
 
 Portable: pure string formatting, no dependencies, lives above the seam.
 """
 
 from __future__ import annotations
 
-INSTRUCTION_MARKER = "### Instruction:\n"
-CONTEXT_MARKER = "### Input:\n"
-RESPONSE_MARKER = "### Response:\n"
+INSTRUCTION_MARKER = "### Instruction:"
+CONTEXT_MARKER = "### Input:"
+RESPONSE_MARKER = "### Response:"
 
 
 def format_prompt(instruction: str, context: str = "") -> str:
-    """The instruction block up to the response marker (model continues from here)."""
-    parts = [f"{INSTRUCTION_MARKER}{instruction.strip()}\n"]
+    """The instruction block up to the response marker (model continues from here).
+
+    Ends exactly at the response marker with no trailing space: in a full example the
+    answer follows as " {response}", so the model predicts that leading-space token —
+    appending a trailing space here would tokenize the boundary differently than train.
+    """
+    parts = [f"{INSTRUCTION_MARKER} {instruction.strip()}"]
     if context and context.strip():
-        parts.append(f"\n{CONTEXT_MARKER}{context.strip()}\n")
-    parts.append(f"\n{RESPONSE_MARKER}")
-    return "".join(parts)
+        parts.append(f"{CONTEXT_MARKER} {context.strip()}")
+    parts.append(RESPONSE_MARKER)
+    return " ".join(parts)
 
 
 def format_example(instruction: str, response: str, context: str = "") -> str:
     """A full training document: the prompt block followed by the response text."""
-    return f"{format_prompt(instruction, context)}{response.strip()}"
+    return f"{format_prompt(instruction, context)} {response.strip()}"

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -49,6 +49,10 @@ class ByteTokenizer:
     def encode(self, text: str) -> List[int]:
         return list(text.encode("utf-8"))
 
+    def decode(self, ids: Iterable[int]) -> str:
+        """Inverse of `encode` (lossy on invalid byte sequences). For offline serving."""
+        return bytes(int(i) & 0xFF for i in ids).decode("utf-8", "replace")
+
 
 def tokenize_texts(texts: Iterable[str], tokenizer) -> Iterable[int]:
     """Yield a flat stream of token ids across all documents (with EOS if available)."""

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -177,13 +177,14 @@ def generate_until_texts(
         sid = f"gen-{i}"
         store.create(sid)
         try:
-            stop_fn = (lambda gen: any(s in tokenizer.decode(gen) for s in stops)) \
-                if stops else None
+            def stop_fn(gen):  # decode once per step, then test every stop string
+                text = tokenizer.decode(gen)
+                return any(s in text for s in stops)
             out_ids = generate(
                 store, sid, ids,
                 sampler=_sampler_from_kwargs(gen_kwargs, rng),
                 to_numpy=to_numpy, max_new_tokens=max_gen,
-                eos_id=eos_id, stop_fn=stop_fn,
+                eos_id=eos_id, stop_fn=stop_fn if stops else None,
             )
         finally:
             store.remove(sid)

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -145,13 +145,16 @@ def generate_until_texts(
     Pure over `ModelInterface` + tokenizer (no lm-eval), so it is unit-testable. Each
     request gets a fresh single-session `SessionStore`; the context is left-truncated to
     leave room for `max_gen_toks`, prefilled, then continued by the shared `generate`
-    core. Generation halts on the eot token, on `max_gen_toks`, or as soon as a stop
-    string appears in the decoded text; the result is truncated at the earliest stop.
+    core. Generation halts on the tokenizer's EOS (if it has one), on `max_gen_toks`,
+    or as soon as a stop string appears in the decoded text; the result is truncated at
+    the earliest stop.
     """
     store = SessionStore(model, max_concurrent=1)
     rng = np.random.default_rng(seed)
-    eot = getattr(tokenizer, "eos_token_id", None)
-    eot = 0 if eot is None else int(eot)
+    eos = getattr(tokenizer, "eos_token_id", None)
+    # None => no EOS stop condition. Don't coerce a missing EOS to token 0, which would
+    # make an ordinary token (id 0) silently end generation.
+    eos_id = int(eos) if eos is not None else None
 
     outputs: List[str] = []
     for i, (context, gen_kwargs) in enumerate(requests):
@@ -163,7 +166,9 @@ def generate_until_texts(
         keep = max(1, max_length - max_gen)
         ids = ids[-keep:] if len(ids) > keep else ids
         if not ids:
-            ids = [eot]  # nothing to condition on; seed the recurrence
+            # Nothing to condition on; seed the recurrence with EOS (a natural BOS-like
+            # start) if the tokenizer has one, else a generic token 0.
+            ids = [eos_id if eos_id is not None else 0]
 
         sid = f"gen-{i}"
         store.create(sid)
@@ -174,7 +179,7 @@ def generate_until_texts(
                 store, sid, ids,
                 sampler=_sampler_from_kwargs(gen_kwargs, rng),
                 to_numpy=to_numpy, max_new_tokens=max_gen,
-                eos_id=eot, stop_fn=stop_fn,
+                eos_id=eos_id, stop_fn=stop_fn,
             )
         finally:
             store.remove(sid)

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -21,11 +21,15 @@ it runs end to end (scripts/eval_olmes.py), not by leaderboard position.
 
 from __future__ import annotations
 
+from functools import partial
 from typing import List, Sequence, Tuple
 
 import numpy as np
 
 from ..model.interface import ModelInterface
+from ..serve import sampling
+from ..serve.generate import generate
+from ..serve.sessions import SessionStore
 
 
 def _log_softmax(logits: np.ndarray) -> np.ndarray:
@@ -95,6 +99,97 @@ def disjoint_rolling_windows(
     return windows
 
 
+def _normalize_until(until) -> List[str]:
+    """lm-eval passes `until` as a string or list of strings (or omits it)."""
+    if until is None:
+        return []
+    if isinstance(until, str):
+        return [until]
+    return [s for s in until if s]
+
+
+def _truncate_at_stops(text: str, stops: Sequence[str]) -> str:
+    """Cut `text` at the earliest occurrence of any stop string (lm-eval semantics)."""
+    cut = len(text)
+    for s in stops:
+        i = text.find(s)
+        if i != -1:
+            cut = min(cut, i)
+    return text[:cut]
+
+
+def _sampler_from_kwargs(gen_kwargs: dict, rng: np.random.Generator):
+    """Build a `sampler(logits)->int` from lm-eval gen kwargs (greedy unless do_sample)."""
+    if not gen_kwargs.get("do_sample", False):
+        return partial(sampling.sample, temperature=0.0)
+    return partial(
+        sampling.sample,
+        temperature=float(gen_kwargs.get("temperature", 1.0)),
+        top_k=gen_kwargs.get("top_k"),
+        top_p=gen_kwargs.get("top_p"),
+        rng=rng,
+    )
+
+
+def generate_until_texts(
+    model: ModelInterface,
+    tokenizer,
+    requests: Sequence[Tuple[str, dict]],
+    *,
+    max_length: int,
+    to_numpy=np.asarray,
+    seed: int = 0,
+) -> List[str]:
+    """Greedy/sampled generation for each (context, gen_kwargs) request.
+
+    Pure over `ModelInterface` + tokenizer (no lm-eval), so it is unit-testable. Each
+    request gets a fresh single-session `SessionStore`; the context is left-truncated to
+    leave room for `max_gen_toks`, prefilled, then continued by the shared `generate`
+    core. Generation halts on the eot token, on `max_gen_toks`, or as soon as a stop
+    string appears in the decoded text; the result is truncated at the earliest stop.
+    """
+    store = SessionStore(model, max_concurrent=1)
+    rng = np.random.default_rng(seed)
+    eot = getattr(tokenizer, "eos_token_id", None)
+    eot = 0 if eot is None else int(eot)
+
+    outputs: List[str] = []
+    for i, (context, gen_kwargs) in enumerate(requests):
+        gen_kwargs = dict(gen_kwargs or {})
+        stops = _normalize_until(gen_kwargs.get("until"))
+        max_gen = int(gen_kwargs.get("max_gen_toks", 256))
+
+        ids = list(_encode(tokenizer, context))
+        keep = max(1, max_length - max_gen)
+        ids = ids[-keep:] if len(ids) > keep else ids
+        if not ids:
+            ids = [eot]  # nothing to condition on; seed the recurrence
+
+        sid = f"gen-{i}"
+        store.create(sid)
+        try:
+            stop_fn = (lambda gen: any(s in tokenizer.decode(gen) for s in stops)) \
+                if stops else None
+            out_ids = generate(
+                store, sid, ids,
+                sampler=_sampler_from_kwargs(gen_kwargs, rng),
+                to_numpy=to_numpy, max_new_tokens=max_gen,
+                eos_id=eot, stop_fn=stop_fn,
+            )
+        finally:
+            store.remove(sid)
+        outputs.append(_truncate_at_stops(tokenizer.decode(out_ids), stops))
+    return outputs
+
+
+def _encode(tokenizer, string: str) -> List[int]:
+    """Encode without special tokens; tolerate ByteTokenizer's kwarg-free signature."""
+    try:
+        return tokenizer.encode(string, add_special_tokens=False)
+    except TypeError:
+        return tokenizer.encode(string)
+
+
 def make_lm_eval_adapter(
     model: ModelInterface,
     tokenizer,
@@ -147,10 +242,11 @@ def make_lm_eval_adapter(
             return results
 
         def generate_until(self, requests, **kwargs):
-            raise NotImplementedError(
-                "generate_until is not implemented: HellaSwag/ARC/PIQA are "
-                "loglikelihood (multiple-choice) tasks and never call it. "
-                "Implement over ModelInterface.step when generative tasks are "
-                "needed.")
+            # lm-eval Instance.args = (context_str, gen_kwargs); delegate to the shared
+            # generation core so generative tasks share the CLI's inference path.
+            pairs = [(req.args[0], req.args[1] if len(req.args) > 1 else {})
+                     for req in requests]
+            return generate_until_texts(
+                model, tokenizer, pairs, max_length=seq_limit, to_numpy=to_numpy)
 
     return _MonicaLM()

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -142,10 +142,10 @@ def generate_until_texts(
 ) -> List[str]:
     """Greedy/sampled generation for each (context, gen_kwargs) request.
 
-    Pure over `ModelInterface` + tokenizer (no lm-eval), so it is unit-testable. Each
-    request gets a fresh single-session `SessionStore`; the context is left-truncated to
-    leave room for `max_gen_toks`, prefilled, then continued by the shared `generate`
-    core. Generation halts on the tokenizer's EOS (if it has one), on `max_gen_toks`,
+    Pure over `ModelInterface` + tokenizer (no lm-eval), so it is unit-testable. Requests
+    share one single-session `SessionStore` (a fresh session is created and removed per
+    request); the context is left-truncated to leave room for `max_gen_toks`, prefilled,
+    then continued by the shared `generate` core. Generation halts on the tokenizer's EOS (if it has one), on `max_gen_toks`,
     or as soon as a stop string appears in the decoded text; the result is truncated at
     the earliest stop.
     """

--- a/src/eval/olmes_adapter.py
+++ b/src/eval/olmes_adapter.py
@@ -160,7 +160,11 @@ def generate_until_texts(
     for i, (context, gen_kwargs) in enumerate(requests):
         gen_kwargs = dict(gen_kwargs or {})
         stops = _normalize_until(gen_kwargs.get("until"))
-        max_gen = int(gen_kwargs.get("max_gen_toks", 256))
+        # Cap generation so prompt (>=1 token) + new tokens stays within max_length,
+        # mirroring score_continuation's len(cont) <= max_length contract. (Mamba has no
+        # hard context limit, but generating past the trained seq_len goes
+        # off-distribution; capping keeps the eval bounded rather than erroring mid-run.)
+        max_gen = min(int(gen_kwargs.get("max_gen_toks", 256)), max(1, max_length - 1))
 
         ids = list(_encode(tokenizer, context))
         keep = max(1, max_length - max_gen)

--- a/src/serve/generate.py
+++ b/src/serve/generate.py
@@ -1,0 +1,61 @@
+"""Shared generation core: prompt ids -> sampled continuation ids (portable).
+
+One generation loop, two consumers: the CLI (`scripts/generate.py`) streams the
+decoded tokens to a user, and the lm-eval adapter (`src/eval/olmes_adapter.py`)
+collects them for generative tasks. It drives the model purely through
+`SessionStore.step(session_id, token) -> logits` — the proven seam primitive — so it
+adds no new state handling.
+
+Above the seam: only numpy + the `SessionStore` API. Backend logits are converted to
+numpy via the injected `to_numpy` (as in `src/eval/val_loss.py`); the `sampler`
+chooses the next id; `stop_fn` lets a caller end generation on a decoded stop string
+without baking a tokenizer in here; `on_token` streams ids as they are produced.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+
+def generate(
+    store,
+    session_id: str,
+    prompt_ids: Sequence[int],
+    *,
+    sampler: Callable[[np.ndarray], int],
+    to_numpy: Callable[[object], np.ndarray] = np.asarray,
+    max_new_tokens: int = 128,
+    eos_id: Optional[int] = None,
+    stop_fn: Optional[Callable[[List[int]], bool]] = None,
+    on_token: Optional[Callable[[int], None]] = None,
+) -> List[int]:
+    """Generate up to `max_new_tokens` continuation ids for `session_id`.
+
+    Prefill: feed every prompt id through `store.step` (the last one's logits seed the
+    first sample). Then loop: sample the next id, record/stream it, feed it back, and
+    stop on `eos_id`, on reaching `max_new_tokens`, or when `stop_fn(generated)` is
+    True. `prompt_ids` must be non-empty (the recurrence needs a token to advance on).
+    Returns only the generated ids (not the prompt).
+    """
+    if len(prompt_ids) == 0:
+        raise ValueError("prompt_ids must be non-empty")
+
+    logits = None
+    for tok in prompt_ids:
+        logits = store.step(session_id, int(tok))
+
+    generated: List[int] = []
+    for _ in range(max_new_tokens):
+        nxt = sampler(to_numpy(logits)[0])  # (1, vocab) -> (vocab,)
+        if eos_id is not None and nxt == eos_id:
+            break
+        generated.append(nxt)
+        if on_token is not None:
+            on_token(nxt)
+        if stop_fn is not None and stop_fn(generated):
+            break
+        logits = store.step(session_id, nxt)
+
+    return generated

--- a/src/serve/generate.py
+++ b/src/serve/generate.py
@@ -54,8 +54,10 @@ def generate(
         generated.append(nxt)
         if on_token is not None:
             on_token(nxt)
+        # Feed the emitted token back BEFORE the stop check so the session state always
+        # reflects every id in `generated` (a caller can resume generation in-session).
+        logits = store.step(session_id, nxt)
         if stop_fn is not None and stop_fn(generated):
             break
-        logits = store.step(session_id, nxt)
 
     return generated

--- a/src/serve/sampling.py
+++ b/src/serve/sampling.py
@@ -49,9 +49,13 @@ def sample(
     # top-p (nucleus): keep the smallest prefix of the sorted mass reaching top_p.
     if top_p is not None and 0.0 < top_p < 1.0:
         order = np.argsort(probs)[::-1]
-        cumulative = np.cumsum(probs[order])
-        # Keep everything up to and including the token that crosses top_p.
-        keep = cumulative <= top_p
+        sorted_probs = probs[order]
+        cumulative = np.cumsum(sorted_probs)
+        # Standard nucleus: keep the smallest prefix whose mass reaches top_p,
+        # *including* the token that crosses the threshold. A token is dropped only
+        # once the mass strictly BEFORE it has already reached top_p, so the crossing
+        # token survives (unlike a plain `cumulative <= top_p`, which drops it).
+        keep = (cumulative - sorted_probs) < top_p
         keep[0] = True  # always keep the most probable token
         mask = np.zeros_like(probs, dtype=bool)
         mask[order[keep]] = True

--- a/src/serve/sampling.py
+++ b/src/serve/sampling.py
@@ -1,0 +1,69 @@
+"""Token sampling over a logits vector (portable, numpy only).
+
+The generation core hands raw logits here and gets back one token id. Greedy decoding
+(`temperature == 0`) is the lm-eval `do_sample=False` default and is fully
+deterministic; sampling applies temperature, then optional top-k and top-p (nucleus)
+truncation, then draws from the renormalized distribution using a caller-supplied
+`numpy.random.Generator` (so a seed makes runs reproducible).
+
+Above the seam: pure numpy, no backend. The caller converts backend logits to numpy
+at the boundary (as `src/eval/val_loss.py` does), so this never touches mlx/torch.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+def sample(
+    logits: np.ndarray,
+    *,
+    temperature: float = 1.0,
+    top_k: Optional[int] = None,
+    top_p: Optional[float] = None,
+    rng: Optional[np.random.Generator] = None,
+) -> int:
+    """Return one token id sampled from a 1-D logits vector.
+
+    `temperature == 0` is greedy (argmax). Otherwise: scale by 1/temperature, restrict
+    to the top-`k` logits and/or the smallest set whose probability mass reaches
+    `top_p`, renormalize, and draw.
+    """
+    logits = np.asarray(logits, dtype=np.float64).reshape(-1)
+    if temperature == 0:
+        return int(logits.argmax())
+    if temperature < 0:
+        raise ValueError(f"temperature {temperature} must be >= 0")
+
+    logits = logits / temperature
+
+    # top-k: keep only the k highest logits.
+    if top_k is not None and 0 < top_k < logits.size:
+        kth = np.partition(logits, -top_k)[-top_k]
+        logits = np.where(logits < kth, -np.inf, logits)
+
+    probs = _softmax(logits)
+
+    # top-p (nucleus): keep the smallest prefix of the sorted mass reaching top_p.
+    if top_p is not None and 0.0 < top_p < 1.0:
+        order = np.argsort(probs)[::-1]
+        cumulative = np.cumsum(probs[order])
+        # Keep everything up to and including the token that crosses top_p.
+        keep = cumulative <= top_p
+        keep[0] = True  # always keep the most probable token
+        mask = np.zeros_like(probs, dtype=bool)
+        mask[order[keep]] = True
+        probs = np.where(mask, probs, 0.0)
+        probs /= probs.sum()
+
+    rng = rng or np.random.default_rng()
+    return int(rng.choice(probs.size, p=probs))
+
+
+def _softmax(logits: np.ndarray) -> np.ndarray:
+    """Stable softmax over a 1-D vector (handles -inf masking)."""
+    m = np.max(logits)
+    exp = np.exp(logits - m)
+    return exp / exp.sum()

--- a/tests/test_download_sources.py
+++ b/tests/test_download_sources.py
@@ -1,0 +1,98 @@
+"""Offline tests for the Wikipedia + instruction text extractors.
+
+The extractors take an injected iterable of records, so the parsing logic is exercised
+with no network or `datasets` dependency. Covers: structured-section prose extraction,
+JSON-encoded `sections`, the abstract-only fallback, and Dolly formatting + oversample.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.data.download import (
+    iter_instruct_texts,
+    iter_wikipedia_texts,
+    wikipedia_doc_text,
+)
+from src.data.instruct_format import RESPONSE_MARKER, format_example
+
+
+def _record(name, abstract, sections, encode_sections=False):
+    return {
+        "name": name,
+        "abstract": abstract,
+        "sections": json.dumps(sections) if encode_sections else sections,
+    }
+
+
+def test_wikipedia_extracts_title_abstract_and_paragraph_prose():
+    sections = [
+        {"type": "section", "name": "History", "has_parts": [
+            {"type": "paragraph", "value": "First paragraph."},
+            {"type": "table", "value": "SHOULD NOT APPEAR"},
+            {"type": "section", "has_parts": [
+                {"type": "paragraph", "value": "Nested paragraph."},
+            ]},
+        ]},
+    ]
+    doc = wikipedia_doc_text(_record("Cats", "A small feline.", sections))
+    assert doc == "Cats A small feline. First paragraph. Nested paragraph."
+    assert "SHOULD NOT APPEAR" not in doc
+
+
+def test_wikipedia_handles_json_encoded_sections():
+    sections = [{"type": "paragraph", "value": "Encoded body."}]
+    doc = wikipedia_doc_text(_record("T", "Abs.", sections, encode_sections=True))
+    assert doc == "T Abs. Encoded body."
+
+
+def test_wikipedia_falls_back_to_abstract_on_bad_sections():
+    doc = wikipedia_doc_text({"name": "T", "abstract": "Lead only.",
+                              "sections": "{not valid json"})
+    assert doc == "T Lead only."
+
+
+def test_wikipedia_collapses_internal_whitespace_to_one_line():
+    sections = [{"type": "paragraph", "value": "line one\nline two\t\ttabbed"}]
+    doc = wikipedia_doc_text(_record("N", "ab\nstract", sections))
+    assert "\n" not in doc and "\t" not in doc
+    assert doc == "N ab stract line one line two tabbed"
+
+
+def test_iter_wikipedia_skips_empty_docs():
+    records = [
+        {"name": "", "abstract": "", "sections": None},   # yields nothing -> skipped
+        {"name": "Real", "abstract": "Has text.", "sections": None},
+    ]
+    assert list(iter_wikipedia_texts(records)) == ["Real Has text."]
+
+
+def test_instruct_formats_with_shared_template():
+    records = [{"instruction": "Say hi", "response": "Hi!", "context": ""}]
+    (doc,) = list(iter_instruct_texts(records))
+    # Matches the shared template (normalized to one line).
+    assert doc == " ".join(format_example("Say hi", "Hi!").split())
+    assert RESPONSE_MARKER.strip() in doc
+
+
+def test_instruct_repeat_oversamples():
+    records = [{"instruction": "Q", "response": "A"}]
+    out = list(iter_instruct_texts(records, repeat=3))
+    assert len(out) == 3 and len(set(out)) == 1
+
+
+def test_instruct_skips_incomplete_pairs():
+    records = [
+        {"instruction": "no response", "response": ""},
+        {"instruction": "", "response": "no instruction"},
+        {"instruction": "good", "response": "pair"},
+    ]
+    out = list(iter_instruct_texts(records))
+    assert len(out) == 1
+
+
+def test_instruct_repeat_below_one_raises():
+    with pytest.raises(ValueError):
+        list(iter_instruct_texts([{"instruction": "a", "response": "b"}], repeat=0))

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -70,6 +70,16 @@ def test_top_p_restricts_to_nucleus():
         assert sample(logits, temperature=1.0, top_p=0.5, rng=rng) == 0
 
 
+def test_top_p_includes_threshold_crossing_token():
+    # Two near-tied leaders (0.3 each); nucleus 0.5 must include the SECOND token (the
+    # one whose mass crosses 0.5), not just the first. Tokens 2 and 3 stay excluded.
+    # A plain `cumulative <= top_p` would wrongly keep only token 0.
+    logits = np.log(np.array([0.3, 0.3, 0.25, 0.15]))
+    rng = np.random.default_rng(0)
+    draws = {sample(logits, temperature=1.0, top_p=0.5, rng=rng) for _ in range(200)}
+    assert draws == {0, 1}
+
+
 def test_negative_temperature_raises():
     with pytest.raises(ValueError):
         sample(np.zeros(4), temperature=-1.0)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,129 @@
+"""Tests for the sampler + shared generation core (portable, no backend).
+
+A deterministic FakeModel (logits one-hot at ``(token+1) % vocab``) makes greedy
+decoding an exact counter, so stop conditions and state advancement are checkable with
+plain arithmetic — mirroring the FakeModel approach in ``tests/test_serve.py``.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from src.serve.generate import generate
+from src.serve.sampling import sample
+from src.serve.sessions import SessionStore
+
+
+class CounterModel:
+    """ModelInterface stand-in. Greedy next token = (current token + 1) % vocab."""
+
+    def __init__(self, vocab_size: int = 16):
+        self.config = SimpleNamespace(
+            n_layers=2, d_conv=4, d_inner=128, n_heads=8, head_dim=16, d_state=16,
+            precision="fp32", vocab_size=vocab_size,
+        )
+
+    def init_state(self, batch_size: int):
+        return np.zeros((batch_size,), dtype=np.int64)
+
+    def step(self, token, state):
+        token = np.asarray(token)
+        nxt = (token + 1) % self.config.vocab_size
+        logits = np.eye(self.config.vocab_size)[nxt]  # (1, vocab), one-hot
+        return logits, state + token  # state = running sum (fresh array)
+
+    def clone_state(self, state):
+        return np.array(state, copy=True)
+
+
+def _store():
+    store = SessionStore(CounterModel())
+    store.create("s")
+    return store
+
+
+# --- sampler ------------------------------------------------------------------------
+
+def test_greedy_is_argmax_and_deterministic():
+    logits = np.array([0.1, 5.0, 0.2, 3.0])
+    assert sample(logits, temperature=0.0) == 1
+    assert sample(logits, temperature=0.0) == 1
+
+
+def test_top_k_one_collapses_to_argmax():
+    logits = np.array([0.1, 5.0, 0.2, 3.0])
+    rng = np.random.default_rng(0)
+    # With only the top logit surviving, sampling must return the argmax every time.
+    for _ in range(10):
+        assert sample(logits, temperature=1.0, top_k=1, rng=rng) == 1
+
+
+def test_top_p_restricts_to_nucleus():
+    # One token dominates; nucleus of 0.5 keeps only it.
+    logits = np.log(np.array([0.9, 0.05, 0.03, 0.02]))
+    rng = np.random.default_rng(0)
+    for _ in range(10):
+        assert sample(logits, temperature=1.0, top_p=0.5, rng=rng) == 0
+
+
+def test_negative_temperature_raises():
+    with pytest.raises(ValueError):
+        sample(np.zeros(4), temperature=-1.0)
+
+
+# --- generation core ----------------------------------------------------------------
+
+def test_greedy_generation_counts_up():
+    store = _store()
+    greedy = partial(sample, temperature=0.0)
+    out = generate(store, "s", [0], sampler=greedy, max_new_tokens=4)
+    assert out == [1, 2, 3, 4]
+
+
+def test_max_new_tokens_bounds_length():
+    store = _store()
+    out = generate(store, "s", [0], sampler=partial(sample, temperature=0.0),
+                   max_new_tokens=2)
+    assert out == [1, 2]
+
+
+def test_eos_halts_before_appending():
+    store = _store()
+    # Counting up from 2 hits eos_id=5 at the 4th token; it must NOT be appended.
+    out = generate(store, "s", [2], sampler=partial(sample, temperature=0.0),
+                   max_new_tokens=10, eos_id=5)
+    assert out == [3, 4]
+
+
+def test_stop_fn_halts_generation():
+    store = _store()
+    out = generate(store, "s", [0], sampler=partial(sample, temperature=0.0),
+                   max_new_tokens=10, stop_fn=lambda gen: len(gen) >= 3)
+    assert out == [1, 2, 3]
+
+
+def test_on_token_streams_each_generated_id():
+    store = _store()
+    seen = []
+    out = generate(store, "s", [0], sampler=partial(sample, temperature=0.0),
+                   max_new_tokens=3, on_token=seen.append)
+    assert seen == out == [1, 2, 3]
+
+
+def test_generation_advances_session_state():
+    store = _store()
+    generate(store, "s", [1, 2], sampler=partial(sample, temperature=0.0),
+             max_new_tokens=3)  # prefill 1,2 then generate 3,4,5
+    # State is the running sum of every token fed. Prefill feeds 1,2; then each
+    # generated token (3,4,5) is fed back to advance the recurrence. Sum = 15.
+    assert int(store.get_state("s")[0]) == 15
+
+
+def test_empty_prompt_raises():
+    store = _store()
+    with pytest.raises(ValueError):
+        generate(store, "s", [], sampler=partial(sample, temperature=0.0))

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -116,6 +116,17 @@ def test_stop_fn_halts_generation():
     assert out == [1, 2, 3]
 
 
+def test_stop_fn_session_state_reflects_all_emitted_tokens():
+    # Regression: when stop_fn halts, the last emitted token is fed back BEFORE the stop
+    # check, so the session state reflects every id in `generated` (resume-safe).
+    store = _store()
+    out = generate(store, "s", [0], sampler=partial(sample, temperature=0.0),
+                   max_new_tokens=10, stop_fn=lambda gen: len(gen) >= 3)
+    assert out == [1, 2, 3]
+    # state = running sum of all fed tokens: prefill 0 + generated 1+2+3 = 6.
+    assert int(store.get_state("s")[0]) == 6
+
+
 def test_on_token_streams_each_generated_id():
     store = _store()
     seen = []

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -35,6 +35,8 @@ PORTABLE_MODULES = [
     "src.data.loader",
     "src.data.pack",
     "src.data.split",
+    "src.data.download",
+    "src.data.instruct_format",
     "src.train.schedule",
     "src.train.checkpoint",
     "src.train.loss_scale",
@@ -44,6 +46,8 @@ PORTABLE_MODULES = [
     "src.conformance.forward_step_parity",
     "src.serve.sessions",
     "src.serve.rewind",
+    "src.serve.sampling",
+    "src.serve.generate",
 ]
 
 FORBIDDEN_ROOTS = ("mlx", "torch")

--- a/tests/test_olmes_adapter.py
+++ b/tests/test_olmes_adapter.py
@@ -44,7 +44,12 @@ class FakeModel:
     """
 
     def __init__(self, vocab_size=8, seq_len=64):
-        self.config = SimpleNamespace(vocab_size=vocab_size, seq_len=seq_len)
+        # State-shape fields let the same FakeModel back a SessionStore for the
+        # generate_until path (it never inspects the state contents).
+        self.config = SimpleNamespace(
+            vocab_size=vocab_size, seq_len=seq_len, n_layers=2, d_conv=4,
+            d_inner=128, n_heads=8, head_dim=16, d_state=16, precision="fp32",
+        )
         self.last_input = None
 
     def forward(self, token_batch):
@@ -52,6 +57,17 @@ class FakeModel:
         succ = (self.last_input + 1) % self.config.vocab_size
         eye = np.eye(self.config.vocab_size, dtype=np.float32)
         return BIG * eye[succ]
+
+    # Inference path (successor logits, consistent with forward) for generate_until.
+    def init_state(self, batch_size):
+        return np.zeros((batch_size,), dtype=np.int64)
+
+    def step(self, token, state):
+        succ = (np.asarray(token) + 1) % self.config.vocab_size
+        return BIG * np.eye(self.config.vocab_size, dtype=np.float32)[succ], state
+
+    def clone_state(self, state):
+        return np.array(state, copy=True)
 
 
 def _lp_match(v):
@@ -191,8 +207,14 @@ def test_lm_eval_adapter_integration():
         disable_tqdm=True)
     assert len(rolling) == 1 and isinstance(rolling[0], float)
 
-    with pytest.raises(NotImplementedError):
-        lm.generate_until([], disable_tqdm=True)
+    # generate_until now delegates to the shared generation core. From "ab" (last
+    # byte 'b'=98) the successor model emits 'c','d',...; until=["d"] stops and the
+    # returned text is truncated before 'd' -> "c".
+    gen = lm.generate_until(
+        [Instance(request_type="generate_until", doc={},
+                  arguments=("ab", {"until": ["d"], "max_gen_toks": 5}), idx=0)],
+        disable_tqdm=True)
+    assert gen == ["c"]
 
     # Our hand-rolled windows match lm_eval's reference utilities.
     from lm_eval.utils import get_rolling_token_windows, make_disjoint_window

--- a/tests/test_olmes_generate.py
+++ b/tests/test_olmes_generate.py
@@ -1,0 +1,85 @@
+"""Generative-eval compatibility: `generate_until_texts` over the shared core.
+
+Exercises the same code path lm-eval's `generate_until` delegates to, but with a
+FakeModel + a char tokenizer and NO lm-eval dependency. Proves the two behaviors the
+harness relies on: stopping/truncating at an `until` string, and bounding output by
+`max_gen_toks`. The lazily-imported lm-eval shell itself is covered in the live
+eval-harness run (plan Verification step 7).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from src.eval.olmes_adapter import generate_until_texts
+
+
+class CounterModel:
+    """Greedy next token = (current token + 1) % vocab (matches tests/test_generate)."""
+
+    def __init__(self, vocab_size: int = 16):
+        self.config = SimpleNamespace(
+            n_layers=2, d_conv=4, d_inner=128, n_heads=8, head_dim=16, d_state=16,
+            precision="fp32", vocab_size=vocab_size,
+        )
+
+    def init_state(self, batch_size: int):
+        return np.zeros((batch_size,), dtype=np.int64)
+
+    def step(self, token, state):
+        token = np.asarray(token)
+        nxt = (token + 1) % self.config.vocab_size
+        return np.eye(self.config.vocab_size)[nxt], state + token
+
+    def clone_state(self, state):
+        return np.array(state, copy=True)
+
+
+class CharTokenizer:
+    """Maps token id i <-> letter ('a'+i). eos disabled so it never short-circuits."""
+
+    vocab_size = 16
+    eos_token_id = None
+
+    def encode(self, s, add_special_tokens=False):
+        return [(ord(c) - ord("a")) % self.vocab_size for c in s]
+
+    def decode(self, ids):
+        return "".join(chr(ord("a") + (int(i) % self.vocab_size)) for i in ids)
+
+
+def _run(pairs, max_length=32):
+    return generate_until_texts(CounterModel(), CharTokenizer(), pairs,
+                                max_length=max_length)
+
+
+def test_until_string_truncates_output():
+    # Prompt "a"(=0) decodes greedily to b, c, d, ...; until=["d"] stops at d and the
+    # returned text is truncated *before* d -> "bc".
+    (out,) = _run([("a", {"until": ["d"], "max_gen_toks": 10})])
+    assert out == "bc"
+
+
+def test_max_gen_toks_bounds_output():
+    (out,) = _run([("a", {"max_gen_toks": 3})])
+    assert out == "bcd"  # exactly 3 generated tokens, no stop string
+
+
+def test_multiple_requests_preserve_order():
+    out = _run([("a", {"max_gen_toks": 2}), ("b", {"max_gen_toks": 2})])
+    assert out == ["bc", "cd"]
+
+
+def test_string_until_is_accepted():
+    # lm-eval may pass `until` as a bare string rather than a list.
+    (out,) = _run([("a", {"until": "c", "max_gen_toks": 10})])
+    assert out == "b"
+
+
+def test_context_is_left_truncated_to_make_room():
+    # max_length 4, max_gen 3 -> keep only the last context token; still returns a
+    # bounded string (regression guard on the truncation arithmetic).
+    (out,) = _run([("abcdef", {"max_gen_toks": 3})], max_length=4)
+    assert isinstance(out, str) and len(out) == 3

--- a/tests/test_olmes_generate.py
+++ b/tests/test_olmes_generate.py
@@ -83,3 +83,10 @@ def test_context_is_left_truncated_to_make_room():
     # bounded string (regression guard on the truncation arithmetic).
     (out,) = _run([("abcdef", {"max_gen_toks": 3})], max_length=4)
     assert isinstance(out, str) and len(out) == 3
+
+
+def test_max_gen_toks_capped_to_max_length():
+    # max_gen_toks (100) far exceeds max_length (4); generation must be capped so
+    # prompt (>=1 token) + new tokens stays within max_length -> at most 3 generated.
+    (out,) = _run([("a", {"max_gen_toks": 100})], max_length=4)
+    assert len(out) <= 3


### PR DESCRIPTION
## What

Builds the two things still missing to **train and serve** the POC end-to-end: a generation core that turns the model into text, and the data sources for a short English + instruction run. Implements the approved plan (short-run deliverable + CLI generate/chat + eval-framework compatibility).

The actual ~300M-token data build and the ~2.6-day training run are operator-driven (network + days of compute); this PR is the code they depend on.

## Generation core (one core, two consumers)
- `src/serve/sampling.py` — portable greedy / temperature / top-k / top-p sampler (numpy, above the seam).
- `src/serve/generate.py` — shared generation loop over `SessionStore.step`, with `stop_fn` (decode-and-match stop strings) and `on_token` (streaming) hooks; no new state handling.
- `scripts/generate.py` — CLI entry (mlx imported locally). Completion mode (`--prompt`) and `--chat` (instruction-template REPL); streams decoded tokens.
- `src/eval/olmes_adapter.py` — **implements `generate_until`** over the same core, so generative lm-eval/OLMES tasks run end-to-end. This is the *"serving output must be compatible with eval frameworks"* requirement. `scripts/eval_olmes.py` already routes `--tasks` through it.

## Data sources
- `src/data/instruct_format.py` — single source of truth for the instruction template, reused at train time **and** by `--chat`, so the formats can't drift.
- `src/data/download.py` — `--source {fineweb,wikipedia,instruct}`. Wikipedia extracts prose from `wikimedia/structured-wikipedia` (title + abstract + section paragraphs, abstract-only fallback); instruct formats `databricks/databricks-dolly-15k` with `--repeat` oversampling. Extractors are pure functions over injected records → unit-tested offline.
- `src/data/tokenize.py` — `ByteTokenizer.decode()` for offline round-trip.

## Fixes
- `.gitignore`: anchored `/data/` and `/runs/` to root. The unanchored `data/` was silently ignoring new files under `src/data/` (caught `instruct_format.py`).

## Tests
- New: `test_download_sources.py`, `test_generate.py`, `test_olmes_generate.py`.
- Updated: `test_olmes_adapter.py` (old `generate_until`-raises assertion → real path), `test_import_guard.py` (new portable modules).
- **Suite: 95 passed (was 70).** Seam guard green.
- Manually verified the real MLX generation loop runs end-to-end (toy model + byte-fallback), completion and chat modes — output is gibberish as expected for random-init weights, but encode→step→sample→decode→stream works.

## Expectation
At ~100M params / ~300M tokens, `--chat` yields *template-shaped* output (emits a `### Response:` section) but not reliably correct answers. POC success remains a smoothly-decreasing val-perplexity curve.

Part of #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)