### PR TITLE
[M8] backend_parity MLX-vs-torch + portable round-trip (#38)

### DIFF
--- a/docs/design/03-conformance.md
+++ b/docs/design/03-conformance.md
@@ -36,15 +36,22 @@ the parity check proves train/infer equivalence. Both are needed.
 
 ## backend-vs-backend parity
 
-When the CUDA backend exists, the same weights and input must give the same logits on
-MLX and CUDA. From
+The same weights and input must give the same logits on MLX and the CUDA/PyTorch
+backend. From
 [`src/conformance/backend_parity.py`](../../src/conformance/backend_parity.py):
 
 > Fixed seed, fixed weights, fixed input batch. Run `forward` through both the MLX
 > and CUDA backends and assert agreement. Run the comparison in FP32 on BOTH sides.
 
 It loads identical [portable weights](05-training.md) into each backend (the seam's
-`save`/`load`), then compares.
+`save`/`load`), then compares. Because the CUDA backend is **pure PyTorch and runs on
+CPU**, this is runnable entirely on a Mac (mlx + torch-CPU both present) — no GPU
+required. `tests/test_backend_parity.py` exercises it on the toy config, and also tests
+the **portable-weights round-trip in both directions** (MLX → safetensors → torch →
+safetensors → MLX, logits unchanged), which is what lets a CUDA-trained model come back
+to the Mac. The only layout subtlety is the depthwise-conv weight: the portable format
+is MLX-canonical `(out, k, in/groups)`, and the torch backend transposes to/from torch's
+`(out, in/groups, k)` in `_portable_state_dict`/`_load_portable`.
 
 ## Why fp32, ~1e-4
 
@@ -60,12 +67,11 @@ to catch *math* bugs, not measure numerical noise.
 
 ## Status
 
-`forward_step_parity` is active and passing on MLX. `backend_parity` requires both
-backends present, so it:
-
-> runs only where CUDA is available; until then it stays a stub the seam can point at.
-
-It will come online with the M8 CUDA backend.
+`forward_step_parity` is active and passing on both backends (MLX, and the pure-PyTorch
+CUDA backend on torch-CPU). `backend_parity` is implemented and exercised by
+`tests/test_backend_parity.py`; the cross-backend cases need both backends present, so
+they **skip cleanly** on a single-backend host (e.g. a Linux/CUDA box without mlx, or a
+Mac without torch) and run in full on a Mac with torch-CPU installed.
 
 ## Related
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
 data = ["datasets>=2.0", "transformers>=4.40"]
 # Apple Silicon backend (NOT installable on Linux/CUDA hosts).
 mlx = ["mlx>=0.18"]
+# CUDA / PyTorch backend (Linux/CUDA host; also runs CPU-only for conformance on a Mac).
+# The optional mamba-ssm fused selective-scan kernel is a separate perf extra (#40).
+cuda = ["torch>=2.0"]
 # Experiment logging.
 logging = ["wandb>=0.16"]
 # Tier-2 OLMES/lm-eval benchmark harness. A heavy optional dependency (some

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ pytest>=8.0
 # Apple Silicon ONLY (uncomment on a Mac; not installable on Linux/CUDA):
 # mlx>=0.18
 
-# CUDA scale-up ONLY (added at that milestone):
-# torch
-# mamba-ssm
+# CUDA / PyTorch backend (uncomment on a Linux/CUDA host; also CPU-only for conformance):
+# torch>=2.0
+# mamba-ssm   # optional fused selective-scan kernel (#40); CUDA-only

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -24,13 +24,13 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-import numpy as np
-
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--config", type=Path, default=Path("config/toy.yaml"))
     ap.add_argument("--data", type=Path, required=True, help="dir with train.bin/val.bin")
+    ap.add_argument("--backend", choices=("auto", "mlx", "cuda"), default="auto",
+                    help="hardware backend (auto: try mlx, fall back to cuda/torch)")
     ap.add_argument("--steps", type=int, default=50)
     ap.add_argument("--batch-size", type=int, default=8)
     ap.add_argument("--seed", type=int, default=0)
@@ -38,32 +38,21 @@ def main() -> None:
     ap.add_argument("--atol", type=float, default=1e-4)
     args = ap.parse_args()
 
-    # MLX-only imports kept local so the seam stays clean for portable hosts.
-    try:
-        import mlx.core as mx
-        import mlx.optimizers as optim
-    except ModuleNotFoundError as e:
-        if e.name != "mlx":
-            raise
-        raise SystemExit(
-            "mlx not found — run with the project venv on Apple Silicon:\n"
-            "    .venv/bin/python scripts/smoke_test.py ...\n"
-            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
-            "`python` likely points at a different interpreter.)"
-        ) from e
+    # Backend selection stays behind the seam factory; only portable modules are
+    # imported at module scope.
+    from src.model.backend import get_backend
     from src.model.blocks import load_config
-    from src.model.mlx_backend import MLXMambaModel
-    from src.model.mlx_train_step import make_train_step, save_optimizer, load_optimizer
     from src.data.loader import PackedLoader
     from src.train.schedule import CosineSchedule
     from src.train.checkpoint import save_weights, save_resume, load_resume
     from src.eval.val_loss import evaluate
 
+    backend = get_backend(args.backend)
     cfg = load_config(str(args.config))
     assert cfg.precision == "fp32", "smoke test requires fp32 for exact resume"
     N = args.steps
     half = N // 2
