### PR TITLE
feat(model): [M10] Mamba-2 hybrid attention layers behind the seam (#67)

### DIFF
--- a/config/toy-hybrid.yaml
+++ b/config/toy-hybrid.yaml
@@ -1,0 +1,27 @@
+# Toy HYBRID config (#67): tiny Mamba-2 with config-gated attention layers.
+# Used by the parity + sizing tests so they exercise a model with BOTH block types.
+# attn_every 2 over 4 layers -> blocks [Mamba, Attn, Mamba, Attn]. fp32 for exact parity.
+d_model: 64
+n_layers: 4
+d_state: 16            # SSM state width N (per head)
+expand: 2              # d_inner = 128
+d_conv: 4
+head_dim: 16           # Mamba-2/SSD: 128/16 = 8 SSM heads (scalar A per head)
+dt_rank: auto
+
+# Hybrid attention: every 2nd block is causal MHA + RoPE instead of a Mamba block.
+attn_every: 2          # layers 1 and 3 (0-indexed (i+1)%2==0) are attention
+n_attn_heads: 4        # attn_head_dim = d_model // n_attn_heads = 16
+
+vocab_size: 256        # byte-fallback tokenizer for offline tests
+seq_len: 64
+tie_embeddings: true
+
+precision: fp32        # correctness first; fp32 makes forward/step + backend parity exact
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false # tiny; keep tests cheap
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/scripts/retrieval_probe.py
+++ b/scripts/retrieval_probe.py
@@ -1,0 +1,108 @@
+"""Retrieval probe (#67): does the attention fraction actually help recall?
+
+Trains a **pure-Mamba** and a **hybrid** (same dims, a few attention layers) on the
+multi-query associative-recall (MQAR) task from `src.eval.retrieval_probe`, with a
+FIXED seed, and reports each model's recall accuracy. Pure SSMs have a fixed-width
+state, so their recall degrades as the number of key-value pairs grows; the hybrid's
+attention layers do not. Run at enough pairs, the hybrid wins — that gap is the
+evidence the config-gated attention earns its keep.
+
+  python scripts/retrieval_probe.py                      # default probe
+  python scripts/retrieval_probe.py --n-pairs 64 --steps 2000
+  python scripts/retrieval_probe.py --include-attn       # also a pure-attention upper bound
+
+Runs on whatever backend is present (MLX on the Mac); SFT-style masked-CE training is
+MLX-only today, so this is an Apple-Silicon probe (mirrors scripts/smoke_test.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+
+from src.model.blocks import MambaConfig
+from src.model.backend import get_backend
+from src.eval.retrieval_probe import make_recall_batch, recall_accuracy, seq_len, vocab_size
+
+
+def _make_cfg(d_model, n_layers, n_keys, n_values, slen, attn_every, n_attn_heads):
+    cfg = MambaConfig(
+        d_model=d_model, n_layers=n_layers, head_dim=16, d_state=16,
+        vocab_size=vocab_size(n_keys, n_values), seq_len=slen, precision="fp32",
+        attn_every=attn_every, n_attn_heads=n_attn_heads)
+    cfg.validate()
+    return cfg
+
+
+def train_and_eval(backend, cfg, *, steps, batch_size, n_pairs, n_keys, n_values,
+                   n_queries, lr, seed) -> float:
+    """Train one model on MQAR and return its held-out recall accuracy."""
+    backend.seed(seed)
+    model = backend.model_cls(cfg)
+    opt = backend.make_optimizer(model, lr)
+    train_step = backend.make_sft_train_step(model, opt)        # masked CE over query positions
+    rng = np.random.default_rng(seed)
+    for _ in range(steps):
+        batch = make_recall_batch(rng, batch_size, n_pairs, n_keys, n_values, n_queries)
+        train_step(model, [batch], lr)                          # batch is (inputs, targets, mask)
+    ev = np.random.default_rng(seed + 999)
+    inputs, targets, mask = make_recall_batch(ev, 512, n_pairs, n_keys, n_values, n_queries)
+    logits = backend.to_numpy(model.forward(inputs))
+    return recall_accuracy(logits, targets, mask)
+
+
+def run_probe(*, steps=800, batch_size=64, n_pairs=16, n_keys=32, n_values=24,
+              n_queries=None, d_model=64, n_layers=4, attn_every=2, n_attn_heads=4,
+              lr=2e-3, seed=0, backend_name="auto", include_attn=False) -> dict:
+    """Train pure-Mamba vs hybrid (optionally a pure-attention upper bound) on MQAR."""
+    backend = get_backend(backend_name)
+    n_queries = n_pairs if n_queries is None else n_queries
+    slen = seq_len(n_pairs, n_queries)
+    common = dict(steps=steps, batch_size=batch_size, n_pairs=n_pairs, n_keys=n_keys,
+                  n_values=n_values, n_queries=n_queries, lr=lr, seed=seed)
+    variants = {
+        "mamba": _make_cfg(d_model, n_layers, n_keys, n_values, slen, None, n_attn_heads),
+        "hybrid": _make_cfg(d_model, n_layers, n_keys, n_values, slen, attn_every, n_attn_heads),
+    }
+    if include_attn:
+        variants["attn"] = _make_cfg(d_model, n_layers, n_keys, n_values, slen, 1, n_attn_heads)
+    out = {f"{name}_acc": train_and_eval(backend, cfg, **common)
+           for name, cfg in variants.items()}
+    out.update(n_pairs=n_pairs, n_keys=n_keys, n_values=n_values, chance=1.0 / n_values)
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--steps", type=int, default=800)
+    ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--n-pairs", type=int, default=16)
+    ap.add_argument("--n-keys", type=int, default=32)
+    ap.add_argument("--n-values", type=int, default=24)
+    ap.add_argument("--n-queries", type=int, default=None)
+    ap.add_argument("--lr", type=float, default=2e-3)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--include-attn", action="store_true",
+                    help="also train a pure-attention model (recall upper bound)")
+    args = ap.parse_args()
+
+    r = run_probe(steps=args.steps, batch_size=args.batch_size, n_pairs=args.n_pairs,
+                  n_keys=args.n_keys, n_values=args.n_values, n_queries=args.n_queries,
+                  lr=args.lr, seed=args.seed, include_attn=args.include_attn)
+    print(f"MQAR ({r['n_pairs']} pairs, {r['n_keys']} keys, {r['n_values']} values; "
+          f"chance={r['chance']:.3f})")
+    print(f"  pure-Mamba accuracy : {r['mamba_acc']:.3f}")
+    if "attn_acc" in r:
+        print(f"  pure-attn  accuracy : {r['attn_acc']:.3f}")
+    print(f"  hybrid     accuracy : {r['hybrid_acc']:.3f}")
+    print(f"  delta (hybrid-pure) : {r['hybrid_acc'] - r['mamba_acc']:+.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/retrieval_probe.py
+++ b/src/eval/retrieval_probe.py
@@ -1,0 +1,84 @@
+"""Associative-recall probe data (#67) — the test that the attention fraction works.
+
+Pure SSMs lag Transformers on in-context retrieval (recall a value bound to a key
+seen earlier) — and the gap widens with the number of key-value pairs, because an
+SSM's fixed-width recurrent state is a capacity bottleneck while attention can look
+back at any position. This generates the standard **multi-query associative recall
+(MQAR)** task used to measure exactly that: a context of (key, value) pairs followed
+by a query section that re-presents some keys; the model must emit each queried key's
+value. A pure-Mamba and a hybrid are trained on it (`scripts/retrieval_probe.py`) and
+the hybrid's higher recall accuracy at enough pairs is the measurable signal.
+
+ABOVE THE SEAM — pure numpy, no backend. Keys occupy token ids `[0, n_keys)` and
+values `[n_keys, n_keys + n_values)` (disjoint → `vocab_size = n_keys + n_values`).
+
+Sequence layout (length `2*n_pairs + 2*n_queries`):
+    k1 v1 ... k_n v_n   q1 vq1  q2 vq2 ...        (context ++ query section)
+Each query key `qj` re-presents one of the context keys; under next-token prediction
+the position holding `qj` is supervised to predict its value `vqj` (mask=1 there,
+0 elsewhere — context-value positions are random and carry no signal). Dense
+supervision over many query positions trains fast and makes the capacity gap visible.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+
+
+def vocab_size(n_keys: int, n_values: int) -> int:
+    """Token-id space for the task (disjoint key/value ranges)."""
+    return n_keys + n_values
+
+
+def seq_len(n_pairs: int, n_queries: Optional[int] = None) -> int:
+    """Sequence length produced by `make_recall_batch` for these settings."""
+    n_queries = n_pairs if n_queries is None else n_queries
+    return 2 * n_pairs + 2 * n_queries
+
+
+def make_recall_batch(rng: np.random.Generator, batch_size: int, n_pairs: int,
+                      n_keys: int, n_values: int,
+                      n_queries: Optional[int] = None) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """A batch of MQAR sequences as an (inputs, targets, mask) 3-tuple.
+
+    Matches the SFTLoader contract so it feeds straight into `make_sft_train_step`
+    (masked cross-entropy over the supervised positions).
+      * inputs  (B, L) int64 — context pairs then the query section.
+      * targets (B, L) int64 — the queried value at each query-key position (else 0).
+      * mask    (B, L) int64 — 1 at the supervised query-key positions, else 0.
+    """
+    if n_pairs > n_keys:
+        raise ValueError(f"n_pairs={n_pairs} cannot exceed n_keys={n_keys} (distinct keys)")
+    n_queries = n_pairs if n_queries is None else n_queries
+    L = seq_len(n_pairs, n_queries)
+    inputs = np.zeros((batch_size, L), dtype=np.int64)
+    targets = np.zeros((batch_size, L), dtype=np.int64)
+    mask = np.zeros((batch_size, L), dtype=np.int64)
+    for b in range(batch_size):
+        keys = rng.choice(n_keys, size=n_pairs, replace=False)          # distinct keys
+        values = rng.integers(0, n_values, size=n_pairs) + n_keys       # value id range
+        inputs[b, 0:2 * n_pairs:2] = keys
+        inputs[b, 1:2 * n_pairs:2] = values
+        # Query section: re-present a (possibly repeated) sample of keys to recall.
+        qidx = rng.integers(0, n_pairs, size=n_queries)
+        base = 2 * n_pairs
+        for j, qi in enumerate(qidx):
+            kp = base + 2 * j                                          # query-key position
+            inputs[b, kp] = keys[qi]
+            inputs[b, kp + 1] = values[qi]                            # teacher-forced value
+            targets[b, kp] = values[qi]                              # predict value from key
+            mask[b, kp] = 1
+    return inputs, targets, mask
+
+
+def recall_accuracy(logits: np.ndarray, targets: np.ndarray, mask: np.ndarray) -> float:
+    """Fraction of supervised (mask=1) positions whose argmax prediction is correct.
+
+    `logits` (B, L, V); `targets`/`mask` (B, L). Pure numpy — usable from any host."""
+    pred = np.asarray(logits).argmax(axis=-1)                          # (B, L)
+    m = np.asarray(mask).astype(bool)
+    if not m.any():
+        return float("nan")
+    return float((pred[m] == np.asarray(targets)[m]).mean())

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -75,6 +75,17 @@ class MambaConfig:
     # 32GB and swaps). Off for toy/smoke (tiny; keep exact-resume cheap).
     grad_checkpoint: bool = False
 
+    # --- hybrid attention (#67) ---
+    # Make the model a Mamba-2 HYBRID: every Nth block is a causal multi-head
+    # attention block INSTEAD OF a Mamba block (n_layers unchanged). Pure SSMs lag on
+    # exact copying / in-context retrieval; a few attention layers (Jamba pattern ~1
+    # attn per 7 Mamba => attn_every 8) recover it. None = pure Mamba (current default).
+    # Layer i is attention iff `attn_every and (i+1) % attn_every == 0`.
+    attn_every: Optional[int] = None
+    # Heads for the attention blocks. None => d_model // 64 (so attn_head_dim ~= 64).
+    # Must divide d_model. Unused when attn_every is None.
+    n_attn_heads: Optional[int] = None
+
     # --- dt-projection bias init (LOAD-BEARING) ---
     # Inverse-softplus of a sample in [dt_min, dt_max] initializes the dt bias.
     # Without this the model fails to learn recall. Carry these into every backend.
@@ -95,6 +106,29 @@ class MambaConfig:
         if self.dt_rank == "auto":
             return math.ceil(self.d_model / 16)
         return int(self.dt_rank)
+
+    # --- hybrid attention derived params ---
+    @property
+    def n_attn_heads_resolved(self) -> int:
+        if self.n_attn_heads is not None:
+            return int(self.n_attn_heads)
+        return max(1, self.d_model // 64)
+
+    @property
+    def attn_head_dim(self) -> int:
+        """Attention head width. qkv project d_model -> n_attn_heads * attn_head_dim,
+        with attn_head_dim = d_model // n_attn_heads (so d_attn == d_model)."""
+        return self.d_model // self.n_attn_heads_resolved
+
+    def is_attention_layer(self, i: int) -> bool:
+        """True if block `i` (0-indexed) is a causal-attention block, not a Mamba block."""
+        return bool(self.attn_every) and (i + 1) % self.attn_every == 0
+
+    @property
+    def n_attention_layers(self) -> int:
+        if not self.attn_every:
+            return 0
+        return self.n_layers // self.attn_every
 
     def parameter_breakdown(self) -> dict:
         """Closed-form trainable-parameter count, broken out by named term.
@@ -128,11 +162,21 @@ class MambaConfig:
             + d_inner * d_model                      # out_proj
         )
 
+        n_attn = self.n_attention_layers
+        n_mamba = self.n_layers - n_attn
+
         bd = {
             "embedding": self.vocab_size * d_model,
-            "layers": self.n_layers * per_layer,
+            "layers": n_mamba * per_layer,
             "final_norm": d_model,
         }
+        # Hybrid (#67): attention blocks REPLACE that many Mamba blocks. Each is a
+        # pre-norm + bias-free qkv (d_model -> 3*d_attn) + bias-free o_proj
+        # (d_attn -> d_model); d_attn = n_attn_heads * attn_head_dim = d_model.
+        if n_attn:
+            d_attn = self.n_attn_heads_resolved * self.attn_head_dim
+            attn_per_layer = d_model + 3 * d_model * d_attn + d_attn * d_model
+            bd["attention"] = n_attn * attn_per_layer
         # Tied embedding reuses the input matrix as the LM head -> no extra params.
         if not self.tie_embeddings:
             bd["lm_head"] = self.vocab_size * d_model
@@ -159,6 +203,15 @@ class MambaConfig:
                 f"head_dim={self.head_dim} must divide d_inner={self.d_inner} "
                 "(d_inner = expand*d_model)."
             )
+        if self.attn_every is not None:
+            if self.attn_every <= 0:
+                raise ValueError("attn_every must be a positive int or None")
+            nah = self.n_attn_heads_resolved
+            if nah <= 0 or self.d_model % nah != 0:
+                raise ValueError(
+                    f"n_attn_heads={nah} must divide d_model={self.d_model} "
+                    "(attn_head_dim = d_model // n_attn_heads)."
+                )
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -264,6 +264,94 @@ class MambaBlock(nn.Module):
 
 
 # --------------------------------------------------------------------------- #
+# Hybrid attention (#67): causal MHA with RoPE — torch port of the MLX block.
+# --------------------------------------------------------------------------- #
+def _rope_cos_sin(positions: Array, head_dim: int) -> Tuple[Array, Array]:
+    """RoPE cos/sin for absolute `positions` (fp32). Computed on the fly (no buffer),
+    so the parameter set matches MLX exactly. Returns (T, head_dim) each."""
+    half = head_dim // 2
+    device = positions.device
+    inv_freq = torch.exp(-math.log(10000.0)
+                         * torch.arange(0, half, dtype=torch.float32, device=device) / half)
+    ang = positions.to(torch.float32)[:, None] * inv_freq[None, :]    # (T, half)
+    cos = torch.cat([torch.cos(ang), torch.cos(ang)], dim=-1)         # (T, head_dim)
+    sin = torch.cat([torch.sin(ang), torch.sin(ang)], dim=-1)
+    return cos, sin
+
+
+def _rotate_half(x: Array) -> Array:
+    half = x.shape[-1] // 2
+    return torch.cat([-x[..., half:], x[..., :half]], dim=-1)
+
+
+def _apply_rope(x: Array, cos: Array, sin: Array) -> Array:
+    # x: (B, H, T, Dh); cos/sin: (T, Dh) -> broadcast over (B, H).
+    return x * cos[None, None] + _rotate_half(x) * sin[None, None]
+
+
+def _softmax_lastdim(scores: Array) -> Array:
+    scores = scores - torch.amax(scores, dim=-1, keepdim=True)
+    w = torch.exp(scores)
+    return w / torch.sum(w, dim=-1, keepdim=True)
+
+
+class AttentionBlock(nn.Module):
+    """Pre-norm causal multi-head attention with RoPE (mirror of mlx_backend.AttentionBlock).
+
+    Same `forward_seq` / `step` contract and the same submodule names/shapes
+    (`norm`, `qkv_proj`, `o_proj`) so portable weights round-trip MLX<->torch. State is
+    a (k_cache, v_cache) pair, each (B, H, T, Dh), grown one token per `step`."""
+
+    def __init__(self, config: MambaConfig):
+        super().__init__()
+        self.config = config
+        self.H = config.n_attn_heads_resolved
+        self.Dh = config.attn_head_dim
+        d_attn = self.H * self.Dh
+        self.norm = RMSNorm(config.d_model)
+        self.qkv_proj = nn.Linear(config.d_model, 3 * d_attn, bias=False)
+        self.o_proj = nn.Linear(d_attn, config.d_model, bias=False)
+
+    def _qkv(self, xn: Array, cd):
+        B = xn.shape[0]
+        T = xn.shape[1] if xn.dim() == 3 else 1
+        qkv = _linear(self.qkv_proj, xn, cd)                 # (B,[T,]3*d_attn)
+        q, k, v = torch.chunk(qkv, 3, dim=-1)
+        def heads(t):                                        # -> (B,H,T,Dh) fp32
+            return _f32(t).reshape(B, T, self.H, self.Dh).permute(0, 2, 1, 3)
+        return heads(q), heads(k), heads(v)
+
+    def forward_seq(self, x: Array) -> Array:
+        cd = _DTYPES[self.config.precision]
+        L = x.shape[1]
+        xn = self.norm(x)
+        q, k, v = self._qkv(xn, cd)                          # (B,H,L,Dh) fp32
+        cos, sin = _rope_cos_sin(torch.arange(L, device=x.device), self.Dh)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        scores = (q @ k.transpose(-1, -2)) / math.sqrt(self.Dh)      # (B,H,L,L)
+        causal = torch.tril(torch.ones((L, L), dtype=torch.bool, device=x.device))
+        scores = scores.masked_fill(~causal, float("-inf"))
+        out = _softmax_lastdim(scores) @ v                   # (B,H,L,Dh)
+        out = out.permute(0, 2, 1, 3).reshape(x.shape[0], L, self.H * self.Dh)
+        return x + _linear(self.o_proj, _cast(out, cd), cd)
+
+    def step(self, x: Array, state: State) -> Tuple[Array, State]:
+        cd = _DTYPES[self.config.precision]
+        k_cache, v_cache = state                             # (B,H,T,Dh) each, fp32
+        t = k_cache.shape[2]                                 # absolute position
+        xn = self.norm(x)                                    # x: (B, d_model)
+        q, k, v = self._qkv(xn, cd)                          # (B,H,1,Dh) fp32
+        cos, sin = _rope_cos_sin(torch.arange(t, t + 1, device=x.device), self.Dh)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        k_cache = torch.cat([k_cache, k], dim=2)             # (B,H,t+1,Dh)
+        v_cache = torch.cat([v_cache, v], dim=2)
+        scores = (q @ k_cache.transpose(-1, -2)) / math.sqrt(self.Dh)   # (B,H,1,t+1)
+        out = _softmax_lastdim(scores) @ v_cache             # (B,H,1,Dh)
+        out = out.permute(0, 2, 1, 3).reshape(x.shape[0], self.H * self.Dh)
+        return x + _linear(self.o_proj, _cast(out, cd), cd), (k_cache, v_cache)
+
+
+# --------------------------------------------------------------------------- #
 # Top-level model implementing the seam
 # --------------------------------------------------------------------------- #
 class CUDAMambaModel(ModelInterface, nn.Module):
@@ -274,7 +362,10 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         self._cd = _DTYPES[config.precision]         # compute dtype for the heavy GEMMs
         self._device = torch.device(device)
         self.embedding = nn.Embedding(config.vocab_size, config.d_model)
-        self.layers = nn.ModuleList([MambaBlock(config) for _ in range(config.n_layers)])
+        # Hybrid (#67): attention blocks replace Mamba blocks at the gated positions.
+        self.layers = nn.ModuleList(
+            [AttentionBlock(config) if config.is_attention_layer(i) else MambaBlock(config)
+             for i in range(config.n_layers)])
         self.norm_f = RMSNorm(config.d_model)
         self._tie_embeddings = config.tie_embeddings
         if not config.tie_embeddings:
@@ -319,11 +410,17 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         c = self.config
         di, k = c.d_inner, c.d_conv
         H, P, N = c.n_heads, c.head_dim, c.d_state
+        Ha, Dh = c.n_attn_heads_resolved, c.attn_head_dim
         dev = self._device
-        # Per layer: (conv window (B,k-1,di), SSM state (B,H,P,N)). fp32 to match the scan.
-        return [(torch.zeros((batch_size, k - 1, di), device=dev),
-                 torch.zeros((batch_size, H, P, N), device=dev))
-                for _ in range(self.config.n_layers)]
+        # Per Mamba layer: (conv window (B,k-1,di), SSM state (B,H,P,N)), fp32.
+        # Per attention layer: a zero-length KV cache (k,v), each (B,Ha,0,Dh), grown by step.
+        def layer_state(i):
+            if c.is_attention_layer(i):
+                z = torch.zeros((batch_size, Ha, 0, Dh), device=dev)
+                return (z, z)
+            return (torch.zeros((batch_size, k - 1, di), device=dev),
+                    torch.zeros((batch_size, H, P, N), device=dev))
+        return [layer_state(i) for i in range(self.config.n_layers)]
 
     def get_state(self) -> State:
         return self._state

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -294,6 +294,97 @@ class MambaBlock(nn.Module):
 
 
 # --------------------------------------------------------------------------- #
+# Hybrid attention (#67): causal MHA with RoPE, parity-exact forward/step.
+# --------------------------------------------------------------------------- #
+def _rope_cos_sin(positions: Array, head_dim: int) -> Tuple[Array, Array]:
+    """RoPE cos/sin for absolute `positions` (fp32). Computed on the fly (no stored
+    buffer) so nothing extra lands in the parameter tree. Returns (T, head_dim) each."""
+    half = head_dim // 2
+    inv_freq = mx.exp(-math.log(10000.0) * mx.arange(0, half, dtype=mx.float32) / half)
+    ang = positions.astype(mx.float32)[:, None] * inv_freq[None, :]   # (T, half)
+    cos = mx.concatenate([mx.cos(ang), mx.cos(ang)], axis=-1)         # (T, head_dim)
+    sin = mx.concatenate([mx.sin(ang), mx.sin(ang)], axis=-1)
+    return cos, sin
+
+
+def _rotate_half(x: Array) -> Array:
+    half = x.shape[-1] // 2
+    return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
+
+
+def _apply_rope(x: Array, cos: Array, sin: Array) -> Array:
+    # x: (B, H, T, Dh); cos/sin: (T, Dh) -> broadcast over (B, H).
+    cos = cos[None, None]
+    sin = sin[None, None]
+    return x * cos + _rotate_half(x) * sin
+
+
+def _softmax_lastdim(scores: Array) -> Array:
+    scores = scores - mx.max(scores, axis=-1, keepdims=True)
+    w = mx.exp(scores)
+    return w / mx.sum(w, axis=-1, keepdims=True)
+
+
+class AttentionBlock(nn.Module):
+    """Pre-norm causal multi-head attention with RoPE (the hybrid's attention layer).
+
+    Drop-in for MambaBlock: same `forward_seq(x)->x` (training) and
+    `step(x, state)->(x, state)` (inference) contract. State is a (k_cache, v_cache)
+    pair, each (B, H, T, Dh), grown one token per `step` — a 2-tuple of arrays, so the
+    model's state plumbing (init/clone) treats it exactly like the Mamba (conv, ssm)
+    pair. Scores/softmax run in fp32 (qkv/o_proj GEMMs in compute dtype) so forward and
+    step agree at the fp32 ~1e-4 parity tolerance."""
+
+    def __init__(self, config: MambaConfig):
+        super().__init__()
+        self.config = config
+        self.H = config.n_attn_heads_resolved
+        self.Dh = config.attn_head_dim
+        d_attn = self.H * self.Dh
+        self.norm = RMSNorm(config.d_model)
+        self.qkv_proj = nn.Linear(config.d_model, 3 * d_attn, bias=False)
+        self.o_proj = nn.Linear(d_attn, config.d_model, bias=False)
+
+    def _qkv(self, xn: Array, cd):
+        B = xn.shape[0]
+        T = xn.shape[1] if xn.ndim == 3 else 1
+        qkv = _linear(self.qkv_proj, xn, cd)                 # (B,[T,]3*d_attn)
+        q, k, v = mx.split(qkv, 3, axis=-1)
+        def heads(t):                                        # -> (B,H,T,Dh) fp32
+            return _f32(t).reshape(B, T, self.H, self.Dh).transpose(0, 2, 1, 3)
+        return heads(q), heads(k), heads(v)
+
+    def forward_seq(self, x: Array) -> Array:
+        cd = _DTYPES[self.config.precision]
+        L = x.shape[1]
+        xn = self.norm(x)
+        q, k, v = self._qkv(xn, cd)                          # (B,H,L,Dh) fp32
+        cos, sin = _rope_cos_sin(mx.arange(L), self.Dh)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(self.Dh)   # (B,H,L,L)
+        causal = mx.tril(mx.ones((L, L), dtype=mx.bool_))
+        scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        out = _softmax_lastdim(scores) @ v                   # (B,H,L,Dh)
+        out = out.transpose(0, 2, 1, 3).reshape(x.shape[0], L, self.H * self.Dh)
+        return x + _linear(self.o_proj, _cast(out, cd), cd)
+
+    def step(self, x: Array, state: State) -> Tuple[Array, State]:
+        cd = _DTYPES[self.config.precision]
+        k_cache, v_cache = state                             # (B,H,T,Dh) each, fp32
+        t = k_cache.shape[2]                                 # absolute position
+        xn = self.norm(x)                                    # x: (B, d_model)
+        q, k, v = self._qkv(xn, cd)                          # (B,H,1,Dh) fp32
+        cos, sin = _rope_cos_sin(mx.arange(t, t + 1), self.Dh)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        k_cache = mx.concatenate([k_cache, k], axis=2)       # (B,H,t+1,Dh)
+        v_cache = mx.concatenate([v_cache, v], axis=2)
+        scores = (q @ k_cache.transpose(0, 1, 3, 2)) / math.sqrt(self.Dh)  # (B,H,1,t+1)
+        out = _softmax_lastdim(scores) @ v_cache             # (B,H,1,Dh)
+        out = out.transpose(0, 2, 1, 3).reshape(x.shape[0], self.H * self.Dh)
+        return x + _linear(self.o_proj, _cast(out, cd), cd), (k_cache, v_cache)
+
+
+# --------------------------------------------------------------------------- #
 # Top-level model implementing the seam
 # --------------------------------------------------------------------------- #
 class MLXMambaModel(ModelInterface, nn.Module):
@@ -303,7 +394,9 @@ class MLXMambaModel(ModelInterface, nn.Module):
         self.config = config
         self._cd = _DTYPES[config.precision]         # compute dtype for the heavy GEMMs
         self.embedding = nn.Embedding(config.vocab_size, config.d_model)
-        self.layers = [MambaBlock(config) for _ in range(config.n_layers)]
+        # Hybrid (#67): attention blocks replace Mamba blocks at the gated positions.
+        self.layers = [AttentionBlock(config) if config.is_attention_layer(i)
+                       else MambaBlock(config) for i in range(config.n_layers)]
         self.norm_f = RMSNorm(config.d_model)
         self._tie_embeddings = config.tie_embeddings
         if not config.tie_embeddings:
@@ -344,9 +437,15 @@ class MLXMambaModel(ModelInterface, nn.Module):
         c = self.config
         di, k = c.d_inner, c.d_conv
         H, P, N = c.n_heads, c.head_dim, c.d_state
-        # Per layer: (conv window (B,k-1,di), SSM state (B,H,P,N)).
-        return [(mx.zeros((batch_size, k - 1, di)), mx.zeros((batch_size, H, P, N)))
-                for _ in range(self.config.n_layers)]
+        Ha, Dh = c.n_attn_heads_resolved, c.attn_head_dim
+        # Per Mamba layer: (conv window (B,k-1,di), SSM state (B,H,P,N)).
+        # Per attention layer: a zero-length KV cache (k,v), each (B,Ha,0,Dh), grown by step.
+        def layer_state(i):
+            if c.is_attention_layer(i):
+                z = mx.zeros((batch_size, Ha, 0, Dh))
+                return (z, z)
+            return (mx.zeros((batch_size, k - 1, di)), mx.zeros((batch_size, H, P, N)))
+        return [layer_state(i) for i in range(self.config.n_layers)]
 
     def get_state(self) -> State:
         return self._state

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -75,6 +75,33 @@ def test_backend_parity_mlx_vs_torch(tmp_path):
 
 @pytest.mark.skipif(not (HAVE_MLX and HAVE_TORCH),
                     reason="needs both mlx and torch (run on a Mac)")
+def test_backend_parity_hybrid(tmp_path):
+    """Hybrid (attention layers present): identical portable weights in both backends ->
+    `forward` agrees in fp32. Proves the attention block ports MLX<->torch, including the
+    qkv_proj/o_proj weights round-tripping through the portable state dict."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.cuda_backend import CUDAMambaModel
+
+    cfg = load_config("config/toy-hybrid.yaml")
+    torch.manual_seed(0)
+    src = CUDAMambaModel(cfg)
+    assert any(type(l).__name__ == "AttentionBlock" for l in src.layers)
+    path = str(tmp_path / "weights.safetensors")
+    src.save(path)
+
+    mlx_m = MLXMambaModel(cfg); mlx_m.load(path)
+    cuda_m = CUDAMambaModel(cfg); cuda_m.load(path)
+
+    tokens = _tokens(cfg, B=2, L=24)
+    with torch.no_grad():
+        result = check_backend_parity(mlx_m, cuda_m, tokens,
+                                      to_numpy_a=_mlx_np, to_numpy_b=_torch_np,
+                                      rtol=1e-4, atol=1e-5)
+    assert result["ok"], result
+
+
+@pytest.mark.skipif(not (HAVE_MLX and HAVE_TORCH),
+                    reason="needs both mlx and torch (run on a Mac)")
 def test_portable_weights_roundtrip_both_directions(tmp_path):
     """MLX save -> torch _load_portable -> torch save -> load back into MLX; the MLX
     logits are unchanged. Proves the cross-backend bridge in both directions (a

--- a/tests/test_cuda_parity.py
+++ b/tests/test_cuda_parity.py
@@ -131,6 +131,20 @@ def test_forward_step_parity_toy():
     assert result["ok"], result
 
 
+def test_forward_step_parity_hybrid():
+    # Attention block (RoPE + KV cache) on the torch backend: forward vs step parity.
+    torch.manual_seed(0)
+    cfg = load_config("config/toy-hybrid.yaml")
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    assert any(type(l).__name__ == "AttentionBlock" for l in model.layers)
+    B, L = 2, 40
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    with torch.no_grad():
+        result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
+    assert result["ok"], result
+
+
 def test_portable_roundtrip(tmp_path):
     """save -> reload into a fresh instance -> identical logits (the portable bridge)."""
     torch.manual_seed(0)

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -50,6 +50,7 @@ PORTABLE_MODULES = [
     "src.train.loop",
     "src.eval.val_loss",
     "src.eval.olmes_adapter",
+    "src.eval.retrieval_probe",
     "src.conformance.forward_step_parity",
     "src.conformance.backend_parity",
     "src.serve.sessions",

--- a/tests/test_mlx_parity.py
+++ b/tests/test_mlx_parity.py
@@ -129,3 +129,17 @@ def test_forward_step_parity_toy():
     tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
     result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
     assert result["ok"], result
+
+
+def test_forward_step_parity_hybrid():
+    # The hybrid model interleaves attention blocks (RoPE + KV cache). forward (full
+    # causal attention) and step (incremental cache) must still agree — the attention
+    # path's train/infer equivalence, alongside the SSM's.
+    mx.random.seed(0)
+    cfg = load_config("config/toy-hybrid.yaml")
+    model = MLXMambaModel(cfg)
+    assert any(type(l).__name__ == "AttentionBlock" for l in model.layers)
+    B, L = 2, 40
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
+    assert result["ok"], result

--- a/tests/test_retrieval_probe.py
+++ b/tests/test_retrieval_probe.py
@@ -1,0 +1,84 @@
+"""Retrieval probe (#67): task-generator correctness (portable) + a small end-to-end
+train comparing pure-Mamba vs hybrid recall (MLX-gated).
+
+The portable tests pin the MQAR data contract. The MLX test trains both architectures
+briefly and checks the harness produces valid recall accuracies and that the hybrid
+clears a recall bar pure SSMs struggle at when the number of pairs stresses their
+fixed-width state — the signal the attention fraction is doing its job. (At toy scale
+pure Mamba-2 is itself strong at recall; the headline pure-vs-hybrid comparison at
+larger scale is what `scripts/retrieval_probe.py` runs.)
+"""
+
+import numpy as np
+import pytest
+
+from src.eval.retrieval_probe import (make_recall_batch, recall_accuracy, seq_len,
+                                       vocab_size)
+
+
+def test_vocab_and_seq_len():
+    assert vocab_size(40, 24) == 64
+    assert seq_len(n_pairs=8, n_queries=5) == 2 * 8 + 2 * 5
+
+
+def test_recall_batch_shapes_and_ranges():
+    rng = np.random.default_rng(0)
+    B, n_pairs, n_keys, n_values, n_q = 4, 8, 16, 10, 5
+    inputs, targets, mask = make_recall_batch(rng, B, n_pairs, n_keys, n_values, n_q)
+    L = seq_len(n_pairs, n_q)
+    assert inputs.shape == targets.shape == mask.shape == (B, L)
+    # Exactly n_queries supervised positions per row.
+    assert (mask.sum(axis=1) == n_q).all()
+    # Keys live in [0, n_keys); values in [n_keys, n_keys+n_values).
+    keys = inputs[:, 0:2 * n_pairs:2]
+    vals = inputs[:, 1:2 * n_pairs:2]
+    assert keys.max() < n_keys and keys.min() >= 0
+    assert vals.min() >= n_keys and vals.max() < n_keys + n_values
+
+
+def test_recall_batch_targets_consistent_with_context():
+    # Each supervised position predicts the value bound to that key in the context.
+    rng = np.random.default_rng(1)
+    n_pairs, n_keys, n_values = 6, 12, 8
+    inputs, targets, mask = make_recall_batch(rng, 16, n_pairs, n_keys, n_values, n_pairs)
+    for b in range(inputs.shape[0]):
+        ctx = {int(inputs[b, 2 * i]): int(inputs[b, 2 * i + 1]) for i in range(n_pairs)}
+        for p in np.flatnonzero(mask[b]):
+            assert targets[b, p] == ctx[int(inputs[b, p])]      # value matches the binding
+
+
+def test_recall_batch_rejects_too_many_pairs():
+    with pytest.raises(ValueError):
+        make_recall_batch(np.random.default_rng(0), 2, n_pairs=10, n_keys=8, n_values=4)
+
+
+def test_recall_accuracy_perfect_and_chance():
+    rng = np.random.default_rng(2)
+    _, targets, mask = make_recall_batch(rng, 8, 6, 12, 8, 6)
+    V = 20
+    # Perfect logits: argmax == target everywhere -> accuracy 1.0 over masked positions.
+    perfect = np.full(targets.shape + (V,), -10.0)
+    for idx in np.ndindex(targets.shape):
+        perfect[idx + (targets[idx],)] = 10.0
+    assert recall_accuracy(perfect, targets, mask) == 1.0
+    # All-zero logits argmax to class 0; targets are >= n_keys so accuracy ~ 0.
+    assert recall_accuracy(np.zeros(targets.shape + (V,)), targets, mask) == 0.0
+
+
+# --- end-to-end probe: the hybrid measurably out-recalls pure Mamba (MLX, ~20s) ---
+mx = pytest.importorskip("mlx.core")
+
+
+def test_hybrid_outrecalls_pure_mamba():
+    """At enough key-value pairs the SSM's fixed-width state saturates and pure Mamba
+    stays near chance, while a hybrid with a couple of attention layers recalls almost
+    perfectly. Fixed seed; the measured gap is ~0.85 (hybrid ~1.0 vs Mamba ~0.15) — we
+    assert a comfortable margin. `scripts/retrieval_probe.py` runs the fuller sweep."""
+    from scripts.retrieval_probe import run_probe
+
+    r = run_probe(n_pairs=16, n_keys=32, n_values=24, steps=300, lr=2e-3,
+                  batch_size=64, d_model=64, n_layers=4, attn_every=2, n_attn_heads=4,
+                  seed=0, backend_name="mlx")
+    assert 0.0 <= r["mamba_acc"] <= 1.0 and 0.0 <= r["hybrid_acc"] <= 1.0
+    assert r["hybrid_acc"] > 0.7, r                    # the hybrid learns recall
+    assert r["hybrid_acc"] - r["mamba_acc"] > 0.3, r   # measurable improvement vs pure Mamba

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -34,6 +34,28 @@ def test_num_parameters_equals_breakdown_sum():
         assert all(v > 0 for v in bd.values())
 
 
+def test_hybrid_breakdown_sums_and_counts_attention():
+    cfg = load_config(CONFIG_DIR / "toy-hybrid.yaml")
+    cfg.validate()
+    bd = cfg.parameter_breakdown()
+    assert "attention" in bd and bd["attention"] > 0
+    assert cfg.num_parameters() == sum(bd.values())
+    assert cfg.n_attention_layers == cfg.n_layers // cfg.attn_every
+    # Attention layers REPLACE Mamba layers: at toy dims a Mamba block is heavier than
+    # an attention block, so the hybrid has fewer params than the all-Mamba twin.
+    pure = MambaConfig(**{**cfg.to_dict(), "attn_every": None})
+    assert cfg.num_parameters() < pure.num_parameters()
+
+
+def test_attention_param_formula():
+    # attn layer = norm(d_model) + qkv(3*d_model*d_attn) + o_proj(d_attn*d_model), d_attn=d_model.
+    cfg = MambaConfig(d_model=64, n_layers=4, head_dim=16, vocab_size=256,
+                      attn_every=2, n_attn_heads=4)
+    d_model, d_attn = 64, 64
+    expect_per = d_model + 3 * d_model * d_attn + d_attn * d_model
+    assert cfg.parameter_breakdown()["attention"] == cfg.n_attention_layers * expect_per
+
+
 def test_untied_adds_lm_head():
     tied = MambaConfig(d_model=64, n_layers=2, head_dim=16, vocab_size=256,
                        tie_embeddings=True)

--- a/tests/test_sizing_mlx.py
+++ b/tests/test_sizing_mlx.py
@@ -17,7 +17,7 @@ from src.model.mlx_backend import MLXMambaModel
 CONFIG_DIR = Path(__file__).resolve().parents[1] / "config"
 
 
-@pytest.mark.parametrize("name", ["toy", "poc"])
+@pytest.mark.parametrize("name", ["toy", "poc", "toy-hybrid"])
 def test_num_parameters_matches_built_model(name):
     cfg = load_config(CONFIG_DIR / f"{name}.yaml")
     model = MLXMambaModel(cfg)


### PR DESCRIPTION
Closes #67

## Summary
Make the model a **config-gated Mamba-2 hybrid**: every Nth block is causal multi-head attention *instead of* a Mamba block. Pure SSMs lag on in-context recall because their fixed-width state saturates with the number of key-value pairs; a few attention layers (Jamba ~1:7) recover it. Implemented in **both** backends below the seam.

- **`MambaConfig`** (`src/model/blocks.py`): `attn_every` / `n_attn_heads` (+ `attn_head_dim`, `is_attention_layer`, `n_attention_layers`). `validate()` and `parameter_breakdown()` gain an `"attention"` term (attention blocks **replace** Mamba blocks, so `n_layers` is unchanged). `attn_every=None` stays the default → toy/poc/1b/2b/4b are byte-for-byte unchanged.
- **`AttentionBlock`** in `mlx_backend.py` and `cuda_backend.py`, mirrored: pre-norm, bias-free `qkv_proj`/`o_proj`, **RoPE computed on the fly** (no stored buffer → portable weights round-trip MLX↔torch and the param count stays exact), causal softmax in **fp32**. State stays a per-layer 2-tuple of arrays — Mamba `(conv, ssm)` or attention `(k_cache, v_cache)` — so `init_state` branches per layer while `clone_state`/`get_state`/`set_state` (and the serve layer) are unchanged.
- **Retrieval probe** (#67 acceptance, user opted in): `src/eval/retrieval_probe.py` (portable multi-query associative-recall generator) + `scripts/retrieval_probe.py` (trains pure-Mamba vs hybrid and reports recall).

Part of epic #65 (M10). Everything is above the seam except the two backends and the MLX-gated tests.

## Retrieval probe result (`scripts/retrieval_probe.py`)
At 16 key-value pairs the SSM's fixed state saturates and pure Mamba stays near chance, while the hybrid recalls almost perfectly:

| model (16 pairs, 32 keys, 24 values; chance 0.042) | recall |
|---|---|
| pure Mamba | 0.150 |
| **hybrid** | **1.000** |

**Honest scope note:** the attention advantage emerges only once the pair count stresses the SSM's fixed state. At small/easy scale pure Mamba-2 is itself strong at recall (its dt-bias init targets recall), so there is no gap there — the script runs the comparison at any scale, and this is the regime the literature predicts the hybrid wins.

## Testing
- [x] forward_step_parity + backend_parity (MLX↔torch) green **with attention layers present** (fp32 ~1e-4): MLX forward/step 1.2e-6, torch 2.3e-5, MLX↔torch 2.3e-5
- [x] sizing safety-net pins the attention param formula to the built model's real tensors (`toy-hybrid`)
- [x] MLX end-to-end probe test asserts the measurable hybrid > pure-Mamba recall gap
- [x] Full suite **198 passed**
- [x] Smoke gate still exact on a fresh toy split (resume max|diff| 2.4e-7) — pure-Mamba toy/poc unchanged