### PR TITLE
feat(data): [M10] dtype-aware token packing (uint16/uint32) + Qwen2.5 tokenizer (#90)

### DIFF
--- a/config/manifests/student-1b-attn12pct.yaml
+++ b/config/manifests/student-1b-attn12pct.yaml
@@ -1,0 +1,20 @@
+# Student sweep manifest (#98) — one architecture trial against the FROZEN teacher signal.
+# A sweep is a set of sibling manifests (this + student-1b-attn8pct.yaml ...) pointing at the
+# SAME teacher_outputs/corpus; only `layout` changes. Changing layout invalidates nothing
+# upstream (docs/design/10-distillation.md). Resolves to a student config via the harness (#98).
+student: 1b-attn12pct
+conversion_teacher: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B   # #91/#93
+tokenizer: qwen25                # Qwen2.5 vocab 151646 (#90)
+seq_len: 8192
+layout:
+  d_model: 2048
+  n_layers: 48
+  attention_every: 8             # ~12.5% attention
+  state_size: 128                # -> MambaConfig.d_state
+init: mamba-in-the-llama         # or: mohawk  (#99)
+stages: [mixing-match, hidden-align, logit-distill, instruct-sft, reasoning-sft, tool-sft, grpo]  # tool-sft optional
+corpus: poc-distill/corpus/tokenized/qwen25-8k        # #92
+teacher_outputs: poc-distill/teacher-outputs/topk-logits   # #94
+sft: shared/sft/tokenized/qwen25-8k                   # #95/#96/#102
+rl: shared/rl                                          # #103
+schedule: { lr: 3.0e-4, warmup: 0.02, batch_tokens: 1_000_000 }

--- a/config/manifests/student-1b-attn8pct.yaml
+++ b/config/manifests/student-1b-attn8pct.yaml
@@ -1,0 +1,19 @@
+# Sibling sweep manifest (#98) — same frozen teacher signal as student-1b-attn12pct.yaml,
+# only the layout differs (lower attention fraction, larger state). Demonstrates that a sweep
+# reuses corpus + teacher_outputs unchanged; the student layout is the only free variable.
+student: 1b-attn8pct
+conversion_teacher: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+tokenizer: qwen25
+seq_len: 8192
+layout:
+  d_model: 2048
+  n_layers: 48
+  attention_every: 12            # ~8.3% attention (fewer attn layers; lean harder on the SSM)
+  state_size: 192                # wider state to compensate for less attention
+init: mamba-in-the-llama
+stages: [mixing-match, hidden-align, logit-distill, instruct-sft, reasoning-sft, grpo]
+corpus: poc-distill/corpus/tokenized/qwen25-8k
+teacher_outputs: poc-distill/teacher-outputs/topk-logits
+sft: shared/sft/tokenized/qwen25-8k
+rl: shared/rl
+schedule: { lr: 3.0e-4, warmup: 0.02, batch_tokens: 1_000_000 }

--- a/config/student-1b.yaml
+++ b/config/student-1b.yaml
@@ -3,9 +3,8 @@
 # layer placement, and state size are the FREE variables (see docs/design/10-distillation.md).
 # Distilled from DeepSeek-R1-Distill-Qwen-1.5B (#91/#93), NOT pretrained from scratch.
 #
-# NOTE: vocab_size 151646 (Qwen2.5) exceeds the uint16 ceiling, so MambaConfig.validate()
-# REJECTS this config until #90 (uint32 packing + ceiling relaxation) lands. Land this file
-# WITH #90, or treat the validate() error as the expected Phase-0 gate, not a failure.
+# NOTE: vocab_size 151646 (Qwen2.5) exceeds the uint16 ceiling; it packs as uint32 and
+# MambaConfig.validate() accepts it now that #90 (dtype-aware packing) has landed.
 d_model: 2048          # d_inner = expand*d_model = 4096
 n_layers: 48           # ~1 attn per 8 -> 6 attention layers (~12.5%); swept by #98
 d_state: 128           # SSM state size N (Mamba-2 runs wider than Mamba-1's 16) — swept variable

--- a/config/student-1b.yaml
+++ b/config/student-1b.yaml
@@ -1,0 +1,36 @@
+# ~1-1.5B Mamba-2 HYBRID student — distillation sweep seed (epic #65, distillation-first).
+# This is the seed layout the student sweep (#98) searches over: attention fraction,
+# layer placement, and state size are the FREE variables (see docs/design/10-distillation.md).
+# Distilled from DeepSeek-R1-Distill-Qwen-1.5B (#91/#93), NOT pretrained from scratch.
+#
+# NOTE: vocab_size 151646 (Qwen2.5) exceeds the uint16 ceiling, so MambaConfig.validate()
+# REJECTS this config until #90 (uint32 packing + ceiling relaxation) lands. Land this file
+# WITH #90, or treat the validate() error as the expected Phase-0 gate, not a failure.
+d_model: 2048          # d_inner = expand*d_model = 4096
+n_layers: 48           # ~1 attn per 8 -> 6 attention layers (~12.5%); swept by #98
+d_state: 128           # SSM state size N (Mamba-2 runs wider than Mamba-1's 16) — swept variable
+expand: 2
+d_conv: 4
+head_dim: 64           # Mamba-2/SSD: 4096/64 = 64 heads (scalar A per head)
+dt_rank: auto
+
+# Hybrid attention (#67): every 8th block is causal MHA + RoPE. Raise if retrieval probes
+# (#79) lag, lower for speed. attention_every / placement / state size = the sweep variables.
+attn_every: 8
+n_attn_heads: 16       # must divide d_model 2048 -> attn_head_dim = 128
+
+vocab_size: 151646     # Qwen2.5 — FIXED by the conversion teacher for logit/hidden matching.
+                       # Exceeds uint16 (65536) -> uint32 packing (#90). Same vocab POC+prod.
+seq_len: 8192          # long context: reasoning traces + multi-file code (pack traces atomically, #68)
+tie_embeddings: true   # vocab x d_model ~= 311M — tied head is EVEN MORE mandatory at this vocab.
+
+# bf16: distillation trains on CUDA (the state-spaces/mamba kernels are mature there), where
+# bf16 is native and needs no loss scaling. (poc's fp16>bf16 was an MLX/Metal finding, #3.)
+precision: bf16
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: true  # REQUIRED at this depth: recompute layers in backward to fit VRAM.
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/src/data/pack.py
+++ b/src/data/pack.py
@@ -35,7 +35,11 @@ def packing_dtype_for(vocab_or_max_id: int) -> np.dtype:
 
 def typecode_for(dtype) -> str:
     """`array` module typecode for a packed dtype ('H' uint16 / 'I' uint32)."""
-    return _TYPECODE[np.dtype(dtype)]
+    try:
+        return _TYPECODE[np.dtype(dtype)]
+    except KeyError:
+        raise ValueError(
+            f"unsupported packing dtype {np.dtype(dtype).name}; use uint16 or uint32")
 
 
 def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
@@ -51,6 +55,9 @@ def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
     hi = int(np.iinfo(dtype).max)
 
     if isinstance(ids, np.ndarray):
+        if not np.issubdtype(ids.dtype, np.integer):
+            raise ValueError(f"ids array must have an integer dtype, got {ids.dtype} "
+                             "(float ids would silently truncate/wrap on cast)")
         if ids.size and (int(ids.min()) < 0 or int(ids.max()) > hi):
             raise ValueError(f"token id out of range for {dtype.name} [0, {hi}]")
         arr = ids.astype(dtype, copy=False)

--- a/src/data/pack.py
+++ b/src/data/pack.py
@@ -1,10 +1,11 @@
-"""Pack token-id streams into a flat memory-mapped uint16 file.
+"""Pack token-id streams into a flat memory-mapped token file.
 
-uint16 because the OLMo vocab (~50k) fits under 65536 — confirm the actual vocab
-before committing (see MambaConfig.validate / tokenize.load_olmo_tokenizer). The
-loader reads this format directly at train time; no JSON parsing during training.
-
-A small sidecar `<name>.meta.json` records dtype and token count.
+The packed dtype follows the tokenizer vocab: **uint16** for the original POC path
+(OLMo, vocab ~50k < 65536) and **uint32** for the distillation student (Qwen2.5, vocab
+151,646 — see #90 and docs/design/10-distillation.md). `packing_dtype_for` picks it; the
+dtype is recorded in the `<name>.meta.json` sidecar so the loader reads the file back
+correctly with no JSON parsing during training. Defaults preserve the uint16 behavior, so
+existing artifacts are unchanged.
 """
 
 from __future__ import annotations
@@ -16,21 +17,43 @@ from typing import Iterable
 
 import numpy as np
 
+#: Default packed dtype (the POC/legacy path). uint32 is opt-in via `dtype=`.
 DTYPE = np.uint16
+
+#: The uint16 ceiling — vocabs below this pack as uint16, at/above as uint32.
+UINT16_CEILING = 1 << 16
+
+#: array-module typecodes per packed dtype (used by the streaming writer in shard.py).
+_TYPECODE = {np.dtype(np.uint16): "H", np.dtype(np.uint32): "I"}
+
+
+def packing_dtype_for(vocab_or_max_id: int) -> np.dtype:
+    """Smallest unsigned dtype that holds token ids for this vocab / max id: uint16 if it
+    fits under 65536, else uint32 (the only two we pack)."""
+    return np.dtype(np.uint16) if vocab_or_max_id < UINT16_CEILING else np.dtype(np.uint32)
+
+
+def typecode_for(dtype) -> str:
+    """`array` module typecode for a packed dtype ('H' uint16 / 'I' uint32)."""
+    return _TYPECODE[np.dtype(dtype)]
 
 
 def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
-             chunk: int = 1 << 20) -> int:
-    """Write a flat uint16 token file. Returns the number of tokens written."""
+             chunk: int = 1 << 20, dtype=DTYPE) -> int:
+    """Write a flat token file in `dtype` (uint16 or uint32). Returns the tokens written.
+
+    Validates the ORIGINAL ids against `dtype`'s range before casting (casting first would
+    silently wrap out-of-range / negative ids). The chosen dtype is recorded in the
+    `.meta.json` sidecar so `open_packed` reads the file back correctly."""
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
+    dtype = np.dtype(dtype)
+    hi = int(np.iinfo(dtype).max)
 
     if isinstance(ids, np.ndarray):
-        # Validate the ORIGINAL values: casting to uint16 first would silently
-        # wrap out-of-range / negative ids and defeat the check.
-        if ids.size and (int(ids.min()) < 0 or int(ids.max()) >= 65536):
-            raise ValueError("token id out of range for uint16 [0, 65535]")
-        arr = ids.astype(DTYPE, copy=False)
+        if ids.size and (int(ids.min()) < 0 or int(ids.max()) > hi):
+            raise ValueError(f"token id out of range for {dtype.name} [0, {hi}]")
+        arr = ids.astype(dtype, copy=False)
         arr.tofile(out_path)
         n = arr.size
     else:
@@ -38,40 +61,55 @@ def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
         with open(out_path, "wb") as f:
             buf = []
             for tid in ids:
-                if tid < 0 or tid >= 65536:
-                    raise ValueError("token id out of range for uint16 [0, 65535]")
+                if tid < 0 or tid > hi:
+                    raise ValueError(f"token id out of range for {dtype.name} [0, {hi}]")
                 buf.append(tid)
                 if len(buf) >= chunk:
-                    np.asarray(buf, dtype=DTYPE).tofile(f)
+                    np.asarray(buf, dtype=dtype).tofile(f)
                     n += len(buf)
                     buf = []
             if buf:
-                np.asarray(buf, dtype=DTYPE).tofile(f)
+                np.asarray(buf, dtype=dtype).tofile(f)
                 n += len(buf)
 
     with open(out_path.with_suffix(".meta.json"), "w") as f:
-        json.dump({"dtype": "uint16", "n_tokens": int(n)}, f)
+        json.dump({"dtype": dtype.name, "n_tokens": int(n)}, f)
     return n
 
 
+def packed_dtype(path: Path) -> np.dtype:
+    """The packed dtype recorded in `<name>.meta.json` (fallback uint16 for legacy files)."""
+    meta_path = Path(path).with_suffix(".meta.json")
+    if meta_path.exists():
+        return np.dtype(json.loads(meta_path.read_text()).get("dtype", "uint16"))
+    return np.dtype(DTYPE)
+
+
 def open_packed(path: Path) -> np.memmap:
-    """Memory-map a packed file read-only as uint16."""
+    """Memory-map a packed file read-only at the dtype its sidecar records (uint16 legacy)."""
     path = Path(path)
     meta_path = path.with_suffix(".meta.json")
     n = None
+    dtype = np.dtype(DTYPE)
     if meta_path.exists():
-        n = json.loads(meta_path.read_text())["n_tokens"]
-    return np.memmap(path, dtype=DTYPE, mode="r", shape=(n,) if n else None)
+        meta = json.loads(meta_path.read_text())
+        n = meta["n_tokens"]
+        dtype = np.dtype(meta.get("dtype", "uint16"))
+    return np.memmap(path, dtype=dtype, mode="r", shape=(n,) if n else None)
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--in", dest="inp", type=Path, required=True, help=".npy uint16 ids")
+    ap.add_argument("--in", dest="inp", type=Path, required=True, help=".npy uint16/uint32 ids")
     ap.add_argument("--out", type=Path, required=True, help="packed .bin")
+    ap.add_argument("--dtype", choices=("auto", "uint16", "uint32"), default="auto",
+                    help="packed dtype; 'auto' picks uint16/uint32 from the max id")
     args = ap.parse_args()
     ids = np.load(args.inp)
-    n = pack_ids(ids, args.out)
-    print(f"packed {n} tokens -> {args.out}")
+    dtype = (packing_dtype_for(int(ids.max()) + 1 if ids.size else 0)
+             if args.dtype == "auto" else np.dtype(args.dtype))
+    n = pack_ids(ids, args.out, dtype=dtype)
+    print(f"packed {n} tokens ({dtype.name}) -> {args.out}")
 
 
 if __name__ == "__main__":

--- a/src/data/shard.py
+++ b/src/data/shard.py
@@ -7,13 +7,13 @@ to low-GB) to keep R2 Class-A op counts down. Alongside each token shard we writ
 #68 can **reset the SSM state at boundaries** instead of letting recurrent state bleed
 across packed docs.
 
-ABOVE THE SEAM — numpy + stdlib only. Token shards are the same flat uint16 format as
-``pack.py`` (so the existing ``PackedLoader`` reads them unchanged); the `.bounds` sidecar
-is the new, optional artifact a boundary-aware loader consumes. The storage URI is an
-fsspec seam (`file://` now, `s3://` at #80) — same code path.
+ABOVE THE SEAM — numpy + stdlib only. Token shards are the same flat format as ``pack.py``
+(uint16 for the POC vocab, uint32 for the Qwen2.5 distillation vocab, #90 — the dtype is
+recorded in the manifest, so ``PackedLoader``/``open_shard`` read them back correctly); the
+`.bounds` sidecar is the new artifact a boundary-aware loader consumes.
 
 Layout per output dir:
-    part-00000.bin     uint16 tokens, length = n_sequences * seq_len
+    part-00000.bin     uint16/uint32 tokens, length = n_sequences * seq_len
     part-00000.bounds  uint8 doc-start flags, same length
     manifest.json      {seq_len, dtype, tokenizer, shards:[{name,n_sequences,n_tokens}], ...}
 """
@@ -28,12 +28,12 @@ from typing import Iterable, List, Sequence, Tuple
 
 import numpy as np
 
-DTYPE = np.uint16
+from .pack import DTYPE, typecode_for
 
 
 def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int = 8192,
                    shard_size_mb: int = 512, prefix: str = "part", tokenizer: str = "",
-                   chunk_align: int | None = None, pad_id: int = 0) -> dict:
+                   chunk_align: int | None = None, pad_id: int = 0, dtype=DTYPE) -> dict:
     """Pack per-document token lists into fixed `seq_len` sequences across few large shards,
     writing token `.bin` + doc-boundary `.bounds` sidecars + a `manifest.json`. The final
     partial sequence (< seq_len) is dropped. Returns the manifest dict.
@@ -44,30 +44,36 @@ def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int
     `chunk_align` (set it to the model's `chunk_size`) pads each document up to a multiple of
     that length with `pad_id`, so every document **starts on a chunk boundary** — the
     requirement for the SSM's packing-aware boundary reset (#68). `seq_len` should be a
-    multiple of `chunk_align`."""
+    multiple of `chunk_align`.
+
+    `dtype` is the packed token dtype: uint16 (POC default) or uint32 (Qwen2.5 vocab, #90).
+    The shards are the same flat format as `pack.py`; the manifest records the dtype."""
+    dtype = np.dtype(dtype)
+    hi = int(np.iinfo(dtype).max)
     if chunk_align is not None:
         if chunk_align <= 0:
             raise ValueError(f"chunk_align must be positive, got {chunk_align}")
         if seq_len % chunk_align:
             raise ValueError(
                 f"seq_len {seq_len} must be a multiple of chunk_align {chunk_align}")
-    if not 0 <= pad_id < 65536:
-        raise ValueError(f"pad_id {pad_id} out of uint16 range [0, 65535]")
+    if not 0 <= pad_id <= hi:
+        raise ValueError(f"pad_id {pad_id} out of {dtype.name} range [0, {hi}]")
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
     # Shard budget rounded down to a whole number of sequences (>= 1 sequence).
-    budget = max(seq_len, (shard_size_mb * (1 << 20)) // 2)   # 2 bytes/token (uint16)
+    bytes_per_token = dtype.itemsize
+    budget = max(seq_len, (shard_size_mb * (1 << 20)) // bytes_per_token)
     budget -= budget % seq_len
 
-    tok_buf = array("H")          # uint16 — raises OverflowError on out-of-range ids
+    tok_buf = array(typecode_for(dtype))   # uint16 'H' / uint32 'I' — overflow-checked
     bnd_buf = bytearray()
     shards: List[dict] = []
     state = {"idx": 0, "docs": 0, "seqs": 0, "tokens": 0}
 
     def emit(n_tokens: int) -> None:
         name = f"{prefix}-{state['idx']:05d}"
-        toks = np.frombuffer(tok_buf, dtype=DTYPE, count=n_tokens)
+        toks = np.frombuffer(tok_buf, dtype=dtype, count=n_tokens)
         toks.tofile(out_dir / f"{name}.bin")
         del toks   # release the exported buffer before resizing tok_buf below
         (out_dir / f"{name}.bounds").write_bytes(bytes(bnd_buf[:n_tokens]))
@@ -90,7 +96,7 @@ def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int
             rem = len(ids) % chunk_align
             if rem:
                 ids = ids + [pad_id] * (chunk_align - rem)
-        tok_buf.extend(ids)                       # OverflowError if any id not in [0, 65535]
+        tok_buf.extend(ids)                       # OverflowError if any id exceeds the dtype
         bnd_buf.append(1)
         bnd_buf.extend(b"\x00" * (len(ids) - 1))
         while len(tok_buf) >= budget:
@@ -100,7 +106,7 @@ def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int
     if full:
         emit(full)
 
-    manifest = {"seq_len": seq_len, "dtype": "uint16", "tokenizer": tokenizer,
+    manifest = {"seq_len": seq_len, "dtype": dtype.name, "tokenizer": tokenizer,
                 "n_documents": state["docs"], "n_sequences": state["seqs"],
                 "n_tokens": state["tokens"], "shards": shards}
     (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
@@ -108,9 +114,14 @@ def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int
 
 
 def open_shard(out_dir, name: str) -> Tuple[np.memmap, np.memmap]:
-    """Memory-map a shard's (tokens uint16, boundaries uint8) pair, read-only."""
+    """Memory-map a shard's (tokens, boundaries uint8) pair, read-only. Token dtype comes
+    from the manifest (uint16 / uint32; fallback uint16 for legacy shards)."""
     out_dir = Path(out_dir)
-    toks = np.memmap(out_dir / f"{name}.bin", dtype=DTYPE, mode="r")
+    manifest_path = Path(out_dir) / "manifest.json"
+    dtype = np.dtype(DTYPE)
+    if manifest_path.exists():
+        dtype = np.dtype(json.loads(manifest_path.read_text()).get("dtype", "uint16"))
+    toks = np.memmap(out_dir / f"{name}.bin", dtype=dtype, mode="r")
     bnds = np.memmap(out_dir / f"{name}.bounds", dtype=np.uint8, mode="r")
     return toks, bnds
 
@@ -141,25 +152,30 @@ def main() -> None:
     ap.add_argument("--seq-len", type=int, default=8192)
     ap.add_argument("--shard-size-mb", type=int, default=512)
     ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
-    ap.add_argument("--tokenizer", choices=("starcoder2", "olmo"), default="starcoder2")
+    ap.add_argument("--tokenizer", choices=("qwen25", "starcoder2", "olmo"),
+                    default="qwen25")
     ap.add_argument("--model-id", default=None)
     args = ap.parse_args()
 
     from .corpus import iter_shard_texts
-    from .tokenize import (ByteTokenizer, load_olmo_tokenizer,
+    from .pack import packing_dtype_for
+    from .tokenize import (ByteTokenizer, load_olmo_tokenizer, load_qwen25_tokenizer,
                            load_starcoder2_tokenizer, tokenize_docs)
 
     if args.byte_fallback:
         tok = ByteTokenizer()
     elif args.tokenizer == "olmo":
         tok = load_olmo_tokenizer(args.model_id)
-    else:
+    elif args.tokenizer == "starcoder2":
         tok = load_starcoder2_tokenizer(args.model_id)
+    else:
+        tok = load_qwen25_tokenizer(args.model_id)
 
     tok_label = "byte" if args.byte_fallback else getattr(tok, "name_or_path", args.tokenizer)
+    dtype = packing_dtype_for(tok.vocab_size)          # uint16 (POC) / uint32 (Qwen2.5)
     docs = tokenize_docs(iter_shard_texts(args.inp), tok)
     manifest = pack_sequences(docs, args.out, seq_len=args.seq_len,
-                              shard_size_mb=args.shard_size_mb, tokenizer=tok_label)
+                              shard_size_mb=args.shard_size_mb, tokenizer=tok_label, dtype=dtype)
     print(f"packed {manifest['n_sequences']} seq x {args.seq_len} "
           f"({manifest['n_tokens']} tokens, {len(manifest['shards'])} shard(s)) -> {args.out}")
 

--- a/src/data/split.py
+++ b/src/data/split.py
@@ -14,7 +14,7 @@ from typing import Tuple
 
 import numpy as np
 
-from .pack import open_packed, DTYPE
+from .pack import open_packed, packed_dtype
 
 
 def split_packed(packed_path: Path, out_dir: Path, val_tokens: int,
@@ -26,6 +26,7 @@ def split_packed(packed_path: Path, out_dir: Path, val_tokens: int,
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     data = open_packed(packed_path)
+    dtype = packed_dtype(packed_path)          # uint16 (POC) / uint32 (Qwen2.5) — preserved
     n = data.shape[0]
     if val_tokens >= n:
         raise ValueError(f"val_tokens={val_tokens} >= total tokens={n}")
@@ -36,11 +37,11 @@ def split_packed(packed_path: Path, out_dir: Path, val_tokens: int,
         val, train = data[:val_tokens], data[val_tokens:]
 
     train_path, val_path = out_dir / "train.bin", out_dir / "val.bin"
-    np.asarray(train, dtype=DTYPE).tofile(train_path)
-    np.asarray(val, dtype=DTYPE).tofile(val_path)
+    np.asarray(train, dtype=dtype).tofile(train_path)
+    np.asarray(val, dtype=dtype).tofile(val_path)
     for p, a in ((train_path, train), (val_path, val)):
         with open(p.with_suffix(".meta.json"), "w") as f:
-            json.dump({"dtype": "uint16", "n_tokens": int(a.shape[0])}, f)
+            json.dump({"dtype": dtype.name, "n_tokens": int(a.shape[0])}, f)
     return train_path, val_path
 
 

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -43,9 +43,9 @@ def _load_hf_tokenizer(candidates, model_id, label, max_vocab: int = _MAX_PACKAB
     for mid in ids:
         try:
             tok = AutoTokenizer.from_pretrained(mid)
-            if tok.vocab_size >= max_vocab:
+            if tok.vocab_size > max_vocab:   # max id = vocab-1 must fit (uint32: 2**32-1)
                 raise ValueError(f"{mid} vocab {tok.vocab_size} too large to pack "
-                                 f"(>= {max_vocab})")
+                                 f"(> {max_vocab})")
             return tok
         except Exception as e:  # pragma: no cover - network/availability dependent
             last_err = e

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -1,16 +1,16 @@
-"""Tokenize raw text to token-id streams using the OLMo tokenizer.
+"""Tokenize raw text to token-id streams using a configured HF tokenizer.
 
-Use the OLMo tokenizer (via HuggingFace) so the vocab matches AI2's, enabling
-later comparison.
+The packed token dtype follows the tokenizer vocab (`pack.packing_dtype_for`):
+- **OLMo** (``allenai/OLMo-7B-hf``, vocab 50280 < 65536) — the original POC tokenizer,
+  packs as uint16. (``allenai/OLMo-2-1124-7B`` at 100278 was rejected at POC scale.)
+- **Qwen2.5** (vocab 151,646) — fixed by the distillation conversion teacher
+  (DeepSeek-R1-Distill-Qwen-1.5B); exceeds uint16, so it packs as **uint32** (#90, see
+  docs/design/10-distillation.md). This is the scale-up / distillation default.
+- **StarCoder2** (vocab ~49,152) — a legacy code-corpus tokenizer (the old uint16 scale
+  pick, now superseded by Qwen2.5).
 
-CONFIRMED (issue #4): ``allenai/OLMo-7B-hf`` is reachable on the HF Hub with
-vocab_size=50280 (eos_token_id=50279), which fits the uint16 packing requirement
-(< 65536). ``allenai/OLMo-2-1124-7B`` is deliberately NOT a candidate: its vocab is
-100278 (> 65536) and can never satisfy the uint16 constraint enforced by
-``MambaConfig.validate()``.
-
-A byte-level fallback tokenizer is provided ONLY for offline pipeline testing; it
-is not vocab-compatible with OLMo and must not be used for a real run.
+A byte-level fallback tokenizer is provided ONLY for offline pipeline testing; it is not
+vocab-compatible with any real tokenizer and must not be used for a real run.
 """
 
 from __future__ import annotations
@@ -20,16 +20,22 @@ import contextlib
 from pathlib import Path
 from typing import Iterable, Iterator, List
 
-# Confirmed OLMo tokenizer ids on the HF Hub (uint16-compatible, vocab < 65536).
+# OLMo — the POC tokenizer (uint16-compatible, vocab < 65536).
 OLMO_TOKENIZER_CANDIDATES = ("allenai/OLMo-7B-hf",)
-# StarCoder2 tokenizer (#74): mixed prose+code, vocab ~49,152 — FITS uint16 (< 65536).
-# Llama-3 (~128,256) deliberately excluded: it exceeds the bound and would force uint32
-# packing (~2x shard storage) + relaxing MambaConfig.validate(). Flag that before choosing.
+# Qwen2.5 (#90) — fixed by the conversion teacher; vocab 151,646 -> uint32 packing. The
+# DeepSeek-R1-Distill-Qwen variants share this exact tokenizer.
+QWEN25_TOKENIZER_CANDIDATES = ("Qwen/Qwen2.5-1.5B",
+                               "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
+# StarCoder2 — legacy code-corpus tokenizer (~49,152, uint16); superseded by Qwen2.5.
 STARCODER2_TOKENIZER_CANDIDATES = ("bigcode/starcoder2-3b", "bigcode/starcoder2-15b")
 
+#: Largest vocab we can pack (uint32 ceiling). uint16 vs uint32 is chosen per-vocab.
+_MAX_PACKABLE_VOCAB = 1 << 32
 
-def _load_hf_tokenizer(candidates, model_id, label):
-    """Load an HF tokenizer, confirming its vocab fits uint16 packing (< 65536)."""
+
+def _load_hf_tokenizer(candidates, model_id, label, max_vocab: int = _MAX_PACKABLE_VOCAB):
+    """Load an HF tokenizer, confirming its vocab fits the packed token dtype (uint32
+    ceiling by default; uint16 vs uint32 is then chosen per-vocab by `pack`)."""
     from transformers import AutoTokenizer  # imported lazily
 
     ids = (model_id,) if model_id else candidates
@@ -37,8 +43,9 @@ def _load_hf_tokenizer(candidates, model_id, label):
     for mid in ids:
         try:
             tok = AutoTokenizer.from_pretrained(mid)
-            if tok.vocab_size >= 65536:
-                raise ValueError(f"{mid} vocab {tok.vocab_size} too large for uint16")
+            if tok.vocab_size >= max_vocab:
+                raise ValueError(f"{mid} vocab {tok.vocab_size} too large to pack "
+                                 f"(>= {max_vocab})")
             return tok
         except Exception as e:  # pragma: no cover - network/availability dependent
             last_err = e
@@ -46,12 +53,18 @@ def _load_hf_tokenizer(candidates, model_id, label):
 
 
 def load_olmo_tokenizer(model_id: str | None = None):
-    """Load the OLMo tokenizer via transformers. Raises if unavailable."""
+    """Load the OLMo tokenizer (POC path, uint16). Raises if unavailable."""
     return _load_hf_tokenizer(OLMO_TOKENIZER_CANDIDATES, model_id, "OLMo")
 
 
+def load_qwen25_tokenizer(model_id: str | None = None):
+    """Load the Qwen2.5 tokenizer — the distillation-student default (vocab 151,646 ->
+    uint32 packing, #90), shared with the conversion teacher. Raises if unavailable."""
+    return _load_hf_tokenizer(QWEN25_TOKENIZER_CANDIDATES, model_id, "Qwen2.5")
+
+
 def load_starcoder2_tokenizer(model_id: str | None = None):
-    """Load the StarCoder2 tokenizer (#74 scale-run default). Raises if unavailable."""
+    """Load the StarCoder2 tokenizer (legacy code-corpus, uint16). Raises if unavailable."""
     return _load_hf_tokenizer(STARCODER2_TOKENIZER_CANDIDATES, model_id, "StarCoder2")
 
 
@@ -121,9 +134,11 @@ def _open_texts(inp: Path):
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--in", dest="inp", type=Path, required=True)
-    ap.add_argument("--out", type=Path, required=True, help="uint16 ids; .bin streams "
+    ap.add_argument("--out", type=Path, required=True, help="uint16/uint32 ids; .bin streams "
                     "straight into the packed format, .npy goes through `pack` separately")
     ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--tokenizer", choices=("olmo", "qwen25", "starcoder2"), default="olmo",
+                    help="HF tokenizer; the packed dtype is uint16/uint32 per its vocab")
     ap.add_argument("--model-id", default=None)
     ap.add_argument("--max-tokens", type=int, default=None,
                     help="stop after this many tokens (caps the scale run)")
@@ -131,7 +146,11 @@ def main() -> None:
     if args.max_tokens is not None and args.max_tokens <= 0:
         ap.error("--max-tokens must be positive (a value <= 0 silently yields 0 tokens)")
 
-    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
+    from .pack import packing_dtype_for
+    _loaders = {"olmo": load_olmo_tokenizer, "qwen25": load_qwen25_tokenizer,
+                "starcoder2": load_starcoder2_tokenizer}
+    tok = ByteTokenizer() if args.byte_fallback else _loaders[args.tokenizer](args.model_id)
+    dtype = packing_dtype_for(tok.vocab_size)   # uint16 (POC) / uint32 (Qwen2.5)
     # Input is either a one-doc-per-line text file or corpus Parquet shards (dir/.parquet).
     with _open_texts(args.inp) as texts:
         stream = _capped(tokenize_texts(texts, tok), args.max_tokens)
@@ -141,14 +160,14 @@ def main() -> None:
             # sidecar, so `split` can consume the output directly.
             from .pack import pack_ids
 
-            n = pack_ids(stream, args.out)
-            print(f"tokenized+packed {n} ids (vocab {tok.vocab_size}) -> {args.out}")
+            n = pack_ids(stream, args.out, dtype=dtype)
+            print(f"tokenized+packed {n} ids ({dtype.name}, vocab {tok.vocab_size}) -> {args.out}")
         else:
             import numpy as np
 
-            ids = np.fromiter(stream, dtype=np.uint16)
+            ids = np.fromiter(stream, dtype=dtype)
             np.save(args.out, ids)
-            print(f"tokenized {ids.size} ids (vocab {tok.vocab_size}) -> {args.out}")
+            print(f"tokenized {ids.size} ids ({dtype.name}, vocab {tok.vocab_size}) -> {args.out}")
 
 
 if __name__ == "__main__":

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -53,7 +53,9 @@ class MambaConfig:
     dt_rank: Union[int, str] = "auto"
 
     # --- vocab / sequence ---
-    # OLMo tokenizer vocab. MUST stay < 65536 to pack token ids as uint16.
+    # Tokenizer vocab. Determines the packed token dtype (see `packing_dtype`): < 65536
+    # packs as uint16 (POC: OLMo 50280), otherwise uint32 (Qwen2.5 151646, #90). Bounded
+    # by the uint32 ceiling (2**32).
     vocab_size: int = 50280
     seq_len: int = 1024
     tie_embeddings: bool = True
@@ -186,11 +188,16 @@ class MambaConfig:
         """Total trainable parameters (sum of `parameter_breakdown()`)."""
         return sum(self.parameter_breakdown().values())
 
+    @property
+    def packing_dtype(self) -> str:
+        """The token packing dtype implied by the vocab: 'uint16' (< 65536) or 'uint32'."""
+        return "uint16" if self.vocab_size < 65536 else "uint32"
+
     def validate(self) -> None:
-        if self.vocab_size >= 65536:
+        if self.vocab_size >= (1 << 32):
             raise ValueError(
-                f"vocab_size={self.vocab_size} does not fit uint16 packing (<65536). "
-                "Either confirm the tokenizer vocab or change the packed dtype."
+                f"vocab_size={self.vocab_size} exceeds the uint32 packing ceiling (2**32). "
+                "Token ids would not fit the packed token files."
             )
         if self.precision not in ("fp32", "fp16", "bf16"):
             raise ValueError(f"unknown precision {self.precision!r}")

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -194,10 +194,10 @@ class MambaConfig:
         return "uint16" if self.vocab_size < 65536 else "uint32"
 
     def validate(self) -> None:
-        if self.vocab_size >= (1 << 32):
+        if self.vocab_size > (1 << 32):     # max id = vocab_size-1 must fit uint32 (2**32-1)
             raise ValueError(
-                f"vocab_size={self.vocab_size} exceeds the uint32 packing ceiling (2**32). "
-                "Token ids would not fit the packed token files."
+                f"vocab_size={self.vocab_size} exceeds the uint32 packing capacity "
+                "(max 2**32 token ids). Token ids would not fit the packed token files."
             )
         if self.precision not in ("fp32", "fp16", "bf16"):
             raise ValueError(f"unknown precision {self.precision!r}")

--- a/tests/test_packing_dtype.py
+++ b/tests/test_packing_dtype.py
@@ -1,0 +1,107 @@
+"""Dtype-aware token packing (#90): uint16 (POC) stays the default; uint32 unlocks the
+Qwen2.5 vocab (151,646). Pure numpy + stdlib, no backend.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from src.data.pack import (DTYPE, open_packed, pack_ids, packed_dtype, packing_dtype_for,
+                          typecode_for)
+from src.data.loader import PackedLoader
+from src.data.shard import open_shard, pack_sequences
+from src.model.blocks import MambaConfig, load_config
+
+
+# --- dtype selection -----------------------------------------------------------------
+def test_packing_dtype_for():
+    assert packing_dtype_for(256) == np.dtype(np.uint16)
+    assert packing_dtype_for(50280) == np.dtype(np.uint16)      # OLMo POC
+    assert packing_dtype_for(65535) == np.dtype(np.uint16)
+    assert packing_dtype_for(65536) == np.dtype(np.uint32)      # at the ceiling -> uint32
+    assert packing_dtype_for(151646) == np.dtype(np.uint32)     # Qwen2.5
+    assert typecode_for(np.uint16) == "H" and typecode_for(np.uint32) == "I"
+
+
+# --- pack_ids round-trips ------------------------------------------------------------
+def test_pack_ids_uint16_default_unchanged(tmp_path):
+    p = tmp_path / "u16.bin"
+    n = pack_ids([1, 2, 3, 65535], p)                           # default dtype
+    arr = open_packed(p)
+    assert n == 4 and arr.dtype == np.uint16 and list(arr) == [1, 2, 3, 65535]
+    assert json.loads((tmp_path / "u16.meta.json").read_text())["dtype"] == "uint16"
+    assert packed_dtype(p) == np.dtype(np.uint16)
+
+
+def test_pack_ids_uint32_roundtrip(tmp_path):
+    p = tmp_path / "u32.bin"
+    ids = [1, 2, 70000, 151645, 3]                              # 70000/151645 > uint16 max
+    n = pack_ids(ids, p, dtype=np.uint32)
+    arr = open_packed(p)                                        # reads dtype from sidecar
+    assert n == 5 and arr.dtype == np.uint32 and list(arr) == ids
+    assert packed_dtype(p) == np.dtype(np.uint32)
+
+
+def test_pack_ids_rejects_out_of_range(tmp_path):
+    with pytest.raises(ValueError):
+        pack_ids([1, 70000], tmp_path / "bad.bin", dtype=np.uint16)        # > uint16 max
+    with pytest.raises(ValueError):
+        pack_ids(np.array([1, 70000]), tmp_path / "bad2.bin", dtype=np.uint16)
+
+
+def test_pack_ids_ndarray_uint32(tmp_path):
+    p = tmp_path / "arr.bin"
+    pack_ids(np.array([0, 151645], dtype=np.int64), p, dtype=np.uint32)
+    assert list(open_packed(p)) == [0, 151645]
+
+
+def test_loader_reads_uint32(tmp_path):
+    p = tmp_path / "u32.bin"
+    pack_ids(list(range(70000, 70000 + 64)), p, dtype=np.uint32)
+    loader = PackedLoader(p, seq_len=4, batch_size=2, shuffle=False)
+    inputs, _ = next(iter(loader.epoch()))
+    assert inputs.dtype == np.int64 and int(inputs.max()) >= 70000   # uint32 ids survive
+
+
+def test_legacy_file_without_dtype_meta_defaults_uint16(tmp_path):
+    # A meta.json missing "dtype" (an old artifact) is read back as uint16.
+    p = tmp_path / "legacy.bin"
+    np.array([1, 2, 3], dtype=np.uint16).tofile(p)
+    (tmp_path / "legacy.meta.json").write_text(json.dumps({"n_tokens": 3}))
+    assert packed_dtype(p) == np.dtype(np.uint16)
+    assert list(open_packed(p)) == [1, 2, 3]
+
+
+# --- shard path ----------------------------------------------------------------------
+def test_pack_sequences_uint32_roundtrip(tmp_path):
+    docs = [[1, 2, 70000, 151645], [5, 6, 7, 8]]
+    m = pack_sequences(docs, tmp_path, seq_len=4, dtype=np.uint32, tokenizer="qwen25")
+    assert m["dtype"] == "uint32"
+    toks, _ = open_shard(tmp_path, m["shards"][0]["name"])      # dtype read from manifest
+    assert toks.dtype == np.uint32 and list(toks) == [1, 2, 70000, 151645, 5, 6, 7, 8]
+
+
+def test_pack_sequences_uint32_allows_large_pad_id(tmp_path):
+    # pad_id beyond uint16 is fine under uint32 (would raise under the default uint16).
+    m = pack_sequences([[1, 2, 3]], tmp_path, seq_len=2, chunk_align=2, pad_id=70000,
+                       dtype=np.uint32)
+    toks, _ = open_shard(tmp_path, m["shards"][0]["name"])
+    assert 70000 in list(toks)
+
+
+# --- config gate ---------------------------------------------------------------------
+def test_mambaconfig_packing_dtype_and_validate():
+    base = dict(d_model=64, n_layers=2, head_dim=16)
+    assert MambaConfig(vocab_size=50280, **base).packing_dtype == "uint16"
+    big = MambaConfig(vocab_size=151646, **base)
+    assert big.packing_dtype == "uint32"
+    big.validate()                                              # no longer raises (#90)
+    with pytest.raises(ValueError):
+        MambaConfig(vocab_size=1 << 32, **base).validate()     # above the uint32 ceiling
+
+
+def test_student_1b_config_validates():
+    cfg = load_config("config/student-1b.yaml")
+    cfg.validate()
+    assert cfg.vocab_size == 151646 and cfg.packing_dtype == "uint32"

--- a/tests/test_packing_dtype.py
+++ b/tests/test_packing_dtype.py
@@ -22,6 +22,13 @@ def test_packing_dtype_for():
     assert packing_dtype_for(65536) == np.dtype(np.uint32)      # at the ceiling -> uint32
     assert packing_dtype_for(151646) == np.dtype(np.uint32)     # Qwen2.5
     assert typecode_for(np.uint16) == "H" and typecode_for(np.uint32) == "I"
+    with pytest.raises(ValueError):
+        typecode_for(np.int64)                                  # clear error, not KeyError
+
+
+def test_pack_ids_rejects_float_array(tmp_path):
+    with pytest.raises(ValueError):
+        pack_ids(np.array([0.0, 1.0, 2.0]), tmp_path / "f.bin")   # float ids would truncate
 
 
 # --- pack_ids round-trips ------------------------------------------------------------
@@ -97,8 +104,9 @@ def test_mambaconfig_packing_dtype_and_validate():
     big = MambaConfig(vocab_size=151646, **base)
     assert big.packing_dtype == "uint32"
     big.validate()                                              # no longer raises (#90)
+    MambaConfig(vocab_size=1 << 32, **base).validate()         # max id 2**32-1 still fits
     with pytest.raises(ValueError):
-        MambaConfig(vocab_size=1 << 32, **base).validate()     # above the uint32 ceiling
+        MambaConfig(vocab_size=(1 << 32) + 1, **base).validate()   # over the uint32 capacity
 
 
 def test_student_1b_config_validates():

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -77,7 +77,7 @@ def test_known_poc_count():
 def test_family_config_valid_and_on_target(name, target):
     cfg = _cfg(name)
     cfg.validate()                                   # raises on any invariant break
-    assert cfg.vocab_size < 65536
+    assert cfg.packing_dtype == "uint16"             # the POC family is uint16-packable
     assert cfg.d_inner % cfg.head_dim == 0
     dev = abs(cfg.num_parameters() - target) / target
     assert dev <= 0.05, f"{name}: {cfg.num_parameters()/1e6:.1f}M is {dev:.1%} off {target/1e6:.0f}M"


### PR DESCRIPTION
## Summary
Part of reconciling the codebase with the **distillation-first** rewrite of epic #65. The pivot fixes the tokenizer to **Qwen2.5 (vocab 151,646)**, which exceeds the uint16 packing ceiling — so token packing must support **uint32**. This lifts the ceiling while keeping the POC path **byte-identical** (uint16 default; uint32 opt-in, derived from vocab).

- **`pack.py`** — `pack_ids`/`open_packed` take a `dtype` (default uint16), validate against the dtype range, and record the real dtype in `.meta.json` (read back on open; missing dtype → uint16 for legacy files). New `packing_dtype_for(vocab)` / `typecode_for` / `packed_dtype`.
- **`shard.py`** — `pack_sequences`/`open_shard` dtype-aware: array typecode `H`/`I`, bytes-per-token from `itemsize`, pad_id bound from the dtype, manifest records the dtype.
- **`split.py`** — preserves the input's dtype into the train/val shards.
- **`blocks.py`** — `MambaConfig.validate()` ceiling relaxed to **uint32 (2³²)**; new `packing_dtype` property. This is what lets `config/student-1b.yaml` (Qwen2.5) validate.
- **`tokenize.py`** — `load_qwen25_tokenizer` (Qwen / DeepSeek-R1-Distill-Qwen ids); the vocab guard is the uint32 ceiling; CLIs pick the packed dtype per tokenizer vocab.

Also lands the distillation-sweep configs: `config/student-1b.yaml` + `config/manifests/student-1b-attn{8,12}pct.yaml` (sweep schema/examples for #98).

## Tests
- New `tests/test_packing_dtype.py`: dtype selection, uint16/uint32 round-trips through pack/shard/loader, legacy-file fallback, and the **config gate** (`load_config('config/student-1b.yaml').validate()` → `packing_dtype == 'uint32'`).
- Full suite **286 passed**; **M4 smoke gate exact** (uint16 path byte-identical, resume diff 2.4e-7).

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)