### PR TITLE
feat(model): [M10] packing-aware document-boundary reset (8K+ long-seq) (#68)

### DIFF
--- a/src/conformance/doc_boundary_parity.py
+++ b/src/conformance/doc_boundary_parity.py
@@ -1,0 +1,61 @@
+"""Packing-aware document-boundary parity (#68).
+
+When several documents are packed into one training sequence, recurrent SSM state (and
+attention) must not bleed across the boundaries — a packed multi-document forward has to
+equal running each document on its own. This is the conformance gate for the `seg_ids`
+path added to `ModelInterface.forward`: a silent leak across a boundary corrupts training
+in a way ordinary losses don't surface (mirrors `forward_step_parity` for the SSD scan).
+
+Document boundaries must be **chunk-aligned** (each doc starts at a multiple of
+`chunk_size`); this helper pads each doc up to a chunk multiple, packs them with `seg_ids`,
+and checks each document's logit slice against its standalone forward. Run in fp32 at
+~1e-4 relative tolerance — bf16's epsilon is too coarse.
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+import numpy as np
+
+from ..model.interface import ModelInterface
+
+
+def check_doc_boundary_parity(model: ModelInterface, docs: Sequence[Sequence[int]],
+                              chunk_size: int, *, to_numpy=np.asarray, pad_id: int = 0,
+                              rtol: float = 1e-4, atol: float = 1e-5) -> dict:
+    """Pack `docs` chunk-aligned into one sequence with `seg_ids` and assert each document's
+    logits match its standalone forward. Returns `{max_abs_diff, ok}`; raises on mismatch.
+
+    Each doc is padded up to a multiple of `chunk_size` (padding follows the real tokens, so
+    causality keeps it from affecting them); only the real positions are compared.
+    """
+    packed: List[int] = []
+    seg: List[int] = []
+    spans: List[tuple] = []
+    off = 0
+    for d, doc in enumerate(docs):
+        doc = [int(t) for t in doc]
+        n = len(doc)
+        plen = ((n + chunk_size - 1) // chunk_size) * chunk_size
+        packed.extend(doc + [pad_id] * (plen - n))
+        seg.extend([d] * plen)
+        spans.append((off, off + n))
+        off += plen
+
+    packed_arr = np.asarray(packed, dtype=np.int64)[None]      # (1, Lp)
+    seg_arr = np.asarray(seg, dtype=np.int64)[None]            # (1, Lp)
+    packed_logits = to_numpy(model.forward(packed_arr, seg_arr))   # (1, Lp, V)
+
+    max_abs = 0.0
+    for d, doc in enumerate(docs):
+        solo = to_numpy(model.forward(np.asarray([list(doc)], dtype=np.int64)))  # (1, n, V)
+        s, e = spans[d]
+        sub = packed_logits[:, s:e]
+        diff = np.abs(sub.astype(np.float64) - solo.astype(np.float64))
+        max_abs = max(max_abs, float(diff.max()))
+        if not np.allclose(sub, solo, rtol=rtol, atol=atol):
+            raise AssertionError(
+                f"doc-boundary parity FAILED for document {d}: max|diff|={diff.max():.3e} "
+                "— state leaked across a packed boundary")
+    return {"max_abs_diff": max_abs, "ok": True}

--- a/src/data/shard.py
+++ b/src/data/shard.py
@@ -32,14 +32,21 @@ DTYPE = np.uint16
 
 
 def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int = 8192,
-                   shard_size_mb: int = 512, prefix: str = "part",
-                   tokenizer: str = "") -> dict:
+                   shard_size_mb: int = 512, prefix: str = "part", tokenizer: str = "",
+                   chunk_align: int | None = None, pad_id: int = 0) -> dict:
     """Pack per-document token lists into fixed `seq_len` sequences across few large shards,
     writing token `.bin` + doc-boundary `.bounds` sidecars + a `manifest.json`. The final
     partial sequence (< seq_len) is dropped. Returns the manifest dict.
 
     `token_docs` yields one id list per document (see `tokenize.tokenize_docs`); each doc's
-    first token is flagged 1 in `.bounds`, the rest 0."""
+    first token is flagged 1 in `.bounds`, the rest 0.
+
+    `chunk_align` (set it to the model's `chunk_size`) pads each document up to a multiple of
+    that length with `pad_id`, so every document **starts on a chunk boundary** — the
+    requirement for the SSM's packing-aware boundary reset (#68). `seq_len` should be a
+    multiple of `chunk_align`."""
+    if chunk_align is not None and seq_len % chunk_align:
+        raise ValueError(f"seq_len {seq_len} must be a multiple of chunk_align {chunk_align}")
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
@@ -73,6 +80,10 @@ def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int
         ids = list(doc)
         if not ids:
             continue
+        if chunk_align is not None:               # pad doc so the NEXT doc is chunk-aligned
+            rem = len(ids) % chunk_align
+            if rem:
+                ids = ids + [pad_id] * (chunk_align - rem)
         tok_buf.extend(ids)                       # OverflowError if any id not in [0, 65535]
         bnd_buf.append(1)
         bnd_buf.extend(b"\x00" * (len(ids) - 1))
@@ -105,6 +116,14 @@ def read_manifest(out_dir) -> dict:
 def doc_start_offsets(bounds: Sequence[int]) -> List[int]:
     """Global token offsets where a document begins (where bounds == 1)."""
     return [int(i) for i in np.nonzero(np.asarray(bounds))[0]]
+
+
+def segment_ids(bounds: Sequence[int]) -> np.ndarray:
+    """Per-position document id from the doc-start `.bounds` flags: `cumsum(bounds) - 1`.
+
+    This is the `seg_ids` the boundary-aware forward (#68) consumes — feed a sequence's
+    slice of it alongside the tokens so SSM/attention state resets at each document."""
+    return np.cumsum(np.asarray(bounds, dtype=np.int64)) - 1
 
 
 def main() -> None:

--- a/src/data/shard.py
+++ b/src/data/shard.py
@@ -45,8 +45,14 @@ def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int
     that length with `pad_id`, so every document **starts on a chunk boundary** — the
     requirement for the SSM's packing-aware boundary reset (#68). `seq_len` should be a
     multiple of `chunk_align`."""
-    if chunk_align is not None and seq_len % chunk_align:
-        raise ValueError(f"seq_len {seq_len} must be a multiple of chunk_align {chunk_align}")
+    if chunk_align is not None:
+        if chunk_align <= 0:
+            raise ValueError(f"chunk_align must be positive, got {chunk_align}")
+        if seq_len % chunk_align:
+            raise ValueError(
+                f"seq_len {seq_len} must be a multiple of chunk_align {chunk_align}")
+    if not 0 <= pad_id < 65536:
+        raise ValueError(f"pad_id {pad_id} out of uint16 range [0, 65535]")
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -390,7 +390,13 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         return layer.forward_seq(h)
 
     # --- ModelInterface ---
-    def forward(self, token_batch: Array) -> Array:
+    def forward(self, token_batch: Array, seg_ids: Array = None) -> Array:
+        if seg_ids is not None:
+            # Packing-aware document boundaries (#68) are MLX-only for now; the CUDA scan
+            # would need the same inter-chunk mask. Deferred with the rest of this backend.
+            raise NotImplementedError(
+                "seg_ids (packing-aware doc boundaries, #68) is not implemented on the "
+                "CUDA backend yet — run packed-boundary training on MLX.")
         ids = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
         h = _cast(self.embedding(ids), self._cd)     # activation stream in cd
         for layer in self.layers:

--- a/src/model/interface.py
+++ b/src/model/interface.py
@@ -40,9 +40,10 @@ class ModelInterface(ABC):
         packing-aware training (#68): positions in different documents never interact, so
         recurrent SSM state and attention can't bleed across packed document boundaries.
         `None` (the default) is the original single-segment behavior. Document boundaries
-        must be **chunk-aligned** (each document starts at a multiple of `chunk_size`) — the
-        packer (`src/data/shard.py`) enforces this; `src/conformance/doc_boundary_parity.py`
-        verifies a packed multi-doc forward equals the per-document forwards.
+        must be **chunk-aligned** (each document starts at a multiple of `chunk_size`) —
+        `src/data/shard.py::pack_sequences` enforces this when packing with `chunk_align`
+        set; `src/conformance/doc_boundary_parity.py` verifies a packed multi-doc forward
+        equals the per-document forwards.
         """
 
     # --- inference path ---

--- a/src/model/interface.py
+++ b/src/model/interface.py
@@ -31,10 +31,18 @@ class ModelInterface(ABC):
 
     # --- training path ---
     @abstractmethod
-    def forward(self, token_batch: Array) -> Array:
+    def forward(self, token_batch: Array, seg_ids: Array = None) -> Array:
         """Full-sequence parallel forward. `token_batch` is (batch, seq_len) ids.
 
         Returns logits (batch, seq_len, vocab_size). Uses the parallel scan.
+
+        `seg_ids` (optional, (batch, seq_len) int) is a per-position **document id** for
+        packing-aware training (#68): positions in different documents never interact, so
+        recurrent SSM state and attention can't bleed across packed document boundaries.
+        `None` (the default) is the original single-segment behavior. Document boundaries
+        must be **chunk-aligned** (each document starts at a multiple of `chunk_size`) — the
+        packer (`src/data/shard.py`) enforces this; `src/conformance/doc_boundary_parity.py`
+        verifies a packed multi-doc forward equals the per-document forwards.
         """
 
     # --- inference path ---

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -107,6 +107,30 @@ def _segsum(x: Array) -> Array:
     return mx.where(mask, seg, mx.array(float("-inf"), dtype=seg.dtype))
 
 
+def _chunk_seg_mask(seg_ids: Array, B: int, Q: int, nc: int, pad: int) -> Array:
+    """Boundary mask for the SSD inter-chunk decay matrix (#68).
+
+    Doc boundaries are chunk-aligned, so each length-Q scan chunk is single-document. The
+    inter-chunk recurrence carries each chunk's final state into later chunks; this mask
+    zeros that carry across documents, so SSM state can't bleed past a packed boundary. The
+    intra-chunk block needs no mask (single-document by construction) and chunk 0 already
+    gets a zero entering state from the decay matrix's lower-triangular structure.
+
+    `seg_ids` (B, L) document ids -> (B, nc+1, nc+1): entry [i, c] keeps the decay from
+    state c (chunk c-1's final; c=0 is the zero initial state) into entering chunk i iff
+    they share a document.
+    """
+    seg = mx.array(seg_ids)
+    if pad:
+        seg = mx.concatenate([seg, mx.broadcast_to(seg[:, -1:], (B, pad))], axis=1)
+    seg_chunks = seg.reshape(B, nc, Q)[:, :, 0]                  # (B, nc) doc id per chunk
+    sentinel_a = mx.full((B, 1), -1, dtype=seg_chunks.dtype)     # zero-state column
+    sentinel_b = mx.full((B, 1), -2, dtype=seg_chunks.dtype)     # dropped output row
+    src = mx.concatenate([sentinel_a, seg_chunks], axis=1)       # state c axis
+    out = mx.concatenate([seg_chunks, sentinel_b], axis=1)       # entering-chunk i axis
+    return (out[:, :, None] == src[:, None, :])                  # (B, nc+1, nc+1) bool
+
+
 class SelectiveSSM(nn.Module):
     """Scalar-A Mamba-2 / SSD selective state space.
 
@@ -166,12 +190,16 @@ class SelectiveSSM(nn.Module):
         a = -mx.exp(self.A_log)                    # (H,) scalar decay, fp32
         return delta, a, B, C
 
-    def parallel(self, x: Array) -> Array:
+    def parallel(self, x: Array, seg_ids: Array = None) -> Array:
         """SSD chunked-matmul scan. x: (B, L, d_inner) -> (B, L, d_inner).
 
         Pads L up to a multiple of the chunk length Q (padded steps carry zero
         input and are trimmed). All decays are exp of non-positive sums, so the
-        scan is overflow-safe by construction."""
+        scan is overflow-safe by construction.
+
+        `seg_ids` (B, L) document ids (chunk-aligned boundaries) makes the scan
+        packing-aware (#68): the inter-chunk state carry is masked so recurrent state can't
+        bleed across documents. `None` is the original single-segment scan."""
         B_, L, d_inner = x.shape
         H, P, N = self.config.n_heads, self.config.head_dim, self.config.d_state
         Q = self.config.chunk_size or 64
@@ -213,6 +241,9 @@ class SelectiveSSM(nn.Module):
             [mx.zeros((B_, 1, H, P, N), dtype=states.dtype), states], axis=1)
         chunk_tot = mx.pad(Acum[..., -1], [(0, 0), (0, 0), (1, 0)])   # (B,H,nc+1)
         decay_chunk = mx.exp(_segsum(chunk_tot))                      # (B,H,nc+1,nc+1)
