### PR TITLE
feat(data): [M10] datatrove pipeline skeleton — schema + local Parquet shards (#69)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# Data pipeline at full scale (download/tokenize).
-data = ["datasets>=2.0", "transformers>=4.40"]
+# Data pipeline at full scale (download/tokenize). pyarrow + fsspec back the corpus
+# Parquet sharded IO (src/data/corpus.py); fsspec also gives the file://-now /
+# s3://-later storage URI seam (the R2 writer swap is #80).
+data = ["datasets>=2.0", "transformers>=4.40", "pyarrow>=14", "fsspec>=2024.0"]
+# Scale corpus engine (#65/#80): HF datatrove runs the same pipeline shape on
+# R2/RunPod. The local skeleton (src/data/corpus.py) is pyarrow-native and does NOT
+# require this; install it only where the cloud pipeline runs.
+datatrove = ["datatrove>=0.6"]
 # Apple Silicon backend (NOT installable on Linux/CUDA hosts).
 mlx = ["mlx>=0.18"]
 # CUDA / PyTorch backend (Linux/CUDA host; also runs CPU-only for conformance on a Mac).

--- a/src/data/corpus.py
+++ b/src/data/corpus.py
@@ -1,0 +1,213 @@
+"""Corpus pipeline skeleton (#69): the staged flow that turns raw sources into cleaned,
+re-mixable text shards — runnable locally on the Mac before any cloud exists.
+
+This is the laptop-scale, pyarrow-native version of the datatrove pipeline in
+docs/design/08-corpus-pipeline.md (Stage 2, Normalize). Every source maps into one
+COMMON SCHEMA record `{text, source, lang, license, meta}`; the flow is
+ingest -> normalize -> filter -> write Parquet shards. At scale (#80) the same shape
+runs on HF `datatrove` with the writer pointed at R2 via `s3fs` — the `out_uri` seam
+below (an fsspec URI) is exactly where that swap happens: `file://` now, `s3://` later.
+
+ABOVE THE SEAM — no `mlx`/`torch`. Heavy data deps (pyarrow, fsspec) are imported
+LAZILY inside the IO functions, mirroring download.py/tokenize.py, so importing this
+module stays cheap and the seam guard (tests/test_import_guard.py) needs nothing extra.
+
+CLI (mirrors download/tokenize/pack/split):
+    python -m src.data.corpus --source dummy --in data/raw/dummy.txt --out data/cleaned
+The Parquet shards it writes feed the existing tokenize/pack/split stages:
+    python -m src.data.tokenize --in data/cleaned --out data/packed.bin --byte-fallback
+    python -m src.data.split    --packed data/packed.bin --out data/split --val-tokens 2000
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator, List
+
+from .download import _normalize_doc, dummy_texts
+
+#: The common-schema columns, in Parquet column order.
+RECORD_FIELDS = ("text", "source", "lang", "license", "meta")
+
+
+@dataclass
+class Record:
+    """One document in the common corpus schema. `meta` is free-form per-source
+    metadata, stored as a JSON-string column in Parquet so the table schema is stable
+    across sources."""
+
+    text: str
+    source: str
+    lang: str = "en"
+    license: str = "unknown"
+    meta: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {"text": self.text, "source": self.source, "lang": self.lang,
+                "license": self.license, "meta": dict(self.meta)}
+
+
+# --------------------------------------------------------------------------- #
+# Stages: ingest -> normalize -> filter
+# --------------------------------------------------------------------------- #
+def ingest_text_file(path, source: str, lang: str = "en",
+                     license: str = "unknown") -> Iterator[Record]:
+    """One raw Record per line of a UTF-8 text file (normalize() cleans it)."""
+    with open(Path(path), encoding="utf-8") as f:
+        for line in f:
+            yield Record(text=line.rstrip("\r\n"), source=source, lang=lang, license=license)
+
+
+def ingest_dummy(n_docs: int = 1000, seed: int = 0,
+                 source: str = "dummy") -> Iterator[Record]:
+    """Synthetic Records for offline testing (no network), via download.dummy_texts."""
+    for text in dummy_texts(n_docs, seed):
+        yield Record(text=text, source=source, lang="en", license="synthetic")
+
+
+def normalize(records: Iterable[Record]) -> Iterator[Record]:
+    """Collapse each doc's whitespace to one line (reuses download._normalize_doc) and
+    drop docs that normalize to empty — the Stage-2 contract."""
+    for r in records:
+        text = _normalize_doc(r.text)
+        if text:
+            yield Record(text=text, source=r.source, lang=r.lang,
+                         license=r.license, meta=r.meta)
+
+
+def filter_records(records: Iterable[Record], min_chars: int = 1) -> Iterator[Record]:
+    """Light length heuristic placeholder (the real Stage-3 filters are #72): keep docs
+    with at least `min_chars` characters."""
+    for r in records:
+        if len(r.text) >= min_chars:
+            yield r
+
+
+# --------------------------------------------------------------------------- #
+# Local sharded Parquet IO (the durable, re-mixable artifact)
+# --------------------------------------------------------------------------- #
+def _table_from_records(batch: List[Record]):
+    import pyarrow as pa
+    return pa.table({
+        "text": [r.text for r in batch],
+        "source": [r.source for r in batch],
+        "lang": [r.lang for r in batch],
+        "license": [r.license for r in batch],
+        "meta": [json.dumps(r.meta, separators=(",", ":"), sort_keys=True) for r in batch],
+    })
+
+
+def write_shards(records: Iterable[Record], out_uri, shard_size_mb: int = 128,
+                 prefix: str = "part", compression: str = "zstd") -> List[str]:
+    """Write Records as Parquet shards under `out_uri` (an fsspec URI: a local path /
+    `file://` now, `s3://` later via s3fs at #80 — same code path). Rolls a new shard
+    once the buffered text passes `shard_size_mb`, so output is FEW LARGE files (the R2
+    Class-A-ops constraint). Returns the shard paths written, in order.
+    """
+    import fsspec
+    import pyarrow.parquet as pq
+
+    fs, root = fsspec.core.url_to_fs(str(out_uri))
+    root = root.rstrip("/")
+    fs.makedirs(root, exist_ok=True)
+    budget = shard_size_mb * (1 << 20)
+    written: List[str] = []
+    buf: List[Record] = []
+    nbytes = 0
+    idx = 0
+
+    def flush() -> None:
+        nonlocal buf, nbytes, idx
+        if not buf:
+            return
+        shard = f"{root}/{prefix}-{idx:05d}.parquet"
+        with fs.open(shard, "wb") as fo:
+            pq.write_table(_table_from_records(buf), fo, compression=compression)
+        written.append(shard)
+        idx += 1
+        buf, nbytes = [], 0
+
+    for r in records:
+        buf.append(r)
+        nbytes += len(r.text.encode("utf-8"))
+        if nbytes >= budget:
+            flush()
+    flush()
+    return written
+
+
+def _shard_paths(uri) -> List[str]:
+    import fsspec
+    fs, root = fsspec.core.url_to_fs(str(uri))
+    if fs.isdir(root):
+        return sorted(fs.glob(f"{root.rstrip('/')}/*.parquet"))
+    return [root]
+
+
+def read_shards(uri) -> Iterator[Record]:
+    """Read Records back from the Parquet shard(s) at `uri` (reverses write_shards)."""
+    import fsspec
+    import pyarrow.parquet as pq
+
+    fs, _ = fsspec.core.url_to_fs(str(uri))
+    for shard in _shard_paths(uri):
+        with fs.open(shard, "rb") as fo:
+            tbl = pq.read_table(fo)
+        d = tbl.to_pydict()
+        for i in range(tbl.num_rows):
+            yield Record(text=d["text"][i], source=d["source"][i], lang=d["lang"][i],
+                         license=d["license"][i], meta=json.loads(d["meta"][i] or "{}"))
+
+
+def iter_shard_texts(uri) -> Iterator[str]:
+    """Just the `text` column from the shard(s) at `uri` — this is what feeds tokenize."""
+    for r in read_shards(uri):
+        yield r.text
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator + CLI
+# --------------------------------------------------------------------------- #
+def build_corpus(records: Iterable[Record], out_uri, *, min_chars: int = 1,
+                 shard_size_mb: int = 128) -> List[str]:
+    """The Stage-2 flow end to end: normalize -> filter -> write Parquet shards.
+    Returns the shard paths written."""
+    cleaned = filter_records(normalize(records), min_chars=min_chars)
+    return write_shards(cleaned, out_uri, shard_size_mb=shard_size_mb)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--source", choices=("dummy", "text"), default="text",
+                    help="dummy: synthetic offline docs; text: a UTF-8 text file (--in)")
+    ap.add_argument("--in", dest="inp", default=None, help="input text file (--source text)")
+    ap.add_argument("--out", required=True, help="output dir / fsspec URI for Parquet shards")
+    ap.add_argument("--source-name", default=None,
+                    help="value for the schema `source` field (default: source type / filename)")
+    ap.add_argument("--lang", default="en")
+    ap.add_argument("--license", default="unknown")
+    ap.add_argument("--max-docs", type=int, default=1000, help="--source dummy: #synthetic docs")
+    ap.add_argument("--min-chars", type=int, default=1)
+    ap.add_argument("--shard-size-mb", type=int, default=128,
+                    help="roll a new shard past this size (few large shards)")
+    args = ap.parse_args()
+
+    if args.source == "dummy":
+        records = ingest_dummy(args.max_docs, source=args.source_name or "dummy")
+    else:
+        if not args.inp:
+            ap.error("--in is required for --source text")
+        name = args.source_name or Path(args.inp).stem
+        records = ingest_text_file(args.inp, source=name, lang=args.lang, license=args.license)
+
+    shards = build_corpus(records, args.out, min_chars=args.min_chars,
+                          shard_size_mb=args.shard_size_mb)
+    print(f"wrote {len(shards)} shard(s) -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -16,6 +16,7 @@ is not vocab-compatible with OLMo and must not be used for a real run.
 from __future__ import annotations
 
 import argparse
+import contextlib
 from pathlib import Path
 from typing import Iterable, Iterator, List
 
@@ -75,6 +76,22 @@ def _capped(stream: Iterable[int], max_tokens: int | None) -> Iterator[int]:
         yield tid
 
 
+@contextlib.contextmanager
+def _open_texts(inp: Path):
+    """Yield an iterator of doc texts from `inp`, transparently handling both inputs:
+    a one-doc-per-line text file (the download.py output), or a directory / `.parquet`
+    file of corpus Parquet shards (the corpus.py output) — so the cleaned shards feed
+    this stage with no extra step. Parquet text is already normalized one-line-per-doc."""
+    if inp.is_dir() or inp.suffix == ".parquet":
+        from .corpus import iter_shard_texts
+        yield iter_shard_texts(inp)
+    else:
+        # Explicit UTF-8 (corpus is UTF-8; avoids locale-dependent decoding) and strip
+        # any trailing \r so \r\n-terminated input doesn't leak a carriage return.
+        with open(inp, encoding="utf-8") as f:
+            yield (line.rstrip("\r\n") for line in f)
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--in", dest="inp", type=Path, required=True)
@@ -89,10 +106,8 @@ def main() -> None:
         ap.error("--max-tokens must be positive (a value <= 0 silently yields 0 tokens)")
 
     tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
-    # Explicit UTF-8 (corpus is UTF-8; avoids locale-dependent decoding) and strip any
-    # trailing \r so \r\n-terminated input doesn't leak a stray carriage return into a doc.
-    with open(args.inp, encoding="utf-8") as f:
-        texts = (line.rstrip("\r\n") for line in f)
+    # Input is either a one-doc-per-line text file or corpus Parquet shards (dir/.parquet).
+    with _open_texts(args.inp) as texts:
         stream = _capped(tokenize_texts(texts, tok), args.max_tokens)
         if args.out.suffix == ".bin":
             # Stream straight into the packed format (chunked, bounded memory) — this

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,91 @@
+"""Corpus pipeline skeleton (#69): schema, local Parquet sharded IO, and the local
+gate — the shards compose with the existing tokenize/pack/split stages.
+
+Pure numpy + pyarrow (no backend). Skips cleanly where pyarrow is absent.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pyarrow")
+
+from src.data import corpus
+from src.data.corpus import (Record, build_corpus, ingest_dummy, ingest_text_file,
+                             iter_shard_texts, normalize, read_shards, write_shards)
+from src.data.tokenize import ByteTokenizer, tokenize_texts
+from src.data.pack import pack_ids, open_packed
+from src.data.split import split_packed
+from src.data.loader import PackedLoader
+
+
+def test_record_schema():
+    r = Record(text="hi", source="dummy", meta={"k": 1})
+    assert r.to_dict() == {"text": "hi", "source": "dummy", "lang": "en",
+                           "license": "unknown", "meta": {"k": 1}}
+    assert corpus.RECORD_FIELDS == ("text", "source", "lang", "license", "meta")
+
+
+def test_normalize_collapses_and_drops_empty():
+    recs = [Record("a\n  b\tc", "s"), Record("   ", "s"), Record("x", "s")]
+    out = list(normalize(recs))
+    assert [r.text for r in out] == ["a b c", "x"]      # whitespace collapsed, empty dropped
+
+
+def test_write_read_roundtrip_schema_and_meta(tmp_path):
+    recs = [Record(f"doc {i}", "src", lang="en", license="MIT", meta={"i": i})
+            for i in range(5)]
+    shards = write_shards(recs, tmp_path / "cleaned", shard_size_mb=128)
+    assert len(shards) == 1                              # large budget -> one shard
+    back = list(read_shards(tmp_path / "cleaned"))
+    assert [r.text for r in back] == [f"doc {i}" for i in range(5)]
+    assert back[0].license == "MIT" and back[2].meta == {"i": 2}   # meta JSON round-trips
+
+
+def test_few_large_shards_rolls_by_size(tmp_path):
+    # ~1 KB docs with a tiny 0-MB-ish budget -> each doc rolls its own shard; a big
+    # budget keeps them in one. Proves the few-large-shard rolling logic both ways.
+    recs = [Record("x" * 1000, "src") for _ in range(4)]
+    many = write_shards(recs, tmp_path / "many", shard_size_mb=0, prefix="part")
+    assert len(many) == 4
+    one = write_shards(recs, tmp_path / "one", shard_size_mb=64)
+    assert len(one) == 1
+    assert {r.text for r in read_shards(tmp_path / "many")} == {"x" * 1000}
+
+
+def test_build_corpus_composes_with_tokenize_pack_split(tmp_path):
+    """The local gate: dummy -> Parquet shards -> the EXISTING tokenize/pack/split."""
+    shards = build_corpus(ingest_dummy(200, seed=0), tmp_path / "cleaned")
+    assert shards and all(s.endswith(".parquet") for s in shards)
+
+    # shards -> text -> tokenize (byte fallback) -> pack -> split, all offline.
+    ids = tokenize_texts(iter_shard_texts(tmp_path / "cleaned"), ByteTokenizer())
+    packed = tmp_path / "packed.bin"
+    n = pack_ids(ids, packed)
+    assert n > 0 and open_packed(packed).shape[0] == n
+
+    split_packed(packed, tmp_path / "split", val_tokens=64)
+    loader = PackedLoader(tmp_path / "split" / "train.bin", seq_len=16, batch_size=2,
+                          shuffle=False, seed=0)
+    inputs, targets = next(iter(loader.epoch()))
+    assert inputs.shape == (2, 16) and targets.shape == (2, 16)
+
+
+def test_cli_dummy_then_tokenize_consumes_shards(tmp_path):
+    """End-to-end at the CLI: `python -m src.data.corpus` writes shards that
+    `python -m src.data.tokenize --in <dir>` consumes directly."""
+    cleaned = tmp_path / "cleaned"
+    r1 = subprocess.run([sys.executable, "-m", "src.data.corpus", "--source", "dummy",
+                         "--out", str(cleaned), "--max-docs", "100"],
+                        capture_output=True, text=True)
+    assert r1.returncode == 0, r1.stderr
+    assert list(cleaned.glob("*.parquet"))
+
+    packed = tmp_path / "packed.bin"
+    r2 = subprocess.run([sys.executable, "-m", "src.data.tokenize", "--in", str(cleaned),
+                         "--out", str(packed), "--byte-fallback"],
+                        capture_output=True, text=True)
+    assert r2.returncode == 0, r2.stderr
+    assert packed.exists() and open_packed(packed).shape[0] > 0

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -35,6 +35,7 @@ PORTABLE_MODULES = [
     "src.model.backend",
     "src.model.sizing",
     "src.data.loader",
+    "src.data.corpus",
     "src.data.pack",
     "src.data.split",
     "src.data.download",


### PR DESCRIPTION
Closes #69

## Summary
Stand up the corpus pipeline's **local shape** (epic #65, Stage-2 *Normalize*) so the whole flow is verifiable on the Mac before any cloud account exists. **pyarrow-native, datatrove-shaped**: the same flow runs on HF `datatrove` at scale (#80) by swapping the storage URI `file://` → `s3://`.

- **`src/data/corpus.py`** (portable, above the seam): common-schema `Record {text, source, lang, license, meta}`; the staged flow `ingest → normalize → filter → write Parquet shards`. Local sharded IO via **pyarrow + fsspec** (imported **lazily**, matching `download.py`/`tokenize.py`), rolling **few large shards** by size (the R2 Class-A-ops constraint). `out_uri` is an fsspec URI — `file://`/local now, `s3://` later via `s3fs` (#80), same code path. CLI `python -m src.data.corpus --source dummy --in … --out …`. Reuses `download._normalize_doc` / `download.dummy_texts`.
- **`src/data/tokenize.py`**: `--in` now accepts a corpus shard directory / `.parquet` (reads the `text` column via `corpus.iter_shard_texts`) in addition to a one-doc-per-line text file — so the cleaned shards feed the existing `tokenize`/`pack`/`split` with no extra step.
- **`pyproject.toml`**: `pyarrow` + `fsspec` added to the `data` extra; a new `datatrove` extra (the declared scale engine for #80 — the local skeleton does not require it).
- **`tests/test_corpus.py`** + `src.data.corpus` added to the import-guard `PORTABLE_MODULES`.

Above the seam (no `mlx`/`torch`). R2/`s3fs` writer + RunPod (#80), Stack ingest (#70), cluster dedup (#73) are explicitly out of scope.

## Acceptance — the local gate (all offline, no GPU/cloud)
```
python -m src.data.corpus  --source dummy --out cleaned/ --max-docs 2000
#   -> cleaned/part-00000.parquet  columns: [text, source, lang, license, meta]
python -m src.data.tokenize --in cleaned/ --out packed.bin --byte-fallback   # consumes shards
python -m src.data.split    --packed packed.bin --out split/ --val-tokens 2000
```
Verified end to end: the shards carry the common schema and feed today's tokenize/pack/split.

## Testing
- [x] `tests/test_corpus.py`: schema, `write→read` round-trip (incl. `meta` JSON + few-large-shard rolling), the build→tokenize→pack→split composition, and a CLI subprocess test
- [x] `src.data.corpus` in the seam guard (no backend leak)
- [x] Full suite **204 passed**
- [x] Smoke gate still exact on a fresh toy split (2.4e-7)