### PR TITLE
[M8] Backend-selection harness for MLX/CUDA drivers (#35)

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -24,13 +24,13 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-import numpy as np
-
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--config", type=Path, default=Path("config/toy.yaml"))
     ap.add_argument("--data", type=Path, required=True, help="dir with train.bin/val.bin")
+    ap.add_argument("--backend", choices=("auto", "mlx", "cuda"), default="auto",
+                    help="hardware backend (auto: try mlx, fall back to cuda/torch)")
     ap.add_argument("--steps", type=int, default=50)
     ap.add_argument("--batch-size", type=int, default=8)
     ap.add_argument("--seed", type=int, default=0)
@@ -38,32 +38,21 @@ def main() -> None:
     ap.add_argument("--atol", type=float, default=1e-4)
     args = ap.parse_args()
 
-    # MLX-only imports kept local so the seam stays clean for portable hosts.
-    try:
-        import mlx.core as mx
-        import mlx.optimizers as optim
-    except ModuleNotFoundError as e:
-        if e.name != "mlx":
-            raise
-        raise SystemExit(
-            "mlx not found — run with the project venv on Apple Silicon:\n"
-            "    .venv/bin/python scripts/smoke_test.py ...\n"
-            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
-            "`python` likely points at a different interpreter.)"
-        ) from e
+    # Backend selection stays behind the seam factory; only portable modules are
+    # imported at module scope.
+    from src.model.backend import get_backend
     from src.model.blocks import load_config
-    from src.model.mlx_backend import MLXMambaModel
-    from src.model.mlx_train_step import make_train_step, save_optimizer, load_optimizer
     from src.data.loader import PackedLoader
     from src.train.schedule import CosineSchedule
     from src.train.checkpoint import save_weights, save_resume, load_resume
     from src.eval.val_loss import evaluate
 
+    backend = get_backend(args.backend)
     cfg = load_config(str(args.config))
     assert cfg.precision == "fp32", "smoke test requires fp32 for exact resume"
     N = args.steps
     half = N // 2
-    np_to = lambda a: np.array(a)
+    np_to = backend.to_numpy
 
     # --- fixed batch stream (shuffle off => batch at step s is deterministic) ---
     train_loader = PackedLoader(args.data / "train.bin", cfg.seq_len,
@@ -77,10 +66,10 @@ def main() -> None:
     sched = CosineSchedule(base_lr=3e-4, warmup_steps=max(1, N // 6), total_steps=N)
 
     def fresh_model_opt():
-        mx.random.seed(args.seed)                 # identical init weights each run
-        model = MLXMambaModel(cfg)
-        opt = optim.AdamW(learning_rate=sched.base_lr)
-        return model, opt, make_train_step(model, opt, grad_clip=1.0, scaler=None)
+        backend.seed(args.seed)                   # identical init weights each run
+        model = backend.model_cls(cfg)
+        opt = backend.make_optimizer(model, sched.base_lr)
+        return model, opt, backend.make_train_step(model, opt, grad_clip=1.0, scaler=None)
 
     def run_window(model, step_fn, lo, hi, into):
         for s in range(lo, hi):
@@ -105,16 +94,17 @@ def main() -> None:
     run_window(model_a, step_fn_a, 0, half, res)
     model_a.save(weights_path)                                  # portable weights
     save_resume(bundle_dir, step=half, rng_state=None,
-                optimizer_serializer=lambda p: save_optimizer(opt_a, p))
+                optimizer_serializer=lambda p: backend.save_optimizer(opt_a, p))
     del model_a, opt_a, step_fn_a                               # "kill" the process state
 
-    mx.random.seed(args.seed + 999)            # different RNG: weights come from disk
-    model_b = MLXMambaModel(cfg)
+    backend.seed(args.seed + 999)              # different RNG: weights come from disk
+    model_b = backend.model_cls(cfg)
     model_b.load(weights_path)
-    opt_b = optim.AdamW(learning_rate=sched.base_lr)
-    meta = load_resume(bundle_dir, optimizer_deserializer=lambda p: load_optimizer(opt_b, p))
+    opt_b = backend.make_optimizer(model_b, sched.base_lr)
+    meta = load_resume(bundle_dir,
+                       optimizer_deserializer=lambda p: backend.load_optimizer(opt_b, p))
     start = meta["step"]
-    step_fn_b = make_train_step(model_b, opt_b, grad_clip=1.0)
+    step_fn_b = backend.make_train_step(model_b, opt_b, grad_clip=1.0)
     run_window(model_b, step_fn_b, start, N, res)
     print(f"[resumed]   resumed at step={start}  step{N-1} loss={res[N-1]:.5f}")
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -21,7 +21,9 @@ Resume after an interruption:
         --out runs/poc --total-tokens 3_000_000_000 --batch-size 32 --grad-accum 4 \\
         --resume runs/poc/resume
 
-MLX imports are kept local so the module stays importable for `--help` on any host.
+The backend (MLX or CUDA/PyTorch) is selected via `--backend {auto,mlx,cuda}`; backend
+imports stay behind `src.model.backend.get_backend`, so the module stays importable for
+`--help` on any host.
 """
 
 from __future__ import annotations
@@ -36,6 +38,8 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
     ap.add_argument("--data", type=Path, required=True, help="dir with train.bin/val.bin")
     ap.add_argument("--out", type=Path, default=Path("runs/poc"))
+    ap.add_argument("--backend", choices=("auto", "mlx", "cuda"), default="auto",
+                    help="hardware backend (auto: try mlx, fall back to cuda/torch)")
     g = ap.add_mutually_exclusive_group(required=True)
     g.add_argument("--total-steps", type=int, help="number of optimizer steps")
     g.add_argument("--total-tokens", type=int,
@@ -61,32 +65,20 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    # MLX-only imports kept local so the seam stays clean for portable hosts.
+    # Backend selection stays behind the seam factory; only portable modules are
+    # imported at module scope.
     import numpy as np
-    try:
-        import mlx.core as mx
-        import mlx.optimizers as optim
-    except ModuleNotFoundError as e:
-        if e.name != "mlx":
-            raise
-        raise SystemExit(
-            "mlx not found — run with the project venv on Apple Silicon:\n"
-            "    .venv/bin/python scripts/train.py ...\n"
-            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
-            "`python` likely points at a different interpreter.)"
-        ) from e
 
+    from src.model.backend import get_backend
     from src.model.blocks import load_config
-    from src.model.mlx_backend import MLXMambaModel
-    from src.model.mlx_train_step import (
-        make_train_step, save_optimizer, load_optimizer,
-    )
     from src.data.loader import PackedLoader
     from src.train.loss_scale import scaler_for_precision
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
     from src.train.checkpoint import save_resume, load_resume
     from src.eval.val_loss import evaluate
+
+    backend = get_backend(args.backend)
 
     cfg = load_config(str(args.config))                 # validates (vocab < 65536, ...)
 
@@ -96,21 +88,21 @@ def main() -> None:
     warmup = args.warmup_steps if args.warmup_steps is not None else max(1, total_steps // 100)
 
     # --- model + optimizer + (dynamic) loss scaling ----------------------------
-    mx.random.seed(args.seed)
-    model = MLXMambaModel(cfg)
-    opt = optim.AdamW(learning_rate=args.base_lr)
+    backend.seed(args.seed)
+    model = backend.model_cls(cfg)
+    opt = backend.make_optimizer(model, args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
     if scaler is None and cfg.precision != "fp32":
         print(f"[info] precision={cfg.precision!r}: training unscaled "
               "(loss scaling is fp16-only; expected for bf16)")
-    train_step = make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler)
+    train_step = backend.make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler)
 
     # --- data ------------------------------------------------------------------
     train_loader = PackedLoader(args.data / "train.bin", cfg.seq_len,
                                 args.batch_size, shuffle=True, seed=args.seed)
     val_loader = PackedLoader(args.data / "val.bin", cfg.seq_len,
                               args.batch_size, shuffle=False, drop_last=False)
-    np_to = lambda a: np.array(a)
+    np_to = backend.to_numpy
     max_b = args.eval_batches or None
     val_eval = lambda m: evaluate(m, val_loader, max_batches=max_b, to_numpy=np_to)
 
@@ -126,7 +118,7 @@ def main() -> None:
     if resume_dir is not None:
         model.load(weights_path)
         meta = load_resume(str(resume_dir),
-                           optimizer_deserializer=lambda p: load_optimizer(opt, p))
+                           optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
             scaler.load_state_dict(meta.get("rng_state") or {})
@@ -138,7 +130,7 @@ def main() -> None:
         model.save(weights_path)                        # portable weights + config
         save_resume(bundle_dir, step=step,
                     rng_state=(scaler.state_dict() if scaler else None),
-                    optimizer_serializer=lambda p: save_optimizer(opt, p))
+                    optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
 
     tcfg = TrainConfig(
         total_steps=total_steps, base_lr=args.base_lr, warmup_steps=warmup,

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -1,0 +1,132 @@
+"""Backend selection — the portable factory above the seam.
+
+The driver scripts (`scripts/train.py`, `scripts/smoke_test.py`) must run on either
+Apple Silicon (MLX) or a CUDA host (PyTorch) without code changes. The `ModelInterface`
+seam already isolates the *model*; this module isolates the rest of the backend wiring
+the drivers need — the optimizer, the injected `train_step`, the resume-bundle
+(de)serializers, RNG seeding, and the array->numpy converter — behind one
+`get_backend(name)` call.
+
+THIS MODULE MUST NOT IMPORT A BACKEND AT MODULE LEVEL (no `mlx`, no `torch`). Every
+backend import lives inside a `get_backend` branch (lazy), so the module is importable
+on any host and stays in `tests/test_import_guard.py`'s portable set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class Backend:
+    """Everything a driver needs to run on one hardware backend.
+
+    `model_cls(config)` builds a `ModelInterface`; `make_optimizer(model, base_lr)`
+    builds its optimizer. The remaining callables mirror the backend's `*_train_step`
+    module so the drivers never import `mlx`/`torch` directly.
+    """
+
+    name: str
+    model_cls: type
+    make_train_step: Callable[..., Callable]
+    save_optimizer: Callable[[Any, str], None]
+    load_optimizer: Callable[[Any, str], None]
+    make_optimizer: Callable[[Any, float], Any]
+    seed: Callable[[int], None]
+    to_numpy: Callable[[Any], Any]
+
+
+def get_backend(name: str = "auto") -> Backend:
+    """Return the `Backend` for `name` in {"auto", "mlx", "cuda"}.
+
+    "auto" tries MLX (the Apple-Silicon dev backend) and falls back to CUDA/PyTorch.
+    All backend imports happen inside the branch, so importing this module never pulls
+    in a hardware library.
+    """
+    if name == "auto":
+        try:
+            return _mlx_backend()
+        except SystemExit:
+            # mlx absent on this host — fall back to the torch backend.
+            return _cuda_backend()
+    if name == "mlx":
+        return _mlx_backend()
+    if name == "cuda":
+        return _cuda_backend()
+    raise ValueError(f"unknown backend {name!r}; expected one of auto, mlx, cuda")
+
+
+def _mlx_backend() -> Backend:
+    try:
+        import mlx.core as mx
+        import mlx.optimizers as optim
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/<driver>.py ...\n"
+            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
+            "`python` likely points at a different interpreter.)"
+        ) from e
+    import numpy as np
+
+    from .mlx_backend import MLXMambaModel
+    from .mlx_train_step import make_train_step, save_optimizer, load_optimizer
+
+    return Backend(
+        name="mlx",
+        model_cls=MLXMambaModel,
+        make_train_step=make_train_step,
+        save_optimizer=save_optimizer,
+        load_optimizer=load_optimizer,
+        # MLX AdamW holds no parameter refs at construction (params arrive at update);
+        # `model` is accepted for a uniform signature and ignored.
+        make_optimizer=lambda model, base_lr: optim.AdamW(learning_rate=base_lr),
+        seed=lambda value: mx.random.seed(value),
+        to_numpy=lambda a: np.array(a),
+    )
+
+
+def _cuda_backend() -> Backend:
+    try:
+        import torch
+    except ModuleNotFoundError as e:
+        if e.name != "torch":
+            raise
+        raise SystemExit(
+            "torch not found — install the CUDA backend extra on a Linux/CUDA host:\n"
+            "    pip install -e '.[cuda]'\n"
+            "(torch is omitted from the default deps; mlx is the Apple-Silicon backend.)"
+        ) from e
+    import numpy as np
+
+    from .cuda_backend import CUDAMambaModel
+
+    # The train-step primitives land with the CUDA train_step issue (#37); import them
+    # lazily so the `cuda` branch is usable for model construction (which raises the
+    # stub's clear NotImplementedError) before they exist.
+    def _make_train_step(*args, **kwargs):
+        from .cuda_train_step import make_train_step
+        return make_train_step(*args, **kwargs)
+
+    def _save_optimizer(optimizer, path):
+        from .cuda_train_step import save_optimizer
+        return save_optimizer(optimizer, path)
+
+    def _load_optimizer(optimizer, path):
+        from .cuda_train_step import load_optimizer
+        return load_optimizer(optimizer, path)
+
+    return Backend(
+        name="cuda",
+        model_cls=CUDAMambaModel,
+        make_train_step=_make_train_step,
+        save_optimizer=_save_optimizer,
+        load_optimizer=_load_optimizer,
+        make_optimizer=lambda model, base_lr: torch.optim.AdamW(
+            model.parameters(), lr=base_lr),
+        seed=lambda value: torch.manual_seed(value),
+        to_numpy=lambda a: a.detach().to("cpu").numpy(),
+    )

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -32,6 +32,7 @@ import pytest
 PORTABLE_MODULES = [
     "src.model.interface",
     "src.model.blocks",
+    "src.model.backend",
     "src.data.loader",
     "src.data.pack",
     "src.data.split",


### PR DESCRIPTION
Part of #16. Closes #35.

First PR in the M8 CUDA chain — a pure refactor with **no torch dependency**, so it lands first and the CUDA issues plug into it.

## What
Adds `src/model/backend.py`, a portable factory above the seam so the driver scripts pick a hardware backend via `--backend {auto,mlx,cuda}` (default `auto`: try mlx, fall back to torch). All backend imports live **inside** the `get_backend` branches (lazy), so the module imports clean on any host.

`scripts/train.py` and `scripts/smoke_test.py` now wire model, optimizer, `train_step`, optimizer (de)serializers, RNG seeding, and the array→numpy converter through `get_backend(...)` instead of importing `mlx` directly. The `cuda` branch surfaces the stub's `NotImplementedError` (or a clear "install torch" hint) until the CUDA backend lands (#36/#37).

`src.model.backend` is added to `PORTABLE_MODULES` so the import guard proves the factory leaks no backend into `sys.modules`.

## Verification
- `pytest tests/test_import_guard.py` green (new module guarded, holds even with torch installed).
- Full suite green; MLX tests skip on non-Mac hosts.
- `scripts/train.py --help` works with no backend installed; `--backend cuda` reaches the stub cleanly.

## Stack
This is the base of a 4-PR stack: #35 (this) → #36 → #37 → #38.

https://claude.ai/code/session_01VzRW5Eu7xGAfWMUw4Krqv5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzRW5Eu7xGAfWMUw4Krqv5)_