+        if seg_ids is not None:                                       # #68: cross-doc reset
+            seg_mask = _chunk_seg_mask(seg_ids, B_, Q, nc, pad)       # (B,nc+1,nc+1) bool
+            decay_chunk = decay_chunk * seg_mask[:, None].astype(decay_chunk.dtype)
         new_states = mx.einsum("bhzc,bchpn->bzhpn", decay_chunk, states)
         S_enter = new_states[:, :-1]                                  # (B,nc,H,P,N)
         # 4) off-diagonal output: entering state decayed to each position
@@ -263,15 +294,44 @@ class MambaBlock(nn.Module):
                       c.stride, c.padding, c.dilation, c.groups)
         return y + c.bias.astype(cd)
 
-    def forward_seq(self, x: Array) -> Array:
+    def _conv_seq_seg(self, x_main: Array, cd, seg: Array) -> Array:
+        """Boundary-aware causal depthwise conv (#68): taps reaching into a previous
+        document are zeroed, so the conv window can't bleed across a packed boundary (the
+        conv is part of the per-doc recurrent state). `seg` is (B, L). Returns length L,
+        matching the full conv exactly within a single document."""
+        c = self.conv
+        K = self.config.d_conv
+        B_, L, _ = x_main.shape
+        x = x_main.astype(cd)
+        w = c.weight.astype(cd)                     # (d_inner, K, 1) MLX Conv1d layout
+        acc = None
+        for k in range(K):
+            shift = K - 1 - k                       # how far this tap reaches into the past
+            wk = w[:, k, 0]                          # (d_inner,)
+            if shift == 0:
+                xs = x
+            else:
+                xs = mx.pad(x[:, :L - shift], [(0, 0), (shift, 0), (0, 0)])   # x[t-shift]
+                same = seg[:, shift:] == seg[:, :-shift]                       # (B, L-shift)
+                valid = mx.pad(same, [(0, 0), (shift, 0)]).astype(cd)         # 0 across boundary
+                xs = xs * valid[..., None]
+            term = xs * wk
+            acc = term if acc is None else acc + term
+        return acc + c.bias.astype(cd)
+
+    def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:
         L = x.shape[1]
         cd = _DTYPES[self.config.precision]
         xn = self.norm(x)
         x_main, z = mx.split(_linear(self.in_proj, xn, cd), 2, axis=-1)   # (B,L,di) each
