### PR TITLE
feat(model): [M10] frozen conversion-teacher loader (DeepSeek-R1-Distill-Qwen-1.5B) (#93)

### DIFF
--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -48,6 +48,24 @@ Code/math conversion alternatives on the same tokenizer: Qwen2.5-Coder-1.5B, Qwe
 tokenizer source (use restrictions). The MOHAWK lineage's demonstrated teacher family was Phi
 (Phi-4-mini, MIT) — usable, but on a different tokenizer.
 
+### The teacher loader behind the seam (#93)
+
+The conversion teacher is loaded **frozen and forward-only** behind the hardware seam, exactly
+like DPO's frozen reference (`mlx_train_step.make_dpo_train_step` holds a distinct `ref_model`
+the optimizer never touches). The portable protocol is `ConversionTeacher`
+(`src/model/teacher.py`): `forward(return_hidden=...)` (logits + optional per-layer hidden
+states), `topk_logits(tokens, k)` (the cached signal #94/#100 match against), and
+`attention_projection(layer)` (the Q/K/V/O the #99 init maps onto the student SSM's
+C/B/input/output). Above the seam, callers see only opaque arrays plus a `to_numpy` converter —
+never a backend array type — and the teacher reports **no** trainable parameters, so it is
+structurally excluded from the optimizer and the resume bundle.
+
+The MLX implementation (`src/model/mlx_teacher.py`, a minimal self-contained Qwen2 forward — no
+`mlx-lm` dependency) loads real HF weights via `from_pretrained` (a checkpoint dir or, lazily, an
+HF repo id) and builds a tiny **synthetic** teacher via `from_config` for offline tests and small
+local checks. Build one through `get_backend(...).make_teacher(...)`; the CUDA teacher is deferred
+(the branch raises `NotImplementedError`).
+
 ## The tokenizer is fixed by the conversion teacher (#90, #91)
 
 The student must **share a vocabulary with the conversion teacher** for logit and hidden-state

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -99,6 +99,9 @@ def _mlx_backend() -> Backend:
         from .mlx_teacher import MLXConversionTeacher
         if pretrained is not None:
             return MLXConversionTeacher.from_pretrained(pretrained, config)
+        if config is None:
+            raise ValueError("make_teacher needs a TeacherConfig for the synthetic path "
+                             "(pass `config=...`), or `pretrained=<dir/repo>` for real weights")
         return MLXConversionTeacher.from_config(config, seed=seed)
 
     return Backend(

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -40,6 +40,9 @@ class Backend:
     make_sft_train_step: Callable[..., Callable]
     make_dpo_train_step: Callable[..., Callable]
     make_grpo_train_step: Callable[..., Callable]
+    # Distillation (M10): build a frozen, forward-only conversion teacher behind the seam
+    # (`ConversionTeacher`). MLX-only for now; the CUDA branch raises NotImplementedError.
+    make_teacher: Callable[..., Any]
 
 
 def get_backend(name: str = "auto") -> Backend:
@@ -90,6 +93,14 @@ def _mlx_backend() -> Backend:
         from .mlx_train_step import make_grpo_train_step
         return make_grpo_train_step(*args, **kwargs)
 
+    def _make_teacher(config=None, *, pretrained=None, seed=0):
+        """Frozen conversion teacher (#93): `pretrained` (an HF checkpoint dir / repo id)
+        loads real weights; otherwise a synthetic teacher is built from `config`."""
+        from .mlx_teacher import MLXConversionTeacher
+        if pretrained is not None:
+            return MLXConversionTeacher.from_pretrained(pretrained, config)
+        return MLXConversionTeacher.from_config(config, seed=seed)
+
     return Backend(
         name="mlx",
         model_cls=MLXMambaModel,
@@ -104,6 +115,7 @@ def _mlx_backend() -> Backend:
         make_sft_train_step=make_sft_train_step,
         make_dpo_train_step=_make_dpo_train_step,
         make_grpo_train_step=_make_grpo_train_step,
+        make_teacher=_make_teacher,
     )
 
 
@@ -143,6 +155,11 @@ def _cuda_backend() -> Backend:
             "post-training steps are deferred (run scripts/sft.py / scripts/dpo.py on "
             "Apple Silicon).")
 
+    def _teacher_unsupported(*args, **kwargs):
+        raise NotImplementedError(
+            "The conversion teacher (M10/#93) is implemented on the MLX dev backend only; "
+            "the CUDA teacher loader is deferred.")
+
     return Backend(
         name="cuda",
         model_cls=CUDAMambaModel,
@@ -156,4 +173,5 @@ def _cuda_backend() -> Backend:
         make_sft_train_step=_post_training_unsupported,
         make_dpo_train_step=_post_training_unsupported,
         make_grpo_train_step=_post_training_unsupported,
+        make_teacher=_teacher_unsupported,
     )

--- a/src/model/mlx_teacher.py
+++ b/src/model/mlx_teacher.py
@@ -1,0 +1,222 @@
+"""MLX conversion teacher (Apple Silicon, below the seam — may import mlx).
+
+A frozen, forward-only **Qwen2** decoder (the DeepSeek-R1-Distill-Qwen-1.5B family) used
+as the distillation conversion teacher. It implements the portable `ConversionTeacher`
+protocol (`src/model/teacher.py`) so the precompute (#94) and the distill loss (#100) see
+only opaque arrays + a `to_numpy` converter, and the student init (#99) can read the
+attention Q/K/V/O projections.
+
+The weights are held as a plain `dict[str, mx.array]` rather than an `nn.Module`, so the
+teacher exposes **no** parameter tree — it can never be handed to an optimizer, and
+`trainable_parameters()` is empty. Forward outputs are wrapped in `mx.stop_gradient`, so
+even when the teacher's logits/hidden states are composed into a student loss, no gradient
+flows back into the teacher. `mlx-lm` is not a dependency; this is a minimal self-contained
+forward pass, reusing the RoPE/softmax idioms from `mlx_backend`.
+
+This file imports `mlx`, so it does NOT import on Linux/CUDA hosts — intentional and
+allowed: it lives below the seam and nothing portable imports it.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import numpy as np
+
+from .teacher import (AttnProjections, ConversionTeacher, TeacherConfig,
+                      TeacherForward)
+from .mlx_backend import _rotate_half, _silu, _softmax_lastdim
+
+
+def _rms_norm(x: mx.array, weight: mx.array, eps: float) -> mx.array:
+    """RMSNorm in fp32 (matches `mlx_backend.RMSNorm`)."""
+    xf = x.astype(mx.float32)
+    norm = mx.rsqrt(mx.mean(xf * xf, axis=-1, keepdims=True) + eps)
+    return weight * (xf * norm)
+
+
+def _rope_cos_sin(positions: mx.array, head_dim: int, theta: float) -> Tuple[mx.array, mx.array]:
+    """RoPE cos/sin for absolute `positions` (fp32), theta-configurable (Qwen2 rope_theta).
+    Generalizes `mlx_backend._rope_cos_sin` (which hardcodes theta=10000). (T, head_dim)."""
+    half = head_dim // 2
+    inv_freq = mx.exp(-math.log(theta) * mx.arange(0, half, dtype=mx.float32) / half)
+    ang = positions.astype(mx.float32)[:, None] * inv_freq[None, :]   # (T, half)
+    cos = mx.concatenate([mx.cos(ang), mx.cos(ang)], axis=-1)         # (T, head_dim)
+    sin = mx.concatenate([mx.sin(ang), mx.sin(ang)], axis=-1)
+    return cos, sin
+
+
+def _apply_rope(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    # x: (B, H, T, Dh); cos/sin: (T, Dh) broadcast over (B, H).
+    return x * cos[None, None] + _rotate_half(x) * sin[None, None]
+
+
+class MLXConversionTeacher(ConversionTeacher):
+    """Frozen Qwen2 conversion teacher on MLX. See module docstring."""
+
+    def __init__(self, config: TeacherConfig, weights: Dict[str, mx.array]):
+        config.validate()
+        self.config = config
+        # All compute in fp32: teacher logits feed a KL term, so stability beats speed at
+        # POC scale and the teacher forward is a one-time precompute (#94) anyway.
+        self._w = {k: v.astype(mx.float32) for k, v in weights.items()}
+
+    # --- constructors --------------------------------------------------------
+    @classmethod
+    def from_config(cls, config: TeacherConfig, *, seed: int = 0) -> "MLXConversionTeacher":
+        """Random-init synthetic teacher (offline tests / small local checks)."""
+        config.validate()
+        key = mx.random.key(seed)
+        c = config
+        scale = 1.0 / math.sqrt(c.d_model)
+
+        def rand(shape, k):
+            return mx.random.normal(shape, key=k) * scale
+
+        keys = mx.random.split(key, 4 + c.n_layers * 9)
+        ki = iter(keys)
+        w: Dict[str, mx.array] = {"embed": rand((c.vocab_size, c.d_model), next(ki))}
+        for i in range(c.n_layers):
+            p = f"layer.{i}."
+            w[p + "input_ln"] = mx.ones((c.d_model,))
+            w[p + "q_w"] = rand((c.q_dim, c.d_model), next(ki))
+            w[p + "q_b"] = mx.zeros((c.q_dim,))
+            w[p + "k_w"] = rand((c.kv_dim, c.d_model), next(ki))
+            w[p + "k_b"] = mx.zeros((c.kv_dim,))
+            w[p + "v_w"] = rand((c.kv_dim, c.d_model), next(ki))
+            w[p + "v_b"] = mx.zeros((c.kv_dim,))
+            w[p + "o_w"] = rand((c.d_model, c.q_dim), next(ki))
+            w[p + "post_ln"] = mx.ones((c.d_model,))
+            w[p + "gate_w"] = rand((c.intermediate_size, c.d_model), next(ki))
+            w[p + "up_w"] = rand((c.intermediate_size, c.d_model), next(ki))
+            w[p + "down_w"] = rand((c.d_model, c.intermediate_size), next(ki))
+        w["final_ln"] = mx.ones((c.d_model,))
+        if not c.tie_embeddings:
+            w["lm_head"] = rand((c.vocab_size, c.d_model), next(ki))
+        mx.eval(list(w.values()))
+        return cls(config, w)
+
+    @classmethod
+    def from_pretrained(cls, path, config: Optional[TeacherConfig] = None
+                        ) -> "MLXConversionTeacher":
+        """Load a local HuggingFace Qwen2 checkpoint directory (config.json + safetensors).
+
+        If `path` does not exist locally and `config.model_id` is set, the weights are
+        fetched lazily via `huggingface_hub.snapshot_download` (guarded — never reached in
+        offline tests). HF row-major projection weights are mapped onto the internal dict."""
+        p = Path(path)
+        if not p.exists():
+            if config is None or not config.model_id:
+                raise FileNotFoundError(
+                    f"teacher path {p} not found and no config.model_id to download from")
+            from huggingface_hub import snapshot_download   # lazy: optional dep, not in tests
+            p = Path(snapshot_download(config.model_id))
+        if config is None:
+            with open(p / "config.json") as f:
+                config = TeacherConfig.from_hf_dict(json.load(f))
+        hf = _load_safetensors_dir(p)
+        return cls(config, _hf_to_internal(hf, config))
+
+    # --- ConversionTeacher ---------------------------------------------------
+    def forward(self, token_batch, *, return_hidden: bool = False) -> TeacherForward:
+        tokens = mx.array(token_batch)
+        c = self.config
+        h = self._w["embed"][tokens]                          # (B, L, D)
+        L = h.shape[1]
+        cos, sin = _rope_cos_sin(mx.arange(L), c.head_dim, c.rope_theta)
+        hidden: List[mx.array] = [h] if return_hidden else []
+        for i in range(c.n_layers):
+            h = h + self._attn(h, i, cos, sin)
+            h = h + self._mlp(h, i)
+            if return_hidden:
+                hidden.append(h)
+        logits = _rms_norm(h, self._w["final_ln"], c.rms_norm_eps) @ self._lm_head().T
+        hs = tuple(mx.stop_gradient(t) for t in hidden) if return_hidden else None
+        return TeacherForward(logits=mx.stop_gradient(logits), hidden_states=hs)
+
+    def topk_logits(self, token_batch, k: int) -> Tuple[mx.array, mx.array]:
+        logits = self.forward(token_batch).logits             # (B, L, V)
+        idx = mx.argsort(-logits, axis=-1)[..., :k]            # descending, (B, L, k)
+        vals = mx.take_along_axis(logits, idx, axis=-1)
+        return mx.stop_gradient(vals), idx
+
+    def attention_projection(self, layer: int) -> AttnProjections:
+        p = f"layer.{layer}."
+        g = lambda s: mx.stop_gradient(self._w[p + s])
+        return AttnProjections(q=g("q_w"), k=g("k_w"), v=g("v_w"), o=g("o_w"),
+                               q_bias=g("q_b"), k_bias=g("k_b"), v_bias=g("v_b"))
+
+    def to_numpy(self, array) -> np.ndarray:
+        return np.array(array)
+
+    # --- internals -----------------------------------------------------------
+    def _lm_head(self) -> mx.array:
+        return self._w["embed"] if self.config.tie_embeddings else self._w["lm_head"]
+
+    def _attn(self, x: mx.array, i: int, cos: mx.array, sin: mx.array) -> mx.array:
+        c = self.config
+        p = f"layer.{i}."
+        B, L, _ = x.shape
+        Hq, Hkv, Dh = c.n_heads, c.n_kv_heads, c.head_dim
+        xn = _rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps)
+        q = xn @ self._w[p + "q_w"].T + self._w[p + "q_b"]    # (B,L,q_dim)
+        k = xn @ self._w[p + "k_w"].T + self._w[p + "k_b"]    # (B,L,kv_dim)
+        v = xn @ self._w[p + "v_w"].T + self._w[p + "v_b"]
+
+        def heads(t, H):
+            return t.reshape(B, L, H, Dh).transpose(0, 2, 1, 3)   # (B,H,L,Dh)
+        q, k, v = heads(q, Hq), heads(k, Hkv), heads(v, Hkv)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        if Hkv != Hq:                                         # GQA: repeat kv across groups
+            rep = Hq // Hkv
+            k, v = mx.repeat(k, rep, axis=1), mx.repeat(v, rep, axis=1)
+        scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(Dh)   # (B,Hq,L,L)
+        causal = mx.tril(mx.ones((L, L), dtype=mx.bool_))
+        scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        out = _softmax_lastdim(scores) @ v                   # (B,Hq,L,Dh)
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, Hq * Dh)
+        return out @ self._w[p + "o_w"].T                    # (B,L,D), o has no bias
+
+    def _mlp(self, x: mx.array, i: int) -> mx.array:
+        c = self.config
+        p = f"layer.{i}."
+        xn = _rms_norm(x, self._w[p + "post_ln"], c.rms_norm_eps)
+        gate = _silu(xn @ self._w[p + "gate_w"].T)
+        up = xn @ self._w[p + "up_w"].T
+        return (gate * up) @ self._w[p + "down_w"].T
+
+
+# --- HuggingFace checkpoint loading ------------------------------------------
+def _load_safetensors_dir(p: Path) -> Dict[str, mx.array]:
+    """Load + merge every `*.safetensors` shard in a directory into one dict."""
+    files = sorted(p.glob("*.safetensors"))
+    if not files:
+        raise FileNotFoundError(f"no .safetensors found in {p}")
+    out: Dict[str, mx.array] = {}
+    for f in files:
+        out.update(mx.load(str(f)))
+    return out
+
+
+def _hf_to_internal(hf: Dict[str, mx.array], cfg: TeacherConfig) -> Dict[str, mx.array]:
+    """Map HuggingFace Qwen2 parameter names onto the internal weight-dict layout."""
+    w: Dict[str, mx.array] = {"embed": hf["model.embed_tokens.weight"]}
+    for i in range(cfg.n_layers):
+        hp, p = f"model.layers.{i}.", f"layer.{i}."
+        w[p + "input_ln"] = hf[hp + "input_layernorm.weight"]
+        w[p + "post_ln"] = hf[hp + "post_attention_layernorm.weight"]
+        for proj, dst in (("q_proj", "q"), ("k_proj", "k"), ("v_proj", "v")):
+            w[p + dst + "_w"] = hf[hp + f"self_attn.{proj}.weight"]
+            w[p + dst + "_b"] = hf[hp + f"self_attn.{proj}.bias"]
+        w[p + "o_w"] = hf[hp + "self_attn.o_proj.weight"]
+        w[p + "gate_w"] = hf[hp + "mlp.gate_proj.weight"]
+        w[p + "up_w"] = hf[hp + "mlp.up_proj.weight"]
+        w[p + "down_w"] = hf[hp + "mlp.down_proj.weight"]
+    w["final_ln"] = hf["model.norm.weight"]
+    if not cfg.tie_embeddings:
+        w["lm_head"] = hf["lm_head.weight"]
+    return w

--- a/src/model/mlx_teacher.py
+++ b/src/model/mlx_teacher.py
@@ -105,16 +105,21 @@ class MLXConversionTeacher(ConversionTeacher):
                         ) -> "MLXConversionTeacher":
         """Load a local HuggingFace Qwen2 checkpoint directory (config.json + safetensors).
 
-        If `path` does not exist locally and `config.model_id` is set, the weights are
-        fetched lazily via `huggingface_hub.snapshot_download` (guarded — never reached in
-        offline tests). HF row-major projection weights are mapped onto the internal dict."""
+        `path` may be a local checkpoint directory or an HF repo id. When it is not a local
+        path, it is treated as the repo id (so `from_pretrained("deepseek-ai/...")` works with
+        no config); a bare name falls back to `config.model_id`. The fetch is lazy via
+        `huggingface_hub.snapshot_download` (guarded — never reached in offline tests). HF
+        row-major projection weights are mapped onto the internal dict."""
         p = Path(path)
         if not p.exists():
-            if config is None or not config.model_id:
+            # Not a local dir: use `path` as the repo id when it looks like one, else config.model_id.
+            repo_id = str(path) if "/" in str(path) else (config.model_id if config else None)
+            if not repo_id:
                 raise FileNotFoundError(
-                    f"teacher path {p} not found and no config.model_id to download from")
+                    f"teacher path {p} not found and no repo id (pass an HF 'owner/name' path "
+                    "or a config with model_id)")
             from huggingface_hub import snapshot_download   # lazy: optional dep, not in tests
