### PR TITLE
feat(eval): [M10] copying / retrieval / long-context probe harness (#79)

### DIFF
--- a/scripts/probes.py
+++ b/scripts/probes.py
@@ -1,0 +1,110 @@
+"""Copying / retrieval / long-context probes (#79): is the attention fraction high enough?
+
+Trains a small model on each probe (needle-in-a-haystack, phonebook exact-copy, 5-shot
+recall) with a FIXED seed and reports accuracy; with `--compare` it trains a pure-Mamba and
+a hybrid side by side, so the gap shows whether the config-gated attention earns its keep.
+Pure SSMs lag on copying/retrieval and the gap widens with context length — raise the
+attention fraction if the needle curve sags, lower it for speed. First run at the 100M gate
+(#81), re-run on each Phase-5 tier (#75).
+
+  python scripts/probes.py                       # hybrid, all three probes
+  python scripts/probes.py --compare             # pure-Mamba vs hybrid
+  python scripts/probes.py --probe needle --needle-lengths 64 256 1024 --steps 1500
+
+MLX-only training (masked-CE), like scripts/retrieval_probe.py — an Apple-Silicon probe.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+
+from src.model.blocks import MambaConfig
+from src.model.backend import get_backend
+from src.eval.probes import (fewshot_vocab, make_fewshot_copy_batch, make_needle_batch,
+                            make_phonebook_batch, needle_vocab, phonebook_vocab,
+                            probe_accuracy)
+
+# (name, batch-generator, vocab, seq_len) factories — each keyed by a "size" knob.
+def _needle(rng, bs, size):
+    return make_needle_batch(rng, bs, size), needle_vocab(), size
+
+
+def _phonebook(rng, bs, size):
+    x, t, m = make_phonebook_batch(rng, bs, size)
+    return (x, t, m), phonebook_vocab(), x.shape[1]
+
+
+def _fewshot(rng, bs, size):
+    x, t, m = make_fewshot_copy_batch(rng, bs, size)
+    return (x, t, m), fewshot_vocab(), x.shape[1]
+
+
+PROBES = {"needle": _needle, "phonebook": _phonebook, "fewshot": _fewshot}
+
+
+def _cfg(vocab, slen, *, hybrid):
+    cfg = MambaConfig(
+        d_model=64, n_layers=4, head_dim=16, d_state=16, vocab_size=vocab,
+        seq_len=slen, precision="fp32",
+        attn_every=2 if hybrid else None, n_attn_heads=4 if hybrid else None)
+    cfg.validate()
+    return cfg
+
+
+def train_eval(backend, gen, size, *, hybrid, steps, batch_size, lr, seed) -> float:
+    """Train one model on a probe at the given size, return held-out accuracy."""
+    rng = np.random.default_rng(seed)
+    (_, _, _), vocab, slen = gen(rng, 1, size)        # peek vocab/seq_len for the config
+    backend.seed(seed)
+    model = backend.model_cls(_cfg(vocab, slen, hybrid=hybrid))
+    opt = backend.make_optimizer(model, lr)
+    train_step = backend.make_sft_train_step(model, opt)
+    for _ in range(steps):
+        batch, _, _ = gen(rng, batch_size, size)
+        train_step(model, [batch], lr)
+    ev = np.random.default_rng(seed + 999)
+    (inputs, targets, mask), _, _ = gen(ev, 512, size)
+    logits = backend.to_numpy(model.forward(inputs))
+    return probe_accuracy(logits, targets, mask)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--probe", choices=(*PROBES, "all"), default="all")
+    ap.add_argument("--compare", action="store_true", help="pure-Mamba vs hybrid")
+    ap.add_argument("--needle-lengths", type=int, nargs="+", default=[64, 256])
+    ap.add_argument("--phonebook-entries", type=int, nargs="+", default=[16, 64])
+    ap.add_argument("--fewshot-shots", type=int, nargs="+", default=[5])
+    ap.add_argument("--steps", type=int, default=1200)
+    ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--lr", type=float, default=1e-3)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    backend = get_backend()
+    sizes = {"needle": args.needle_lengths, "phonebook": args.phonebook_entries,
+             "fewshot": args.fewshot_shots}
+    probes = list(PROBES) if args.probe == "all" else [args.probe]
+    archs = [("pure", False), ("hybrid", True)] if args.compare else [("hybrid", True)]
+
+    print(f"# probe accuracy (steps={args.steps}, seed={args.seed})")
+    for name in probes:
+        for size in sizes[name]:
+            cells = []
+            for label, hybrid in archs:
+                acc = train_eval(backend, PROBES[name], size, hybrid=hybrid,
+                                 steps=args.steps, batch_size=args.batch_size,
+                                 lr=args.lr, seed=args.seed)
+                cells.append(f"{label}={acc:.3f}")
+            print(f"{name:10s} size={size:<6d} " + "  ".join(cells))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/probes.py
+++ b/src/eval/probes.py
@@ -1,0 +1,167 @@
+"""Copying / retrieval / long-context probes (#79).
+
+Pure SSMs lag Transformers on exact copying and in-context retrieval, and the gap widens
+with context length / number of pairs (a fixed-width recurrent state is a capacity
+bottleneck). These probes measure exactly that, so the **hybrid attention fraction** can be
+tuned — raise it if retrieval lags, lower it for speed. First exercised at the 100M smoke
+gate (#81), then re-run on each Phase-5 tier (#75).
+
+Three probes, all framed as the standard capacity tasks (like the MQAR probe in
+``retrieval_probe.py``) with **disjoint synthetic id ranges**, so each is an architecture
+probe runnable on a fresh model and scored by an oracle:
+
+* **needle-in-a-haystack** — one (key,value) needle buried in `context_len` filler tokens,
+  re-queried at the end (sweep `context_len` for the long-context curve).
+* **phonebook** — N (name, multi-digit code) entries; query a name and **exactly copy** its
+  whole code (the code-copying analog; multi-token exact copy).
+* **few-shot copy (5-shot MMLU-style)** — K labeled demos, then re-query one; recall its label.
+
+ABOVE THE SEAM — pure numpy, no backend. Each returns an (inputs, targets, mask) 3-tuple
+matching the SFTLoader contract, scored by ``recall_accuracy`` (re-exported as
+``probe_accuracy``).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .retrieval_probe import recall_accuracy
+
+#: Same scorer as MQAR — argmax accuracy over the supervised (mask=1) positions.
+probe_accuracy = recall_accuracy
+
+Batch = Tuple[np.ndarray, np.ndarray, np.ndarray]
+
+
+# --------------------------------------------------------------------------- #
+# Needle in a haystack
+# --------------------------------------------------------------------------- #
+def needle_vocab(n_filler: int = 128, n_keys: int = 64, n_values: int = 64) -> int:
+    return n_filler + n_keys + n_values
+
+
+def make_needle_batch(rng: np.random.Generator, batch_size: int, context_len: int, *,
+                      n_filler: int = 128, n_keys: int = 64, n_values: int = 64) -> Batch:
+    """One (key,value) needle planted at a random depth in `context_len` filler tokens,
+    re-queried at the end. ids: filler [0,n_filler); keys [n_filler,..); values [..,..)."""
+    if context_len < 4:
+        raise ValueError("context_len must be >= 4")
+    key_base, val_base = n_filler, n_filler + n_keys
+    L = context_len
+    inputs = rng.integers(0, n_filler, size=(batch_size, L)).astype(np.int64)   # haystack
+    targets = np.zeros((batch_size, L), dtype=np.int64)
+    mask = np.zeros((batch_size, L), dtype=np.int64)
+    for b in range(batch_size):
+        key = key_base + int(rng.integers(0, n_keys))
+        val = val_base + int(rng.integers(0, n_values))
+        p = int(rng.integers(0, L - 3))            # needle at p (key), p+1 (value)
+        inputs[b, p], inputs[b, p + 1] = key, val
+        q = L - 2                                   # query re-presents the key at the end
+        inputs[b, q], inputs[b, q + 1] = key, val   # teacher-forced value at q+1
+        targets[b, q], mask[b, q] = val, 1          # predict the value from the queried key
+    return inputs, targets, mask
+
+
+# --------------------------------------------------------------------------- #
+# Phonebook (multi-token exact copy)
+# --------------------------------------------------------------------------- #
+def phonebook_vocab(n_names: int = 128, n_digits: int = 10) -> int:
+    return n_names + n_digits
+
+
+def make_phonebook_batch(rng: np.random.Generator, batch_size: int, n_entries: int, *,
+                         n_names: int = 128, n_digits: int = 10, code_len: int = 4,
+                         n_queries: int = 1) -> Batch:
+    """`n_entries` (name, code) rows where code is `code_len` digit tokens; then query a
+    name and exactly copy its whole code. ids: names [0,n_names); digits [n_names,..)."""
+    if n_entries > n_names:
+        raise ValueError(f"n_entries={n_entries} cannot exceed n_names={n_names}")
+    digit_base = n_names
+    entry_len = 1 + code_len
+    L = n_entries * entry_len + n_queries * entry_len
+    inputs = np.zeros((batch_size, L), dtype=np.int64)
+    targets = np.zeros((batch_size, L), dtype=np.int64)
+    mask = np.zeros((batch_size, L), dtype=np.int64)
+    for b in range(batch_size):
+        names = rng.choice(n_names, size=n_entries, replace=False)
+        codes = rng.integers(0, n_digits, size=(n_entries, code_len)) + digit_base
+        for i in range(n_entries):
+            o = i * entry_len
+            inputs[b, o] = names[i]
+            inputs[b, o + 1:o + 1 + code_len] = codes[i]
+        qsel = rng.integers(0, n_entries, size=n_queries)
+        base = n_entries * entry_len
+        for j, qi in enumerate(qsel):
+            o = base + j * entry_len
+            inputs[b, o] = names[qi]
+            inputs[b, o + 1:o + 1 + code_len] = codes[qi]      # teacher-forced code
+            # positions [name, d0..d_{code_len-2}] predict [d0..d_{code_len-1}] — exact copy
+            for c in range(code_len):
+                targets[b, o + c] = codes[qi][c]
+                mask[b, o + c] = 1
+    return inputs, targets, mask
+
+
+# --------------------------------------------------------------------------- #
+# Few-shot copy (5-shot MMLU-style in-context recall)
+# --------------------------------------------------------------------------- #
+def fewshot_vocab(n_questions: int = 64, n_answers: int = 4) -> int:
+    return n_questions + n_answers
+
+
+def make_fewshot_copy_batch(rng: np.random.Generator, batch_size: int, n_shots: int = 5, *,
+                            n_questions: int = 64, n_answers: int = 4) -> Batch:
+    """`n_shots` (question, answer) demos, then re-query one question; recall its answer.
+    ids: questions [0,n_questions); answers [n_questions,..)."""
+    if n_shots > n_questions:
+        raise ValueError(f"n_shots={n_shots} cannot exceed n_questions={n_questions}")
+    ans_base = n_questions
+    L = 2 * n_shots + 2
+    inputs = np.zeros((batch_size, L), dtype=np.int64)
+    targets = np.zeros((batch_size, L), dtype=np.int64)
+    mask = np.zeros((batch_size, L), dtype=np.int64)
+    for b in range(batch_size):
+        qs = rng.choice(n_questions, size=n_shots, replace=False)
+        ans = rng.integers(0, n_answers, size=n_shots) + ans_base
+        inputs[b, 0:2 * n_shots:2] = qs
+        inputs[b, 1:2 * n_shots:2] = ans
+        sel = int(rng.integers(0, n_shots))
+        qp = 2 * n_shots
+        inputs[b, qp], inputs[b, qp + 1] = qs[sel], ans[sel]   # teacher-forced answer
+        targets[b, qp], mask[b, qp] = ans[sel], 1
+    return inputs, targets, mask
+
+
+# --------------------------------------------------------------------------- #
+# Harness: run all probes, return per-setting accuracy curves
+# --------------------------------------------------------------------------- #
+def run_probes(forward: Callable[[np.ndarray], object], *, to_numpy=np.asarray,
+               batch_size: int = 16, seed: int = 0,
+               needle_lengths: Sequence[int] = (64, 256, 1024),
+               phonebook_entries: Sequence[int] = (16, 64),
+               n_shots: int = 5) -> Dict[str, Dict[int, float]]:
+    """Run every probe through `forward` (a model.forward-style callable) and return
+    ``{probe: {setting: accuracy}}``. Per-context-length needle curves let the attention
+    fraction be tuned. The probe vocab (see the ``*_vocab`` helpers) must fit the model."""
+    rng = np.random.default_rng(seed)
+    out: Dict[str, Dict[int, float]] = {"needle": {}, "phonebook": {}, "fewshot": {}}
+    for L in needle_lengths:
+        x, t, m = make_needle_batch(rng, batch_size, L)
+        out["needle"][L] = probe_accuracy(to_numpy(forward(x)), t, m)
+    for n in phonebook_entries:
+        x, t, m = make_phonebook_batch(rng, batch_size, n)
+        out["phonebook"][n] = probe_accuracy(to_numpy(forward(x)), t, m)
+    x, t, m = make_fewshot_copy_batch(rng, batch_size, n_shots)
+    out["fewshot"][n_shots] = probe_accuracy(to_numpy(forward(x)), t, m)
+    return out
+
+
+def format_probe_table(results: Dict[str, Dict[int, float]]) -> str:
+    """One line per probe/setting: ``needle  len=1024  acc=0.123``."""
+    lines = []
+    for probe, curve in results.items():
+        for setting, acc in curve.items():
+            lines.append(f"{probe:10s} setting={setting:<6d} acc={acc:.3f}")
+    return "\n".join(lines)

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -56,6 +56,7 @@ PORTABLE_MODULES = [
     "src.eval.val_loss",
     "src.eval.olmes_adapter",
     "src.eval.retrieval_probe",
+    "src.eval.probes",
     "src.conformance.forward_step_parity",
     "src.conformance.backend_parity",
     "src.serve.sessions",

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,81 @@
+"""Copying / retrieval / long-context probes (#79).
+
+Pure numpy. Verifies the generators produce well-formed supervised positions and that an
+oracle (one-hot on targets) scores 1.0 — the scorer/target/mask alignment is the contract.
+"""
+
+import numpy as np
+import pytest
+
+from src.eval.probes import (fewshot_vocab, format_probe_table, make_fewshot_copy_batch,
+                            make_needle_batch, make_phonebook_batch, needle_vocab,
+                            phonebook_vocab, probe_accuracy, run_probes)
+
+
+def _oracle_logits(inputs, targets, vocab):
+    """Logits whose argmax is the target id at every position (a perfect model)."""
+    B, L = inputs.shape
+    logits = np.zeros((B, L, vocab), dtype=np.float64)
+    for b in range(B):
+        for l in range(L):
+            logits[b, l, targets[b, l]] = 1.0
+    return logits
+
+
+def test_needle_shapes_and_supervision():
+    rng = np.random.default_rng(0)
+    x, t, m = make_needle_batch(rng, 4, 64)
+    assert x.shape == t.shape == m.shape == (4, 64)
+    assert m.sum() == 4                                    # exactly one supervised pos/seq
+    # supervised target is a value id, and the queried key earlier in the context matches
+    for b in range(4):
+        q = int(np.flatnonzero(m[b])[0])
+        assert t[b, q] >= needle_vocab() - 64              # value range
+        assert x[b, q] == x[b, q]                          # query key present
+    assert probe_accuracy(_oracle_logits(x, t, needle_vocab()), t, m) == 1.0
+
+
+def test_needle_rejects_tiny_context():
+    with pytest.raises(ValueError):
+        make_needle_batch(np.random.default_rng(0), 1, 3)
+
+
+def test_phonebook_exact_multi_token_copy():
+    rng = np.random.default_rng(1)
+    x, t, m = make_phonebook_batch(rng, 3, n_entries=5, code_len=4)
+    assert m.sum() == 3 * 4                                # code_len supervised per seq
+    # every supervised target is a digit token, and the oracle copies the whole code
+    assert (t[m.astype(bool)] >= 128).all()               # digit range starts at n_names
+    assert probe_accuracy(_oracle_logits(x, t, phonebook_vocab()), t, m) == 1.0
+
+
+def test_phonebook_rejects_too_many_entries():
+    with pytest.raises(ValueError):
+        make_phonebook_batch(np.random.default_rng(0), 1, n_entries=200, n_names=128)
+
+
+def test_fewshot_recall():
+    rng = np.random.default_rng(2)
+    x, t, m = make_fewshot_copy_batch(rng, 4, n_shots=5)
+    assert x.shape == (4, 2 * 5 + 2) and m.sum() == 4
+    assert (t[m.astype(bool)] >= 64).all()                # answers in [n_questions, ..)
+    assert probe_accuracy(_oracle_logits(x, t, fewshot_vocab()), t, m) == 1.0
+
+
+def test_run_probes_structure_and_perfect_oracle():
+    # A forward that perfectly recalls: returns one-hot logits at the *input* positions'
+    # required targets is impossible without the targets, so use a chance model and just
+    # assert the harness shape + value ranges.
+    V = 512
+
+    def chance_forward(x):
+        return np.zeros((x.shape[0], x.shape[1], V))
+
+    res = run_probes(chance_forward, batch_size=8, seed=3,
+                     needle_lengths=(16, 64), phonebook_entries=(8,), n_shots=5)
+    assert set(res) == {"needle", "phonebook", "fewshot"}
+    assert set(res["needle"]) == {16, 64} and set(res["phonebook"]) == {8}
+    for curve in res.values():
+        for acc in curve.values():
+            assert 0.0 <= acc <= 1.0
+    assert "needle" in format_probe_table(res)

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -27,11 +27,15 @@ def test_needle_shapes_and_supervision():
     x, t, m = make_needle_batch(rng, 4, 64)
     assert x.shape == t.shape == m.shape == (4, 64)
     assert m.sum() == 4                                    # exactly one supervised pos/seq
-    # supervised target is a value id, and the queried key earlier in the context matches
+    # default needle id ranges: filler [0,128), keys [128,192), values [192,256)
     for b in range(4):
         q = int(np.flatnonzero(m[b])[0])
-        assert t[b, q] >= needle_vocab() - 64              # value range
-        assert x[b, q] == x[b, q]                          # query key present
+        qkey = x[b, q]
+        assert 128 <= qkey < 192                           # query is a key id
+        earlier = np.flatnonzero(x[b, :q] == qkey)         # the planted needle key, earlier
+        assert earlier.size >= 1
+        p = int(earlier[0])
+        assert x[b, p + 1] == t[b, q] >= 192               # planted value == supervised target
     assert probe_accuracy(_oracle_logits(x, t, needle_vocab()), t, m) == 1.0
 
 


### PR DESCRIPTION
## Summary
Adds the **copying / retrieval / long-context probes** (`docs/design/08-corpus-pipeline.md`, #79) that catch the known SSM weakness directly and tell you whether the **hybrid attention fraction is high enough** — first run at the 100M gate (#81), re-run per Phase-5 tier (#75).

- **`src/eval/probes.py`** (portable): three capacity probes with disjoint synthetic id ranges, each returning `(inputs, targets, mask)` (the SFTLoader contract) and scored by the shared `recall_accuracy` (re-exported as `probe_accuracy`):
  - **needle-in-a-haystack** — one (key,value) needle buried in `context_len` filler, re-queried at the end (sweep length for the long-context curve);
  - **phonebook** — N (name, multi-digit code) entries; query a name and **exactly copy** its whole code (multi-token exact copy / the code-copying analog);
  - **few-shot copy** — 5-shot MMLU-style in-context recall.
  - `run_probes()` returns per-setting accuracy curves; `*_vocab` helpers size a fresh probe model.
- **`scripts/probes.py`**: trains a model per probe (pure-Mamba vs hybrid with `--compare`) and reports the curves, mirroring `scripts/retrieval_probe.py`.

These benchmarks feed #73's `Decontaminator` n-gram lists (synthetic ids → no corpus-leak risk here).

## Tests
- `tests/test_probes.py` (generators' shapes/supervision/vocab ranges, oracle scores 1.0, harness structure) + import-guard. Full suite **244 passed**; `scripts/probes.py` smoke-trains on MLX.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)