### PR TITLE
feat(train): [M10] RLVR / GRPO with verifiable rewards (#78)

### DIFF
--- a/scripts/rlvr.py
+++ b/scripts/rlvr.py
@@ -102,9 +102,11 @@ def main() -> None:
             store.create(sid)
             sampler = partial(sample, temperature=args.temperature, top_k=args.top_k,
                               rng=np.random.default_rng(int(rng.integers(1 << 30))))
-            gen = generate(store, sid, prompt_ids, sampler=sampler, to_numpy=np_to,
-                           max_new_tokens=args.max_new_tokens, eos_id=eos)
-            store.remove(sid)
+            try:
+                gen = generate(store, sid, prompt_ids, sampler=sampler, to_numpy=np_to,
+                               max_new_tokens=args.max_new_tokens, eos_id=eos)
+            finally:
+                store.remove(sid)   # never leak the session if generate/sampling raises
             rollouts.append((prompt_ids, gen or [eos or 0]))
             rewards.append(reward_fn(tok.decode(gen), str(prob.get("answer", ""))))
 

--- a/scripts/rlvr.py
+++ b/scripts/rlvr.py
@@ -1,0 +1,124 @@
+"""RLVR / GRPO with verifiable rewards (#78) — math first.
+
+The cleanest post-training stage: sample K completions per problem from a checkpoint,
+reward each with a **verifier** (math exact-match by default — no sandbox, the cheapest
+clean reward loop), standardize the rewards within the group to advantages, and take a GRPO
+step. The model generates the solutions; the verifier judges — so only problems + answers
+are needed, no reference solutions (docs/design/08-corpus-pipeline.md lines 120-123).
+
+  python scripts/rlvr.py --config config/poc.yaml --init runs/sft/weights.safetensors \
+      --problems math.jsonl --steps 200
+
+`--problems` is JSONL with `{"prompt": "...", "answer": "..."}` per line. `--reward math`
+(default) uses the final-number exact-match; `--reward exact` uses normalized string match.
+Code rewards need a sandbox (CodeVerifier is opt-in, off in CI) — out of scope for this
+driver. MLX-only (backend + serving recurrence), like scripts/sft.py / scripts/dpo.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from functools import partial
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+
+from src.train.grpo import group_advantages, reward_stats
+from src.train.verifiers import exact_match_reward, math_reward
+
+
+def collate_rollouts(rollouts, advantages, *, pad_id: int = 0):
+    """Pad a group of (prompt_ids, gen_ids) rollouts into a GRPO micro-batch
+    `(inputs, targets, mask, advantages)`; mask = 1 on the generated (completion) tokens
+    so the GRPO loss only credits what the model produced."""
+    fulls = [list(p) + list(g) for p, g in rollouts]
+    glens = [len(g) for _, g in rollouts]
+    L = max(len(f) for f in fulls)
+    B = len(fulls)
+    full = np.full((B, L), pad_id, dtype=np.int64)
+    gen_mask = np.zeros((B, L), dtype=np.float32)
+    for i, (f, gl) in enumerate(zip(fulls, glens)):
+        full[i, :len(f)] = f
+        gen_mask[i, len(f) - gl:len(f)] = 1.0          # the trailing gl tokens are generated
+    inputs, targets = full[:, :-1], full[:, 1:]
+    mask = gen_mask[:, 1:]                              # target j is a gen token?
+    return inputs, targets, mask, np.asarray(advantages, dtype=np.float32)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
+    ap.add_argument("--init", type=Path, required=True, help="checkpoint weights (SFT base)")
+    ap.add_argument("--problems", type=Path, required=True, help="JSONL {prompt, answer}")
+    ap.add_argument("--reward", choices=("math", "exact"), default="math")
+    ap.add_argument("--steps", type=int, default=200)
+    ap.add_argument("--group-size", type=int, default=8, help="K completions per problem")
+    ap.add_argument("--lr", type=float, default=1e-6)
+    ap.add_argument("--temperature", type=float, default=1.0)
+    ap.add_argument("--top-k", type=int, default=50)
+    ap.add_argument("--max-new-tokens", type=int, default=256)
+    ap.add_argument("--log-every", type=int, default=10)
+    ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--model-id", default=None)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    from src.model.backend import get_backend
+    from src.model.blocks import load_config
+    from src.serve.generate import generate
+    from src.serve.sessions import SessionStore
+    from src.serve.sampling import sample
+    from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
+
+    backend = get_backend()
+    cfg = load_config(str(args.config))
+    model = backend.model_cls(cfg)
+    model.load(str(args.init))
+    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
+    eos = getattr(tok, "eos_token_id", None)
+    store = SessionStore(model)
+    np_to = backend.to_numpy
+    opt = backend.make_optimizer(model, args.lr)
+    grpo_step = backend.make_grpo_train_step(model, opt)
+    reward_fn = math_reward if args.reward == "math" else exact_match_reward
+
+    problems = [json.loads(ln) for ln in args.problems.read_text(encoding="utf-8").splitlines()
+                if ln.strip()]
+    if not problems:
+        raise SystemExit(f"no problems in {args.problems}")
+    rng = np.random.default_rng(args.seed)
+
+    for step in range(args.steps):
+        prob = problems[step % len(problems)]
+        prompt_ids = list(tok.encode(prob["prompt"])) or [eos or 0]
+        rollouts, rewards = [], []
+        for k in range(args.group_size):
+            sid = f"s{step}-{k}"
+            store.create(sid)
+            sampler = partial(sample, temperature=args.temperature, top_k=args.top_k,
+                              rng=np.random.default_rng(int(rng.integers(1 << 30))))
+            gen = generate(store, sid, prompt_ids, sampler=sampler, to_numpy=np_to,
+                           max_new_tokens=args.max_new_tokens, eos_id=eos)
+            store.remove(sid)
+            rollouts.append((prompt_ids, gen or [eos or 0]))
+            rewards.append(reward_fn(tok.decode(gen), str(prob.get("answer", ""))))
+
+        adv = group_advantages([rewards])[0]            # (K,)
+        out = grpo_step(model, [collate_rollouts(rollouts, adv)], args.lr)
+        if step % args.log_every == 0:
+            stats = reward_stats(rewards)
+            print(f"step {step:4d}  loss {out['loss']:.4f}  "
+                  f"mean_reward {stats['mean_reward']:.3f}  solved {stats['frac_solved']:.3f}")
+
+    save_dir = args.init.parent
+    model.save(str(save_dir / "rlvr_weights.safetensors"))
+    print(f"done — wrote {save_dir / 'rlvr_weights.safetensors'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -39,6 +39,7 @@ class Backend:
     # MLX-only for now; the CUDA branch raises a clear NotImplementedError.
     make_sft_train_step: Callable[..., Callable]
     make_dpo_train_step: Callable[..., Callable]
+    make_grpo_train_step: Callable[..., Callable]
 
 
 def get_backend(name: str = "auto") -> Backend:
@@ -80,10 +81,14 @@ def _mlx_backend() -> Backend:
     from .mlx_train_step import (make_train_step, make_sft_train_step,
                                  save_optimizer, load_optimizer)
 
-    # Lazy so constructing the backend never requires the DPO step to exist yet.
+    # Lazy so constructing the backend never requires the DPO/GRPO step to exist yet.
     def _make_dpo_train_step(*args, **kwargs):
         from .mlx_train_step import make_dpo_train_step
         return make_dpo_train_step(*args, **kwargs)
+
+    def _make_grpo_train_step(*args, **kwargs):
+        from .mlx_train_step import make_grpo_train_step
+        return make_grpo_train_step(*args, **kwargs)
 
     return Backend(
         name="mlx",
@@ -98,6 +103,7 @@ def _mlx_backend() -> Backend:
         to_numpy=lambda a: np.array(a),
         make_sft_train_step=make_sft_train_step,
         make_dpo_train_step=_make_dpo_train_step,
+        make_grpo_train_step=_make_grpo_train_step,
     )
 
 
@@ -149,4 +155,5 @@ def _cuda_backend() -> Backend:
         to_numpy=lambda a: a.detach().to("cpu").numpy(),
         make_sft_train_step=_post_training_unsupported,
         make_dpo_train_step=_post_training_unsupported,
+        make_grpo_train_step=_post_training_unsupported,
     )

--- a/src/model/mlx_train_step.py
+++ b/src/model/mlx_train_step.py
@@ -186,6 +186,35 @@ def make_dpo_train_step(policy_model, ref_model, optimizer, *, beta: float = 0.1
     return train_step
 
 
+def make_grpo_train_step(model, optimizer, *, grad_clip: float = 1.0,
+                         scaler=None) -> Callable:
+    """Build a GRPO `train_step(model, micro_batches, lr) -> dict`.
+
+    `micro_batches` is a list of `(inputs, targets, mask, advantages)`: a batch of sampled
+    rollouts (mask = 1 on the generated/completion tokens) and their group-standardized
+    advantages (one per sequence, precomputed in the driver via `train.grpo.group_advantages`
+    from verifier rewards). The loss is `-mean(advantage * logpθ(completion))` — REINFORCE
+    with the GRPO group baseline; gradients flow through the policy only. Accumulation /
+    fp16 scaling / clipping are shared via `_accumulate_and_step`.
+    """
+    def loss_fn(model, inputs, targets, mask, advantages):
+        logp = _masked_seq_logprob(model, inputs, targets, mask)     # (B,)
+        adv = mx.array(advantages).astype(mx.float32).reshape(-1)    # (B,)
+        loss = -mx.mean(adv * logp)
+        return loss * scaler.scale if scaler else loss
+
+    value_and_grad = nn.value_and_grad(model, loss_fn)
+
+    def loss_and_grad(model, mb):
+        return value_and_grad(model, *mb)
+
+    def train_step(model, micro_batches, lr: float) -> dict:
+        return _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches,
+                                    lr, grad_clip, scaler)
+
+    return train_step
+
+
 def _unscale(grads, factor):
     from mlx.utils import tree_map
     return tree_map(lambda g: g * factor, grads)

--- a/src/train/grpo.py
+++ b/src/train/grpo.py
@@ -1,0 +1,49 @@
+"""GRPO math (portable numpy — above the seam, no backend).
+
+Group Relative Policy Optimization (Shao et al.) replaces PPO's learned value baseline with
+a **group baseline**: sample K completions per prompt, score each with a verifier
+(`train/verifiers.py`), and standardize the rewards *within the group* to advantages. The
+policy-gradient objective is then `-mean(advantage * logp)` — REINFORCE with the group
+mean/std baseline, no critic. The numeric core lives here so it is unit-testable anywhere;
+the MLX GRPO step (`src/model/mlx_train_step.py`) mirrors the same loss on the autodiff
+graph (advantages precomputed here, in the driver).
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+
+def group_advantages(rewards: np.ndarray, eps: float = 1e-6) -> np.ndarray:
+    """Standardize rewards within each group to advantages.
+
+    `rewards` (n_groups, K) -> advantages (n_groups, K) = (r - mean_g) / (std_g + eps). A
+    group whose rewards are all equal (e.g. all-correct or all-wrong) yields ~0 advantage,
+    so it contributes no gradient — exactly the GRPO degenerate case.
+    """
+    r = np.asarray(rewards, dtype=np.float64)
+    mean = r.mean(axis=-1, keepdims=True)
+    std = r.std(axis=-1, keepdims=True)
+    return (r - mean) / (std + eps)
+
+
+def grpo_loss_from_logprobs(logp: np.ndarray, advantages: np.ndarray,
+                            ) -> Tuple[float, float]:
+    """GRPO policy-gradient loss `-mean(advantage * logp)` + the mean |advantage| diagnostic.
+
+    `logp` and `advantages` are the same shape (per-sample sequence log-prob and its
+    group-standardized advantage). Returns `(loss, mean_abs_advantage)`.
+    """
+    logp = np.asarray(logp, dtype=np.float64)
+    adv = np.asarray(advantages, dtype=np.float64)
+    loss = float(-np.mean(adv * logp))
+    return loss, float(np.mean(np.abs(adv)))
+
+
+def reward_stats(rewards: np.ndarray) -> dict:
+    """Run diagnostics for logging: mean reward and fraction solved (reward == max)."""
+    r = np.asarray(rewards, dtype=np.float64)
+    return {"mean_reward": float(r.mean()),
+            "frac_solved": float(np.mean(r >= r.max())) if r.size else 0.0}

--- a/src/train/grpo.py
+++ b/src/train/grpo.py
@@ -43,7 +43,10 @@ def grpo_loss_from_logprobs(logp: np.ndarray, advantages: np.ndarray,
 
 
 def reward_stats(rewards: np.ndarray) -> dict:
-    """Run diagnostics for logging: mean reward and fraction solved (reward == max)."""
+    """Run diagnostics for logging: mean reward and fraction *fully solved* (reward >= 1.0,
+    i.e. a perfect score — not merely the group max, so partial-credit groups with no
+    perfect solution report 0, not 1). Empty input yields zeros, not NaN."""
     r = np.asarray(rewards, dtype=np.float64)
-    return {"mean_reward": float(r.mean()),
-            "frac_solved": float(np.mean(r >= r.max())) if r.size else 0.0}
+    if r.size == 0:
+        return {"mean_reward": 0.0, "frac_solved": 0.0}
+    return {"mean_reward": float(r.mean()), "frac_solved": float(np.mean(r >= 1.0))}

--- a/src/train/verifiers.py
+++ b/src/train/verifiers.py
@@ -82,8 +82,11 @@ class CodeVerifier:
         for t in tests:
             program = f"{code}\n{t}\n"
             try:
+                # Discard untrusted stdout/stderr (a candidate can print unbounded data);
+                # only the exit code matters.
                 r = subprocess.run([sys.executable, "-c", program],
-                                   capture_output=True, timeout=self.timeout)
+                                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                   timeout=self.timeout)
                 passed += int(r.returncode == 0)
             except subprocess.TimeoutExpired:
                 pass

--- a/src/train/verifiers.py
+++ b/src/train/verifiers.py
@@ -1,0 +1,90 @@
+"""Verifiable rewards for RLVR / GRPO (#78).
+
+The cleanest post-training stage on licensing: the reward comes from a **verifier**
+(exact-match, compiler, test runner) — not licensed data — so only problems + tests are
+needed; the model generates the solutions (docs/design/08-corpus-pipeline.md lines 120-123).
+**Math first** (exact-match, no sandbox — the cheapest clean reward loop), then a guarded
+code path.
+
+ABOVE THE SEAM — stdlib only, no backend. `exact_match_reward` / `math_reward` are pure and
+safe. `CodeVerifier` **executes untrusted model output** and is therefore disabled by
+default (`enabled=False`) and never run in CI; real TS/Rust/SQL grading uses an external
+sandbox (SandboxFusion), out of scope here.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from typing import List, Optional, Sequence
+
+_WS = re.compile(r"\s+")
+_NUM = re.compile(r"-?\d+(?:\.\d+)?")
+
+
+def normalize_text(s: str) -> str:
+    """Lowercase, trim, collapse internal whitespace."""
+    return _WS.sub(" ", (s or "").strip().lower())
+
+
+def exact_match_reward(answer: str, gold: str) -> float:
+    """1.0 if `answer` matches `gold` after normalization, else 0.0."""
+    return 1.0 if normalize_text(answer) == normalize_text(gold) else 0.0
+
+
+def extract_final_number(s: str) -> Optional[float]:
+    """The final numeric answer in `s` (GSM8K-style: prefer text after `####`, else the
+    last number). Strips thousands separators. Returns None if there is no number."""
+    if not s:
+        return None
+    txt = s.split("####")[-1] if "####" in s else s
+    nums = _NUM.findall(txt.replace(",", ""))
+    if not nums:
+        return None
+    try:
+        return float(nums[-1])
+    except ValueError:
+        return None
+
+
+def math_reward(answer: str, gold: str, *, tol: float = 1e-6) -> float:
+    """1.0 if the final number in `answer` equals the gold answer within `tol`, else 0.0.
+    `gold` may be a bare number or a full solution string (its final number is used)."""
+    a, g = extract_final_number(answer), extract_final_number(gold)
+    if a is None or g is None:
+        return 0.0
+    return 1.0 if abs(a - g) <= tol else 0.0
+
+
+class CodeVerifier:
+    """Run candidate code against a test suite, rewarding the **fraction of tests passing**
+    (partial credit; use >=5 tests per problem so a thin suite can't be gamed — the main
+    RLVR failure mode).
+
+    UNSAFE: executes untrusted model output in a subprocess. Disabled by default; set
+    `enabled=True` to opt in (never in CI). Python only — TS/Rust/SQL belong in an external
+    sandbox.
+    """
+
+    def __init__(self, *, timeout: float = 5.0, enabled: bool = False):
+        self.timeout = timeout
+        self.enabled = enabled
+
+    def reward(self, code: str, tests: Sequence[str]) -> float:
+        if not self.enabled:
+            raise RuntimeError(
+                "CodeVerifier is disabled (it executes untrusted code). "
+                "Pass enabled=True to opt in — never in CI.")
+        if not tests:
+            return 0.0
+        passed = 0
+        for t in tests:
+            program = f"{code}\n{t}\n"
+            try:
+                r = subprocess.run([sys.executable, "-c", program],
+                                   capture_output=True, timeout=self.timeout)
+                passed += int(r.returncode == 0)
+            except subprocess.TimeoutExpired:
+                pass
+        return passed / len(tests)

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -1,0 +1,38 @@
+"""GRPO math (#78). Pure numpy reference for the group baseline + policy-gradient loss."""
+
+import numpy as np
+import pytest
+
+from src.train.grpo import group_advantages, grpo_loss_from_logprobs, reward_stats
+
+
+def test_group_advantages_all_equal_is_zero():
+    # A group that's all-correct or all-wrong yields ~0 advantage -> no gradient.
+    adv = group_advantages([[1.0, 1.0, 1.0]])
+    assert np.allclose(adv, 0.0, atol=1e-5)
+
+
+def test_group_advantages_standardized_per_group():
+    adv = group_advantages([[0.0, 1.0], [5.0, 5.0]])
+    assert np.isclose(adv[0].mean(), 0.0, atol=1e-9)
+    assert adv[0, 1] > adv[0, 0]                 # higher reward -> higher advantage
+    assert np.allclose(adv[1], 0.0, atol=1e-5)   # second group independent + degenerate
+
+
+def test_grpo_loss_matches_formula():
+    logp = np.array([-1.0, -2.0, -0.5])
+    adv = np.array([1.0, -1.0, 0.0])
+    loss, mabs = grpo_loss_from_logprobs(logp, adv)
+    assert np.isclose(loss, float(-np.mean(adv * logp)))
+    assert np.isclose(mabs, float(np.mean(np.abs(adv))))
+
+
+def test_grpo_loss_zero_advantage_is_zero():
+    loss, _ = grpo_loss_from_logprobs([-1.0, -2.0], [0.0, 0.0])
+    assert loss == 0.0
+
+
+def test_reward_stats():
+    s = reward_stats([1.0, 0.0, 1.0])
+    assert s["mean_reward"] == pytest.approx(2 / 3)
+    assert s["frac_solved"] == pytest.approx(2 / 3)   # reward == max (1.0) for 2 of 3

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -35,4 +35,14 @@ def test_grpo_loss_zero_advantage_is_zero():
 def test_reward_stats():
     s = reward_stats([1.0, 0.0, 1.0])
     assert s["mean_reward"] == pytest.approx(2 / 3)
-    assert s["frac_solved"] == pytest.approx(2 / 3)   # reward == max (1.0) for 2 of 3
+    assert s["frac_solved"] == pytest.approx(2 / 3)   # two perfect (1.0) of three
+
+
+def test_reward_stats_partial_credit_not_solved():
+    # No completion is perfect -> frac_solved must be 0, not 1 (the group-max trap).
+    s = reward_stats([0.2, 0.4, 0.6])
+    assert s["mean_reward"] == pytest.approx(0.4) and s["frac_solved"] == 0.0
+
+
+def test_reward_stats_empty_is_zero_not_nan():
+    assert reward_stats([]) == {"mean_reward": 0.0, "frac_solved": 0.0}

--- a/tests/test_grpo_train_step.py
+++ b/tests/test_grpo_train_step.py
@@ -1,0 +1,64 @@
+"""MLX GRPO train_step (Apple Silicon only). Verifies the step's loss matches the portable
+numpy reference `-mean(advantage * seq_logp)` and that the policy is updated.
+"""
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+import mlx.optimizers as optim
+from mlx.utils import tree_flatten
+
+from src.model.blocks import load_config
+from src.model.mlx_backend import MLXMambaModel
+from src.model.mlx_train_step import _masked_seq_logprob, make_grpo_train_step
+
+TOY_CFG = "config/toy.yaml"
+
+
+def _batch(cfg, B=4, L=16, seed=0):
+    rng = np.random.default_rng(seed)
+    inp = rng.integers(0, cfg.vocab_size, size=(B, L)).astype(np.int64)
+    tgt = rng.integers(0, cfg.vocab_size, size=(B, L)).astype(np.int64)
+    mask = (rng.random((B, L)) > 0.4).astype(np.float32)
+    adv = rng.standard_normal(B).astype(np.float32)
+    return inp, tgt, mask, adv
+
+
+def _flat(model):
+    return [np.array(v) for _, v in tree_flatten(model.parameters())]
+
+
+def test_grpo_loss_matches_reference_and_updates_policy():
+    cfg = load_config(TOY_CFG)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    batch = _batch(cfg)
+
+    # numpy reference loss at the initial params
+    logp = np.array(_masked_seq_logprob(model, batch[0], batch[1], batch[2]))
+    ref_loss = float(-np.mean(batch[3] * logp))
+
+    before = _flat(model)
+    opt = optim.AdamW(learning_rate=1e-3)
+    step = make_grpo_train_step(model, opt)
+    out = step(model, [batch], 1e-3)
+
+    assert np.isfinite(out["loss"])
+    assert np.isclose(out["loss"], ref_loss, rtol=1e-4, atol=1e-4)
+    after = _flat(model)
+    assert any(not np.allclose(a, b) for a, b in zip(before, after))   # policy updated
+
+
+def test_zero_advantage_gives_no_update():
+    cfg = load_config(TOY_CFG)
+    mx.random.seed(1)
+    model = MLXMambaModel(cfg)
+    inp, tgt, mask, _ = _batch(cfg, seed=2)
+    batch = (inp, tgt, mask, np.zeros(inp.shape[0], dtype=np.float32))   # all-zero advantage
+    before = _flat(model)
+    step = make_grpo_train_step(model, optim.AdamW(learning_rate=1e-3, weight_decay=0.0))
+    out = step(model, [batch], 1e-3)
+    assert out["loss"] == 0.0
+    after = _flat(model)
+    assert all(np.allclose(a, b) for a, b in zip(before, after))        # no gradient -> no change

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -51,6 +51,8 @@ PORTABLE_MODULES = [
     "src.data.dpo_loader",
     "src.data.dpo_sources",
     "src.train.dpo_math",
+    "src.train.grpo",
+    "src.train.verifiers",
     "src.train.schedule",
     "src.train.checkpoint",
     "src.train.loss_scale",

--- a/tests/test_verifiers.py
+++ b/tests/test_verifiers.py
@@ -1,0 +1,43 @@
+"""Verifiable rewards for RLVR/GRPO (#78). Pure stdlib; the code path is gated."""
+
+import os
+
+import pytest
+
+from src.train.verifiers import (CodeVerifier, exact_match_reward, extract_final_number,
+                                 math_reward, normalize_text)
+
+
+def test_exact_match_normalizes():
+    assert exact_match_reward("Yes", " yes ") == 1.0
+    assert exact_match_reward("a   b", "a b") == 1.0          # whitespace collapse
+    assert exact_match_reward("foo", "bar") == 0.0
+    assert normalize_text("  Hello   World ") == "hello world"
+
+
+def test_extract_final_number():
+    assert extract_final_number("The answer is 42.") == 42.0
+    assert extract_final_number("blah #### 1,234") == 1234.0   # GSM8K marker + separators
+    assert extract_final_number("step 3, then -7.5") == -7.5   # last number
+    assert extract_final_number("no digits here") is None
+
+
+def test_math_reward():
+    assert math_reward("so there are 18 apples", "#### 18") == 1.0
+    assert math_reward("the total is 19", "18") == 0.0
+    assert math_reward("no number at all", "5") == 0.0
+    assert math_reward("answer: 3.0", "3") == 1.0             # tolerance
+
+
+def test_code_verifier_disabled_raises():
+    # Executing untrusted model output must be an explicit opt-in.
+    with pytest.raises(RuntimeError):
+        CodeVerifier().reward("x = 1", ["assert x == 1"])
+    assert CodeVerifier(enabled=True).reward("x = 1", []) == 0.0   # no tests -> 0
+
+
+@pytest.mark.skipif(not os.environ.get("RUN_CODE_VERIFIER"),
+                    reason="CodeVerifier runs code in a subprocess; opt-in via RUN_CODE_VERIFIER")
+def test_code_verifier_partial_credit():
+    cv = CodeVerifier(enabled=True)
+    assert cv.reward("def f():\n    return 2\n", ["assert f() == 2", "assert f() == 3"]) == 0.5


### PR DESCRIPTION
## Summary
Stage C — **RL with verifiable rewards**, the cleanest post-training stage on licensing: the reward comes from a **verifier** (exact-match / test runner), not licensed data, so only problems + answers are needed (the model generates the solutions). **Math first** (`docs/design/08-corpus-pipeline.md` lines 120-123).

**Portable (above the seam):**
- **`src/train/verifiers.py`** — `exact_match_reward`, `math_reward` (GSM8K-style final-number extraction: `####` marker + thousands separators + tolerance), and `CodeVerifier` rewarding the **fraction of tests passing** (partial credit; ≥5 tests/problem avoids gaming). `CodeVerifier` **executes untrusted output → disabled by default, never in CI**; TS/Rust/SQL go to an external sandbox.
- **`src/train/grpo.py`** — `group_advantages` (within-group reward standardization; an all-correct/all-wrong group → ~0 advantage → no gradient) + `grpo_loss_from_logprobs` (`-mean(advantage * logp)`, REINFORCE with the GRPO group baseline) + `reward_stats`.

**Backend:**
- `mlx_train_step.make_grpo_train_step` mirroring `make_dpo_train_step`: micro-batches are `(inputs, targets, mask, advantages)`; gradients flow through the policy only.
- `backend.Backend` gains `make_grpo_train_step` (MLX wired; CUDA stub like SFT/DPO).

**Driver:** `scripts/rlvr.py` — sample K completions/problem, reward, group-standardize, GRPO step (math exact-match default; code rewards need a sandbox, out of scope).

## Tests
- `tests/test_verifiers.py`, `tests/test_grpo.py`, and `tests/test_grpo_train_step.py` (MLX step matches the numpy reference loss; policy updates; zero-advantage → no update). Code-verifier subprocess test gated behind `RUN_CODE_VERIFIER`. New modules in the seam import-guard. Full suite **267 passed**.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)