-        # Causal depthwise conv: pad both sides (d_conv-1), keep the first L outputs.
-        xc = self._conv_seq(x_main, cd)[:, :L]
+        # Causal depthwise conv: pad both sides (d_conv-1), keep the first L outputs. With
+        # seg_ids the conv is boundary-aware so its window can't cross a packed doc boundary.
+        if seg_ids is None:
+            xc = self._conv_seq(x_main, cd)[:, :L]
+        else:
+            xc = self._conv_seq_seg(x_main, cd, mx.array(seg_ids))
         xc = _silu(xc)
-        y = self.ssm.parallel(xc)
+        y = self.ssm.parallel(xc, seg_ids)
         y = y * _silu(z)
         return x + _linear(self.out_proj, y, cd)
 
@@ -354,7 +414,7 @@ class AttentionBlock(nn.Module):
             return _f32(t).reshape(B, T, self.H, self.Dh).transpose(0, 2, 1, 3)
         return heads(q), heads(k), heads(v)
 
-    def forward_seq(self, x: Array) -> Array:
+    def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:
         cd = _DTYPES[self.config.precision]
         L = x.shape[1]
         xn = self.norm(x)
@@ -363,7 +423,16 @@ class AttentionBlock(nn.Module):
         q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
         scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(self.Dh)   # (B,H,L,L)
         causal = mx.tril(mx.ones((L, L), dtype=mx.bool_))