-            p = Path(snapshot_download(config.model_id))
+            p = Path(snapshot_download(repo_id))
         if config is None:
             with open(p / "config.json") as f:
                 config = TeacherConfig.from_hf_dict(json.load(f))
@@ -128,20 +133,29 @@ class MLXConversionTeacher(ConversionTeacher):
         h = self._w["embed"][tokens]                          # (B, L, D)
         L = h.shape[1]
         cos, sin = _rope_cos_sin(mx.arange(L), c.head_dim, c.rope_theta)
+        mask = mx.tril(mx.ones((L, L), dtype=mx.bool_))       # causal mask, built once
         hidden: List[mx.array] = [h] if return_hidden else []
         for i in range(c.n_layers):
-            h = h + self._attn(h, i, cos, sin)
+            h = h + self._attn(h, i, cos, sin, mask)
             h = h + self._mlp(h, i)
             if return_hidden:
                 hidden.append(h)
-        logits = _rms_norm(h, self._w["final_ln"], c.rms_norm_eps) @ self._lm_head().T
+        # Emit logits over the tokenizer vocab (padded embedding rows are never teacher targets).
+        logits = (_rms_norm(h, self._w["final_ln"], c.rms_norm_eps)
+                  @ self._lm_head().T)[..., :c.effective_vocab_size]
         hs = tuple(mx.stop_gradient(t) for t in hidden) if return_hidden else None
         return TeacherForward(logits=mx.stop_gradient(logits), hidden_states=hs)
 
     def topk_logits(self, token_batch, k: int) -> Tuple[mx.array, mx.array]:
