### PR TITLE
docs: reconcile design docs + framing with the distillation-first pivot (#65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,15 @@ Consequences of the seam that shape how code is written:
 
 Model dims and run params live in `config/toy.yaml` and `config/poc.yaml`, loaded into
 `MambaConfig` (`src/model/blocks.py`). `MambaConfig.validate()` enforces cross-cutting
-invariants (notably `vocab_size < 65536` for uint16 token packing). The YAML **comments
-are the decision record** — read them before changing values. Key locked decisions:
+invariants; **token packing is dtype-aware (#90)** — `vocab < 65536` packs as **uint16**
+(the original POC: OLMo-7B-hf), at/above it packs as **uint32** (the distillation student:
+Qwen2.5, vocab 151,646 — see `config/student-1b.yaml` and `docs/design/10-distillation.md`).
+The ceiling `validate()` enforces is now uint32 (`2**32`). The YAML **comments are the
+decision record** — read them before changing values. Key locked decisions:
 
 - **toy.yaml** (smoke/correctness): tiny, `fp32` for bit-exact fixed-seed resume,
   `vocab_size 256` (byte-fallback tokenizer, offline).
-- **poc.yaml** (~100M scale run): `vocab_size 50280` (OLMo-7B-hf, confirmed `<65536`),
+- **poc.yaml** (~100M scale run): `vocab_size 50280` (OLMo-7B-hf, confirmed `<65536`, uint16),
   `precision fp16` + (dynamic) loss scaling (~18% faster than bf16 on Metal per the M1
   micro-benchmark — **do not assume bf16**), tied embedding **mandatory** (~38M of
   ~100M params), `grad_checkpoint: true` (required at this depth — see below).

--- a/docs/design/08-corpus-pipeline.md
+++ b/docs/design/08-corpus-pipeline.md
@@ -72,6 +72,12 @@ it early (only the IDs stream from the Hub; the blobs come from SWH S3).
 
 ## Tokenize + shard (Phase 3, #74)
 
+> **Superseded by the distillation pivot ([10](10-distillation.md)).** The tokenizer is now
+> **fixed to Qwen2.5 (vocab 151,646)** by the conversion teacher — it intentionally *exceeds*
+> the uint16 bound, so packing is **uint32** (#90, now implemented: dtype-aware `pack.py` +
+> relaxed `MambaConfig.validate()`). The StarCoder2/uint16 reasoning below is the historical
+> record of the from-scratch plan (still used for the #75 production-reserve corpus).
+
 - **Tokenizer:** reuse a mixed prose+code tokenizer, chosen with the **uint16 packing bound
   (`vocab < 65536`)** in mind — enforced by `src/data/pack.py` and `MambaConfig.validate()`
   (see [data pipeline](04-data-pipeline.md)). **StarCoder2** (vocab ~49,152) **fits**;
@@ -89,7 +95,7 @@ it early (only the IDs stream from the Hub; the blobs come from SWH S3).
 ```
 r2://<bucket>/
   cleaned/   <source>/*.parquet   # Stage-4/5 output: durable, re-mixable text shards
-  tokens/    <tokenizer>/<seqlen>/*.bin   # Stage-6 output: training shards (uint16, vocab<65k)
+  tokens/    <tokenizer>/<seqlen>/*.bin   # Stage-6 output: training shards (uint16, or uint32 for Qwen2.5)
   ckpt/      <run>/...            # checkpoints synced from RunPod (RunPod is not durable)
 ```
 

--- a/docs/design/08-corpus-pipeline.md
+++ b/docs/design/08-corpus-pipeline.md
@@ -76,7 +76,9 @@ it early (only the IDs stream from the Hub; the blobs come from SWH S3).
 > **fixed to Qwen2.5 (vocab 151,646)** by the conversion teacher — it intentionally *exceeds*
 > the uint16 bound, so packing is **uint32** (#90, now implemented: dtype-aware `pack.py` +
 > relaxed `MambaConfig.validate()`). The StarCoder2/uint16 reasoning below is the historical
-> record of the from-scratch plan (still used for the #75 production-reserve corpus).
+> record of the from-scratch plan; the #75 production-reserve corpus reuses these
+> clean-corpus *stages* but under the **same Qwen2.5 tokenizer + uint32 packing** — the
+> tokenizer lock is POC *and* production, so StarCoder2/uint16 is fully superseded.
 
 - **Tokenizer:** reuse a mixed prose+code tokenizer, chosen with the **uint16 packing bound
   (`vocab < 65536`)** in mind — enforced by `src/data/pack.py` and `MambaConfig.validate()`

--- a/docs/design/09-hybrid-architectures.md
+++ b/docs/design/09-hybrid-architectures.md
@@ -69,8 +69,9 @@ Adam** — the VRAM-tight lever used in Phase 5 (#75).
 (see [configs & decisions](07-configs-and-decisions.md)). The scale configs train on **CUDA**,
 where **bf16 is native** and needs no loss scaling — so `config/{1b,2b,4b}.yaml` set
 `precision: bf16` (`scaler_for_precision` already returns `None` for bf16). `tie_embeddings`
-and `grad_checkpoint` stay on; vocab follows the chosen tokenizer (must stay < 65536 — see
-[corpus pipeline](08-corpus-pipeline.md)).
+and `grad_checkpoint` stay on; vocab follows the chosen tokenizer and sets the packed dtype —
+uint16 below 65536 (POC), uint32 for Qwen2.5 (the distillation student, #90; see
+[distillation](10-distillation.md)).
 
 ## Verifying the attention fraction
 

--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -1,0 +1,111 @@
+# Distillation (teacher → hybrid student)
+
+[← Index](README.md)
+
+Why the POC **distills** a compact Mamba-2 hybrid from a frozen transformer teacher instead of
+pretraining from scratch, and how that makes an architecture search cheap. The tracker is
+[issue #65](https://github.com/travisgalloway/monica/issues/65); the corpus + teacher-output
+storage is in [corpus pipeline](08-corpus-pipeline.md); the model is in
+[hybrid architectures](09-hybrid-architectures.md).
+
+## Why distill, not pretrain
+
+The POC is an **architecture search** over attention fraction, layer placement, and state size,
+and each candidate is a fresh student. From-scratch pretraining makes that search impossible —
+each trial would cost hundreds of billions of tokens. Distilling against a **frozen teacher
+signal** reaches capability for **under 1% of the from-scratch token count** (MOHAWK produced a
+capable student from ~3B tokens, a hybrid from ~5B), so each candidate is cheap. From-scratch
+pretraining is demoted to a **production-reserve** stage (#75) that begins only after a layout
+validates.
+
+## Two conversion methods
+
+**Mamba-in-the-Llama** (default, #99) initializes the Mamba layers **directly from the teacher's
+attention projections** — mapping **Q, K, V, O** onto the SSM's **C, B, input, and output**
+projections — keeps a fraction of attention layers, **freezes the MLPs**, and runs progressive
+distillation followed by SFT and DPO. The reference run took under five days on 8 A100s.
+Reference: [Mamba in the Llama](https://arxiv.org/abs/2408.15237),
+[`jxiw/MambaInLlama`](https://github.com/jxiw/MambaInLlama).
+
+**MOHAWK** (alternative, #99) distills a Mamba-2 student through **progressive matching**: first
+the mixing matrices, then hidden states, then final logits. Reference:
+[MOHAWK](https://arxiv.org/abs/2408.10189).
+
+Both reuse the teacher's attention projections and layer structure, which is why the **conversion
+teacher must be close to the student's size (~1.5B)** and **fixes the tokenizer**. The matching
+runs as the distillation loss + train step (#100): KL on the teacher's top-k logits combined with
+cross-entropy, staged per the manifest's `stages` list.
+
+## Two teacher roles — keep them separate
+
+| Role | Used for | Constrained by | Choice |
+|---|---|---|---|
+| **Conversion teacher** | init + matching (the student is built from it) | **must** be ~student size + fix the tokenizer | **DeepSeek-R1-Distill-Qwen-1.5B** (MIT, already reasoning, Qwen tokenizer) |
+| **Trace-generation teacher** | producing reasoning traces in post-training | **unconstrained** — traces are re-tokenized | the strongest Qwen-tokenizer R1 distill you can run (14B/32B) |
+
+Code/math conversion alternatives on the same tokenizer: Qwen2.5-Coder-1.5B, Qwen2.5-Math-1.5B
+(Apache-2.0). Avoid Qwen2.5 3B/72B (Qwen license, not Apache-2.0) and Llama / StarCoder2 as a
+tokenizer source (use restrictions). The MOHAWK lineage's demonstrated teacher family was Phi
+(Phi-4-mini, MIT) — usable, but on a different tokenizer.
+
+## The tokenizer is fixed by the conversion teacher (#90, #91)
+
+The student must **share a vocabulary with the conversion teacher** for logit and hidden-state
+matching, so the tokenizer is **Qwen2.5 (vocab 151,646)** — shared across Qwen2.5/-Coder/-Math and
+every DeepSeek-R1-Distill-Qwen variant, so those teachers are interchangeable. Adopted for the
+production model too, which collapses the POC-to-production tokenizer question (no re-tokenization).
+This exceeds the uint16 bound → **uint32 packing** (#90); see
+[corpus pipeline](08-corpus-pipeline.md).
+
+## Precompute once, sweep students cheaply (#94, #98)
+
+Everything that depends only on the **teacher + corpus** — not the student — is computed a single
+time and reused by every trial:
+
+- The tokenized distillation corpus (#92).
+- **Teacher outputs** over it: top-50..100 logits + indices per token (#94); optionally hidden
+  states for MOHAWK matching. The teacher forward pass is the dominant cost — paid **once**.
+- The shared SFT corpora and verifiable RL sets ([post-training](11-post-training.md)).
+
+Each student trial is then a lightweight **manifest** naming the frozen artifacts + the layout:
+
+```yaml
+student: 1b-attn12pct
+conversion_teacher: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+tokenizer: qwen25               # Qwen2.5 vocab, 151646
+seq_len: 8192
+layout: { d_model: 2048, n_layers: 48, attention_every: 8, state_size: 128 }
+init: mamba-in-the-llama        # or mohawk
+stages: [mixing-match, hidden-align, logit-distill, instruct-sft, reasoning-sft, tool-sft, grpo]
+corpus: poc-distill/corpus/tokenized/qwen25-8k
+teacher_outputs: poc-distill/teacher-outputs/topk-logits
+sft: shared/sft/tokenized/qwen25-8k
+rl: shared/rl
+schedule: { lr: 3.0e-4, warmup: 0.02, batch_tokens: 1_000_000 }
+```
+
+A sweep over architectures is a set of sibling manifests pointing at the **same** teacher signal.
+
+## What invalidates the precompute
+
+- **Change the teacher** → invalidates the teacher outputs and the traces (the largest artifacts).
+  So the teacher is **fixed first** (#91).
+- **Change the tokenizer** → invalidates the tokenized corpus and the logits (indices shift) —
+  which is why the teacher's tokenizer is the natural pinned choice.
+- **Change the student layout** → invalidates **nothing** upstream. *This is the point: the
+  student is free, so layout sweeps are cheap.*
+- **Add RL problems** → appends to the verifiable sets rather than rebuilding anything.
+
+## Reading the POC
+
+It validates the architecture — the attention fraction, the layer placement, and the state size —
+which are **tokenizer-independent and transfer**. Absolute capability numbers still come from the
+from-scratch production run, so the POC is a **layout decision and a feasibility check**, sealed
+by the local-hardware headline metric (#104).
+
+## Related
+
+- [Corpus pipeline](08-corpus-pipeline.md) — the distillation corpus, teacher outputs, storage layout.
+- [Hybrid architectures](09-hybrid-architectures.md) — the student the teacher converts into.
+- [Post-training](11-post-training.md) — the three capability layers applied after conversion.
+- [Training](05-training.md) — the backend-free loop the distill train step plugs into.

--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -84,7 +84,10 @@ rl: shared/rl
 schedule: { lr: 3.0e-4, warmup: 0.02, batch_tokens: 1_000_000 }
 ```
 
-A sweep over architectures is a set of sibling manifests pointing at the **same** teacher signal.
+The `layout` keys (`attention_every`, `state_size`) are the manifest's own sweep-schema
+names; the #98 harness maps them onto the model config fields (`MambaConfig.attn_every` /
+`d_state`). A sweep over architectures is a set of sibling manifests pointing at the **same**
+teacher signal.
 
 ## What invalidates the precompute
 

--- a/docs/design/11-post-training.md
+++ b/docs/design/11-post-training.md
@@ -1,0 +1,84 @@
+# Post-training (instruct → thinking → tool-use, + GRPO)
+
+[← Index](README.md)
+
+Once a capable hybrid base exists (via [distillation](10-distillation.md)), post-training builds
+**three capability layers in order**. Instruct is the substrate that makes the model usable at
+all; thinking is the headline skill of this POC; tool use is the extensibility layer enabled when
+the product needs it. All three are taught by **SFT** on data from the shared post-training track,
+with **GRPO** as a final reinforcement pass on the thinking layer. The tracker is
+[issue #65](https://github.com/travisgalloway/monica/issues/65); the data lives under the
+`shared/` prefix ([corpus pipeline](08-corpus-pipeline.md)) and reuses the M9 SFT/DPO machinery
+(`make_sft_train_step`, `make_dpo_train_step`, the response-masked loaders).
+
+The order matters: instruct is assumed by everything later, thinking is the point, tool use is
+optional. GRPO is **polish**, not the source of reasoning — at ~1B the emergent self-reflection
+that makes pure RL shine in large models does not reliably appear, so reasoning comes from trace
+SFT and GRPO refines it.
+
+## Instruct (#101, corpus #95)
+
+**What.** Turn a text-continuer into a model that follows instructions, adopts a chat template,
+and respects a system prompt — the foundation every later layer assumes.
+
+**Why a stage at all.** The conversion teacher (DeepSeek-R1-Distill-Qwen-1.5B) is already
+instruction-tuned, so the hybrid inherits much of this through the matching — but the architecture
+conversion can blur instruction-following, so an explicit instruct SFT stage re-establishes it.
+
+**Method.** SFT on general instruction–response pairs under the Qwen chat template (a set such as
+UltraChat plus the reasoning traces, which also carry instruction-following), optionally DPO (#77)
+for format/preference polish, via TRL `SFTTrainer` / `DPOTrainer` shapes. References: InstructGPT,
+FLAN, DPO.
+
+## Thinking (#96 SFT, #103 GRPO)
+
+**What.** Reason through a long trace before committing to an answer — the headline skill.
+
+**Method.** SFT on reasoning traces formatted `<think> ... </think>` then `<answer> ... </answer>`
+(#96), then GRPO with verifiable rewards as polish (#103). The primary trace corpus is open-r1
+**Mixture-of-Thoughts** (~350k verified math/code/science traces distilled from R1, already on the
+Qwen tokenizer), topped up from a larger R1 distill (14B/32B) only where coverage is thin. **Trace
+SFT is the main event.** GSM8K + MATH and code-with-executable-tests supply the GRPO rewards and
+evaluation; the [open-r1](https://github.com/huggingface/open-r1) harness provides GRPO with
+code-execution rewards and 1.5B configs that adapt directly. References: Chain-of-Thought,
+DeepSeek-R1.
+
+**Two GRPO rules:** start with **math before code** (exact-match, no sandbox — the cheapest clean
+reward loop) and require **≥5 tests per coding problem** (thin suites get gamed). For RLVR you need
+only **problems + verifiers**, not reference solutions — the model generates, the verifier judges —
+so problems whose reference solutions came from a restricted model are still usable.
+
+## Tool use (#102, optional)
+
+**What.** Emit a structured function call the runtime executes and feeds back, optionally in a
+[ReAct](https://arxiv.org/abs/2210.03629) loop. Optional for the POC (headline skills are
+reasoning/math/code); the path to enable if the product calls tools.
+
+**Why it leans on attention.** At ~1B the achievable target is reliable function calling over a
+**fixed tool set** — exact tool selection and argument fidelity are the associative-recall job pure
+SSM layers do poorly, the same reason the hybrid keeps attention. TinyAgent (1.1B, runs locally on
+Apple Silicon) is the direct precedent and maps onto the MLX serving target.
+
+**Method.** SFT on function-calling data with **distractor tools as negatives** and **abstention
+examples** (learn when *not* to call), validating every call against the schema in the runtime.
+Sources: Glaive function-calling-v2, xLAM, ToolACE, plus When2Call for restraint; BFCL for eval.
+References: ReAct, Toolformer, TinyAgent.
+
+## The detail that bites: chat-template consistency
+
+The Qwen base defines **`<|im_end|>`** as the chat EOS. Keep it **identical across SFT, RL, and
+serving** — a mismatch degrades the model at serving time. This is a cross-cutting invariant for
+all three layers and the GRPO pass.
+
+## Shared with production
+
+These corpora and RL sets are **class-shared**: both the POC student and the eventual production
+model post-train the same way, so they are curated once (much of it teacher inference) and reused
+unchanged on the production-reserve run (#75). Curating them is expensive — that is why they are
+precomputed once and reused everywhere.
+
+## Related
+
+- [Corpus pipeline](08-corpus-pipeline.md) — the `shared/` SFT corpora and verifiable RL sets.
+- [Distillation](10-distillation.md) — how the base these layers post-train is built.
+- [Training](05-training.md) — the SFT/DPO machinery (M9) these layers reuse.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -70,5 +70,5 @@ Every claim here is sourced from a docstring or config comment in the code, with
 | Build method | **distillation** from a frozen teacher (not pretrain) | reaches capability at <1% of from-scratch tokens; cheap layout sweep | `docs/design/10-distillation.md` |
 | Scale-up tokenizer | **Qwen2.5** (vocab 151,646) | fixed by the conversion teacher for logit/hidden matching; uint32 packing (#90). POC stays OLMo. StarCoder2 (the old uint16 pick) superseded. | `docs/design/10-distillation.md` |
 | Conversion teacher | DeepSeek-R1-Distill-Qwen-1.5B (MIT) | reasoning-ready, Qwen tokenizer, ~student size | `docs/design/10-distillation.md` |
-| Scale-up model | compact ~1–1.5B Mamba-2 hybrid reasoning student | attention layers close the SSM retrieval gap; no-KV-cache local inference | `docs/design/{09,10}-*.md` |
+| Scale-up model | compact ~1–1.5B Mamba-2 hybrid reasoning student | attention layers close the SSM retrieval gap; no-KV-cache local inference | `docs/design/10-distillation.md` |
 | Data framework | `datatrove` + R2 + RunPod | builds the teacher corpus + production-reserve from-scratch data (#75) | `docs/design/08-corpus-pipeline.md` |

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -29,23 +29,33 @@ Every claim here is sourced from a docstring or config comment in the code, with
    gate, and val perplexity as the success metric.
 7. [Configs & locked decisions](07-configs-and-decisions.md) — `toy.yaml` /
    `poc.yaml` in full, plus the precision benchmark and sizing math.
-8. [Corpus pipeline](08-corpus-pipeline.md) — the scale-up data flow: `datatrove`
-   stages, the common schema, R2 storage layout, RunPod topology, and clean-license
-   post-training (SFT/DPO/RLVR).
-9. [Hybrid architectures](09-hybrid-architectures.md) — why the scale-up model is a
-   Mamba-2 hybrid (config-gated attention), and the 100M/1B/2B/4B sizing.
+8. [Corpus pipeline](08-corpus-pipeline.md) — the clean-license data flow: `datatrove`
+   stages, the common schema, R2 storage layout, RunPod topology. Now the **teacher
+   corpus + production-reserve** path (its uint16/StarCoder2 from-scratch framing is
+   superseded by the distillation pivot — see 10).
+9. [Hybrid architectures](09-hybrid-architectures.md) — why the model is a Mamba-2
+   hybrid (config-gated attention) and how it sizes.
+10. [Distillation (teacher → hybrid student)](10-distillation.md) — the **distillation-first
+    pivot**: distil a compact (~1–1.5B) hybrid from a frozen DeepSeek-R1-Distill-Qwen-1.5B
+    teacher (Qwen2.5 tokenizer → uint32 packing, #90), precompute teacher artifacts once,
+    sweep student layouts cheaply (#98).
+11. [Post-training](11-post-training.md) — instruct SFT → reasoning-trace SFT → optional
+    tool-use → GRPO, the Qwen `<|im_end|>` chat-template invariant, shared with production.
 
-> Topics 8–9 are the **scale-up** design record (the datatrove + RunPod + R2 program,
-> [issue #65](https://github.com/travisgalloway/monica/issues/65)) — forward-looking
-> decisions, not yet implemented, unlike the verified POC in topics 1–7.
+> Topics 8–11 are the **scale-up / distillation** design record (epic
+> [#65](https://github.com/travisgalloway/monica/issues/65)) — forward-looking decisions,
+> partly implemented (the corpus stages, hybrid attention, post-training machinery, and the
+> #90 uint32 packing exist; the distillation pipeline #92–#104 is pending), unlike the fully
+> verified POC in topics 1–7. The current plan is **distillation-first** (10/11); the
+> from-scratch pretraining in 08 is deferred to a production reserve (#75).
 
 ## Locked decisions at a glance
 
 | Decision | Choice | Why | Source |
 |---|---|---|---|
 | Hardware isolation | one seam (`ModelInterface`) | clean MLX→CUDA migration | `src/model/interface.py` |
-| Token storage | uint16 packing | compact; vocab must be < 65536 | `src/data/pack.py` |
-| Tokenizer | `allenai/OLMo-7B-hf` (vocab 50280) | fits uint16; matches AI2 for comparison | `src/data/tokenize.py` |
+| Token storage | uint16/uint32 packing (per vocab, #90) | uint16 when vocab < 65536 (POC), uint32 for Qwen2.5 (151,646) | `src/data/pack.py` |
+| Tokenizer (POC) | `allenai/OLMo-7B-hf` (vocab 50280) | fits uint16; matches AI2 for comparison | `src/data/tokenize.py` |
 | Embedding | tied (input = output) | ~38M of ~100M budget at POC scale | `config/poc.yaml` |
 | dt-bias init | inverse-softplus, log-uniform (per head) | **load-bearing** — model can't learn recall without it | `src/model/mlx_backend.py` |
 | Selective SSM | Mamba-2 / SSD, scalar A per head | matmul scan; ~62× faster than diagonal-A at poc scale | `src/model/mlx_backend.py` |
@@ -57,6 +67,8 @@ Every claim here is sourced from a docstring or config comment in the code, with
 | Checkpoints | portable weights + separate resume bundle | weights port across backends; optimizer state doesn't need to | `src/train/checkpoint.py` |
 | Success metric | held-out val perplexity (Tier-1) | a smoothly decreasing curve *is* the POC goal | `src/eval/val_loss.py` |
 | OLMES / lm-eval | deferred (Tier-2) | its own milestone-sized task; not needed for the POC | `src/eval/olmes_adapter.py` |
-| Scale-up data framework | `datatrove` + R2 + RunPod | one framework, durable re-mixable shards, zero-egress storage | `docs/design/08-corpus-pipeline.md` |
-| Scale-up tokenizer | StarCoder2 (vocab ~49k) | mixed prose+code; fits uint16 (Llama-3 ~128k does not) | `docs/design/08-corpus-pipeline.md` |
-| Scale-up model family | Mamba-2 hybrid, 100M/1B/2B/4B | attention layers close the SSM retrieval gap; no-KV-cache sizing | `docs/design/09-hybrid-architectures.md` |
+| Build method | **distillation** from a frozen teacher (not pretrain) | reaches capability at <1% of from-scratch tokens; cheap layout sweep | `docs/design/10-distillation.md` |
+| Scale-up tokenizer | **Qwen2.5** (vocab 151,646) | fixed by the conversion teacher for logit/hidden matching; uint32 packing (#90). POC stays OLMo. StarCoder2 (the old uint16 pick) superseded. | `docs/design/10-distillation.md` |
+| Conversion teacher | DeepSeek-R1-Distill-Qwen-1.5B (MIT) | reasoning-ready, Qwen tokenizer, ~student size | `docs/design/10-distillation.md` |
+| Scale-up model | compact ~1–1.5B Mamba-2 hybrid reasoning student | attention layers close the SSM retrieval gap; no-KV-cache local inference | `docs/design/{09,10}-*.md` |
+| Data framework | `datatrove` + R2 + RunPod | builds the teacher corpus + production-reserve from-scratch data (#75) | `docs/design/08-corpus-pipeline.md` |

--- a/src/data/corpus.py
+++ b/src/data/corpus.py
@@ -8,6 +8,11 @@ ingest -> normalize -> filter -> write Parquet shards. At scale (#80) the same s
 runs on HF `datatrove` with the writer pointed at R2 via `s3fs` — the `out_uri` seam
 below (an fsspec URI) is exactly where that swap happens: `file://` now, `s3://` later.
 
+Under the distillation-first plan (docs/design/10-distillation.md) this corpus builds the
+**teacher corpus + the production-reserve from-scratch data (#75)**, not the distillation
+student's training data — the student consumes pre-tokenized Qwen2.5 artifacts + teacher
+top-k logits (#92/#94), which are precomputed once, not re-derived through these stages.
+
 ABOVE THE SEAM — no `mlx`/`torch`. Heavy data deps (pyarrow, fsspec) are imported
 LAZILY inside the IO functions, mirroring download.py/tokenize.py, so importing this
 module stays cheap and the seam guard (tests/test_import_guard.py) needs nothing extra.


### PR DESCRIPTION
## Summary
Second half of reconciling the codebase with the rewritten epic #65 (PR #108 landed the #90 code). Epic #65 pivoted from the M10 from-scratch program (StarCoder2, uint16, datatrove pretraining) to **distillation-first** (Qwen2.5 tokenizer, uint32, distil from a frozen DeepSeek-R1-Distill-Qwen-1.5B teacher). This brings the docs in line with the code.

- **Commit the new design docs:** `10-distillation.md` (why distil, two conversion methods, teacher roles, Qwen tokenizer lock, precompute-once sweep) and `11-post-training.md` (instruct → reasoning-trace → tool-use → GRPO; the Qwen `<|im_end|>` chat-template invariant).
- **`README.md`** — index topics 10–11; update the locked-decisions table (uint16 → uint16/uint32 per vocab; scale tokenizer StarCoder2 → **Qwen2.5**; add build-method = distillation, conversion teacher, compact ~1–1.5B student); reframe the topics-8–11 footer.
- **`08-corpus-pipeline.md` / `09-hybrid-architectures.md`** — mark the StarCoder2/uint16/`vocab < 65536` claims **superseded** by the pivot (the six clean-corpus stages still build the teacher corpus + #75 production reserve); R2 layout note allows uint32.
- **`corpus.py`** docstring — these stages build the teacher/production-reserve corpus, not the student's data.
- **`CLAUDE.md`** — token packing is dtype-aware (uint16 POC / uint32 Qwen2.5); `validate()` ceiling is now uint32.

Pure docs/docstrings — no code behavior change (the dtype-aware code merged in #108). `grep` confirms no stale "must stay < 65536" / "StarCoder2 is the scale tokenizer" assertions remain outside clearly-marked historical notes.

Refs #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)