### PR TITLE
feat(model): [M10] 100M/1B/2B/4B config family + param/memory sizing (#66)

### DIFF
--- a/config/1b.yaml
+++ b/config/1b.yaml
@@ -1,0 +1,28 @@
+# ~1B Mamba-2 config (M10 scaling ladder; epic #65). 100M(poc)->1B->2B->4B.
+# d_model 2048 x 36 layers -> ~1.03B params (verify: `python scripts/model_size.py`).
+# bf16 weights ~2.0 GB; Mamba has no KV cache so that ~= the inference footprint.
+# Fits L4 / A10 24GB for training. This is the first RENTED-CUDA scale tier (#75);
+# everything below the seam is validated on the Mac first.
+d_model: 2048          # d_inner = expand*d_model = 4096
+n_layers: 36
+d_state: 16            # SSM state width N (per head, shared B/C group)
+expand: 2
+d_conv: 4
+head_dim: 64           # Mamba-2/SSD: 4096/64 = 64 heads (scalar A per head)
+dt_rank: auto
+
+vocab_size: 50280      # OLMo-7B-hf, < 65536 (uint16 packing). Final tokenizer pending #74.
+seq_len: 1024
+tie_embeddings: true   # vocab x d_model ~= 103M; tied head stays mandatory at scale.
+
+# bf16, NOT fp16: poc's fp16>bf16 was an MLX/Metal micro-benchmark finding (issue #3).
+# The scale runs are CUDA, where bf16 is native and needs no loss scaling
+# (scaler_for_precision returns None for bf16). toy/smoke stay fp32 for exact resume.
+precision: bf16
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: true  # REQUIRED at this depth: recompute layers in backward to fit VRAM.
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/config/2b.yaml
+++ b/config/2b.yaml
@@ -1,0 +1,28 @@
+# ~2B Mamba-2 config (M10 scaling ladder; epic #65). 100M(poc)->1B->2B->4B.
+# d_model 2560 x 46 layers -> ~1.98B params (verify: `python scripts/model_size.py`).
+# Provisional dims from #66: n_layers nudged 44->46 to land within +-5% of the 2B
+# target with margin. bf16 weights ~4.0 GB (~= inference footprint; no KV cache).
+# Fits A100 40GB / L40S 48GB for training.
+d_model: 2560          # d_inner = expand*d_model = 5120
+n_layers: 46
+d_state: 16            # SSM state width N (per head, shared B/C group)
+expand: 2
+d_conv: 4
+head_dim: 64           # Mamba-2/SSD: 5120/64 = 80 heads (scalar A per head)
+dt_rank: auto
+
+vocab_size: 50280      # OLMo-7B-hf, < 65536 (uint16 packing). Final tokenizer pending #74.
+seq_len: 1024
+tie_embeddings: true   # vocab x d_model ~= 129M; tied head stays mandatory at scale.
+
+# bf16, NOT fp16: poc's fp16>bf16 was an MLX/Metal micro-benchmark finding (issue #3).
+# The scale runs are CUDA, where bf16 is native and needs no loss scaling
+# (scaler_for_precision returns None for bf16). toy/smoke stay fp32 for exact resume.
+precision: bf16
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: true  # REQUIRED at this depth: recompute layers in backward to fit VRAM.
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/config/4b.yaml
+++ b/config/4b.yaml
@@ -1,0 +1,29 @@
+# ~4B Mamba-2 config (M10 scaling ladder; epic #65) — top of the series.
+# d_model 3584 x 48 layers -> ~3.97B params (verify: `python scripts/model_size.py`).
+# bf16 weights ~7.9 GB (~= inference footprint; no KV cache). Fits A100 80GB /
+# H100 80GB for training.
+d_model: 3584          # d_inner = expand*d_model = 7168
+n_layers: 48
+d_state: 16            # SSM state width N (per head, shared B/C group)
+expand: 2
+d_conv: 4
+# Mamba-2/SSD: 7168/64 = 112 heads (scalar A per head). head_dim 128 (-> 56 heads)
+# is a lever here: fewer, wider heads trade some recall for throughput at 4B.
+head_dim: 64
+dt_rank: auto
+
+vocab_size: 50280      # OLMo-7B-hf, < 65536 (uint16 packing). Final tokenizer pending #74.
+seq_len: 1024
+tie_embeddings: true   # vocab x d_model ~= 180M; tied head stays mandatory at scale.
+
+# bf16, NOT fp16: poc's fp16>bf16 was an MLX/Metal micro-benchmark finding (issue #3).
+# The scale runs are CUDA, where bf16 is native and needs no loss scaling
+# (scaler_for_precision returns None for bf16). toy/smoke stay fp32 for exact resume.
+precision: bf16
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: true  # REQUIRED at this depth: recompute layers in backward to fit VRAM.
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/scripts/model_size.py
+++ b/scripts/model_size.py
@@ -1,0 +1,42 @@
+"""Print the Mamba config-family sizing table (params + memory per tier).
+
+Portable — imports no backend. Loads the 100M -> 1B -> 2B -> 4B ladder from
+`config/*.yaml` and prints the table that backs the #65 epic's GPU/RAM sizing.
+
+  python scripts/model_size.py                 # the whole family (poc,1b,2b,4b)
+  python scripts/model_size.py --config config/1b.yaml   # one config
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+# Allow `python scripts/model_size.py` from the repo root without installation.
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.model.blocks import load_config  # noqa: E402
+from src.model.sizing import format_family_table, load_family  # noqa: E402
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=None,
+                    help="size a single config YAML instead of the whole family")
+    ap.add_argument("--config-dir", type=Path, default=Path("config"),
+                    help="directory holding the family YAMLs (default: config/)")
+    args = ap.parse_args()
+
+    if args.config is not None:
+        cfg = load_config(args.config)
+        configs = [(args.config.stem, cfg)]
+    else:
+        configs = load_family(args.config_dir)
+
+    print(format_family_table(configs))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -96,6 +96,52 @@ class MambaConfig:
             return math.ceil(self.d_model / 16)
         return int(self.dt_rank)
 
+    def parameter_breakdown(self) -> dict:
+        """Closed-form trainable-parameter count, broken out by named term.
+
+        Returned as an ordered dict {term: count} so callers can inspect where the
+        budget goes and so the hybrid-attention work (#67) can add an "attention"
+        term without disturbing the existing keys. Verified exactly against the
+        built model's `_portable_state_dict()` (tests/test_sizing.py MLX safety-net):
+        every weight/bias/buffer registered as a parameter is accounted for here,
+        including the per-head SSM `A_log` and `D` (the `ssm_A_D` term).
+
+        Mirrors the layer construction in the backends:
+          in_proj  (d_model -> 2*d_inner)      conv (depthwise, width d_conv, + bias)
+          x_proj   (d_inner -> dt_rank+2*N)     dt_proj (dt_rank -> n_heads, + bias)
+          A_log,D  (n_heads each)               out_proj (d_inner -> d_model)
+        plus a pre-block RMSNorm per layer, a final RMSNorm, and the (tied) embedding.
+        """
+        d_model = self.d_model
+        d_inner = self.d_inner
+        n_heads = self.n_heads
+        dt_rank = self.dt_rank_resolved
+        N = self.d_state
+
+        per_layer = (
+            d_model                                  # pre-block RMSNorm weight
+            + 2 * d_inner * d_model                  # in_proj
+            + d_inner * (self.d_conv + 1)            # depthwise conv weight + bias
+            + d_inner * (dt_rank + 2 * N)            # x_proj (delta, B, C)
+            + dt_rank * n_heads + n_heads            # dt_proj weight + bias
+            + 2 * n_heads                            # A_log + D (scalar per head)
+            + d_inner * d_model                      # out_proj
+        )
+
+        bd = {
+            "embedding": self.vocab_size * d_model,
+            "layers": self.n_layers * per_layer,
+            "final_norm": d_model,
+        }
+        # Tied embedding reuses the input matrix as the LM head -> no extra params.
+        if not self.tie_embeddings:
+            bd["lm_head"] = self.vocab_size * d_model
+        return bd
+
+    def num_parameters(self) -> int:
+        """Total trainable parameters (sum of `parameter_breakdown()`)."""
+        return sum(self.parameter_breakdown().values())
+
     def validate(self) -> None:
         if self.vocab_size >= 65536:
             raise ValueError(

--- a/src/model/sizing.py
+++ b/src/model/sizing.py
@@ -1,0 +1,139 @@
+"""Portable parameter/memory sizing for the Mamba config family.
+
+Turns a `MambaConfig` into the numbers the #65 epic's sizing table needs: exact
+parameter count (via `MambaConfig.num_parameters()`), inference footprint, a
+documented training-memory estimate, and a formatted family table mapping each
+tier (100M -> 1B -> 2B -> 4B) to a GPU/RAM class.
+
+ABOVE THE SEAM — imports no backend (`mlx`/`torch`). Memory figures are closed-form
+estimates from the parameter count and a few documented per-param/activation
+constants, NOT measurements; treat them as planning aids (the real peak is measured
+by `scripts/bench_train_step.py`). Mamba has **no KV cache**, so for inference the
+weights ARE essentially the whole footprint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Union
+
+from .blocks import MambaConfig, load_config
+
+GIB = 1024 ** 3
+
+# Bytes per element for the weight/activation dtype.
+BYTES_PER_DTYPE = {"fp32": 4, "fp16": 2, "bf16": 2}
+
+# Training memory ~ (weights + grads + optimizer state) per parameter. Both options
+# below are the epic's "VRAM-tight" levers vs the classic ~16 B/param fp32 AdamW:
+#   adamw    ~8 B/param : lean all-bf16 Adam — bf16 weight(2) + bf16 grad(2)
+#                         + bf16 Adam m,v(2+2), no fp32 master copy.
+#   adam8bit ~10 B/param: 8-bit Adam moments + an fp32 master weight copy for
+#                         stability — fp32 master(4) + bf16 weight(2) + bf16 grad(2)
+#                         + 8-bit m,v(1+1). The VRAM-tight lever called out in #65.
+OPTIMIZER_BYTES_PER_PARAM = {"adamw": 8, "adam8bit": 10}
+
+# Crude per-token activation footprint: a handful of (batch, seq, d_model) tensors
+# live per layer in the block (in_proj output ~2*d_inner, conv, ssm y, ...). We fold
+# that into a single multiplier on d_model. With gradient checkpointing only one
+# layer's activations are held live in the backward (the rest are recomputed), plus
+# a per-layer residual save at each checkpoint boundary.
+ACT_BYTES_MULTIPLIER = 16  # ~tensors-worth of d_model-wide activations per layer
+
+
+def _bytes_per(dtype: str) -> int:
+    if dtype not in BYTES_PER_DTYPE:
+        raise ValueError(f"unknown dtype {dtype!r} (expected one of {list(BYTES_PER_DTYPE)})")
+    return BYTES_PER_DTYPE[dtype]
+
+
+def inference_bytes(cfg: MambaConfig, dtype: str = "bf16") -> int:
+    """Bytes to hold the model for inference. No KV cache -> weights are the footprint."""
+    return cfg.num_parameters() * _bytes_per(dtype)
+
+
+def activation_bytes(cfg: MambaConfig, batch_size: int, seq_len: int,
+                     dtype: str = "bf16") -> int:
+    """Rough peak activation bytes for one training step (documented estimate)."""
+    per_layer_token = cfg.d_model * ACT_BYTES_MULTIPLIER * _bytes_per(dtype)
+    tokens = batch_size * seq_len
+    if cfg.grad_checkpoint:
+        # One live layer being recomputed + a cheap residual save per checkpoint boundary.
+        return tokens * (per_layer_token + cfg.n_layers * cfg.d_model * _bytes_per(dtype))
+    return tokens * per_layer_token * cfg.n_layers
+
+
+def training_bytes(cfg: MambaConfig, optimizer: str = "adam8bit",
+                   batch_size: int = 8, seq_len: int | None = None,
+                   dtype: str = "bf16") -> dict:
+    """Estimated peak training memory, broken into model+optimizer and activations.
+
+    Returns {model_opt, activations, total} in bytes. `optimizer` selects the
+    per-param constant (see OPTIMIZER_BYTES_PER_PARAM). Defaults to a modest
+    micro-batch shape; the real run tunes batch/grad-accum to the GPU.
+    """
+    if optimizer not in OPTIMIZER_BYTES_PER_PARAM:
+        raise ValueError(
+            f"unknown optimizer {optimizer!r} (expected one of {list(OPTIMIZER_BYTES_PER_PARAM)})"
+        )
+    seq_len = cfg.seq_len if seq_len is None else seq_len
+    model_opt = cfg.num_parameters() * OPTIMIZER_BYTES_PER_PARAM[optimizer]
+    acts = activation_bytes(cfg, batch_size, seq_len, dtype)
+    return {"model_opt": model_opt, "activations": acts, "total": model_opt + acts}
+
+
+# GPU/RAM tiers keyed on parameter count, matching the #65 sizing table. Bucketed on
+# params (not on the activation-sensitive train total) so the column tracks model size
+# the way the epic's table does. (lo_exclusive, hi_inclusive, gpu_train, ram_infer)
+_TIERS = [
+    (0,        0.3e9, "T4 16GB / L4 24GB",       "any (<1GB)"),
+    (0.3e9,    1.3e9, "L4 / A10 24GB",            "16GB Mac"),
+    (1.3e9,    2.5e9, "A100 40GB / L40S 48GB",    "16GB Mac"),
+    (2.5e9,    4.5e9, "A100 80GB / H100 80GB",    "32GB Mac"),
+]
+
+
+def _tier(num_params: int) -> tuple:
+    for lo, hi, gpu, ram in _TIERS:
+        if lo < num_params <= hi:
+            return gpu, ram
+    return ">80GB (multi-GPU)", "64GB+ Mac"
+
+
+def family_row(name: str, cfg: MambaConfig) -> dict:
+    """One sizing-table row for a named config."""
+    n = cfg.num_parameters()
+    gpu, ram = _tier(n)
+    return {
+        "tier": name,
+        "params": n,
+        "weights_gb": inference_bytes(cfg, "bf16") / GIB,   # bf16 weights == inference footprint
+        "train_gb": training_bytes(cfg)["total"] / GIB,
+        "gpu_train": gpu,
+        "ram_infer": ram,
+    }
+
+
+def family_table(configs: Iterable[tuple]) -> list:
+    """Rows for a list of (name, cfg) pairs, in order."""
+    return [family_row(name, cfg) for name, cfg in configs]
+
+
+def format_family_table(configs: Iterable[tuple]) -> str:
+    """Render the family table as fixed-width text (matches the #65 sizing table)."""
+    rows = family_table(configs)
+    header = f"{'tier':<6} {'params':>10} {'bf16 wt':>9} {'train':>8}  {'GPU (train)':<24} {'RAM (infer)':<10}"
+    lines = [header, "-" * len(header)]
+    for r in rows:
+        lines.append(
+            f"{r['tier']:<6} {r['params'] / 1e6:>9.1f}M {r['weights_gb']:>8.2f}G "
+            f"{r['train_gb']:>7.1f}G  {r['gpu_train']:<24} {r['ram_infer']:<10}"
+        )
+    return "\n".join(lines)
+
+
+def load_family(config_dir: Union[str, Path] = "config",
+                names: Iterable[str] = ("poc", "1b", "2b", "4b")) -> list:
+    """Load (name, cfg) pairs for the standard ladder from `config/<name>.yaml`."""
+    config_dir = Path(config_dir)
+    return [(name, load_config(config_dir / f"{name}.yaml")) for name in names]

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -33,6 +33,7 @@ PORTABLE_MODULES = [
     "src.model.interface",
     "src.model.blocks",
     "src.model.backend",
+    "src.model.sizing",
     "src.data.loader",
     "src.data.pack",
     "src.data.split",

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,0 +1,106 @@
+"""Param-count + sizing tests (portable; runs anywhere, no backend).
+
+Guards the closed-form `MambaConfig.num_parameters()` and the `sizing` memory
+estimates, and pins the scaling-config family (poc/1b/2b/4b) to its targets.
+
+The exact-vs-real-tensors safety net (num_parameters == built model param sum)
+lives in the MLX-gated test below — only a real backend has the actual tensors.
+"""
+
+import math
+from pathlib import Path
+
+import pytest
+
+from src.model.blocks import MambaConfig, load_config
+from src.model import sizing
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "config"
+
+# (name, approx target params) for the scaling ladder. poc is the existing ~127M.
+FAMILY = [("poc", 127e6), ("1b", 1e9), ("2b", 2e9), ("4b", 4e9)]
+
+
+def _cfg(name):
+    return load_config(CONFIG_DIR / f"{name}.yaml")
+
+
+def test_num_parameters_equals_breakdown_sum():
+    # Toy/poc plus every ladder config: the total must equal the sum of named terms.
+    cfgs = [load_config(CONFIG_DIR / "toy.yaml")] + [_cfg(n) for n, _ in FAMILY]
+    for cfg in cfgs:
+        bd = cfg.parameter_breakdown()
+        assert cfg.num_parameters() == sum(bd.values())
+        assert all(v > 0 for v in bd.values())
+
+
+def test_untied_adds_lm_head():
+    tied = MambaConfig(d_model=64, n_layers=2, head_dim=16, vocab_size=256,
+                       tie_embeddings=True)
+    untied = MambaConfig(d_model=64, n_layers=2, head_dim=16, vocab_size=256,
+                         tie_embeddings=False)
+    bd = untied.parameter_breakdown()
+    assert "lm_head" in bd and "lm_head" not in tied.parameter_breakdown()
+    # The only difference is the extra vocab x d_model head.
+    assert untied.num_parameters() - tied.num_parameters() == 256 * 64
+
+
+def test_known_poc_count():
+    # The poc config is the validated ~127M anchor; pin it tightly.
+    poc = _cfg("poc")
+    assert abs(poc.num_parameters() - 126.7e6) < 0.5e6
+
+
+@pytest.mark.parametrize("name,target", FAMILY)
+def test_family_config_valid_and_on_target(name, target):
+    cfg = _cfg(name)
+    cfg.validate()                                   # raises on any invariant break
+    assert cfg.vocab_size < 65536
+    assert cfg.d_inner % cfg.head_dim == 0
+    dev = abs(cfg.num_parameters() - target) / target
+    assert dev <= 0.05, f"{name}: {cfg.num_parameters()/1e6:.1f}M is {dev:.1%} off {target/1e6:.0f}M"
+
+
+def test_family_param_counts_monotonic():
+    counts = [_cfg(n).num_parameters() for n, _ in FAMILY]
+    assert counts == sorted(counts), "ladder params must increase by tier"
+
+
+def test_inference_bytes_no_kv_cache():
+    cfg = _cfg("1b")
+    # No KV cache -> inference footprint is exactly weights * dtype bytes.
+    assert sizing.inference_bytes(cfg, "bf16") == cfg.num_parameters() * 2
+    assert sizing.inference_bytes(cfg, "fp32") == cfg.num_parameters() * 4
+    with pytest.raises(ValueError):
+        sizing.inference_bytes(cfg, "int4")
+
+
+def test_training_bytes_sane_and_optimizer_lever():
+    cfg = _cfg("1b")
+    adamw = sizing.training_bytes(cfg, optimizer="adamw")
+    adam8 = sizing.training_bytes(cfg, optimizer="adam8bit")
+    for t in (adamw, adam8):
+        assert t["total"] == t["model_opt"] + t["activations"]
+        # Training needs more than just the weights.
+        assert t["total"] > sizing.inference_bytes(cfg, "bf16")
+    # The 8-bit-Adam + fp32-master estimate is heavier per param than lean bf16 Adam.
+    assert adam8["model_opt"] > adamw["model_opt"]
+    with pytest.raises(ValueError):
+        sizing.training_bytes(cfg, optimizer="sgd")
+
+
+def test_grad_checkpoint_cuts_activations():
+    base = _cfg("1b")
+    off = MambaConfig(**{**base.to_dict(), "grad_checkpoint": False})
+    on = MambaConfig(**{**base.to_dict(), "grad_checkpoint": True})
+    a_off = sizing.activation_bytes(off, batch_size=8, seq_len=1024)
+    a_on = sizing.activation_bytes(on, batch_size=8, seq_len=1024)
+    assert a_on < a_off
+
+
+def test_family_table_renders_all_tiers():
+    table = sizing.format_family_table(sizing.load_family(CONFIG_DIR))
+    for name, _ in FAMILY:
+        assert name in table
+    # Header columns present.
+    assert "params" in table and "GPU (train)" in table

--- a/tests/test_sizing_mlx.py
+++ b/tests/test_sizing_mlx.py
@@ -1,0 +1,27 @@
+"""MLX safety net for the closed-form param count (skipped where mlx is absent).
+
+`MambaConfig.num_parameters()` is a hand-derived formula; this asserts it equals
+the EXACT number of elements in the built model's portable state dict, so the two
+can never silently drift. Covers toy (cheap) and poc (the real ~127M anchor).
+"""
+
+from pathlib import Path
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from src.model.blocks import load_config
+from src.model.mlx_backend import MLXMambaModel
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "config"
+
+
+@pytest.mark.parametrize("name", ["toy", "poc"])
+def test_num_parameters_matches_built_model(name):
+    cfg = load_config(CONFIG_DIR / f"{name}.yaml")
+    model = MLXMambaModel(cfg)
+    actual = sum(int(v.size) for v in model._portable_state_dict().values())
+    assert cfg.num_parameters() == actual, (
+        f"{name}: formula {cfg.num_parameters()} != built model {actual}"
+    )


### PR DESCRIPTION
Closes #66

## Summary
- **`MambaConfig.parameter_breakdown()` / `num_parameters()`** (`src/model/blocks.py`): closed-form, portable parameter count broken out by named term, extensible so #67 can add an `"attention"` term. Pinned exactly to the built model's `_portable_state_dict()` via an MLX safety-net test.
- **`src/model/sizing.py`** (new, portable): inference footprint (Mamba has no KV cache → weights ≈ the footprint), a documented training-memory estimate (~8 B/param lean AdamW / ~10 B/param 8-bit-Adam VRAM lever + activation estimate), and a `family_table`/`format_family_table` mapping each tier to a GPU/RAM class per epic #65.
- **`scripts/model_size.py`** (new): CLI that prints the family sizing table (`--config` to size one file).
- **`config/{1b,2b,4b}.yaml`** (new): mirror `poc.yaml`'s decision-record comments; `precision: bf16` (CUDA-native, no loss scaling), tied embeddings, `grad_checkpoint: true`, `head_dim 64`. Dims land within ±5% of target (1.03B / 1.98B / 3.97B).
- **Tests**: `tests/test_sizing.py` + `tests/test_sizing_mlx.py`; add `src.model.sizing` to the import-guard `PORTABLE_MODULES`.

Part of epic #65 (M10, local-first band). All work is above the seam (no backend import) except the MLX-gated safety-net test.

## Family sizing table (`scripts/model_size.py`)
| tier | params | bf16 wt | train | GPU (train) |
|---|---|---|---|---|
| poc | 126.7M | 0.24G | 1.6G | T4 16GB / L4 24GB |
| 1b | 1033.7M | 1.93G | 11.3G | L4 / A10 24GB |
| 2b | 1984.6M | 3.70G | 20.9G | A100 40GB / L40S 48GB |
| 4b | 3970.8M | 7.40G | 40.5G | A100 80GB / H100 80GB |

## Testing
- [x] Tests added (`test_sizing.py`, `test_sizing_mlx.py`) + import-guard updated
- [x] All tests passing — full suite **186 passed**
- [x] `scripts/model_size.py` table matches the #65 sizing targets
- [x] Smoke gate green on a freshly-built toy split (resume max|diff| 2.4e-7, eval runs)