-        logits = self.forward(token_batch).logits             # (B, L, V)
-        idx = mx.argsort(-logits, axis=-1)[..., :k]            # descending, (B, L, k)
-        vals = mx.take_along_axis(logits, idx, axis=-1)
+        logits = self.forward(token_batch).logits             # (B, L, Ve)
+        k = min(k, logits.shape[-1])
+        # Partial selection (top-k), then sort only the k — far cheaper than a full argsort
+        # over the ~152k vocab (matters for the #94 precompute).
+        part = mx.argpartition(-logits, kth=k - 1, axis=-1)[..., :k]
+        pv = mx.take_along_axis(logits, part, axis=-1)
+        order = mx.argsort(-pv, axis=-1)                       # descending within the k
+        idx = mx.take_along_axis(part, order, axis=-1)
+        vals = mx.take_along_axis(pv, order, axis=-1)
         return mx.stop_gradient(vals), idx
 
     def attention_projection(self, layer: int) -> AttnProjections:
@@ -157,7 +171,12 @@ class MLXConversionTeacher(ConversionTeacher):
     def _lm_head(self) -> mx.array:
         return self._w["embed"] if self.config.tie_embeddings else self._w["lm_head"]
 
-    def _attn(self, x: mx.array, i: int, cos: mx.array, sin: mx.array) -> mx.array:
+    def _causal_mask(self, L: int) -> mx.array:
+        """Causal (L, L) bool mask, built once per forward and shared across layers."""
+        return mx.tril(mx.ones((L, L), dtype=mx.bool_))
+
+    def _attn(self, x: mx.array, i: int, cos: mx.array, sin: mx.array,
+              mask: mx.array) -> mx.array:
         c = self.config
         p = f"layer.{i}."
         B, L, _ = x.shape
