### PR TITLE
fix(test): [#58] hermetic train-step fixtures + loud vocab guard

### DIFF
--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -20,12 +20,15 @@ from .pack import open_packed
 
 class PackedLoader:
     def __init__(self, packed_path: Path, seq_len: int, batch_size: int,
-                 shuffle: bool = True, seed: int = 0, drop_last: bool = True):
+                 shuffle: bool = True, seed: int = 0, drop_last: bool = True,
+                 vocab_size: Optional[int] = None):
+        self.path = packed_path
         self.data = open_packed(packed_path)
         self.seq_len = seq_len
         self.batch_size = batch_size
         self.shuffle = shuffle
         self.drop_last = drop_last
+        self.vocab_size = vocab_size
         self.rng = np.random.default_rng(seed)
 
         # Non-overlapping chunks of length seq_len+1 (extra token = shift target).
@@ -59,7 +62,14 @@ class PackedLoader:
         if batch and not self.drop_last:
             yield self._collate(batch)
 
-    @staticmethod
-    def _collate(batch: list[np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
+    def _collate(self, batch: list[np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
         arr = np.stack(batch)              # (B, seq_len+1)
+        if self.vocab_size is not None:
+            top = int(arr.max())
+            if top >= self.vocab_size:
+                raise ValueError(
+                    f"token id {top} >= vocab_size {self.vocab_size} in {self.path}. "
+                    "The packed data does not match the model config — likely a stale or "
+                    "clobbered data file (e.g. a real-corpus run overwrote a toy/test path)."
+                )
         return arr[:, :-1], arr[:, 1:]      # inputs, targets

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared test fixtures.
+
+`toy_train_bin` builds a hermetic, learnable byte-fallback corpus so train-step tests
+never read the shared, gitignored `data/split/train.bin` — that path is also written by
+the real POC pipeline (`src.data.split`), so after a real data-prep run it holds
+OLMo-tokenized ids (vocab 50280). Feeding those into the toy model (vocab 256) caused
+out-of-bounds gathers → non-finite grads → the fp16 scaler spuriously skipped, which read
+as flaky math but was a test-isolation bug (issue #58).
+"""
+
+import pytest
+
+from src.data.download import dummy_texts
+from src.data.tokenize import ByteTokenizer
+from src.data.pack import pack_ids
+
+
+@pytest.fixture(scope="session")
+def toy_train_bin(tmp_path_factory):
+    """A learnable byte-fallback corpus (ids < 256, fits toy vocab_size=256).
+
+    Mirrors the documented offline pipeline (dummy_texts -> ByteTokenizer -> pack_ids).
+    200 deterministic docs byte-encode to well over the ~tens-of-thousands of tokens the
+    dt-bias loss-decrease test needs, and are structured/repetitive enough to learn.
+    """
+    tok = ByteTokenizer()
+    ids = [t for doc in dummy_texts(200) for t in tok.encode(doc)]
+    path = tmp_path_factory.mktemp("toydata") / "train.bin"
+    pack_ids(ids, path)
+    return path

--- a/tests/test_dt_bias.py
+++ b/tests/test_dt_bias.py
@@ -33,7 +33,6 @@ from src.train.schedule import CosineSchedule
 from src.data.loader import PackedLoader
 
 TOY_CFG = "config/toy.yaml"
-TRAIN_BIN = "data/split/train.bin"
 
 
 def _np(a):
@@ -44,10 +43,11 @@ def _softplus(x):
     return mx.logaddexp(x, mx.zeros_like(x))
 
 
-def _fixed_batches(cfg, n, batch_size=8):
+def _fixed_batches(cfg, n, train_bin, batch_size=8):
     """A deterministic, pre-materialized batch stream (shuffle off => batch at
     step s is identical across runs), mirroring scripts/smoke_test.py."""
-    loader = PackedLoader(TRAIN_BIN, cfg.seq_len, batch_size, shuffle=False)
+    loader = PackedLoader(train_bin, cfg.seq_len, batch_size, shuffle=False,
+                          vocab_size=cfg.vocab_size)
     out = []
     for inp, tgt in loader.epoch():
         out.append((inp, tgt))
@@ -87,9 +87,9 @@ def test_dt_bias_timescales_in_range():
     assert np.max(np.abs(_np(recon) - _np(bias))) < 1e-4
 
 
-def test_dt_bias_loss_decreases():
+def test_dt_bias_loss_decreases(toy_train_bin):
     cfg = load_config(TOY_CFG)
-    batches = _fixed_batches(cfg, 40)
+    batches = _fixed_batches(cfg, 40, toy_train_bin)
     mx.random.seed(0)
     model = MLXMambaModel(cfg)
     losses = _train_losses(model, batches)

--- a/tests/test_mlx_train_step.py
+++ b/tests/test_mlx_train_step.py
@@ -19,20 +19,22 @@ from src.model.blocks import load_config
 from src.model.mlx_backend import MLXMambaModel
 from src.model.mlx_train_step import make_train_step
 from src.train.loss_scale import DynamicLossScaler
-from src.data.loader import PackedLoader
 
 TOY_CFG = "config/toy.yaml"
-TRAIN_BIN = "data/split/train.bin"
 
 
-def _first_batch(cfg):
-    loader = PackedLoader(TRAIN_BIN, cfg.seq_len, batch_size=4, shuffle=False)
-    return next(iter(loader.epoch()))
+def _rand_batch(cfg, B=4, L=32, seed=0):
+    """An in-range, in-memory batch (ids < vocab_size). Hermetic — no shared data
+    path. Mirrors tests/test_cuda_train_step.py for cross-backend consistency."""
+    rng = np.random.default_rng(seed)
+    inp = rng.integers(0, cfg.vocab_size, size=(B, L)).astype(np.int64)
+    tgt = rng.integers(0, cfg.vocab_size, size=(B, L)).astype(np.int64)
+    return inp, tgt
 
 
 def test_grad_accum_two_identical_microbatches_equal_single():
     cfg = load_config(TOY_CFG)
-    inp, tgt = _first_batch(cfg)
+    inp, tgt = _rand_batch(cfg)
 
     mx.random.seed(0)
     m1 = MLXMambaModel(cfg)
@@ -51,7 +53,7 @@ def test_grad_accum_two_identical_microbatches_equal_single():
 
 def test_fp16_overflow_skips_update_and_backs_off():
     cfg = load_config(TOY_CFG)
-    inp, tgt = _first_batch(cfg)
+    inp, tgt = _rand_batch(cfg)
 
     mx.random.seed(0)
     model = MLXMambaModel(cfg)
@@ -73,7 +75,7 @@ def test_fp16_overflow_skips_update_and_backs_off():
 
 def test_fp16_clean_step_updates_and_reports_scale():
     cfg = load_config(TOY_CFG)
-    inp, tgt = _first_batch(cfg)
+    inp, tgt = _rand_batch(cfg)
 
     mx.random.seed(0)
     model = MLXMambaModel(cfg)


### PR DESCRIPTION
Closes #58.

## Problem
`tests/test_mlx_train_step.py` and `tests/test_dt_bias.py` read batches from the shared, gitignored `data/split/train.bin` under the toy config (`vocab_size=256`). That path is *also* written by the real POC pipeline (`src.data.split`), so after a data-prep run it holds OLMo ids (vocab 50280). Out-of-bounds embedding/target gathers on the toy model produced non-finite grads → the fp16 scaler spuriously reported `skipped=True`. MLX's undefined OOB gather made *which* assertions trip vary run to run — it looked like flaky math but was a **test-isolation bug**.

Audit confirmed only these two files carried the shared-path assumption; `test_data_pipeline.py` and `test_cuda_train_step.py` already build data in `tmp_path`.

## Fix
- **`tests/conftest.py`** (new): session-scoped `toy_train_bin` fixture builds a learnable byte-fallback corpus (`dummy_texts` → `ByteTokenizer` → `pack_ids`) in `tmp_path` — mirrors the documented offline pipeline.
- **`tests/test_mlx_train_step.py`**: use an in-memory random in-range batch (`_rand_batch`, mirroring the CUDA sibling test); drops the shared-path dependency entirely.
- **`tests/test_dt_bias.py`**: thread `toy_train_bin` through `_fixed_batches`; the 10% loss-decrease assertion is preserved (dummy corpus is structured/learnable).
- **`src/data/loader.py`**: optional `vocab_size` guard raises a clear, diagnostic `ValueError` when a packed id ≥ `vocab_size` — defense-in-depth so the silent-NaN mode can't return.

## Verification
- Previously-flaky tests: **stable across 5 repeat runs**.
- Guard fires loudly on an out-of-range id (clear message naming path + ids).
- Full suite: **111 passed**.
- Smoke gate: **PASSED** on a freshly-generated toy split. (It fails against the local `data/split` precisely because that path is the clobbered POC corpus — the same root cause this PR fixes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)