-        scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        if seg_ids is None:
+            scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        else:
+            # Block-diagonal: a token only attends within its own document (#68). Exact for
+            # arbitrary boundaries (attention needs no chunk-alignment, unlike the SSM scan).
+            seg = mx.array(seg_ids)
+            same = seg[:, :, None] == seg[:, None, :]        # (B,L,L)
+            allow = causal[None] & same                      # (B,L,L)
+            scores = mx.where(allow[:, None], scores,
+                              mx.array(float("-inf"), dtype=scores.dtype))
         out = _softmax_lastdim(scores) @ v                   # (B,H,L,Dh)
         out = out.transpose(0, 2, 1, 3).reshape(x.shape[0], L, self.H * self.Dh)
         return x + _linear(self.o_proj, _cast(out, cd), cd)
@@ -419,10 +488,15 @@ class MLXMambaModel(ModelInterface, nn.Module):
         return self.lm_head(h)
 
     # --- ModelInterface ---
-    def forward(self, token_batch: Array) -> Array:
+    def forward(self, token_batch: Array, seg_ids: Array = None) -> Array:
         h = _cast(self.embedding(mx.array(token_batch)), self._cd)   # activation stream in cd
-        for layer_fn in self._layer_fns:
-            h = layer_fn(h)
+        if seg_ids is None:
+            for layer_fn in self._layer_fns:
+                h = layer_fn(h)
+        else:
+            seg = mx.array(seg_ids)                                   # (B, L) document ids
+            for layer_fn in self._layer_fns:
+                h = layer_fn(h, seg)                                  # boundary-aware (#68)
         return self._head(self.norm_f(h))
 
     def step(self, token: Array, state: State) -> Tuple[Array, State]:

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -310,6 +310,8 @@ class MambaBlock(nn.Module):
             wk = w[:, k, 0]                          # (d_inner,)
             if shift == 0:
                 xs = x