@@ -175,8 +194,7 @@ class MLXConversionTeacher(ConversionTeacher):
             rep = Hq // Hkv
             k, v = mx.repeat(k, rep, axis=1), mx.repeat(v, rep, axis=1)
         scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(Dh)   # (B,Hq,L,L)
-        causal = mx.tril(mx.ones((L, L), dtype=mx.bool_))
-        scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        scores = mx.where(mask, scores, mx.array(float("-inf"), dtype=scores.dtype))
         out = _softmax_lastdim(scores) @ v                   # (B,Hq,L,Dh)
         out = out.transpose(0, 2, 1, 3).reshape(B, L, Hq * Dh)
         return out @ self._w[p + "o_w"].T                    # (B,L,D), o has no bias

--- a/src/model/teacher.py
+++ b/src/model/teacher.py
@@ -1,0 +1,192 @@
+"""The conversion-teacher seam: a frozen, forward-only teacher protocol.
+
+THIS MODULE MUST NOT IMPORT ANY BACKEND (no `mlx`, no `torch`/CUDA). Like
+`interface.ModelInterface`, it is the portable contract that the distillation
+stages depend on; each backend provides a concrete `ConversionTeacher` (the MLX
+one is `mlx_teacher.MLXConversionTeacher`).
+
+The conversion teacher is the transformer the student is *built from*
+(DeepSeek-R1-Distill-Qwen-1.5B by default — see `docs/design/10-distillation.md`).
+It is run **forward only** — never trained — so it follows the same frozen-reference
+pattern DPO already uses (`mlx_train_step.make_dpo_train_step` holds a distinct
+`ref_model` the optimizer never touches). Two distillation issues consume it:
+
+  * student init (#99) maps the teacher's attention Q/K/V/O onto the student SSM's
+    C/B/input/output projections — hence `attention_projection`.
+  * the distill loss (#100) matches the student against the teacher's top-k logits
+    and optional hidden states — hence `forward(return_hidden=...)` / `topk_logits`.
+
+Per the seam, portable code sees only opaque arrays plus a `to_numpy` converter and
+these accessors — never the backend array type. The teacher reports **no** trainable
+parameters (`trainable_parameters() == {}`), so it is structurally excluded from any
+optimizer / resume bundle.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+# Opaque, backend-defined arrays (an MLX array, a torch tensor, ...). Code above the
+# seam treats these as blobs it converts with `to_numpy`.
+Array = Any
+
+
+@dataclass
+class TeacherConfig:
+    """Architecture of a Qwen2-family conversion teacher.
+
+    Defaults describe DeepSeek-R1-Distill-Qwen-1.5B (a Qwen2 decoder). The fields are
+    exactly what the MLX forward pass and the #99 projection mapping need; nothing here
+    imports a backend, so the config is shared across backends like `MambaConfig`.
+    """
+
+    vocab_size: int
+    d_model: int                 # hidden_size
+    n_layers: int                # num_hidden_layers
+    n_heads: int                 # num_attention_heads (query heads)
+    n_kv_heads: int              # num_key_value_heads (GQA groups; == n_heads if MHA)
+    head_dim: int                # per-head width (Qwen2-1.5B: 128, not d_model//n_heads)
+    intermediate_size: int       # SwiGLU MLP inner width
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    tie_embeddings: bool = True
+    model_id: Optional[str] = None   # HF repo id, for from_pretrained / provenance
+
+    @classmethod
+    def qwen_1_5b(cls) -> "TeacherConfig":
+        """DeepSeek-R1-Distill-Qwen-1.5B (== Qwen2.5-Math-1.5B architecture).
+
+        Note vocab 151936 is the *model* embedding width (padded); the Qwen2.5
+        tokenizer vocab is 151646 (`docs/design/10-distillation.md`). The student
+        config uses 151646; the distill loss (#100) matches on top-k indices, which
+        fall inside the shared lower range.
+        """
+        return cls(
+            vocab_size=151936, d_model=1536, n_layers=28, n_heads=12, n_kv_heads=2,
+            head_dim=128, intermediate_size=8960, rms_norm_eps=1e-6, rope_theta=10000.0,
+            tie_embeddings=True, model_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+        )
+
+    @classmethod
+    def tiny(cls) -> "TeacherConfig":
+        """A toy Qwen2 teacher for offline tests / small local checks (byte vocab)."""
+        return cls(
+            vocab_size=256, d_model=64, n_layers=2, n_heads=4, n_kv_heads=2,
+            head_dim=16, intermediate_size=128, rms_norm_eps=1e-6, rope_theta=10000.0,
+            tie_embeddings=True, model_id=None,
+        )
+
+    @classmethod
+    def from_hf_dict(cls, hf: Dict[str, Any]) -> "TeacherConfig":
+        """Build from a HuggingFace Qwen2 `config.json` dict."""
+        n_heads = int(hf["num_attention_heads"])
+        d_model = int(hf["hidden_size"])
+        head_dim = int(hf.get("head_dim", d_model // n_heads))
+        return cls(
+            vocab_size=int(hf["vocab_size"]),
+            d_model=d_model,
+            n_layers=int(hf["num_hidden_layers"]),
+            n_heads=n_heads,
+            n_kv_heads=int(hf.get("num_key_value_heads", n_heads)),
+            head_dim=head_dim,
+            intermediate_size=int(hf["intermediate_size"]),
+            rms_norm_eps=float(hf.get("rms_norm_eps", 1e-6)),
+            rope_theta=float(hf.get("rope_theta", 10000.0)),
+            tie_embeddings=bool(hf.get("tie_word_embeddings", True)),
+            model_id=hf.get("_name_or_path"),
+        )
+
+    @property
+    def q_dim(self) -> int:
+        """Width of the concatenated query projection (n_heads * head_dim)."""
+        return self.n_heads * self.head_dim
+
+    @property
+    def kv_dim(self) -> int:
+        """Width of each of the key/value projections (n_kv_heads * head_dim)."""
+        return self.n_kv_heads * self.head_dim
+
+    def validate(self) -> None:
+        if self.n_kv_heads <= 0 or self.n_heads % self.n_kv_heads != 0:
+            raise ValueError(
+                f"n_kv_heads={self.n_kv_heads} must divide n_heads={self.n_heads} (GQA)."
+            )
+        if self.head_dim <= 0 or self.head_dim % 2 != 0:
+            raise ValueError(f"head_dim={self.head_dim} must be positive and even (RoPE).")
+        for name in ("vocab_size", "d_model", "n_layers", "intermediate_size"):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive")
+
+
+@dataclass
+class AttnProjections:
+    """One layer's attention projection weights, for the #99 init mapping.
+
+    Weights are opaque backend arrays in the HF row-major convention (`y = x @ W.T`):
+    `q` is (q_dim, d_model), `k`/`v` are (kv_dim, d_model), `o` is (d_model, q_dim).
+    Qwen2 has biases on q/k/v and none on o. The #99 init maps Q/K/V/O onto the
+    student SSM's C/B/input/output projections.
+    """
+
+    q: Array
+    k: Array
+    v: Array
+    o: Array
+    q_bias: Optional[Array] = None
+    k_bias: Optional[Array] = None
+    v_bias: Optional[Array] = None
+
+
+@dataclass
+class TeacherForward:
+    """Result of a teacher forward pass. `logits` is (batch, seq, vocab).
+
+    `hidden_states`, when requested, is a tuple of length `n_layers + 1`: the embedding
+    output followed by each decoder layer's output, each (batch, seq, d_model) — the HF
+    `output_hidden_states` convention MOHAWK hidden-alignment (#100) consumes.
+    """
+
+    logits: Array
+    hidden_states: Optional[Tuple[Array, ...]] = None
+
+
+class ConversionTeacher(ABC):
+    """Frozen forward-only teacher contract. Concrete impls live below the seam."""
+
+    #: Architecture, the single source of truth for the teacher's shapes.
+    config: TeacherConfig
+
+    @property
+    def n_layers(self) -> int:
+        return self.config.n_layers
+
+    @abstractmethod
+    def forward(self, token_batch: Array, *, return_hidden: bool = False) -> TeacherForward:
+        """Forward over `token_batch` (batch, seq) ids. Returns logits (+ hidden states).
+
+        No gradient flows into the teacher's weights: the implementation wraps its
+        outputs in the backend's stop-gradient so the teacher stays frozen even when
+        its logits/hidden states are composed into a student loss.
+        """
+
+    @abstractmethod
+    def topk_logits(self, token_batch: Array, k: int) -> Tuple[Array, Array]:
+        """Top-`k` logits over the vocab. Returns (values, indices), each (batch, seq, k),
+        values descending. This is the per-token teacher signal cached by the precompute
+        (#94) and matched with KL by the distill loss (#100)."""
+
+    @abstractmethod
+    def attention_projection(self, layer: int) -> AttnProjections:
+        """The Q/K/V/O projection weights of decoder `layer` (0-indexed), for #99."""
+
+    @abstractmethod
+    def to_numpy(self, array: Array) -> Any:
+        """Convert an opaque teacher array to a numpy array (the seam converter)."""
+
+    def trainable_parameters(self) -> Dict[str, Array]:
+        """The frozen contract: a conversion teacher has NO trainable parameters, so it
+        is excluded from the optimizer and the resume bundle. Overridable, but the empty
+        default is what makes the freeze structural rather than merely conventional."""
+        return {}

--- a/src/model/teacher.py
+++ b/src/model/teacher.py
@@ -42,7 +42,7 @@ class TeacherConfig:
     imports a backend, so the config is shared across backends like `MambaConfig`.
     """
 
-    vocab_size: int
+    vocab_size: int              # MODEL embedding width (may be padded above the tokenizer vocab)
     d_model: int                 # hidden_size
     n_layers: int                # num_hidden_layers
     n_heads: int                 # num_attention_heads (query heads)
@@ -53,6 +53,11 @@ class TeacherConfig:
     rope_theta: float = 10000.0
     tie_embeddings: bool = True
     model_id: Optional[str] = None   # HF repo id, for from_pretrained / provenance
+    # The TOKENIZER vocab, when the model embedding is padded above it (Qwen2.5: model 151936,
+    # tokenizer 151646). None => no padding (use `vocab_size`). `forward`/`topk_logits` expose
+    # logits/indices over `effective_vocab_size`, so a student with the tokenizer vocab can
+    # consume them — the padded rows are never emitted as teacher targets.
+    tokenizer_vocab_size: Optional[int] = None
 
     @classmethod
     def qwen_1_5b(cls) -> "TeacherConfig":
@@ -67,6 +72,7 @@ class TeacherConfig:
             vocab_size=151936, d_model=1536, n_layers=28, n_heads=12, n_kv_heads=2,
             head_dim=128, intermediate_size=8960, rms_norm_eps=1e-6, rope_theta=10000.0,
             tie_embeddings=True, model_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+            tokenizer_vocab_size=151646,   # student/tokenizer vocab; padded rows 151646..151936 unused
         )
 
     @classmethod
@@ -99,6 +105,12 @@ class TeacherConfig:
         )
 
     @property
+    def effective_vocab_size(self) -> int:
+        """The vocab the teacher emits logits/top-k over: the tokenizer vocab when the model
+        embedding is padded above it, otherwise the full `vocab_size`."""
+        return self.tokenizer_vocab_size or self.vocab_size
+
+    @property
     def q_dim(self) -> int:
         """Width of the concatenated query projection (n_heads * head_dim)."""
         return self.n_heads * self.head_dim
@@ -118,6 +130,11 @@ class TeacherConfig:
         for name in ("vocab_size", "d_model", "n_layers", "intermediate_size"):
             if getattr(self, name) <= 0:
                 raise ValueError(f"{name} must be positive")
+        if self.tokenizer_vocab_size is not None and not (
+                0 < self.tokenizer_vocab_size <= self.vocab_size):
+            raise ValueError(
+                f"tokenizer_vocab_size={self.tokenizer_vocab_size} must be in "
+                f"(0, vocab_size={self.vocab_size}].")
 
 
 @dataclass

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -33,6 +33,7 @@ PORTABLE_MODULES = [
     "src.model.interface",
     "src.model.blocks",
     "src.model.backend",
+    "src.model.teacher",
     "src.model.sizing",
     "src.data.loader",
     "src.data.corpus",

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -35,6 +35,7 @@ def test_qwen_1_5b_config_shape():
     assert c.intermediate_size == 8960 and c.tie_embeddings
     assert c.q_dim == 1536 and c.kv_dim == 256
     assert c.model_id == "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+    assert c.tokenizer_vocab_size == 151646 and c.effective_vocab_size == 151646
     c.validate()
 
 
@@ -42,6 +43,30 @@ def test_config_validate_rejects_bad_gqa():
     with pytest.raises(ValueError):
         TeacherConfig(vocab_size=8, d_model=16, n_layers=1, n_heads=4, n_kv_heads=3,
                       head_dim=4, intermediate_size=16).validate()
+
+
+def test_config_rejects_tokenizer_vocab_above_model_vocab():
+    with pytest.raises(ValueError):
+        TeacherConfig(vocab_size=256, d_model=16, n_layers=1, n_heads=2, n_kv_heads=1,
+                      head_dim=8, intermediate_size=16, tokenizer_vocab_size=300).validate()
+
+
+def test_make_teacher_requires_config_for_synthetic_path():
+    from src.model.backend import get_backend
+    with pytest.raises(ValueError):
+        get_backend("mlx").make_teacher()                  # no config and no pretrained
+
+
+def test_logits_sliced_to_tokenizer_vocab():
+    """When the model embedding is padded above the tokenizer vocab, forward/top-k emit
+    only the tokenizer-vocab columns, so a student with that vocab can consume the indices."""
+    cfg = TeacherConfig(vocab_size=64, d_model=32, n_layers=1, n_heads=2, n_kv_heads=1,
+                        head_dim=16, intermediate_size=32, tokenizer_vocab_size=50)
+    t = MLXConversionTeacher.from_config(cfg, seed=0)
+    out = t.forward(_tokens(1, 4, cfg.vocab_size))
+    assert out.logits.shape == (1, 4, 50)                  # padded rows 50..64 not emitted
+    _, idx = t.topk_logits(_tokens(1, 4, cfg.vocab_size), 8)
+    assert mx.all(idx < 50).item()
 
 
 # --- forward / shapes --------------------------------------------------------

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -1,0 +1,165 @@
+"""Conversion-teacher loader (#93). MLX-only; skipped where mlx is unavailable.
+
+Exercises the frozen, forward-only teacher behind the seam with the tiny synthetic
+teacher (offline): output shapes (logits / hidden states / top-k), the Q/K/V/O
+projection accessor the #99 init consumes, the frozen contract (no trainable params,
+no gradient flow), determinism, and the real HF-safetensors loader path via an
+offline synthetic checkpoint round-trip.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from src.model.teacher import TeacherConfig
+from src.model.mlx_teacher import MLXConversionTeacher
+
+
+def _tiny():
+    return MLXConversionTeacher.from_config(TeacherConfig.tiny(), seed=0)
+
+
+def _tokens(B, L, vocab):
+    rng = np.random.default_rng(0)
+    return rng.integers(0, vocab, size=(B, L)).astype(np.int32)
+
+
+# --- config ------------------------------------------------------------------
+def test_qwen_1_5b_config_shape():
+    c = TeacherConfig.qwen_1_5b()
+    assert (c.vocab_size, c.d_model, c.n_layers) == (151936, 1536, 28)
+    assert (c.n_heads, c.n_kv_heads, c.head_dim) == (12, 2, 128)
+    assert c.intermediate_size == 8960 and c.tie_embeddings
+    assert c.q_dim == 1536 and c.kv_dim == 256
+    assert c.model_id == "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+    c.validate()
+
+
+def test_config_validate_rejects_bad_gqa():
+    with pytest.raises(ValueError):
+        TeacherConfig(vocab_size=8, d_model=16, n_layers=1, n_heads=4, n_kv_heads=3,
+                      head_dim=4, intermediate_size=16).validate()
+
+
+# --- forward / shapes --------------------------------------------------------
+def test_forward_logits_shape():
+    t = _tiny()
+    c = t.config
+    out = t.forward(_tokens(2, 5, c.vocab_size))
+    assert out.logits.shape == (2, 5, c.vocab_size)
+    assert out.hidden_states is None
+    assert mx.all(mx.isfinite(out.logits)).item()
+
+
+def test_forward_hidden_states():
+    t = _tiny()
+    c = t.config
+    out = t.forward(_tokens(2, 5, c.vocab_size), return_hidden=True)
+    assert len(out.hidden_states) == c.n_layers + 1        # embedding + each layer
+    for h in out.hidden_states:
+        assert h.shape == (2, 5, c.d_model)
+
+
+def test_topk_logits():
+    t = _tiny()
+    c = t.config
+    k = 8
+    vals, idx = t.topk_logits(_tokens(2, 5, c.vocab_size), k)
+    assert vals.shape == (2, 5, k) and idx.shape == (2, 5, k)
+    # descending values, indices in range, and equal to a gather of the full logits
+    diffs = vals[..., :-1] - vals[..., 1:]
+    assert mx.all(diffs >= -1e-5).item()
+    assert mx.all(idx >= 0).item() and mx.all(idx < c.vocab_size).item()
+    full = t.forward(_tokens(2, 5, c.vocab_size)).logits
+    gathered = mx.take_along_axis(full, idx, axis=-1)
+    assert mx.allclose(gathered, vals, atol=1e-5).item()
+
+
+# --- projection accessor (#99) ----------------------------------------------
+def test_attention_projection_shapes_gqa():
+    t = _tiny()
+    c = t.config
+    pr = t.attention_projection(0)
+    assert pr.q.shape == (c.q_dim, c.d_model)
+    assert pr.k.shape == (c.kv_dim, c.d_model)
+    assert pr.v.shape == (c.kv_dim, c.d_model)
+    assert pr.o.shape == (c.d_model, c.q_dim)
+    assert c.n_kv_heads < c.n_heads                        # exercising the GQA path
+    assert pr.q_bias.shape == (c.q_dim,)
+    assert pr.k_bias.shape == (c.kv_dim,) and pr.v_bias.shape == (c.kv_dim,)
+
+
+# --- frozen contract ---------------------------------------------------------
+def test_no_trainable_parameters():
+    assert _tiny().trainable_parameters() == {}
+
+
+def test_no_gradient_flows_to_teacher():
+    """A loss on the teacher's logits must produce zero gradient w.r.t. its weights:
+    forward wraps its outputs in stop_gradient, so the teacher stays frozen even when
+    composed into a student objective."""
+    t = _tiny()
+    toks = _tokens(1, 4, t.config.vocab_size)
+    embed = t._w["embed"]
+
+    def loss(w):
+        t._w["embed"] = w
+        return t.forward(toks).logits.sum()
+
+    g = mx.grad(loss)(embed)
+    t._w["embed"] = embed                                  # restore
+    assert mx.all(g == 0).item()
+
+
+def test_deterministic_forward():
+    t = _tiny()
+    toks = _tokens(2, 6, t.config.vocab_size)
+    a = t.forward(toks).logits
+    b = t.forward(toks).logits
+    assert mx.array_equal(a, b).item()
+
+
+# --- real HF loader path (offline synthetic checkpoint) ----------------------
+def _write_hf_checkpoint(t: MLXConversionTeacher, path):
+    """Serialize a teacher to an HF-named safetensors checkpoint + config.json, so the
+    `from_pretrained` name-mapping is exercised without a multi-GB download."""
+    c = t.config
+    w = t._w
+    hf = {"model.embed_tokens.weight": w["embed"], "model.norm.weight": w["final_ln"]}
+    for i in range(c.n_layers):
+        ip, p = f"model.layers.{i}.", f"layer.{i}."
+        hf[ip + "input_layernorm.weight"] = w[p + "input_ln"]
+        hf[ip + "post_attention_layernorm.weight"] = w[p + "post_ln"]
+        for proj, src in (("q_proj", "q"), ("k_proj", "k"), ("v_proj", "v")):
+            hf[ip + f"self_attn.{proj}.weight"] = w[p + src + "_w"]
+            hf[ip + f"self_attn.{proj}.bias"] = w[p + src + "_b"]
+        hf[ip + "self_attn.o_proj.weight"] = w[p + "o_w"]
+        hf[ip + "mlp.gate_proj.weight"] = w[p + "gate_w"]
+        hf[ip + "mlp.up_proj.weight"] = w[p + "up_w"]
+        hf[ip + "mlp.down_proj.weight"] = w[p + "down_w"]
+    path.mkdir(parents=True, exist_ok=True)
+    mx.save_safetensors(str(path / "model.safetensors"), hf)
+    hf_cfg = {
+        "vocab_size": c.vocab_size, "hidden_size": c.d_model,
+        "num_hidden_layers": c.n_layers, "num_attention_heads": c.n_heads,
+        "num_key_value_heads": c.n_kv_heads, "head_dim": c.head_dim,
+        "intermediate_size": c.intermediate_size, "rms_norm_eps": c.rms_norm_eps,
+        "rope_theta": c.rope_theta, "tie_word_embeddings": c.tie_embeddings,
+    }
+    (path / "config.json").write_text(json.dumps(hf_cfg))
+
+
+def test_from_pretrained_roundtrip(tmp_path):
+    src = MLXConversionTeacher.from_config(TeacherConfig.tiny(), seed=3)
+    _write_hf_checkpoint(src, tmp_path / "ckpt")
+    loaded = MLXConversionTeacher.from_pretrained(tmp_path / "ckpt")
+    # config recovered from config.json
+    assert loaded.config.vocab_size == src.config.vocab_size
+    assert loaded.config.n_layers == src.config.n_layers
+    # identical logits => name-mapping + IO are correct
+    toks = _tokens(2, 5, src.config.vocab_size)
+    assert mx.allclose(loaded.forward(toks).logits, src.forward(toks).logits,
+                       atol=1e-5).item()


### PR DESCRIPTION
Closes #93. Part of #65 (M10 distillation).

## Summary
Adds a **frozen, forward-only conversion teacher** (DeepSeek-R1-Distill-Qwen-1.5B, a Qwen2 architecture) behind the hardware seam — mirroring DPO's frozen-reference pattern (a distinct object the optimizer never touches). It is the upstream dependency for student init (#99) and the distill loss (#100).

- **`src/model/teacher.py`** (portable, no backend import): `ConversionTeacher` protocol + `TeacherConfig` (`qwen_1_5b` / `tiny` / `from_hf_dict`), `AttnProjections`, `TeacherForward`. Exposes `forward(return_hidden=…)`, `topk_logits`, `attention_projection` (Q/K/V/O for the #99 init), `to_numpy`. Reports **no trainable parameters**, so it is structurally excluded from the optimizer and resume bundle.
- **`src/model/mlx_teacher.py`** (below seam): a minimal self-contained Qwen2 forward (GQA + RoPE + SwiGLU, fp32, no `mlx-lm` dependency). `from_config` builds a tiny **synthetic** teacher for offline tests/small local checks; `from_pretrained` loads real HF safetensors (a checkpoint dir, or a lazy hub fetch). Outputs are `stop_gradient`-wrapped, so no gradient flows into the teacher even when composed into a student loss.
- **`src/model/backend.py`**: `Backend.make_teacher` — MLX factory (synthetic vs pretrained); CUDA branch raises `NotImplementedError` (deferred), consistent with the SFT/DPO precedent.
- **`docs/design/10-distillation.md`**: documents the teacher seam (protocol + MLX impl, synthetic vs pretrained, frozen contract).

## Testing
- `tests/test_teacher.py` (10 tests): logits/hidden-state/top-k shapes, GQA Q/K/V/O projection accessor, frozen contract (no trainable params + zero-gradient probe), determinism, and an **offline HF-checkpoint round-trip** exercising the `from_pretrained` name-mapping without a download.
- Added `src.model.teacher` to the import-guard portable set; seam intact.
- Full suite: **297 passed, 1 skipped**.

> **Stacked PRs:** #99 (student init) and #100 (distill loss) depend on this teacher code and will be stacked on top of this branch (each PR's base set to its parent) so they carry the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)