-    np_to = lambda a: np.array(a)
+    np_to = backend.to_numpy
 
     # --- fixed batch stream (shuffle off => batch at step s is deterministic) ---
     train_loader = PackedLoader(args.data / "train.bin", cfg.seq_len,
@@ -77,10 +66,10 @@ def main() -> None:
     sched = CosineSchedule(base_lr=3e-4, warmup_steps=max(1, N // 6), total_steps=N)
 
     def fresh_model_opt():
-        mx.random.seed(args.seed)                 # identical init weights each run
-        model = MLXMambaModel(cfg)
-        opt = optim.AdamW(learning_rate=sched.base_lr)
-        return model, opt, make_train_step(model, opt, grad_clip=1.0, scaler=None)
+        backend.seed(args.seed)                   # identical init weights each run
+        model = backend.model_cls(cfg)
+        opt = backend.make_optimizer(model, sched.base_lr)
+        return model, opt, backend.make_train_step(model, opt, grad_clip=1.0, scaler=None)
 
     def run_window(model, step_fn, lo, hi, into):
         for s in range(lo, hi):
@@ -105,16 +94,17 @@ def main() -> None:
     run_window(model_a, step_fn_a, 0, half, res)
     model_a.save(weights_path)                                  # portable weights
     save_resume(bundle_dir, step=half, rng_state=None,
-                optimizer_serializer=lambda p: save_optimizer(opt_a, p))
+                optimizer_serializer=lambda p: backend.save_optimizer(opt_a, p))
     del model_a, opt_a, step_fn_a                               # "kill" the process state
 
-    mx.random.seed(args.seed + 999)            # different RNG: weights come from disk
-    model_b = MLXMambaModel(cfg)
+    backend.seed(args.seed + 999)              # different RNG: weights come from disk
+    model_b = backend.model_cls(cfg)
     model_b.load(weights_path)
-    opt_b = optim.AdamW(learning_rate=sched.base_lr)
-    meta = load_resume(bundle_dir, optimizer_deserializer=lambda p: load_optimizer(opt_b, p))
+    opt_b = backend.make_optimizer(model_b, sched.base_lr)
+    meta = load_resume(bundle_dir,
+                       optimizer_deserializer=lambda p: backend.load_optimizer(opt_b, p))
     start = meta["step"]
-    step_fn_b = make_train_step(model_b, opt_b, grad_clip=1.0)
+    step_fn_b = backend.make_train_step(model_b, opt_b, grad_clip=1.0)
     run_window(model_b, step_fn_b, start, N, res)
     print(f"[resumed]   resumed at step={start}  step{N-1} loss={res[N-1]:.5f}")
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -21,7 +21,9 @@ Resume after an interruption:
         --out runs/poc --total-tokens 3_000_000_000 --batch-size 32 --grad-accum 4 \\
         --resume runs/poc/resume
 
-MLX imports are kept local so the module stays importable for `--help` on any host.
+The backend (MLX or CUDA/PyTorch) is selected via `--backend {auto,mlx,cuda}`; backend
+imports stay behind `src.model.backend.get_backend`, so the module stays importable for
+`--help` on any host.
 """
 
 from __future__ import annotations
@@ -36,6 +38,8 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
     ap.add_argument("--data", type=Path, required=True, help="dir with train.bin/val.bin")
     ap.add_argument("--out", type=Path, default=Path("runs/poc"))
+    ap.add_argument("--backend", choices=("auto", "mlx", "cuda"), default="auto",
+                    help="hardware backend (auto: try mlx, fall back to cuda/torch)")
     g = ap.add_mutually_exclusive_group(required=True)
     g.add_argument("--total-steps", type=int, help="number of optimizer steps")
     g.add_argument("--total-tokens", type=int,
@@ -61,32 +65,20 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
 
-    # MLX-only imports kept local so the seam stays clean for portable hosts.
+    # Backend selection stays behind the seam factory; only portable modules are
+    # imported at module scope.
     import numpy as np
-    try:
-        import mlx.core as mx
-        import mlx.optimizers as optim
-    except ModuleNotFoundError as e:
-        if e.name != "mlx":
-            raise
-        raise SystemExit(
-            "mlx not found — run with the project venv on Apple Silicon:\n"
-            "    .venv/bin/python scripts/train.py ...\n"
-            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
-            "`python` likely points at a different interpreter.)"
-        ) from e
 
+    from src.model.backend import get_backend
     from src.model.blocks import load_config
-    from src.model.mlx_backend import MLXMambaModel
-    from src.model.mlx_train_step import (
-        make_train_step, save_optimizer, load_optimizer,
-    )
     from src.data.loader import PackedLoader
     from src.train.loss_scale import scaler_for_precision
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
     from src.train.checkpoint import save_resume, load_resume
     from src.eval.val_loss import evaluate
+
+    backend = get_backend(args.backend)
 
     cfg = load_config(str(args.config))                 # validates (vocab < 65536, ...)
 
@@ -96,21 +88,21 @@ def main() -> None:
     warmup = args.warmup_steps if args.warmup_steps is not None else max(1, total_steps // 100)
 
     # --- model + optimizer + (dynamic) loss scaling ----------------------------
-    mx.random.seed(args.seed)
-    model = MLXMambaModel(cfg)
-    opt = optim.AdamW(learning_rate=args.base_lr)
+    backend.seed(args.seed)
+    model = backend.model_cls(cfg)
+    opt = backend.make_optimizer(model, args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
     if scaler is None and cfg.precision != "fp32":
         print(f"[info] precision={cfg.precision!r}: training unscaled "
               "(loss scaling is fp16-only; expected for bf16)")
-    train_step = make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler)
+    train_step = backend.make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler)
 
     # --- data ------------------------------------------------------------------
     train_loader = PackedLoader(args.data / "train.bin", cfg.seq_len,
                                 args.batch_size, shuffle=True, seed=args.seed)
     val_loader = PackedLoader(args.data / "val.bin", cfg.seq_len,
                               args.batch_size, shuffle=False, drop_last=False)
-    np_to = lambda a: np.array(a)
+    np_to = backend.to_numpy
     max_b = args.eval_batches or None
     val_eval = lambda m: evaluate(m, val_loader, max_batches=max_b, to_numpy=np_to)
 
@@ -126,7 +118,7 @@ def main() -> None:
     if resume_dir is not None:
         model.load(weights_path)
         meta = load_resume(str(resume_dir),
-                           optimizer_deserializer=lambda p: load_optimizer(opt, p))
+                           optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
             scaler.load_state_dict(meta.get("rng_state") or {})
@@ -138,7 +130,7 @@ def main() -> None:
         model.save(weights_path)                        # portable weights + config
         save_resume(bundle_dir, step=step,
                     rng_state=(scaler.state_dict() if scaler else None),
-                    optimizer_serializer=lambda p: save_optimizer(opt, p))
+                    optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
 
     tcfg = TrainConfig(
         total_steps=total_steps, base_lr=args.base_lr, warmup_steps=warmup,

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -1,0 +1,132 @@
+"""Backend selection — the portable factory above the seam.
+
+The driver scripts (`scripts/train.py`, `scripts/smoke_test.py`) must run on either
+Apple Silicon (MLX) or a CUDA host (PyTorch) without code changes. The `ModelInterface`
+seam already isolates the *model*; this module isolates the rest of the backend wiring
+the drivers need — the optimizer, the injected `train_step`, the resume-bundle
+(de)serializers, RNG seeding, and the array->numpy converter — behind one
+`get_backend(name)` call.
+
+THIS MODULE MUST NOT IMPORT A BACKEND AT MODULE LEVEL (no `mlx`, no `torch`). Every
+backend import lives inside a `get_backend` branch (lazy), so the module is importable
+on any host and stays in `tests/test_import_guard.py`'s portable set.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class Backend:
+    """Everything a driver needs to run on one hardware backend.
+
+    `model_cls(config)` builds a `ModelInterface`; `make_optimizer(model, base_lr)`
+    builds its optimizer. The remaining callables mirror the backend's `*_train_step`
+    module so the drivers never import `mlx`/`torch` directly.
+    """
+
+    name: str
+    model_cls: type
+    make_train_step: Callable[..., Callable]
+    save_optimizer: Callable[[Any, str], None]
+    load_optimizer: Callable[[Any, str], None]
+    make_optimizer: Callable[[Any, float], Any]
+    seed: Callable[[int], None]
+    to_numpy: Callable[[Any], Any]
+
+
+def get_backend(name: str = "auto") -> Backend:
+    """Return the `Backend` for `name` in {"auto", "mlx", "cuda"}.
+
+    "auto" tries MLX (the Apple-Silicon dev backend) and falls back to CUDA/PyTorch.
+    All backend imports happen inside the branch, so importing this module never pulls
+    in a hardware library.
+    """
+    if name == "auto":
+        try:
+            return _mlx_backend()
+        except SystemExit:
+            # mlx absent on this host — fall back to the torch backend.
+            return _cuda_backend()
+    if name == "mlx":
+        return _mlx_backend()
+    if name == "cuda":
+        return _cuda_backend()
+    raise ValueError(f"unknown backend {name!r}; expected one of auto, mlx, cuda")
+
+
+def _mlx_backend() -> Backend:
+    try:
+        import mlx.core as mx
+        import mlx.optimizers as optim
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/<driver>.py ...\n"
+            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
+            "`python` likely points at a different interpreter.)"
+        ) from e
+    import numpy as np
+
+    from .mlx_backend import MLXMambaModel
+    from .mlx_train_step import make_train_step, save_optimizer, load_optimizer
+
+    return Backend(
+        name="mlx",
+        model_cls=MLXMambaModel,
+        make_train_step=make_train_step,
+        save_optimizer=save_optimizer,
+        load_optimizer=load_optimizer,
+        # MLX AdamW holds no parameter refs at construction (params arrive at update);
+        # `model` is accepted for a uniform signature and ignored.
+        make_optimizer=lambda model, base_lr: optim.AdamW(learning_rate=base_lr),
+        seed=lambda value: mx.random.seed(value),
+        to_numpy=lambda a: np.array(a),
+    )
+
+
+def _cuda_backend() -> Backend:
+    try:
+        import torch
+    except ModuleNotFoundError as e:
+        if e.name != "torch":
+            raise
+        raise SystemExit(
+            "torch not found — install the CUDA backend extra on a Linux/CUDA host:\n"
+            "    pip install -e '.[cuda]'\n"
+            "(torch is omitted from the default deps; mlx is the Apple-Silicon backend.)"
+        ) from e
+    import numpy as np
+
+    from .cuda_backend import CUDAMambaModel
+
+    # The train-step primitives land with the CUDA train_step issue (#37); import them
+    # lazily so the `cuda` branch is usable for model construction (which raises the
+    # stub's clear NotImplementedError) before they exist.
+    def _make_train_step(*args, **kwargs):
+        from .cuda_train_step import make_train_step
+        return make_train_step(*args, **kwargs)
+
+    def _save_optimizer(optimizer, path):
+        from .cuda_train_step import save_optimizer
+        return save_optimizer(optimizer, path)
+
+    def _load_optimizer(optimizer, path):
+        from .cuda_train_step import load_optimizer
+        return load_optimizer(optimizer, path)
+
+    return Backend(
+        name="cuda",
+        model_cls=CUDAMambaModel,
+        make_train_step=_make_train_step,
+        save_optimizer=_save_optimizer,
+        load_optimizer=_load_optimizer,
+        make_optimizer=lambda model, base_lr: torch.optim.AdamW(
+            model.parameters(), lr=base_lr),
+        seed=lambda value: torch.manual_seed(value),
+        to_numpy=lambda a: a.detach().to("cpu").numpy(),
+    )

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -1,53 +1,367 @@
-"""CUDA backend (scale-up milestone) — STUB.
+"""CUDA / PyTorch backend for the Mamba POC (scale-up milestone).
 
-Built at the CUDA scale-up against the now-finalized `ModelInterface`, using the
-`mamba-ssm` fused selective-scan kernel for `forward` and the recurrence form for
-`step`. Certified against the MLX backend by `conformance/backend_parity.py`
-(comparison run in fp32, ~1e-4 relative tolerance).
+A faithful port of `mlx_backend.py`: a Mamba-2 / SSD block (SCALAR-A selective SSM,
+multi-head with one shared B/C group). Written in plain PyTorch ops (no fused kernels)
+so it runs on **CPU as well as CUDA** — forward/step parity (and later backend_parity
+vs MLX) is therefore validatable on a Mac/Linux box before any CUDA hardware exists. The
+optional `mamba-ssm` fused fast path is a separate follow-up (#40).
 
-No `torch` import here yet so the module is inspectable without a CUDA stack; the
-import is added when the backend is implemented.
+Two code paths must agree (forward_step_parity, fp32 ~1e-4 rel):
+
+  * `parallel(x)`     : the SSD chunked-matmul scan over the full sequence (training).
+  * `recurrence(x, h)`: one-step state update (inference).
+
+This file imports `torch`, so it lives BELOW the seam — nothing portable imports it, and
+it stays out of `tests/test_import_guard.py`'s portable set.
 """
 
 from __future__ import annotations
 
-from typing import Tuple
+import math
+from typing import List, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.checkpoint import checkpoint as _checkpoint
 
 from .blocks import MambaConfig
 from .interface import ModelInterface, State, Array
 
 
-class CUDAMambaModel(ModelInterface):
-    """Placeholder. Implement with PyTorch + mamba-ssm at the scale-up milestone."""
+_DTYPES = {"fp32": torch.float32, "fp16": torch.float16, "bf16": torch.bfloat16}
+
+
+def _silu(x: Array) -> Array:
+    return F.silu(x)
+
+
+def _softplus(x: Array) -> Array:
+    # log(1 + exp(x)), numerically stable via logaddexp(x, 0) to match the MLX path.
+    return torch.logaddexp(x, torch.zeros_like(x))
+
+
+# --------------------------------------------------------------------------- #
+# Mixed precision (mirrors mlx_backend): fp32 master weights + fp16/bf16 compute.
+# Params stay fp32; cast to `compute_dtype` (cd) AT THE MATMUL SITE. For fp32 every
+# cast is a no-op (returns the tensor unchanged), so the fp32 path stays verbatim and
+# toy parity/conformance is bit-faithful.
+# --------------------------------------------------------------------------- #
+def _f32(t: Array) -> Array:
+    return t if t.dtype == torch.float32 else t.to(torch.float32)
+
+
+def _cast(t: Array, cd) -> Array:
+    return t if t.dtype == cd else t.to(cd)
+
+
+def _linear(layer: nn.Linear, x: Array, cd) -> Array:
+    """nn.Linear with operands cast to `cd`. fp32 routes to the original call verbatim
+    (fp16 @ fp32 would promote back to fp32, so BOTH operands must be cast)."""
+    if cd == torch.float32:
+        return layer(x)
+    y = x.to(cd) @ layer.weight.to(cd).t()
+    if layer.bias is not None:                       # in/x/out_proj are bias-free; dt_proj has bias
+        y = y + layer.bias.to(cd)
+    return y
+
+
+# --------------------------------------------------------------------------- #
+# Building blocks
+# --------------------------------------------------------------------------- #
+class RMSNorm(nn.Module):
+    def __init__(self, d_model: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x: Array) -> Array:
+        if x.dtype == torch.float32:                 # fp32 path: original op, bit-identical
+            norm = torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+            return self.weight * (x * norm)
+        # Mixed precision: reduce in fp32 (weight is fp32), return in x's dtype.
+        xf = x.to(torch.float32)
+        norm = torch.rsqrt(torch.mean(xf * xf, dim=-1, keepdim=True) + self.eps)
+        return (self.weight * (xf * norm)).to(x.dtype)
+
+
+def _segsum(x: Array) -> Array:
+    """Lower-triangular segment-sum. out[..., i, j] = sum_{j < k <= i} x_k for i >= j,
+    and -inf above the diagonal. `exp(_segsum(g))` is the within-window decay matrix of
+    a scalar SSM (1-semiseparable); the -inf upper triangle exp's to 0 (causality)."""
+    T = x.shape[-1]
+    xc = torch.cumsum(x, dim=-1)
+    seg = xc[..., :, None] - xc[..., None, :]
+    mask = torch.tril(torch.ones((T, T), dtype=torch.bool, device=x.device))
+    return seg.masked_fill(~mask, float("-inf"))
+
+
+class SelectiveSSM(nn.Module):
+    """Scalar-A Mamba-2 / SSD selective state space (see mlx_backend.SelectiveSSM)."""
 
     def __init__(self, config: MambaConfig):
+        super().__init__()
+        self.config = config
+        d_inner, d_state = config.d_inner, config.d_state
+        dt_rank, H = config.dt_rank_resolved, config.n_heads
+
+        # x_proj produces (dt_pre, B, C); B and C are one group, shared across heads.
+        self.x_proj = nn.Linear(d_inner, dt_rank + 2 * d_state, bias=False)
+        # dt is PER-HEAD in Mamba-2: dt_proj maps dt_rank -> n_heads.
+        self.dt_proj = nn.Linear(dt_rank, H, bias=True)
+
+        # Scalar decay A per head, stored as log: A = -exp(A_log). S4D-real init.
+        self.A_log = nn.Parameter(torch.log(torch.arange(1, H + 1, dtype=torch.float32)))
+        self.D = nn.Parameter(torch.ones(H))         # (H,) skip per head
+
+        self._init_dt_bias()
+
+    def _init_dt_bias(self) -> None:
+        """LOAD-BEARING dt-projection bias init (inverse-softplus into a small positive
+        range), per-head. Without this the model fails to learn recall.
+
+            dt   = uniform(log(dt_min), log(dt_max)).exp().clamp(min=dt_init_floor)
+            bias = dt + log(-expm1(-dt))          # inverse softplus
+        """
+        c = self.config
+        u = torch.empty(c.n_heads).uniform_(math.log(c.dt_min), math.log(c.dt_max))
+        dt = torch.clamp(torch.exp(u), min=c.dt_init_floor)
+        with torch.no_grad():
+            self.dt_proj.bias.copy_(dt + torch.log(-torch.expm1(-dt)))   # (H,)
+
+    # --- shared projections --------------------------------------------------
+    def _project(self, x: Array):
+        """x: (..., d_inner) -> delta (..., H), a (H,), B (..., N), C (..., N).
+
+        `x_proj` is the heavy SSM GEMM (runs in compute dtype); its outputs upcast to
+        fp32 so the rest of the scan runs in fp32."""
+        cd = _DTYPES[self.config.precision]
+        dt_rank, d_state = self.config.dt_rank_resolved, self.config.d_state
+        proj = _linear(self.x_proj, x, cd)
+        dt_pre = _f32(proj[..., :dt_rank])
+        B = _f32(proj[..., dt_rank:dt_rank + d_state])
+        C = _f32(proj[..., dt_rank + d_state:])
+        delta = _softplus(self.dt_proj(dt_pre))      # (..., H) per head, fp32
+        a = -torch.exp(self.A_log)                   # (H,) scalar decay, fp32
+        return delta, a, B, C
+
+    def parallel(self, x: Array) -> Array:
+        """SSD chunked-matmul scan. x: (B, L, d_inner) -> (B, L, d_inner).
+
+        Pads L up to a multiple of the chunk length Q (padded steps carry zero input and
+        are trimmed). All decays are exp of non-positive sums, so it is overflow-safe."""
+        B_, L, d_inner = x.shape
+        H, P, N = self.config.n_heads, self.config.head_dim, self.config.d_state
+        Q = self.config.chunk_size or 64
+        cd = _DTYPES[self.config.precision]
+        delta, a, Bm, Cm = self._project(x)          # delta (B,L,H); Bm,Cm (B,L,N) — fp32
+        X = _f32(x).reshape(B_, L, H, P)             # whole scan runs in fp32
+
+        pad = (-L) % Q
+        if pad:
+            zc = lambda t, shp: torch.cat([t, t.new_zeros(shp)], dim=1)
+            X, delta = zc(X, (B_, pad, H, P)), zc(delta, (B_, pad, H))
+            Bm, Cm = zc(Bm, (B_, pad, N)), zc(Cm, (B_, pad, N))
+        Lp, nc = L + pad, (L + pad) // Q
+        g = delta * a                                # (B,Lp,H) log-decay (<= 0)
+        Xin = delta[..., None] * X                   # (B,Lp,H,P) input = dt * X
+
+        gc = g.reshape(B_, nc, Q, H).permute(0, 3, 1, 2)     # (B,H,nc,Q)
+        Xc = Xin.reshape(B_, nc, Q, H, P)
+        Bc = Bm.reshape(B_, nc, Q, N)
+        Cc = Cm.reshape(B_, nc, Q, N)
+        Acum = torch.cumsum(gc, dim=-1)                      # (B,H,nc,Q)
+
+        # 1) intra-chunk diagonal block (attention-like, within each chunk)
+        Lmask = torch.exp(_segsum(gc))                       # (B,H,nc,Q,Q)
+        CB = torch.einsum("bcin,bcjn->bcij", Cc, Bc)         # (B,nc,Q,Q)
+        Ydiag = torch.einsum("bhcij,bcij,bcjhp->bcihp", Lmask, CB, Xc)
+        # 2) each chunk's final state, from that chunk's inputs only
+        decay_end = torch.exp(Acum[..., -1:] - Acum)         # (B,H,nc,Q)
+        states = torch.einsum("bhcj,bcjhp,bcjn->bchpn", decay_end, Xc, Bc)
+        # 3) inter-chunk recurrence over the nc chunk-states, as a matmul against an
+        # (nc+1, nc+1) decay matrix (Dao & Gu SSD form): O(nc^2) but nc is small.
+        states = torch.cat(
+            [states.new_zeros((B_, 1, H, P, N)), states], dim=1)
+        chunk_tot = F.pad(Acum[..., -1], (1, 0))             # (B,H,nc+1)
+        decay_chunk = torch.exp(_segsum(chunk_tot))          # (B,H,nc+1,nc+1)
+        new_states = torch.einsum("bhzc,bchpn->bzhpn", decay_chunk, states)
+        S_enter = new_states[:, :-1]                         # (B,nc,H,P,N)
+        # 4) off-diagonal output: entering state decayed to each position
+        out_decay = torch.exp(Acum)                          # (B,H,nc,Q)
+        Yoff = torch.einsum("bcin,bchpn,bhci->bcihp", Cc, S_enter, out_decay)
+
+        Y = (Ydiag + Yoff).reshape(B_, Lp, H, P)[:, :L]      # (B,L,H,P)
+        Y = Y + X[:, :L] * self.D[None, None, :, None]       # skip
+        return _cast(Y.reshape(B_, L, d_inner), cd)          # back to compute dtype
+
+    def recurrence(self, x: Array, state: State) -> Tuple[Array, State]:
+        """One timestep. x: (B, d_inner), state h: (B, H, P, N) -> y: (B, d_inner)."""
+        B_ = x.shape[0]
+        H, P = self.config.n_heads, self.config.head_dim
+        cd = _DTYPES[self.config.precision]
+        delta, a, Bm, Cm = self._project(x)          # delta (B,H); Bm,Cm (B,N) — fp32
+        Xh = _f32(x).reshape(B_, H, P)               # scan + state stay fp32
+        dA = torch.exp(delta * a)                    # (B,H)
+        dBx = (delta[..., None] * Xh)[..., None] * Bm[:, None, None, :]   # (B,H,P,N)
+        h = dA[:, :, None, None] * state + dBx        # (B,H,P,N) — fp32 state
+        y = torch.sum(h * Cm[:, None, None, :], dim=-1) + Xh * self.D[None, :, None]
+        return _cast(y.reshape(B_, -1), cd), h
+
+
+class MambaBlock(nn.Module):
+    """pre-norm -> input proj -> split main+gate -> causal depthwise conv -> SiLU
+    -> selective SSM -> * SiLU(gate) -> output proj, with a residual."""
+
+    def __init__(self, config: MambaConfig):
+        super().__init__()
+        self.config = config
+        d_inner = config.d_inner
+        self.norm = RMSNorm(config.d_model)
+        self.in_proj = nn.Linear(config.d_model, 2 * d_inner, bias=False)
+        self.conv = nn.Conv1d(d_inner, d_inner, config.d_conv,
+                              groups=d_inner, padding=config.d_conv - 1)
+        self.ssm = SelectiveSSM(config)
+        self.out_proj = nn.Linear(d_inner, config.d_model, bias=False)
+
+    def _conv_seq(self, x_main: Array, cd) -> Array:
+        """Causal depthwise conv in `cd`. torch Conv1d is channels-first, so transpose
+        (B,L,di) <-> (B,di,L) around it; the caller slices to the first L outputs."""
+        c = self.conv
+        y = F.conv1d(x_main.transpose(1, 2).to(cd), c.weight.to(cd), c.bias.to(cd),
+                     c.stride, c.padding, c.dilation, c.groups)
+        return y.transpose(1, 2)
+
+    def forward_seq(self, x: Array) -> Array:
+        L = x.shape[1]
+        cd = _DTYPES[self.config.precision]
+        xn = self.norm(x)
+        x_main, z = torch.chunk(_linear(self.in_proj, xn, cd), 2, dim=-1)   # (B,L,di) each
+        # Causal depthwise conv: pad both sides (d_conv-1), keep the first L outputs.
+        xc = self._conv_seq(x_main, cd)[:, :L]
+        xc = _silu(xc)
+        y = self.ssm.parallel(xc)
+        y = y * _silu(z)
+        return x + _linear(self.out_proj, y, cd)
+
+    def step(self, x: Array, state: State) -> Tuple[Array, State]:
+        conv_state, ssm_state = state                        # (B,k-1,di), (B,H,P,N)
+        cd = _DTYPES[self.config.precision]
+        xn = self.norm(x)
+        x_main, z = torch.chunk(_linear(self.in_proj, xn, cd), 2, dim=-1)   # (B,di) each
+        window = torch.cat([conv_state, x_main[:, None, :]], dim=1)         # (B,k,di)
+        # depthwise conv at this timestep: sum over kernel positions (in cd to match
+        # forward_seq; cast no-ops for fp32). torch conv weight is (di, 1, k).
+        wk = self.conv.weight[:, 0, :].t()                   # (k, di)
+        conv_out = (torch.sum(window.to(cd) * wk.to(cd)[None], dim=1)
+                    + self.conv.bias.to(cd))                 # (B, di)
+        xc = _silu(conv_out)
+        y, new_ssm = self.ssm.recurrence(xc, ssm_state)
+        y = y * _silu(z)
+        out = x + _linear(self.out_proj, y, cd)
+        return out, (window[:, 1:], new_ssm)
+
+
+# --------------------------------------------------------------------------- #
+# Top-level model implementing the seam
+# --------------------------------------------------------------------------- #
+class CUDAMambaModel(ModelInterface, nn.Module):
+    def __init__(self, config: MambaConfig, device: str = "cpu"):
+        nn.Module.__init__(self)
         config.validate()
         self.config = config
-        raise NotImplementedError(
-            "CUDA backend is built at the scale-up milestone (mamba-ssm fused kernel). "
-            "It must implement ModelInterface and pass backend_parity in fp32."
-        )
+        self._cd = _DTYPES[config.precision]         # compute dtype for the heavy GEMMs
+        self._device = torch.device(device)
+        self.embedding = nn.Embedding(config.vocab_size, config.d_model)
+        self.layers = nn.ModuleList([MambaBlock(config) for _ in range(config.n_layers)])
+        self.norm_f = RMSNorm(config.d_model)
+        self._tie_embeddings = config.tie_embeddings
+        if not config.tie_embeddings:
+            self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
+        self._state = None
+        self.to(self._device)
 
-    def forward(self, token_batch: Array) -> Array:  # pragma: no cover
-        raise NotImplementedError
+    def _head(self, h: Array) -> Array:
+        # Logits + cross-entropy run in fp32 (wide-vocab softmax stability); h is upcast
+        # so the head matmul is fp32 regardless of compute dtype.
+        h = _f32(h)
+        if self._tie_embeddings:
+            return h @ self.embedding.weight.t()
+        return self.lm_head(h)
 
-    def step(self, token: Array, state: State) -> Tuple[Array, State]:  # pragma: no cover
-        raise NotImplementedError
+    def _layer_forward(self, layer: MambaBlock, h: Array) -> Array:
+        # Gradient checkpointing: recompute the layer's forward in backward instead of
+        # retaining its activations. Only meaningful under autograd; use_reentrant=False
+        # runs normally in no-grad (eval/parity) contexts.
+        if self.config.grad_checkpoint and torch.is_grad_enabled():
+            return _checkpoint(layer.forward_seq, h, use_reentrant=False)
+        return layer.forward_seq(h)
 
-    def init_state(self, batch_size: int) -> State:  # pragma: no cover
-        raise NotImplementedError
+    # --- ModelInterface ---
+    def forward(self, token_batch: Array) -> Array:
+        ids = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
+        h = _cast(self.embedding(ids), self._cd)     # activation stream in cd
+        for layer in self.layers:
+            h = self._layer_forward(layer, h)
+        return self._head(self.norm_f(h))
 
-    def get_state(self) -> State:  # pragma: no cover
-        raise NotImplementedError
+    def step(self, token: Array, state: State) -> Tuple[Array, State]:
+        ids = torch.as_tensor(np.asarray(token), dtype=torch.long, device=self._device)
+        h = _cast(self.embedding(ids), self._cd)
+        new_state = []
+        for layer, st in zip(self.layers, state):
+            h, st2 = layer.step(h, st)
+            new_state.append(st2)
+        return self._head(self.norm_f(h)), new_state
 
-    def set_state(self, state: State) -> None:  # pragma: no cover
-        raise NotImplementedError
+    def init_state(self, batch_size: int) -> State:
+        c = self.config
+        di, k = c.d_inner, c.d_conv
+        H, P, N = c.n_heads, c.head_dim, c.d_state
+        dev = self._device
+        # Per layer: (conv window (B,k-1,di), SSM state (B,H,P,N)). fp32 to match the scan.
+        return [(torch.zeros((batch_size, k - 1, di), device=dev),
+                 torch.zeros((batch_size, H, P, N), device=dev))
+                for _ in range(self.config.n_layers)]
 
-    def clone_state(self, state: State) -> State:  # pragma: no cover
-        raise NotImplementedError
+    def get_state(self) -> State:
+        return self._state
 
-    def save(self, path: str) -> None:  # pragma: no cover
-        raise NotImplementedError
+    def set_state(self, state: State) -> None:
+        self._state = state
 
-    def load(self, path: str) -> None:  # pragma: no cover
-        raise NotImplementedError
+    def clone_state(self, state: State) -> State:
+        # torch `step` is not immutable, so deep-copy the buffers: the snapshot must not
+        # be aliased by later steps.
+        return [(conv.clone(), ssm.clone()) for (conv, ssm) in state]
+
+    def save(self, path: str) -> None:
+        from ..train.checkpoint import save_weights
+        save_weights(self._portable_state_dict(), path, config=self.config)
+
+    def load(self, path: str) -> None:
+        from ..train.checkpoint import load_weights
+        load_weights(self, path)
+
+    # --- portable bridge: keep the MLX-canonical layout so MLX<->torch round-trips. ---
+    def _portable_state_dict(self) -> dict:
+        # {name: numpy}. The only layout difference vs MLX is the depthwise conv weight:
+        # torch is (out, in/groups, k); MLX is (out, k, in/groups). Emit MLX layout.
+        out = {}
+        for k, v in self.named_parameters():
+            arr = v.detach().to("cpu")
+            if k.endswith(".conv.weight"):
+                arr = arr.transpose(1, 2)            # (out,1,k) -> (out,k,1)
+            out[k] = arr.numpy()
+        return out
+
+    def _load_portable(self, weights: dict) -> None:
+        tensors = {}
+        for k, v in weights.items():
+            t = torch.as_tensor(np.asarray(v))
+            if k.endswith(".conv.weight"):
+                t = t.transpose(1, 2)                # (out,k,1) -> (out,1,k)
+            tensors[k] = t
+        self.load_state_dict(tensors, strict=True)
+        self.to(self._device)

--- a/src/model/cuda_train_step.py
+++ b/src/model/cuda_train_step.py
@@ -1,0 +1,112 @@
+"""CUDA / PyTorch train_step: grad accumulation + dynamic fp16 loss scaling.
+
+The PyTorch counterpart of `mlx_train_step.py`, below the seam (imports torch). Provides
+the backend-specific `train_step` that `train.loop.train` injects, plus optimizer-state
+(de)serialization for within-backend exact resume. The portable loop never imports this;
+it receives `make_train_step(...)`'s closure as a callable matching
+`TrainStepFn = (model, micro_batches, lr) -> {loss, grad_norm, ...}`.
+
+fp16 loss scaling reuses the PORTABLE policy in `src/train/loss_scale.py` (the same
+`DynamicLossScaler` the MLX backend uses) rather than `torch.cuda.amp.GradScaler`, so the
+fp16 skip/backoff behavior is identical across backends. The backend does only the
+inf/nan grad check and skips overflowing steps.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+def _global_grad_norm(params) -> torch.Tensor:
+    leaves = [p.grad for p in params if p.grad is not None]
+    sq = torch.stack([g.detach().float().pow(2).sum() for g in leaves]).sum()
+    return torch.sqrt(sq)
+
+
+def make_train_step(model, optimizer, *, grad_clip: float = 1.0,
+                    scaler=None) -> Callable:
+    """Build a `train_step(model, micro_batches, lr) -> dict`.
+
+    `micro_batches` is a list of `(inputs, targets)` numpy pairs; the step averages
+    grads over them so an effective batch can exceed what fits in memory (one micro-batch
+    is live at a time). Closes over `optimizer` so Adam moments persist across steps.
+
+    `scaler` (a portable `DynamicLossScaler`, fp16 path) scales the loss before backprop;
+    grads are unscaled before the optimizer step. On a non-finite gradient the step is
+    SKIPPED and the scale is backed off; the returned dict carries `loss_scale`/`skipped`.
+    Pass None for fp32 (toy/smoke) — numerically identical to a plain unscaled step.
+    """
+    params = list(model.parameters())
+
+    def _loss(inputs, targets) -> torch.Tensor:
+        logits = model.forward(inputs)                       # (B, L, V)
+        V = logits.shape[-1]
+        t = torch.as_tensor(np.asarray(targets), dtype=torch.long,
+                            device=logits.device).reshape(-1)
+        # Cross-entropy in fp32 (wide-vocab softmax stability).
+        return F.cross_entropy(logits.reshape(-1, V).float(), t, reduction="mean")
+
+    def train_step(model, micro_batches, lr: float) -> dict:
+        n = len(micro_batches)
+        s = scaler.scale if scaler else 1.0
+        optimizer.zero_grad(set_to_none=True)
+        acc_loss = 0.0
+        for inputs, targets in micro_batches:
+            ce = _loss(inputs, targets)
+            # Scale for fp16 dynamic range; divide by n so accumulated .grad is the
+            # average gradient (matches MLX's acc_grads / n).
+            (ce * (s / n)).backward()
+            acc_loss += float(ce.detach())
+        loss = acc_loss / n
+
+        if scaler:
+            inv = 1.0 / s
+            for p in params:                                 # unscale grads
+                if p.grad is not None:
+                    p.grad.mul_(inv)
+            norm = _global_grad_norm(params)
+            overflow = not bool(torch.isfinite(norm))
+            scaler.update(overflow)
+            if overflow:                                     # drop the step
+                optimizer.zero_grad(set_to_none=True)
+                return {"loss": loss, "grad_norm": float("nan"),
+                        "loss_scale": scaler.scale, "skipped": True}
+        else:
+            norm = _global_grad_norm(params)
+
+        if grad_clip:
+            factor = min(1.0, grad_clip / (float(norm) + 1e-6))
+            if factor < 1.0:
+                for p in params:
+                    if p.grad is not None:
+                        p.grad.mul_(factor)
+        for group in optimizer.param_groups:
+            group["lr"] = lr
+        optimizer.step()
+        out = {"loss": loss, "grad_norm": float(norm)}
+        if scaler:
+            out["loss_scale"] = scaler.scale
+            out["skipped"] = False
+        return out
+
+    return train_step
+
+
+# --- optimizer-state (de)serialization for within-backend resume ------------
+def _pt_path(path: str) -> str:
+    path = str(path)
+    return path if path.endswith(".pt") else path + ".pt"
+
+
+def save_optimizer(optimizer, path: str) -> None:
+    torch.save(optimizer.state_dict(), _pt_path(path))
+
+
+def load_optimizer(optimizer, path: str) -> None:
+    # weights_only=False: this is our own trusted optimizer bundle (tensors + the
+    # param_group hyperparameters), not untrusted input.
+    optimizer.load_state_dict(torch.load(_pt_path(path), weights_only=False))

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -1,0 +1,129 @@
+"""Backend parity (#38): MLX and torch agree, and portable weights round-trip.
+
+Because the CUDA backend runs on torch-CPU, the cross-backend checks are runnable
+entirely on a Mac (mlx + torch both present) — no GPU. They SKIP cleanly when either
+backend is missing, so the suite stays green on single-backend hosts:
+  * this Linux container (torch present, mlx not installable) — cross-backend tests
+    skip; the torch-only harness self-check below still runs;
+  * a CUDA host without mlx — same;
+  * a Mac without torch — all skip.
+
+All comparisons are fp32, ~1e-4 rel (the documented tolerance; bf16/fp16 epsilon is too
+coarse to be meaningful), per src/conformance/backend_parity.py.
+"""
+
+import numpy as np
+import pytest
+
+try:
+    import mlx.core  # noqa: F401
+    HAVE_MLX = True
+except ImportError:
+    HAVE_MLX = False
+
+try:
+    import torch
+    HAVE_TORCH = True
+except ImportError:
+    HAVE_TORCH = False
+
+from src.model.blocks import load_config
+from src.conformance.backend_parity import check_backend_parity
+
+CFG = "config/toy.yaml"
+
+
+def _tokens(cfg, B=2, L=24, seed=0):
+    return np.random.default_rng(seed).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+
+
+def _mlx_np(a):
+    return np.array(a)
+
+
+def _torch_np(a):
+    return a.detach().cpu().numpy()
+
+
+@pytest.mark.skipif(not (HAVE_MLX and HAVE_TORCH),
+                    reason="needs both mlx and torch (run on a Mac)")
+def test_backend_parity_mlx_vs_torch(tmp_path):
+    """Identical portable weights in both backends -> `forward` agrees in fp32."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.cuda_backend import CUDAMambaModel
+
+    cfg = load_config(CFG)
+    # One source of weights -> both backends (torch is the source here; the round-trip
+    # test below proves the other direction).
+    torch.manual_seed(0)
+    src = CUDAMambaModel(cfg)
+    path = str(tmp_path / "weights.safetensors")
+    src.save(path)
+
+    mlx_m = MLXMambaModel(cfg)
+    mlx_m.load(path)
+    cuda_m = CUDAMambaModel(cfg)
+    cuda_m.load(path)
+
+    tokens = _tokens(cfg)
+    with torch.no_grad():
+        result = check_backend_parity(mlx_m, cuda_m, tokens,
+                                      to_numpy_a=_mlx_np, to_numpy_b=_torch_np,
+                                      rtol=1e-4, atol=1e-5)
+    assert result["ok"], result
+
+
+@pytest.mark.skipif(not (HAVE_MLX and HAVE_TORCH),
+                    reason="needs both mlx and torch (run on a Mac)")
+def test_portable_weights_roundtrip_both_directions(tmp_path):
+    """MLX save -> torch _load_portable -> torch save -> load back into MLX; the MLX
+    logits are unchanged. Proves the cross-backend bridge in both directions (a
+    CUDA-trained model can come back to the Mac)."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.cuda_backend import CUDAMambaModel
+
+    cfg = load_config(CFG)
+    import mlx.core as mx
+    mx.random.seed(0)
+    mlx_src = MLXMambaModel(cfg)
+    tokens = _tokens(cfg)
+    before = _mlx_np(mlx_src.forward(tokens))
+
+    p_mlx = str(tmp_path / "from_mlx.safetensors")
+    mlx_src.save(p_mlx)                         # MLX -> portable
+    bridge = CUDAMambaModel(cfg)
+    bridge.load(p_mlx)                          # portable -> torch
+    p_torch = str(tmp_path / "from_torch.safetensors")
+    bridge.save(p_torch)                        # torch -> portable
+
+    mlx_back = MLXMambaModel(cfg)
+    mlx_back.load(p_torch)                      # portable -> MLX
+    after = _mlx_np(mlx_back.forward(tokens))
+
+    max_abs = float(np.abs(before.astype(np.float64) - after.astype(np.float64)).max())
+    assert np.allclose(before, after, rtol=1e-4, atol=1e-5), f"round-trip drift {max_abs:.3e}"
+
+
+@pytest.mark.skipif(not HAVE_TORCH, reason="needs torch")
+def test_parity_harness_torch_self(tmp_path):
+    """Runnable without mlx: identical weights in two torch instances pass the parity
+    harness (exercises check_backend_parity + the to_numpy plumbing on this host)."""
+    from src.model.cuda_backend import CUDAMambaModel
+
+    cfg = load_config(CFG)
+    torch.manual_seed(0)
+    src = CUDAMambaModel(cfg)
+    path = str(tmp_path / "weights.safetensors")
+    src.save(path)
+
+    a = CUDAMambaModel(cfg)
+    a.load(path)
+    b = CUDAMambaModel(cfg)
+    b.load(path)
+
+    tokens = _tokens(cfg)
+    with torch.no_grad():
+        result = check_backend_parity(a, b, tokens,
+                                      to_numpy_a=_torch_np, to_numpy_b=_torch_np,
+                                      rtol=1e-4, atol=1e-5)
+    assert result["ok"], result

--- a/tests/test_cuda_parity.py
+++ b/tests/test_cuda_parity.py
@@ -1,0 +1,154 @@
+"""torch-only parity tests for the CUDA backend (#36). Skipped where torch is absent.
+
+The pure-PyTorch backend runs on CPU, so these run anywhere torch installs — no GPU.
+Checks, all in fp32 (~1e-4 rel), mirroring tests/test_mlx_parity.py:
+  * SSM scan parity: chunked `parallel` vs a sequential reference from `recurrence`.
+  * SSM scan vs an INDEPENDENT from-scratch numpy scan (shares no code with the torch
+    paths), plus a long-context case guarding the chunked scan's fp32 overflow-safety.
+  * forward/step parity: whole-model `forward` (parallel) vs `step` (recurrence).
+  * portable round-trip: save -> reload into a fresh instance -> identical logits.
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import load_config
+from src.model.cuda_backend import CUDAMambaModel, SelectiveSSM
+from src.conformance.forward_step_parity import check_forward_step_parity
+
+
+def _np(a):
+    return a.detach().cpu().numpy()
+
+
+def _seq_reference_numpy(ssm, x_np):
+    """Fully independent fp64 sequential scan of the scalar-A Mamba-2 / SSD SSM.
+
+    Computes projections, softplus, scalar-A (per-head) discretization and the
+    recurrence FROM SCRATCH in numpy using only the SSM's raw parameters — shares no
+    code with `SelectiveSSM.parallel` or `.recurrence`. x_np: (B,L,d_inner) ->
+    (B,L,d_inner) float64.
+    """
+    cfg = ssm.config
+    dt_rank, N = cfg.dt_rank_resolved, cfg.d_state
+    H, P = cfg.n_heads, cfg.head_dim
+
+    # torch nn.Linear stores weight as (out, in), computes x @ W.T + b — same as MLX.
+    Wx = _np(ssm.x_proj.weight).astype(np.float64)    # (dt_rank+2N, d_inner)
+    Wdt = _np(ssm.dt_proj.weight).astype(np.float64)  # (H, dt_rank)
+    bdt = _np(ssm.dt_proj.bias).astype(np.float64)    # (H,)
+    a = -np.exp(_np(ssm.A_log).astype(np.float64))    # (H,) scalar decay per head
+    D = _np(ssm.D).astype(np.float64)                 # (H,)
+
+    x = x_np.astype(np.float64)
+    B_, L, di = x.shape
+
+    proj = x @ Wx.T                                   # (B, L, dt_rank+2N)
+    Bm = proj[..., dt_rank:dt_rank + N]               # (B, L, N) shared across heads
+    Cm = proj[..., dt_rank + N:]                      # (B, L, N)
+    delta = np.logaddexp(proj[..., :dt_rank] @ Wdt.T + bdt, 0.0)  # softplus -> (B, L, H)
+
+    X = x.reshape(B_, L, H, P)
+    y = np.zeros((B_, L, H, P), np.float64)
+    h = np.zeros((B_, H, P, N), np.float64)           # per-head state (P, N)
+    for t in range(L):
+        dA = np.exp(delta[:, t] * a)                  # (B, H)
+        Xin = delta[:, t][..., None] * X[:, t]        # (B, H, P) input = dt * X
+        dBx = Xin[..., None] * Bm[:, t][:, None, None, :]    # (B, H, P, N)
+        h = dA[:, :, None, None] * h + dBx
+        y[:, t] = np.sum(h * Cm[:, t][:, None, None, :], axis=-1)  # (B, H, P)
+    y = y + X * D[None, None, :, None]
+    return y.reshape(B_, L, di)
+
+
+def test_ssm_parallel_matches_sequential():
+    torch.manual_seed(0)
+    cfg = load_config("config/toy.yaml")
+    ssm = SelectiveSSM(cfg)
+    B, L, di = 2, cfg.seq_len, cfg.d_inner
+    x = torch.randn(B, L, di) * 0.1
+
+    with torch.no_grad():
+        y_par = _np(ssm.parallel(x))
+
+        # Sequential reference from the one-step recurrence. State is (B,H,P,N).
+        h = torch.zeros((B, cfg.n_heads, cfg.head_dim, cfg.d_state))
+        ys = []
+        for t in range(L):
+            y_t, h = ssm.recurrence(x[:, t], h)
+            ys.append(_np(y_t))
+    y_seq = np.stack(ys, axis=1)
+
+    max_abs = float(np.abs(y_par.astype(np.float64) - y_seq.astype(np.float64)).max())
+    assert np.allclose(y_par, y_seq, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
+
+
+def test_ssm_parallel_matches_independent_reference():
+    """`parallel` vs a from-scratch numpy scan (no shared code) at toy seq_len."""
+    torch.manual_seed(0)
+    cfg = load_config("config/toy.yaml")
+    ssm = SelectiveSSM(cfg)
+    B, L, di = 2, cfg.seq_len, cfg.d_inner
+    x = torch.randn(B, L, di) * 0.1
+
+    with torch.no_grad():
+        y_par = _np(ssm.parallel(x)).astype(np.float64)
+    y_ref = _seq_reference_numpy(ssm, _np(x))
+
+    max_abs = float(np.abs(y_par - y_ref).max())
+    assert np.allclose(y_par, y_ref, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
+
+
+def test_ssm_parallel_overflow_safe_long_context():
+    """Long context (L=512 -> 16 chunks of 32): the chunked scan must stay finite and
+    still match the independent reference."""
+    torch.manual_seed(0)
+    cfg = load_config("config/toy.yaml")
+    ssm = SelectiveSSM(cfg)
+    B, L, di = 2, 512, cfg.d_inner
+    x = torch.randn(B, L, di) * 0.1
+
+    with torch.no_grad():
+        y_par = _np(ssm.parallel(x)).astype(np.float64)
+    assert np.isfinite(y_par).all(), "chunked scan produced NaN/Inf at long context"
+
+    y_ref = _seq_reference_numpy(ssm, _np(x))
+    max_abs = float(np.abs(y_par - y_ref).max())
+    assert np.allclose(y_par, y_ref, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
+
+
+def test_forward_step_parity_toy():
+    torch.manual_seed(0)
+    cfg = load_config("config/toy.yaml")
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    B, L = 2, 32
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    with torch.no_grad():
+        result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
+    assert result["ok"], result
+
+
+def test_portable_roundtrip(tmp_path):
+    """save -> reload into a fresh instance -> identical logits (the portable bridge)."""
+    torch.manual_seed(0)
+    cfg = load_config("config/toy.yaml")
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    tokens = np.random.default_rng(1).integers(0, cfg.vocab_size, size=(2, 16)).astype(np.int32)
+    with torch.no_grad():
+        before = _np(model.forward(tokens))
+
+    path = str(tmp_path / "weights.safetensors")
+    model.save(path)
+
+    reloaded = CUDAMambaModel(cfg)
+    reloaded.load(path)
+    reloaded.eval()
+    with torch.no_grad():
+        after = _np(reloaded.forward(tokens))
+
+    max_abs = float(np.abs(before.astype(np.float64) - after.astype(np.float64)).max())
+    assert np.allclose(before, after, rtol=0, atol=0), f"round-trip drift max|diff|={max_abs:.3e}"

--- a/tests/test_cuda_train_step.py
+++ b/tests/test_cuda_train_step.py
@@ -1,0 +1,168 @@
+"""CUDA/PyTorch train_step: grad accumulation, fp16 loss scaling, loop + resume.
+
+Skipped where torch is unavailable (runs on CPU — no GPU needed). Mirrors
+tests/test_mlx_train_step.py and adds an end-to-end check that the unchanged portable
+train loop drives the torch backend (loss decreases) and that save/kill/resume is exact
+in fp32 — the latter via the M4 smoke-gate's fixed-batch protocol (the loop's shuffled
+infinite stream is not position-resumable by design; the smoke gate bypasses it for the
+same reason).
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import load_config
+from src.model.cuda_backend import CUDAMambaModel
+from src.model.cuda_train_step import make_train_step, save_optimizer, load_optimizer
+from src.train.loss_scale import DynamicLossScaler
+from src.train.loop import TrainConfig, train
+from src.train.checkpoint import save_resume, load_resume
+from src.data.pack import pack_ids
+from src.data.loader import PackedLoader
+
+TOY_CFG = "config/toy.yaml"
+
+
+def _rand_batch(cfg, B=4, L=32, seed=0):
+    rng = np.random.default_rng(seed)
+    inp = rng.integers(0, cfg.vocab_size, size=(B, L)).astype(np.int64)
+    tgt = rng.integers(0, cfg.vocab_size, size=(B, L)).astype(np.int64)
+    return inp, tgt
+
+
+def _adam(model, lr=1e-3):
+    return torch.optim.AdamW(model.parameters(), lr=lr)
+
+
+def _packed_loader(cfg, tmp_path, n_tokens, batch_size=4, shuffle=True, seed=0):
+    ids = np.random.default_rng(0).integers(0, cfg.vocab_size, size=n_tokens)
+    path = tmp_path / "train.bin"
+    pack_ids(ids, path)
+    return PackedLoader(path, cfg.seq_len, batch_size, shuffle=shuffle, seed=seed)
+
+
+def test_grad_accum_two_identical_microbatches_equal_single():
+    cfg = load_config(TOY_CFG)
+    inp, tgt = _rand_batch(cfg)
+
+    torch.manual_seed(0)
+    m1 = CUDAMambaModel(cfg)
+    r1 = make_train_step(m1, _adam(m1), grad_clip=1.0, scaler=None)(m1, [(inp, tgt)], 1e-3)
+
+    torch.manual_seed(0)
+    m2 = CUDAMambaModel(cfg)
+    r2 = make_train_step(m2, _adam(m2), grad_clip=1.0)(m2, [(inp, tgt), (inp, tgt)], 1e-3)
+
+    # Averaging two identical micro-batches == one micro-batch.
+    assert abs(r1["loss"] - r2["loss"]) < 1e-4
+    assert abs(r1["grad_norm"] - r2["grad_norm"]) < 1e-4
+
+
+def test_fp16_overflow_skips_update_and_backs_off():
+    cfg = load_config(TOY_CFG)
+    inp, tgt = _rand_batch(cfg)
+
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    opt = _adam(model)
+    # A scale above fp32-max makes loss*scale -> inf, so the gradients are non-finite
+    # regardless of per-element magnitude (robust trigger).
+    scaler = DynamicLossScaler(init_scale=1e40, backoff=0.5, min_scale=1.0)
+    step_fn = make_train_step(model, opt, grad_clip=1.0, scaler=scaler)
+
+    before = [p.detach().clone() for p in model.parameters()]
+    out = step_fn(model, [(inp, tgt)], 1e-3)
+    after = list(model.parameters())
+
+    assert out["skipped"] is True
+    assert scaler.scale == 0.5e40                 # backed off on overflow
+    for b, a in zip(before, after):
+        assert torch.equal(b, a)                  # weights untouched on a skipped step
+
+
+def test_fp16_clean_step_updates_and_reports_scale():
+    cfg = load_config(TOY_CFG)
+    inp, tgt = _rand_batch(cfg)
+
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    scaler = DynamicLossScaler(init_scale=1024.0)
+    step_fn = make_train_step(model, _adam(model), grad_clip=1.0, scaler=scaler)
+
+    out = step_fn(model, [(inp, tgt)], 1e-3)
+    assert out["skipped"] is False
+    assert out["loss_scale"] == 1024.0
+    assert np.isfinite(out["grad_norm"])
+
+
+def test_loop_loss_decreases(tmp_path):
+    """The unchanged portable train loop drives the torch backend; loss goes down."""
+    cfg = load_config(TOY_CFG)
+    loader = _packed_loader(cfg, tmp_path, n_tokens=70 * (cfg.seq_len + 1))
+
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    model.train()
+    step_fn = make_train_step(model, _adam(model, lr=3e-3), grad_clip=1.0, scaler=None)
+
+    losses = []
+    tcfg = TrainConfig(total_steps=60, base_lr=3e-3, warmup_steps=5, grad_accum=1,
+                       log_every=1, eval_every=10 ** 9, ckpt_every=10 ** 9)
+    train(model, loader, tcfg, step_fn, logger=lambda p: losses.append(p["loss"]))
+
+    assert np.mean(losses[-5:]) < np.mean(losses[:5]), losses
+
+
+def test_save_kill_resume_exact(tmp_path):
+    """fp32 save/kill/resume is exact: rebuild + load weights + optimizer + step, and
+    the post-resume loss trajectory matches the uninterrupted reference (atol 1e-4)."""
+    cfg = load_config(TOY_CFG)
+    assert cfg.precision == "fp32"
+    N, half = 8, 4
+
+    # Fixed batch stream (shuffle off) so batch at step s is identical in both runs.
+    loader = _packed_loader(cfg, tmp_path, n_tokens=(N + 2) * 4 * (cfg.seq_len + 1),
+                            batch_size=4, shuffle=False)
+    batches = []
+    for b in loader.epoch():
+        batches.append(b)
+        if len(batches) == N:
+            break
+    assert len(batches) == N
+
+    def fresh():
+        torch.manual_seed(0)
+        model = CUDAMambaModel(cfg)
+        opt = _adam(model)
+        return model, opt, make_train_step(model, opt, grad_clip=1.0, scaler=None)
+
+    def run(model, step_fn, lo, hi, into):
+        for s in range(lo, hi):
+            into[s] = step_fn(model, [batches[s]], 1e-3)["loss"]
+
+    ref = {}
+    m, _, sf = fresh()
+    run(m, sf, 0, N, ref)
+
+    res = {}
+    ma, oa, sfa = fresh()
+    run(ma, sfa, 0, half, res)
+    weights = str(tmp_path / "weights.safetensors")
+    bundle = str(tmp_path / "resume")
+    ma.save(weights)
+    save_resume(bundle, step=half, rng_state=None,
+                optimizer_serializer=lambda p: save_optimizer(oa, p))
+    del ma, oa, sfa                                   # "kill"
+
+    torch.manual_seed(999)
+    mb = CUDAMambaModel(cfg)
+    mb.load(weights)
+    ob = _adam(mb)
+    meta = load_resume(bundle, optimizer_deserializer=lambda p: load_optimizer(ob, p))
+    sfb = make_train_step(mb, ob, grad_clip=1.0, scaler=None)
+    run(mb, sfb, meta["step"], N, res)
+
+    max_diff = max(abs(ref[s] - res[s]) for s in range(half, N))
+    assert max_diff < 1e-4, f"resume not exact: max|diff|={max_diff:.3e}"

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -43,6 +43,7 @@ PORTABLE_MODULES = [
     "src.eval.val_loss",
     "src.eval.olmes_adapter",
     "src.conformance.forward_step_parity",
+    "src.conformance.backend_parity",
     "src.serve.sessions",
     "src.serve.rewind",
 ]

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -32,6 +32,7 @@ import pytest
 PORTABLE_MODULES = [
     "src.model.interface",
     "src.model.blocks",
+    "src.model.backend",
     "src.data.loader",
     "src.data.pack",
     "src.data.split",


### PR DESCRIPTION
Part of #16. Closes #38. **Stacked on #61 (#37)** — review/merge that first; this PR's diff is only the parity test + doc.

## What
Adds `tests/test_backend_parity.py` certifying the two backends against each other, using `src/conformance/backend_parity.py` as-is:

- **MLX-vs-torch forward parity**: identical portable weights loaded into both `MLXMambaModel` and `CUDAMambaModel` agree in fp32 (~1e-4 rel).
- **Portable-weights round-trip both directions** (MLX → safetensors → torch → safetensors → MLX, logits unchanged) — proves a CUDA-trained model can return to the Mac.
- A **torch-only harness self-check** that runs on single-backend hosts.

The cross-backend cases **skip cleanly** when either backend is absent (mlx is not installable on Linux), so the suite stays green on a Linux/CUDA box while the full check runs on a Mac with torch-CPU. Adds `src.conformance.backend_parity` to the import-guard portable set and refreshes `docs/design/03-conformance.md` for the now-live, CPU-runnable two-backend reality.

## Verification (this Linux host)
`pytest tests/test_backend_parity.py` → torch-only self-check **passes**, 2 cross-backend cases **skip** (run on a Mac). Full suite: 64 passed, 9 skipped.

## Remaining in #16 (need real CUDA hardware)
- **#39** CUDA packaging + GPU smoke gate
- **#40** optional `mamba-ssm` fused-kernel fast path

https://claude.ai/code/session_01VzRW5Eu7xGAfWMUw4Krqv5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzRW5Eu7xGAfWMUw4Krqv5)_