### PR TITLE
feat(data): [M10] clean-license SFT sources incl. OASST1 multi-turn (#76)

### DIFF
--- a/src/data/sft_sources.py
+++ b/src/data/sft_sources.py
@@ -1,0 +1,197 @@
+"""Clean-license SFT sources (#76).
+
+The M9 SFT machinery (`sft_data.build_sft_records`, `scripts/sft.py`) already handles
+multi-turn masking via `instruct_format.response_spans`; #76 is the **clean-license data
+sourcing** layer on top (docs/design/08-corpus-pipeline.md line 115): OASST1 (multi-turn,
+Apache-2.0), Dolly (CC-BY-SA, flagged), FLAN, plus a small hand-authored in-format set. The
+licensing reframe is the load-bearing part — no commercial-model-distilled responses.
+
+Each source yields chat rows in the shape `build_sft_records` consumes — a `{messages:
+[{role, content}, ...]}` dict (or a Dolly `instruction`/`response` triple) — tagged with
+`source` and `license`. The reconstruction/mapping logic is pure and tested; the HF `load_*`
+helpers are thin lazy wrappers (network, optional `data` extra) around it.
+
+ABOVE THE SEAM — stdlib only; `datasets` imported lazily inside the loaders.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Optional
+
+# Source -> license, for the clean-license accounting (CC-BY-SA flagged share-alike).
+SOURCE_LICENSES = {"oasst1": "apache-2.0", "flan": "apache-2.0",
+                   "dolly": "cc-by-sa-3.0", "handauthored": "cc0"}
+
+
+def _tag(messages: List[dict], source: str) -> dict:
+    return {"messages": messages, "source": source,
+            "license": SOURCE_LICENSES.get(source, "unknown")}
+
+
+# --------------------------------------------------------------------------- #
+# OASST1 — reconstruct multi-turn conversation threads from the message tree
+# --------------------------------------------------------------------------- #
+def build_oasst1_threads(rows: Iterable[dict], lang: Optional[str] = "en",
+                         ) -> Iterator[dict]:
+    """Walk the OASST1 message tree: for each assistant node, emit the root->node path as a
+    multi-turn `{messages}` example (so every conversational prefix ending in an assistant
+    turn becomes a training example). `prompter`->user, `assistant`->assistant. If `lang`
+    is set, every node on the path must match it. Rows: {message_id, parent_id, text, role,
+    lang}."""
+    by_id = {r.get("message_id"): r for r in rows}
+    for r in by_id.values():
+        if r.get("role") != "assistant":
+            continue
+        path: List[dict] = []
+        cur: Optional[dict] = r
+        ok = True
+        while cur is not None:
+            if lang is not None and cur.get("lang") not in (None, lang):
+                ok = False
+                break
+            path.append(cur)
+            pid = cur.get("parent_id")
+            cur = by_id.get(pid) if pid else None
+        if not ok:
+            continue
+        path.reverse()
+        messages: List[dict] = []
+        for n in path:
+            content = (n.get("text") or "").strip()
+            if not content:
+                ok = False
+                break
+            role = "user" if n.get("role") == "prompter" else "assistant"
+            messages.append({"role": role, "content": content})
+        if ok and messages and messages[0]["role"] == "user" \
+                and messages[-1]["role"] == "assistant":
+            yield _tag(messages, "oasst1")
+
+
+def load_oasst1(split: str = "train", lang: Optional[str] = "en",
+                max_examples: Optional[int] = None) -> Iterator[dict]:
+    """Stream OASST1 from the Hub and reconstruct multi-turn threads (lazy `datasets`)."""
+    from datasets import load_dataset  # pragma: no cover - network/optional extra
+
+    rows = load_dataset("OpenAssistant/oasst1", split=split)
+    out = build_oasst1_threads(rows, lang=lang)
+    for i, rec in enumerate(out):
+        if max_examples is not None and i >= max_examples:
+            break
+        yield rec
+
+
+# --------------------------------------------------------------------------- #
+# FLAN — single-turn instruction rows (inputs -> targets)
+# --------------------------------------------------------------------------- #
+def flan_to_messages(row: dict) -> Optional[dict]:
+    """A FLAN `{inputs, targets}` row -> a single-turn `{messages}` example (or None)."""
+    user = (row.get("inputs") or "").strip()
+    resp = (row.get("targets") or "").strip()
+    if not user or not resp:
+        return None
+    return _tag([{"role": "user", "content": user},
+                 {"role": "assistant", "content": resp}], "flan")
+
+
+def load_flan_slice(split: str = "train", max_examples: Optional[int] = None,
+                    config: str = "default") -> Iterator[dict]:
+    """Stream a FLAN slice from the Hub (lazy `datasets`)."""
+    from datasets import load_dataset  # pragma: no cover - network/optional extra
+
+    ds = load_dataset("Muennighoff/flan", config, split=split, streaming=True)
+    for i, row in enumerate(ds):
+        if max_examples is not None and i >= max_examples:
+            break
+        rec = flan_to_messages(row)
+        if rec is not None:
+            yield rec
+
+
+# --------------------------------------------------------------------------- #
+# Dolly — reuse the existing instruction/response shape (flagged CC-BY-SA)
+# --------------------------------------------------------------------------- #
+def load_dolly(max_examples: Optional[int] = None) -> Iterator[dict]:
+    """Stream Dolly-15k as instruction/response rows, license-tagged (lazy `datasets`)."""
+    from datasets import load_dataset  # pragma: no cover - network/optional extra
+
+    ds = load_dataset("databricks/databricks-dolly-15k", split="train")
+    for i, row in enumerate(ds):
+        if max_examples is not None and i >= max_examples:
+            break
+        yield {"instruction": row.get("instruction"), "response": row.get("response"),
+               "context": row.get("context"), "source": "dolly",
+               "license": SOURCE_LICENSES["dolly"]}
+
+
+# --------------------------------------------------------------------------- #
+# Hand-authored in-format set (checked in, CC0) — guarantees clean format coverage
+# --------------------------------------------------------------------------- #
+HANDAUTHORED: List[List[dict]] = [
+    [{"role": "user", "content": "What is the capital of France?"},
+     {"role": "assistant", "content": "The capital of France is Paris."}],
+    [{"role": "user", "content": "Write a haiku about autumn."},
+     {"role": "assistant",
+      "content": "Crisp leaves drift downward, amber light fades into dusk, frost waits at the edge."}],
+    [{"role": "user", "content": "Define recursion in one sentence."},
+     {"role": "assistant",
+      "content": "Recursion is when a function solves a problem by calling itself on smaller instances until it reaches a base case."},
+     {"role": "user", "content": "Give a tiny example."},
+     {"role": "assistant",
+      "content": "factorial(n) returns 1 if n == 0, else n * factorial(n - 1)."}],
+    [{"role": "user", "content": "Convert 2 kilometers to meters."},
+     {"role": "assistant", "content": "2 kilometers is 2000 meters."}],
+]
+
+
+def handauthored_records() -> Iterator[dict]:
+    """The checked-in hand-authored multi-turn examples (always available, offline)."""
+    for messages in HANDAUTHORED:
+        yield _tag([dict(m) for m in messages], "handauthored")
+
+
+# --------------------------------------------------------------------------- #
+# Aggregator + CLI
+# --------------------------------------------------------------------------- #
+_LOADERS = {
+    "oasst1": lambda n: load_oasst1(max_examples=n),
+    "flan": lambda n: load_flan_slice(max_examples=n),
+    "dolly": lambda n: load_dolly(max_examples=n),
+    "handauthored": lambda n: handauthored_records(),
+}
+
+
+def iter_clean_sft(sources: Iterable[str], max_per_source: Optional[int] = None,
+                   ) -> Iterator[dict]:
+    """Concatenate chat rows from the named clean-license sources."""
+    for name in sources:
+        if name not in _LOADERS:
+            raise ValueError(f"unknown SFT source {name!r} (have {sorted(_LOADERS)})")
+        yield from _LOADERS[name](max_per_source)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--sources", nargs="+", default=["handauthored"],
+                    choices=tuple(_LOADERS), help="clean-license SFT sources to include")
+    ap.add_argument("--out", type=Path, required=True, help="output SFT JSONL")
+    ap.add_argument("--max-per-source", type=int, default=None)
+    ap.add_argument("--max-seq-len", type=int, default=None)
+    ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--model-id", default=None)
+    args = ap.parse_args()
+
+    from .sft_data import write_sft_jsonl
+    from .tokenize import ByteTokenizer, load_olmo_tokenizer
+
+    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
+    rows = iter_clean_sft(args.sources, max_per_source=args.max_per_source)
+    write_sft_jsonl(rows, tok, args.out, max_seq_len=args.max_seq_len)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/sft_sources.py
+++ b/src/data/sft_sources.py
@@ -39,8 +39,8 @@ def build_oasst1_threads(rows: Iterable[dict], lang: Optional[str] = "en",
     """Walk the OASST1 message tree: for each assistant node, emit the root->node path as a
     multi-turn `{messages}` example (so every conversational prefix ending in an assistant
     turn becomes a training example). `prompter`->user, `assistant`->assistant. If `lang`
-    is set, every node on the path must match it. Rows: {message_id, parent_id, text, role,
-    lang}."""
+    is set, every node on the path must match it OR have no language tag (missing tags are
+    permitted). Rows: {message_id, parent_id, text, role, lang}."""
     by_id = {r.get("message_id"): r for r in rows}
     for r in by_id.values():
         if r.get("role") != "assistant":
@@ -73,7 +73,9 @@ def build_oasst1_threads(rows: Iterable[dict], lang: Optional[str] = "en",
 
 def load_oasst1(split: str = "train", lang: Optional[str] = "en",
                 max_examples: Optional[int] = None) -> Iterator[dict]:
-    """Stream OASST1 from the Hub and reconstruct multi-turn threads (lazy `datasets`)."""
+    """Load OASST1 from the Hub and reconstruct multi-turn threads (lazy `datasets`). The
+    split is materialized, not streamed — thread reconstruction needs the whole message
+    tree (random access by message_id)."""
     from datasets import load_dataset  # pragma: no cover - network/optional extra
 
     rows = load_dataset("OpenAssistant/oasst1", split=split)
@@ -118,7 +120,7 @@ def load_dolly(max_examples: Optional[int] = None) -> Iterator[dict]:
     """Stream Dolly-15k as instruction/response rows, license-tagged (lazy `datasets`)."""
     from datasets import load_dataset  # pragma: no cover - network/optional extra
 
-    ds = load_dataset("databricks/databricks-dolly-15k", split="train")
+    ds = load_dataset("databricks/databricks-dolly-15k", split="train", streaming=True)
     for i, row in enumerate(ds):
         if max_examples is not None and i >= max_examples:
             break
@@ -180,7 +182,8 @@ def main() -> None:
                     choices=tuple(_LOADERS), help="clean-license SFT sources to include")
     ap.add_argument("--out", type=Path, required=True, help="output SFT JSONL")
     ap.add_argument("--max-per-source", type=int, default=None)
-    ap.add_argument("--max-seq-len", type=int, default=None)
+    ap.add_argument("--max-seq-len", type=int, default=1024,
+                    help="drop examples longer than this (bounds SFTLoader batch padding)")
     ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
     ap.add_argument("--model-id", default=None)
     args = ap.parse_args()

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -46,6 +46,7 @@ PORTABLE_MODULES = [
     "src.data.instruct_format",
     "src.data.sft_data",
     "src.data.sft_loader",
+    "src.data.sft_sources",
     "src.data.dpo_data",
     "src.data.dpo_loader",
     "src.train.dpo_math",

--- a/tests/test_sft_sources.py
+++ b/tests/test_sft_sources.py
@@ -1,0 +1,78 @@
+"""Clean-license SFT sources (#76).
+
+Hermetic — no network. The OASST1 tree reconstruction and the format/license tagging are
+the contract; verified end to end through `build_sft_records`.
+"""
+
+from src.data.sft_sources import (HANDAUTHORED, SOURCE_LICENSES, build_oasst1_threads,
+                                  flan_to_messages, handauthored_records, iter_clean_sft)
+from src.data.sft_data import build_sft_records
+from src.data.tokenize import ByteTokenizer
+
+
+def _oasst_rows():
+    # prompter -> assistant -> prompter -> assistant, plus a second assistant leaf.
+    return [
+        {"message_id": "a", "parent_id": None, "role": "prompter", "text": "Hi", "lang": "en"},
+        {"message_id": "b", "parent_id": "a", "role": "assistant", "text": "Hello!", "lang": "en"},
+        {"message_id": "c", "parent_id": "b", "role": "prompter", "text": "Bye", "lang": "en"},
+        {"message_id": "d", "parent_id": "c", "role": "assistant", "text": "Goodbye!", "lang": "en"},
+        {"message_id": "e", "parent_id": "a", "role": "assistant", "text": "Hey there", "lang": "en"},
+    ]
+
+
+def test_oasst1_reconstructs_multiturn_threads():
+    recs = list(build_oasst1_threads(_oasst_rows(), lang="en"))
+    # 3 assistant nodes (b, d, e) -> 3 examples; each ends in assistant, starts with user.
+    assert len(recs) == 3
+    for r in recs:
+        assert r["source"] == "oasst1" and r["license"] == "apache-2.0"
+        assert r["messages"][0]["role"] == "user"
+        assert r["messages"][-1]["role"] == "assistant"
+        roles = [m["role"] for m in r["messages"]]
+        assert all(roles[i] != roles[i + 1] for i in range(len(roles) - 1))   # alternates
+    # the deepest thread (b->...->d) is the 4-message one
+    longest = max(recs, key=lambda r: len(r["messages"]))
+    assert [m["content"] for m in longest["messages"]] == ["Hi", "Hello!", "Bye", "Goodbye!"]
+
+
+def test_oasst1_language_filter():
+    rows = _oasst_rows() + [
+        {"message_id": "x", "parent_id": None, "role": "prompter", "text": "Hola", "lang": "es"},
+        {"message_id": "y", "parent_id": "x", "role": "assistant", "text": "Buenas", "lang": "es"},
+    ]
+    en = list(build_oasst1_threads(rows, lang="en"))
+    assert all(all("Hola" != m["content"] for m in r["messages"]) for r in en)
+    assert len(en) == 3                                   # spanish thread excluded
+
+
+def test_flan_to_messages():
+    assert flan_to_messages({"inputs": "", "targets": "x"}) is None
+    rec = flan_to_messages({"inputs": "Translate hi", "targets": "bonjour"})
+    assert rec["source"] == "flan" and rec["license"] == "apache-2.0"
+    assert rec["messages"] == [{"role": "user", "content": "Translate hi"},
+                               {"role": "assistant", "content": "bonjour"}]
+
+
+def test_handauthored_set_is_clean_and_multiturn():
+    recs = list(handauthored_records())
+    assert len(recs) == len(HANDAUTHORED)
+    assert all(r["license"] == "cc0" for r in recs)
+    assert any(len(r["messages"]) > 2 for r in recs)      # at least one multi-turn example
+
+
+def test_sources_feed_build_sft_records():
+    rows = list(iter_clean_sft(["handauthored"]))
+    rows += list(build_oasst1_threads(_oasst_rows()))
+    tok = ByteTokenizer()
+    stats: dict = {}
+    out = list(build_sft_records(rows, tok, stats=stats))
+    assert out and stats["kept"] == len(out)
+    r0 = out[0]
+    assert set(r0) == {"input_ids", "target_ids", "loss_mask"}
+    assert len(r0["input_ids"]) == len(r0["target_ids"]) == len(r0["loss_mask"])
+    assert any(r["loss_mask"] for r in out)               # response tokens supervised
+
+
+def test_source_licenses_cover_loaders():
+    assert set(SOURCE_LICENSES) >= {"oasst1", "flan", "dolly", "handauthored"}


### PR DESCRIPTION
## Summary
The M9 SFT machinery already does multi-turn masking (`response_spans`) and training; #76 adds the **clean-license data sourcing** layer (`docs/design/08-corpus-pipeline.md`) in a new portable module `src/data/sft_sources.py`. Each source yields chat rows in the shape `build_sft_records` consumes, tagged with `source` + `license`:

- **`build_oasst1_threads()`** — reconstruct OASST1's message tree into **multi-turn** `{messages}` examples (one per assistant node = every conversational prefix ending in an assistant turn), `prompter`→user / `assistant`→assistant, with an optional per-path language filter (Apache-2.0).
- **`flan_to_messages()` / `load_flan_slice()`** — FLAN `inputs`/`targets` → single-turn messages (Apache-2.0).
- **`load_dolly()`** — Dolly instruction/response rows, flagged **CC-BY-SA**.
- **`HANDAUTHORED`** — a small checked-in in-format multi-turn set (CC0), always available offline.
- **`iter_clean_sft()`** aggregator + a `python -m src.data.sft_sources` CLI that writes SFT JSONL via the existing `write_sft_jsonl`.

The HF `load_*` helpers are thin lazy `datasets` wrappers; the reconstruction/mapping logic is pure and **hermetically tested**.

## Tests
- `tests/test_sft_sources.py` (OASST1 tree→threads, language filter, FLAN mapping, hand-authored set, end-to-end through `build_sft_records`) + import-guard. Full suite **250 passed**; offline CLI smoke (handauthored → JSONL) verified.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)