+            elif shift >= L:
+                continue                            # tap reaches entirely before the start
             else:
                 xs = mx.pad(x[:, :L - shift], [(0, 0), (shift, 0), (0, 0)])   # x[t-shift]
                 same = seg[:, shift:] == seg[:, :-shift]                       # (B, L-shift)
@@ -317,6 +319,8 @@ class MambaBlock(nn.Module):
                 xs = xs * valid[..., None]
             term = xs * wk
             acc = term if acc is None else acc + term
+        if acc is None:                             # K > L: all taps reach before the start
+            acc = mx.zeros((B_, L, x.shape[-1]), dtype=cd)
         return acc + c.bias.astype(cd)
 
     def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:

--- a/tests/test_doc_boundary_parity.py
+++ b/tests/test_doc_boundary_parity.py
@@ -1,0 +1,52 @@
+"""Packing-aware document-boundary parity (#68), MLX (Apple Silicon only).
+
+A packed multi-document forward (with seg_ids) must equal each document's standalone
+forward — proving SSM/attention state doesn't bleed across chunk-aligned boundaries.
+"""
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from src.model.blocks import load_config
+from src.model.mlx_backend import MLXMambaModel
+from src.conformance.doc_boundary_parity import check_doc_boundary_parity
+
+
+def _docs(cfg, lengths, seed=0):
+    rng = np.random.default_rng(seed)
+    return [rng.integers(0, cfg.vocab_size, size=n).tolist() for n in lengths]
+
+
+def test_doc_boundary_parity_toy():
+    cfg = load_config("config/toy.yaml")
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    Q = cfg.chunk_size or 64
+    # exact chunk multiples, several chunks, and a short doc that needs padding
+    docs = _docs(cfg, [Q, 2 * Q, 5])
+    res = check_doc_boundary_parity(model, docs, Q, to_numpy=np.array)
+    assert res["ok"] and res["max_abs_diff"] < 1e-3
+
+
+def test_doc_boundary_parity_hybrid():
+    cfg = load_config("config/toy-hybrid.yaml")
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    Q = cfg.chunk_size or 64
+    docs = _docs(cfg, [Q, 7, Q + 3], seed=1)        # mixes attention + Mamba layers
+    res = check_doc_boundary_parity(model, docs, Q, to_numpy=np.array)
+    assert res["ok"] and res["max_abs_diff"] < 1e-3
+
+
+def test_grad_checkpoint_path_supports_seg_ids():
+    # poc uses grad_checkpoint=True; make sure seg_ids threads through the checkpointed
+    # layer wrappers (build a tiny checkpointed config).
+    cfg = load_config("config/toy.yaml")
+    cfg.grad_checkpoint = True
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    Q = cfg.chunk_size or 64
+    res = check_doc_boundary_parity(model, _docs(cfg, [Q, Q]), Q, to_numpy=np.array)
+    assert res["ok"]

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -63,6 +63,7 @@ PORTABLE_MODULES = [
     "src.eval.probes",
     "src.conformance.forward_step_parity",
     "src.conformance.backend_parity",
+    "src.conformance.doc_boundary_parity",
     "src.serve.sessions",
     "src.serve.rewind",
     "src.serve.sampling",

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -6,7 +6,8 @@ Pure numpy + stdlib. The boundary sidecar (consumed by #68) is the contract here
 import numpy as np
 import pytest
 
-from src.data.shard import (doc_start_offsets, open_shard, pack_sequences, read_manifest)
+from src.data.shard import (doc_start_offsets, open_shard, pack_sequences, read_manifest,
+                            segment_ids)
 
 
 def test_pack_sequences_boundaries_and_roundtrip(tmp_path):
@@ -56,6 +57,21 @@ def test_pack_sequences_rolls_few_large_shards(tmp_path):
 def test_pack_sequences_uint16_guard(tmp_path):
     with pytest.raises((OverflowError, ValueError)):
         pack_sequences([[1, 2, 70000]], tmp_path, seq_len=2)   # 70000 > uint16 max
+
+
+def test_chunk_align_pads_docs_to_chunk_starts(tmp_path):
+    # chunk_align=4: doc len 3 -> 4 (1 pad), doc len 5 -> 8 (3 pad); starts at 0 and 4.
+    manifest = pack_sequences([[1, 2, 3], [4, 5, 6, 7, 8]], tmp_path, seq_len=4,
+                              chunk_align=4, pad_id=0)
+    toks, bnds = open_shard(tmp_path, manifest["shards"][0]["name"])
+    assert doc_start_offsets(bnds) == [0, 4]           # both starts are multiples of 4
+    assert list(toks) == [1, 2, 3, 0, 4, 5, 6, 7, 8, 0, 0, 0]
+    assert list(segment_ids(bnds)) == [0, 0, 0, 0] + [1] * 8
+
+
+def test_chunk_align_requires_divisible_seq_len(tmp_path):
+    with pytest.raises(ValueError):
+        pack_sequences([[1, 2]], tmp_path, seq_len=6, chunk_align=4)   # 6 % 4 != 0
 
 
 def test_manifest_persisted(tmp_path):

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -74,6 +74,13 @@ def test_chunk_align_requires_divisible_seq_len(tmp_path):
         pack_sequences([[1, 2]], tmp_path, seq_len=6, chunk_align=4)   # 6 % 4 != 0
 
 
+def test_pack_sequences_validates_inputs(tmp_path):
+    with pytest.raises(ValueError):
+        pack_sequences([[1, 2]], tmp_path, seq_len=4, chunk_align=0)   # not ZeroDivisionError
+    with pytest.raises(ValueError):
+        pack_sequences([[1, 2]], tmp_path, seq_len=4, pad_id=70000)    # out of uint16 range
+
+
 def test_manifest_persisted(tmp_path):
     pack_sequences([[1, 2, 3, 4]], tmp_path, seq_len=2, tokenizer="starcoder2")
     m = read_manifest(tmp_path)


### PR DESCRIPTION
## Summary
Train on **packed multi-document sequences** without SSM/attention state bleeding across document boundaries (`docs/design/08-corpus-pipeline.md`). Seam-level and **backward-compatible**: `ModelInterface.forward` gains an optional `seg_ids` (B, L) document-id arg; `None` (the default) is the original single-segment behavior, so every existing path is unchanged.

**MLX boundary reset** (boundaries are **chunk-aligned**, so each SSD scan chunk is single-document — the simpler exact design):
- **SSD scan** — mask the inter-chunk decay matrix by per-chunk document id, so a chunk's final state can't carry into a later document (the intra-chunk block is single-doc by construction; chunk 0 already gets a zero entering state).
- **Depthwise causal conv** — a boundary-aware path zeros taps that reach into the previous document (the conv is part of the per-doc recurrent state — this was the subtle second leak).
- **Attention** — block-diagonal mask (a token attends only within its own document; exact for arbitrary boundaries).

**Data:** `shard.pack_sequences` gains `chunk_align` (pad each doc up to a chunk multiple so doc starts are chunk-aligned) + `segment_ids(bounds)` to derive `seg_ids` from the `.bounds` sidecar.

**CUDA:** `forward` takes `seg_ids` for signature parity and raises `NotImplementedError` if used (deferred with the rest of that backend).

## Conformance (the gate for this change)
`src/conformance/doc_boundary_parity.py` asserts a packed multi-document forward **equals each document's standalone forward** (fp32 ~1e-4) — the check that catches silent cross-boundary leaks. Passes for **pure-Mamba, hybrid, and the grad-checkpoint path** (max|diff| < 1e-3).

- Full suite **274 passed**.
- **M4 smoke gate exact**: resume max|loss diff| 2.4e-7, eval runs.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)