### PR TITLE
feat(data): [M10] clean-license DPO preference sources + on-policy gen (#77)

### DIFF
--- a/scripts/gen_onpolicy_prefs.py
+++ b/scripts/gen_onpolicy_prefs.py
@@ -1,0 +1,100 @@
+"""On-policy DPO preference generation (#77).
+
+Sample K responses per prompt from a checkpoint, score each, and emit
+`{prompt, chosen, rejected}` pairs (best vs worst) as DPO JSONL. On-policy pairs are
+inherently clean — the responses come from *our* model, not a commercial one — so they
+need no external preference data, only a scorer.
+
+  python scripts/gen_onpolicy_prefs.py --config config/poc.yaml \
+      --init runs/sft/weights.safetensors --prompts prompts.txt --out data/dpo_onpolicy.jsonl
+
+The default scorer is a placeholder (length + lexical diversity); plug a real reward model
+or verifier (#78) via --import for production on-policy DPO. MLX-only (uses the backend +
+serving recurrence), like scripts/sft.py / scripts/dpo.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+from functools import partial
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+
+from src.data.dpo_sources import pairs_from_scored
+
+
+def default_scorer(text: str) -> float:
+    """Placeholder reward: length (capped) + lexical diversity. NOT a real reward — swap
+    in a reward model / verifier (#78) for production use."""
+    toks = text.split()
+    if not toks:
+        return 0.0
+    diversity = len(set(toks)) / len(toks)
+    length = min(len(toks), 64) / 64.0
+    return 0.5 * diversity + 0.5 * length
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
+    ap.add_argument("--init", type=Path, required=True, help="checkpoint weights (SFT base)")
+    ap.add_argument("--prompts", type=Path, required=True, help="one prompt per line")
+    ap.add_argument("--out", type=Path, required=True, help="output DPO JSONL")
+    ap.add_argument("--k", type=int, default=4, help="samples per prompt")
+    ap.add_argument("--temperature", type=float, default=0.9)
+    ap.add_argument("--top-k", type=int, default=50)
+    ap.add_argument("--max-new-tokens", type=int, default=128)
+    ap.add_argument("--max-seq-len", type=int, default=1024)
+    ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--model-id", default=None)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    from src.model.backend import get_backend
+    from src.model.blocks import load_config
+    from src.serve.generate import generate
+    from src.serve.sessions import SessionStore
+    from src.serve.sampling import sample
+    from src.data.dpo_data import write_dpo_jsonl
+    from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
+
+    backend = get_backend()
+    cfg = load_config(str(args.config))
+    model = backend.model_cls(cfg)
+    model.load(str(args.init))
+    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
+    eos = getattr(tok, "eos_token_id", None)
+    store = SessionStore(model)
+    np_to = backend.to_numpy
+
+    prompts = [ln.strip() for ln in args.prompts.read_text(encoding="utf-8").splitlines()
+               if ln.strip()]
+    rng = np.random.default_rng(args.seed)
+    pairs = []
+    for pi, prompt in enumerate(prompts):
+        prompt_ids = list(tok.encode(prompt)) or [0]
+        scored = []
+        for k in range(args.k):
+            sid = f"p{pi}-s{k}"
+            store.create(sid)
+            sampler = partial(sample, temperature=args.temperature, top_k=args.top_k,
+                              rng=np.random.default_rng(int(rng.integers(1 << 30))))
+            gen_ids = generate(store, sid, prompt_ids, sampler=sampler, to_numpy=np_to,
+                               max_new_tokens=args.max_new_tokens, eos_id=eos)
+            store.remove(sid)
+            scored.append((tok.decode(gen_ids), default_scorer(tok.decode(gen_ids))))
+        pref = pairs_from_scored(prompt, scored)
+        if pref is not None:
+            pairs.append(pref)
+
+    n = write_dpo_jsonl(pairs, tok, args.out, max_seq_len=args.max_seq_len)
+    print(f"on-policy: {len(prompts)} prompts -> {len(pairs)} pairs -> {n} DPO records")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_onpolicy_prefs.py
+++ b/scripts/gen_onpolicy_prefs.py
@@ -8,9 +8,9 @@ need no external preference data, only a scorer.
   python scripts/gen_onpolicy_prefs.py --config config/poc.yaml \
       --init runs/sft/weights.safetensors --prompts prompts.txt --out data/dpo_onpolicy.jsonl
 
-The default scorer is a placeholder (length + lexical diversity); plug a real reward model
-or verifier (#78) via --import for production on-policy DPO. MLX-only (uses the backend +
-serving recurrence), like scripts/sft.py / scripts/dpo.py.
+The default scorer is a placeholder (length + lexical diversity); swap in a real reward
+model or verifier (#78) by editing `default_scorer` for production on-policy DPO. MLX-only
+(uses the backend + serving recurrence), like scripts/sft.py / scripts/dpo.py.
 """
 
 from __future__ import annotations
@@ -87,7 +87,8 @@ def main() -> None:
             gen_ids = generate(store, sid, prompt_ids, sampler=sampler, to_numpy=np_to,
                                max_new_tokens=args.max_new_tokens, eos_id=eos)
             store.remove(sid)
-            scored.append((tok.decode(gen_ids), default_scorer(tok.decode(gen_ids))))
+            text = tok.decode(gen_ids)
+            scored.append((text, default_scorer(text)))
         pref = pairs_from_scored(prompt, scored)
         if pref is not None:
             pairs.append(pref)

--- a/src/data/dpo_sources.py
+++ b/src/data/dpo_sources.py
@@ -1,0 +1,163 @@
+"""Clean-license DPO preference sources (#77).
+
+The M9 DPO machinery (`dpo_math`, `make_dpo_train_step`, `scripts/dpo.py`) is complete; #77
+adds the **clean-preference sourcing** on top (docs/design/08-corpus-pipeline.md line 117):
+OASST1 rankings, SHP, and **on-policy self-generated** pairs (inherently clean). HH-RLHF is
+excluded despite its MIT license — its responses are commercial-model output.
+
+Each source yields a `{prompt, chosen, rejected}` row in the shape `dpo_data.build_dpo_records`
+consumes (`chosen`/`rejected` are `[{role: assistant, content}]` message lists), tagged with
+`source` + `license`. The reconstruction/pairing logic is pure and tested; the HF `load_*`
+helpers are thin lazy wrappers, and on-policy pairs come from `scripts/gen_onpolicy_prefs.py`
+via `pairs_from_scored`.
+
+ABOVE THE SEAM — stdlib only; `datasets` imported lazily inside the loaders.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
+
+# SHP: human Reddit preferences (not model-distilled) — clean for our purpose.
+SOURCE_LICENSES = {"oasst1": "apache-2.0", "shp": "open", "onpolicy": "cc0"}
+
+
+def _pref(prompt: str, chosen: str, rejected: str, source: str) -> dict:
+    return {"prompt": prompt,
+            "chosen": [{"role": "assistant", "content": chosen}],
+            "rejected": [{"role": "assistant", "content": rejected}],
+            "source": source, "license": SOURCE_LICENSES.get(source, "unknown")}
+
+
+# --------------------------------------------------------------------------- #
+# OASST1 — rank sibling assistant replies into chosen/rejected pairs
+# --------------------------------------------------------------------------- #
+def build_oasst1_prefs(rows: Iterable[dict], lang: Optional[str] = "en") -> Iterator[dict]:
+    """For each prompter node with >=2 ranked assistant children, pair the best-ranked
+    (chosen) against the worst-ranked (rejected). `rank` 0 is best. Rows: {message_id,
+    parent_id, text, role, rank, lang}."""
+    rows = list(rows)
+    children: dict = defaultdict(list)
+    for r in rows:
+        children[r.get("parent_id")].append(r)
+    for r in rows:
+        if r.get("role") != "prompter":
+            continue
+        if lang is not None and r.get("lang") not in (None, lang):
+            continue
+        kids = [c for c in children.get(r.get("message_id"), [])
+                if c.get("role") == "assistant" and c.get("rank") is not None
+                and (lang is None or c.get("lang") in (None, lang))]
+        if len(kids) < 2:
+            continue
+        kids.sort(key=lambda c: c["rank"])
+        best, worst = kids[0], kids[-1]
+        if best.get("rank") == worst.get("rank"):
+            continue
+        prompt = (r.get("text") or "").strip()
+        bc, wc = (best.get("text") or "").strip(), (worst.get("text") or "").strip()
+        if prompt and bc and wc:
+            yield _pref(prompt, bc, wc, "oasst1")
+
+
+def load_oasst1_prefs(split: str = "train", lang: Optional[str] = "en",
+                      max_examples: Optional[int] = None) -> Iterator[dict]:
+    """Load OASST1 and pair ranked sibling replies (lazy `datasets`; materializes split)."""
+    from datasets import load_dataset  # pragma: no cover - network/optional extra
+
+    rows = load_dataset("OpenAssistant/oasst1", split=split)
+    for i, rec in enumerate(build_oasst1_prefs(rows, lang=lang)):
+        if max_examples is not None and i >= max_examples:
+            break
+        yield rec
+
+
+# --------------------------------------------------------------------------- #
+# SHP — Stanford Human Preferences (history + two refs + a label)
+# --------------------------------------------------------------------------- #
+def shp_to_pref(row: dict) -> Optional[dict]:
+    """A SHP row -> a `{prompt, chosen, rejected}` pref (or None). `labels==1` means
+    `human_ref_A` is preferred."""
+    prompt = (row.get("history") or "").strip()
+    a, b = (row.get("human_ref_A") or "").strip(), (row.get("human_ref_B") or "").strip()
+    if not (prompt and a and b):
+        return None
+    chosen, rejected = (a, b) if row.get("labels") == 1 else (b, a)
+    return _pref(prompt, chosen, rejected, "shp")
+
+
+def load_shp_slice(split: str = "train", max_examples: Optional[int] = None) -> Iterator[dict]:
+    """Stream SHP from the Hub (lazy `datasets`)."""
+    from datasets import load_dataset  # pragma: no cover - network/optional extra
+
+    ds = load_dataset("stanfordnlp/SHP", split=split, streaming=True)
+    n = 0
+    for row in ds:
+        if max_examples is not None and n >= max_examples:
+            break
+        rec = shp_to_pref(row)
+        if rec is not None:
+            n += 1
+            yield rec
+
+
+# --------------------------------------------------------------------------- #
+# On-policy self-generated pairs (the inherently-clean source)
+# --------------------------------------------------------------------------- #
+def pairs_from_scored(prompt: str, scored: Sequence[Tuple[str, float]],
+                      source: str = "onpolicy") -> Optional[dict]:
+    """Build a pref from K scored on-policy samples: highest-scored is chosen, lowest is
+    rejected. Returns None if fewer than 2 distinct-scored non-empty candidates. The
+    scorer (a verifier/reward/heuristic) lives in the caller (gen_onpolicy_prefs.py)."""
+    cands = [(str(resp).strip(), float(s)) for resp, s in scored if str(resp).strip()]
+    if len(cands) < 2:
+        return None
+    best, worst = max(cands, key=lambda c: c[1]), min(cands, key=lambda c: c[1])
+    if best[1] == worst[1]:
+        return None
+    return _pref(prompt, best[0], worst[0], source)
+
+
+# --------------------------------------------------------------------------- #
+# Aggregator + CLI
+# --------------------------------------------------------------------------- #
+_LOADERS = {
+    "oasst1": lambda n: load_oasst1_prefs(max_examples=n),
+    "shp": lambda n: load_shp_slice(max_examples=n),
+}
+
+
+def iter_clean_dpo(sources: Iterable[str], max_per_source: Optional[int] = None,
+                   ) -> Iterator[dict]:
+    """Concatenate preference rows from the named clean-license sources (HF-backed)."""
+    for name in sources:
+        if name not in _LOADERS:
+            raise ValueError(f"unknown DPO source {name!r} (have {sorted(_LOADERS)}; "
+                             "on-policy pairs come from scripts/gen_onpolicy_prefs.py)")
+        yield from _LOADERS[name](max_per_source)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--sources", nargs="+", default=["oasst1"], choices=tuple(_LOADERS))
+    ap.add_argument("--out", type=Path, required=True, help="output DPO JSONL")
+    ap.add_argument("--max-per-source", type=int, default=None)
+    ap.add_argument("--max-seq-len", type=int, default=1024)
+    ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--model-id", default=None)
+    args = ap.parse_args()
+
+    from .dpo_data import write_dpo_jsonl
+    from .tokenize import ByteTokenizer, load_olmo_tokenizer
+
+    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
+    rows = iter_clean_dpo(args.sources, max_per_source=args.max_per_source)
+    write_dpo_jsonl(rows, tok, args.out, max_seq_len=args.max_seq_len)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/dpo_sources.py
+++ b/src/data/dpo_sources.py
@@ -39,13 +39,13 @@ def build_oasst1_prefs(rows: Iterable[dict], lang: Optional[str] = "en") -> Iter
     """For each prompter node with >=2 ranked assistant children, pair the best-ranked
     (chosen) against the worst-ranked (rejected). `rank` 0 is best. Rows: {message_id,
     parent_id, text, role, rank, lang}."""
-    rows = list(rows)
     children: dict = defaultdict(list)
-    for r in rows:
+    prompters: list = []
+    for r in rows:                                   # single pass (streaming-friendly)
         children[r.get("parent_id")].append(r)
-    for r in rows:
-        if r.get("role") != "prompter":
-            continue
+        if r.get("role") == "prompter":
+            prompters.append(r)
+    for r in prompters:
         if lang is not None and r.get("lang") not in (None, lang):
             continue
         kids = [c for c in children.get(r.get("message_id"), [])
@@ -83,9 +83,10 @@ def shp_to_pref(row: dict) -> Optional[dict]:
     `human_ref_A` is preferred."""
     prompt = (row.get("history") or "").strip()
     a, b = (row.get("human_ref_A") or "").strip(), (row.get("human_ref_B") or "").strip()
-    if not (prompt and a and b):
-        return None
-    chosen, rejected = (a, b) if row.get("labels") == 1 else (b, a)
+    label = row.get("labels")
+    if not (prompt and a and b) or label not in (0, 1):
+        return None                                  # reject malformed / non-binary labels
+    chosen, rejected = (a, b) if label == 1 else (b, a)
     return _pref(prompt, chosen, rejected, "shp")
 
 
@@ -110,13 +111,16 @@ def load_shp_slice(split: str = "train", max_examples: Optional[int] = None) -> 
 def pairs_from_scored(prompt: str, scored: Sequence[Tuple[str, float]],
                       source: str = "onpolicy") -> Optional[dict]:
     """Build a pref from K scored on-policy samples: highest-scored is chosen, lowest is
-    rejected. Returns None if fewer than 2 distinct-scored non-empty candidates. The
-    scorer (a verifier/reward/heuristic) lives in the caller (gen_onpolicy_prefs.py)."""
+    rejected. Returns None for an empty prompt, fewer than 2 non-empty candidates, equal
+    best/worst scores, or identical chosen/rejected text (all degenerate). The scorer (a
+    verifier/reward/heuristic) lives in the caller (gen_onpolicy_prefs.py)."""
+    if not prompt or not prompt.strip():
+        return None
     cands = [(str(resp).strip(), float(s)) for resp, s in scored if str(resp).strip()]
     if len(cands) < 2:
         return None
     best, worst = max(cands, key=lambda c: c[1]), min(cands, key=lambda c: c[1])
-    if best[1] == worst[1]:
+    if best[1] == worst[1] or best[0] == worst[0]:
         return None
     return _pref(prompt, best[0], worst[0], source)
 

--- a/tests/test_dpo_sources.py
+++ b/tests/test_dpo_sources.py
@@ -1,0 +1,72 @@
+"""Clean-license DPO preference sources (#77).
+
+Hermetic — no network, no model. The OASST1 ranking pairs, SHP mapping, and on-policy
+pair construction are the contract; verified end to end through `build_dpo_records`.
+"""
+
+from src.data.dpo_sources import (SOURCE_LICENSES, build_oasst1_prefs, pairs_from_scored,
+                                  shp_to_pref)
+from src.data.dpo_data import build_dpo_records
+from src.data.tokenize import ByteTokenizer
+
+
+def test_oasst1_prefs_rank_best_vs_worst():
+    rows = [
+        {"message_id": "p", "parent_id": None, "role": "prompter", "text": "Q?", "lang": "en"},
+        {"message_id": "a", "parent_id": "p", "role": "assistant", "text": "best", "rank": 0, "lang": "en"},
+        {"message_id": "b", "parent_id": "p", "role": "assistant", "text": "mid", "rank": 1, "lang": "en"},
+        {"message_id": "c", "parent_id": "p", "role": "assistant", "text": "worst", "rank": 2, "lang": "en"},
+    ]
+    recs = list(build_oasst1_prefs(rows))
+    assert len(recs) == 1
+    r = recs[0]
+    assert r["prompt"] == "Q?"
+    assert r["chosen"][0]["content"] == "best" and r["rejected"][0]["content"] == "worst"
+    assert r["source"] == "oasst1" and r["license"] == "apache-2.0"
+
+
+def test_oasst1_prefs_needs_two_ranked_children():
+    rows = [
+        {"message_id": "p", "parent_id": None, "role": "prompter", "text": "Q?", "lang": "en"},
+        {"message_id": "a", "parent_id": "p", "role": "assistant", "text": "only", "rank": 0, "lang": "en"},
+    ]
+    assert list(build_oasst1_prefs(rows)) == []
+
+
+def test_shp_to_pref_uses_label():
+    a = {"history": "ctx", "human_ref_A": "A", "human_ref_B": "B", "labels": 1}
+    b = {"history": "ctx", "human_ref_A": "A", "human_ref_B": "B", "labels": 0}
+    ra, rb = shp_to_pref(a), shp_to_pref(b)
+    assert ra["chosen"][0]["content"] == "A" and ra["rejected"][0]["content"] == "B"
+    assert rb["chosen"][0]["content"] == "B" and rb["rejected"][0]["content"] == "A"
+    assert shp_to_pref({"history": "", "human_ref_A": "A", "human_ref_B": "B"}) is None
+
+
+def test_pairs_from_scored_best_vs_worst():
+    pref = pairs_from_scored("prompt", [("low", 0.1), ("high", 0.9), ("mid", 0.5)])
+    assert pref["chosen"][0]["content"] == "high" and pref["rejected"][0]["content"] == "low"
+    assert pref["source"] == "onpolicy" and pref["license"] == "cc0"
+    # need >= 2 distinct-scored non-empty candidates
+    assert pairs_from_scored("p", [("only", 0.5)]) is None
+    assert pairs_from_scored("p", [("a", 0.5), ("b", 0.5)]) is None
+    assert pairs_from_scored("p", [("", 0.1), ("x", 0.9)]) is None
+
+
+def test_prefs_feed_build_dpo_records():
+    rows = [
+        {"message_id": "p", "parent_id": None, "role": "prompter", "text": "Hello?", "lang": "en"},
+        {"message_id": "a", "parent_id": "p", "role": "assistant", "text": "Good answer here", "rank": 0, "lang": "en"},
+        {"message_id": "b", "parent_id": "p", "role": "assistant", "text": "Bad answer", "rank": 1, "lang": "en"},
+    ]
+    prefs = list(build_oasst1_prefs(rows))
+    prefs.append(pairs_from_scored("Q?", [("worse one", 0.2), ("better one", 0.8)]))
+    tok = ByteTokenizer()
+    stats: dict = {}
+    out = list(build_dpo_records(prefs, tok, stats=stats))
+    assert out and stats["kept"] == len(out)
+    r = out[0]
+    assert {"chosen_input_ids", "chosen_mask", "rejected_input_ids", "rejected_mask"} <= set(r)
+
+
+def test_source_licenses_present():
+    assert set(SOURCE_LICENSES) >= {"oasst1", "shp", "onpolicy"}

--- a/tests/test_dpo_sources.py
+++ b/tests/test_dpo_sources.py
@@ -40,6 +40,9 @@ def test_shp_to_pref_uses_label():
     assert ra["chosen"][0]["content"] == "A" and ra["rejected"][0]["content"] == "B"
     assert rb["chosen"][0]["content"] == "B" and rb["rejected"][0]["content"] == "A"
     assert shp_to_pref({"history": "", "human_ref_A": "A", "human_ref_B": "B"}) is None
+    # non-binary / missing labels are rejected, not silently treated as "prefer B"
+    assert shp_to_pref({"history": "c", "human_ref_A": "A", "human_ref_B": "B"}) is None
+    assert shp_to_pref({"history": "c", "human_ref_A": "A", "human_ref_B": "B", "labels": 2}) is None
 
 
 def test_pairs_from_scored_best_vs_worst():
@@ -50,6 +53,8 @@ def test_pairs_from_scored_best_vs_worst():
     assert pairs_from_scored("p", [("only", 0.5)]) is None
     assert pairs_from_scored("p", [("a", 0.5), ("b", 0.5)]) is None
     assert pairs_from_scored("p", [("", 0.1), ("x", 0.9)]) is None
+    assert pairs_from_scored("  ", [("a", 0.1), ("b", 0.9)]) is None   # empty prompt
+    assert pairs_from_scored("p", [("same", 0.1), ("same", 0.9)]) is None   # identical text
 
 
 def test_prefs_feed_build_dpo_records():

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -49,6 +49,7 @@ PORTABLE_MODULES = [
     "src.data.sft_sources",
     "src.data.dpo_data",
     "src.data.dpo_loader",
+    "src.data.dpo_sources",
     "src.train.dpo_math",
     "src.train.schedule",
     "src.train.checkpoint",


### PR DESCRIPTION
## Summary
The M9 DPO machinery (`dpo_math`, `make_dpo_train_step`, `scripts/dpo.py`) is complete; #77 adds the **clean-preference sourcing** (`docs/design/08-corpus-pipeline.md`) in a new portable module `src/data/dpo_sources.py`. Each source yields a `{prompt, chosen, rejected}` row in the shape `build_dpo_records` consumes, tagged with `source` + `license`:

- **`build_oasst1_prefs()`** — pair ranked sibling assistant replies (rank 0 = chosen, worst = rejected) per prompter node (Apache-2.0).
- **`shp_to_pref()` / `load_shp_slice()`** — Stanford Human Preferences (`history` + two refs + label).
- **`pairs_from_scored()`** — build a pref from K scored on-policy samples (best vs worst) — the **inherently-clean** source; the scorer lives in the caller.
- **`iter_clean_dpo()`** aggregator + a `python -m src.data.dpo_sources` CLI.
- **`scripts/gen_onpolicy_prefs.py`** — sample K responses per prompt from a checkpoint (serve recurrence + sampler), score, and emit DPO JSONL via the existing `write_dpo_jsonl`.

**HH-RLHF stays excluded** (commercial-model responses) despite its MIT license, per the design doc.

## Tests
- `tests/test_dpo_sources.py` (OASST1 rank pairing, ≥2-children guard, SHP label mapping, on-policy best-vs-worst + degenerate guards, end-to-end through `build_dpo_records`) + import-guard. Full suite **256 passed**; the on-policy script's pairing logic is hermetically tested (the MLX/checkpoint generation path is not CI-run).

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)