### PR TITLE
feat(train): [M10] distillation loss + staged train step (KL top-k + CE) (#100)

### DIFF
--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -88,6 +88,32 @@ init quality is judged by the downstream distillation curve, not by exactness. F
 native `nn.Module.freeze`, which `nn.value_and_grad` already honors, so the train step is
 unchanged. The CUDA initializer is deferred.
 
+### The staged distillation loss + train step (#100)
+
+The student trains against the **cached** teacher signal through the manifest's distillation
+stages (`distill_stages(manifest)` → `mixing-match → hidden-align → logit-distill`, in order).
+Each stage is a separate injected `TrainStepFn` from
+`get_backend(...).make_distill_train_step(model, opt, stage=...)`
+(`src/model/mlx_distill.py`), mirroring SFT/DPO/GRPO and funnelling through the shared
+`_accumulate_and_step`, so the backend-free loop is unchanged:
+
+- **`logit-distill`** — compound `ce_weight·CE + kl_weight·KL_topk`, where `KL_topk` is the
+  `T²`-scaled KL between the teacher's cached **top-k** distribution and the student's logits
+  renormalized over the same support. No teacher inference in the loop (acceptance: KL+CE from
+  cached top-k).
+- **`hidden-align`** — MSE between per-layer hidden states, with **cached** teacher hidden states
+  in the micro-batch *or* **on-the-fly** recompute (`teacher.forward(return_hidden=True)`,
+  stop-gradient); compared over the overlapping `min(d)` channels (the width mismatch).
+- **`mixing-match`** — MSE between the student's head-averaged SSM **mixing matrix**
+  (`SelectiveSSM.mixing_matrix`, the materialized 1-semiseparable matrix, verified to reproduce
+  the scan) and the teacher's head-averaged causal attention matrix. A tractable simplification of
+  MOHAWK's strict per-layer teacher-forced orientation (each runs on its own forward, since the
+  widths differ).
+
+The compound loss is a single scalar, so the dynamic fp16 loss scaler
+(`train.loss_scale.DynamicLossScaler`) covers it unchanged — the combined term is scaled before
+backprop and overflowing steps skip cleanly. The CUDA distill step is deferred.
+
 ## The tokenizer is fixed by the conversion teacher (#90, #91)
 
 The student must **share a vocabulary with the conversion teacher** for logit and hidden-state

--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -48,6 +48,24 @@ Code/math conversion alternatives on the same tokenizer: Qwen2.5-Coder-1.5B, Qwe
 tokenizer source (use restrictions). The MOHAWK lineage's demonstrated teacher family was Phi
 (Phi-4-mini, MIT) — usable, but on a different tokenizer.
 
+### The teacher loader behind the seam (#93)
+
+The conversion teacher is loaded **frozen and forward-only** behind the hardware seam, exactly
+like DPO's frozen reference (`mlx_train_step.make_dpo_train_step` holds a distinct `ref_model`
+the optimizer never touches). The portable protocol is `ConversionTeacher`
+(`src/model/teacher.py`): `forward(return_hidden=...)` (logits + optional per-layer hidden
+states), `topk_logits(tokens, k)` (the cached signal #94/#100 match against), and
+`attention_projection(layer)` (the Q/K/V/O the #99 init maps onto the student SSM's
+C/B/input/output). Above the seam, callers see only opaque arrays plus a `to_numpy` converter —
+never a backend array type — and the teacher reports **no** trainable parameters, so it is
+structurally excluded from the optimizer and the resume bundle.
+
+The MLX implementation (`src/model/mlx_teacher.py`, a minimal self-contained Qwen2 forward — no
+`mlx-lm` dependency) loads real HF weights via `from_pretrained` (a checkpoint dir or, lazily, an
+HF repo id) and builds a tiny **synthetic** teacher via `from_config` for offline tests and small
+local checks. Build one through `get_backend(...).make_teacher(...)`; the CUDA teacher is deferred
+(the branch raises `NotImplementedError`).
+
 ## The tokenizer is fixed by the conversion teacher (#90, #91)
 
 The student must **share a vocabulary with the conversion teacher** for logit and hidden-state

--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -66,6 +66,28 @@ HF repo id) and builds a tiny **synthetic** teacher via `from_config` for offlin
 local checks. Build one through `get_backend(...).make_teacher(...)`; the CUDA teacher is deferred
 (the branch raises `NotImplementedError`).
 
+### Student init from the teacher (#99)
+
+A trial is a **manifest** (`config/manifests/*.yaml`); `src/train/distill_manifest.py` parses it
+(portable, above the seam): `init:` resolves to an `InitMethod`, `stages:` is validated against
+the canonical list (the distill stages `mixing-match → hidden-align → logit-distill` plus the
+post-training ones), and `manifest_to_config` resolves the `layout` sweep-schema
+(`d_model`, `n_layers`, `attention_every → attn_every`, `state_size → d_state`) + `tokenizer →
+vocab_size` onto a `MambaConfig`.
+
+`get_backend(...).init_student(student, teacher, method)`
+(`src/model/mlx_student_init.py`) then performs the conversion. **Mamba-in-the-Llama** maps the
+teacher attention onto the student SSM — **Q → C**, **K → B** (the two `d_state` slices of the SSM
+`x_proj`), **V → input** (`in_proj` main half), **O → output** (`out_proj`) — copies the kept
+attention layers from the teacher and **freezes** them (the student has no MLP blocks, so the
+retained attention plays the role the paper's frozen MLPs do; the trainable set is the new Mamba
+layers). **MOHAWK** is a lighter init (copy attention, leave Mamba at default, freeze nothing);
+the matching happens in the staged distill loss (#100). Because teacher and student widths differ,
+the mapping is **adaptive** (exact copy where dims align, else copy-overlap + zero-pad/truncate);
+init quality is judged by the downstream distillation curve, not by exactness. Freezing uses MLX's
+native `nn.Module.freeze`, which `nn.value_and_grad` already honors, so the train step is
+unchanged. The CUDA initializer is deferred.
+
 ## The tokenizer is fixed by the conversion teacher (#90, #91)
 
 The student must **share a vocabulary with the conversion teacher** for logit and hidden-state

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -46,6 +46,9 @@ class Backend:
     # Distillation (M10/#99): initialize a student model from a teacher (Mamba-in-the-Llama /
     # MOHAWK), returning an `InitReport`. MLX-only for now; CUDA raises NotImplementedError.
     init_student: Callable[..., Any]
+    # Distillation (M10/#100): staged distill train-step factory (mixing-match / hidden-align /
+    # logit-distill), mirroring make_*_train_step. MLX-only; CUDA raises NotImplementedError.
+    make_distill_train_step: Callable[..., Callable]
 
 
 def get_backend(name: str = "auto") -> Backend:
@@ -109,6 +112,10 @@ def _mlx_backend() -> Backend:
         from .mlx_student_init import init_student
         return init_student(student, teacher, method)
 
+    def _make_distill_train_step(*args, **kwargs):
+        from .mlx_distill import make_distill_train_step
+        return make_distill_train_step(*args, **kwargs)
+
     return Backend(
         name="mlx",
         model_cls=MLXMambaModel,
@@ -125,6 +132,7 @@ def _mlx_backend() -> Backend:
         make_grpo_train_step=_make_grpo_train_step,
         make_teacher=_make_teacher,
         init_student=_init_student,
+        make_distill_train_step=_make_distill_train_step,
     )
 
 
@@ -174,6 +182,11 @@ def _cuda_backend() -> Backend:
             "Student init (M10/#99) is implemented on the MLX dev backend only; "
             "the CUDA initializer is deferred.")
 
+    def _distill_unsupported(*args, **kwargs):
+        raise NotImplementedError(
+            "The distillation train step (M10/#100) is implemented on the MLX dev backend "
+            "only; the CUDA distill step is deferred.")
+
     return Backend(
         name="cuda",
         model_cls=CUDAMambaModel,
@@ -189,4 +202,5 @@ def _cuda_backend() -> Backend:
         make_grpo_train_step=_post_training_unsupported,
         make_teacher=_teacher_unsupported,
         init_student=_student_init_unsupported,
+        make_distill_train_step=_distill_unsupported,
     )

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -43,6 +43,9 @@ class Backend:
     # Distillation (M10): build a frozen, forward-only conversion teacher behind the seam
     # (`ConversionTeacher`). MLX-only for now; the CUDA branch raises NotImplementedError.
     make_teacher: Callable[..., Any]
+    # Distillation (M10/#99): initialize a student model from a teacher (Mamba-in-the-Llama /
+    # MOHAWK), returning an `InitReport`. MLX-only for now; CUDA raises NotImplementedError.
+    init_student: Callable[..., Any]
 
 
 def get_backend(name: str = "auto") -> Backend:
@@ -101,6 +104,11 @@ def _mlx_backend() -> Backend:
             return MLXConversionTeacher.from_pretrained(pretrained, config)
         return MLXConversionTeacher.from_config(config, seed=seed)
 
+    def _init_student(student, teacher, method):
+        """Initialize a student from a teacher (#99); `method` is an `InitMethod`."""
+        from .mlx_student_init import init_student
+        return init_student(student, teacher, method)
+
     return Backend(
         name="mlx",
         model_cls=MLXMambaModel,
@@ -116,6 +124,7 @@ def _mlx_backend() -> Backend:
         make_dpo_train_step=_make_dpo_train_step,
         make_grpo_train_step=_make_grpo_train_step,
         make_teacher=_make_teacher,
+        init_student=_init_student,
     )
 
 
@@ -160,6 +169,11 @@ def _cuda_backend() -> Backend:
             "The conversion teacher (M10/#93) is implemented on the MLX dev backend only; "
             "the CUDA teacher loader is deferred.")
 
+    def _student_init_unsupported(*args, **kwargs):
+        raise NotImplementedError(
+            "Student init (M10/#99) is implemented on the MLX dev backend only; "
+            "the CUDA initializer is deferred.")
+
     return Backend(
         name="cuda",
         model_cls=CUDAMambaModel,
@@ -174,4 +188,5 @@ def _cuda_backend() -> Backend:
         make_dpo_train_step=_post_training_unsupported,
         make_grpo_train_step=_post_training_unsupported,
         make_teacher=_teacher_unsupported,
+        init_student=_student_init_unsupported,
     )

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -40,6 +40,9 @@ class Backend:
     make_sft_train_step: Callable[..., Callable]
     make_dpo_train_step: Callable[..., Callable]
     make_grpo_train_step: Callable[..., Callable]
+    # Distillation (M10): build a frozen, forward-only conversion teacher behind the seam
+    # (`ConversionTeacher`). MLX-only for now; the CUDA branch raises NotImplementedError.
+    make_teacher: Callable[..., Any]
 
 
 def get_backend(name: str = "auto") -> Backend:
@@ -90,6 +93,14 @@ def _mlx_backend() -> Backend:
         from .mlx_train_step import make_grpo_train_step
         return make_grpo_train_step(*args, **kwargs)
 
+    def _make_teacher(config=None, *, pretrained=None, seed=0):
+        """Frozen conversion teacher (#93): `pretrained` (an HF checkpoint dir / repo id)
+        loads real weights; otherwise a synthetic teacher is built from `config`."""
+        from .mlx_teacher import MLXConversionTeacher
+        if pretrained is not None:
+            return MLXConversionTeacher.from_pretrained(pretrained, config)
+        return MLXConversionTeacher.from_config(config, seed=seed)
+
     return Backend(
         name="mlx",
         model_cls=MLXMambaModel,
@@ -104,6 +115,7 @@ def _mlx_backend() -> Backend:
         make_sft_train_step=make_sft_train_step,
         make_dpo_train_step=_make_dpo_train_step,
         make_grpo_train_step=_make_grpo_train_step,
+        make_teacher=_make_teacher,
     )
 
 
@@ -143,6 +155,11 @@ def _cuda_backend() -> Backend:
             "post-training steps are deferred (run scripts/sft.py / scripts/dpo.py on "
             "Apple Silicon).")
 
+    def _teacher_unsupported(*args, **kwargs):
+        raise NotImplementedError(
+            "The conversion teacher (M10/#93) is implemented on the MLX dev backend only; "
+            "the CUDA teacher loader is deferred.")
+
     return Backend(
         name="cuda",
         model_cls=CUDAMambaModel,
@@ -156,4 +173,5 @@ def _cuda_backend() -> Backend:
         make_sft_train_step=_post_training_unsupported,
         make_dpo_train_step=_post_training_unsupported,
         make_grpo_train_step=_post_training_unsupported,
+        make_teacher=_teacher_unsupported,
     )

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -254,6 +254,24 @@ class SelectiveSSM(nn.Module):
         Y = Y + X[:, :L] * self.D[None, None, :, None]             # skip
         return _cast(Y.reshape(B_, L, d_inner), cd)                # back to compute dtype
 
+    def mixing_matrix(self, x: Array) -> Array:
+        """Materialize the dense (B, H, L, L) 1-semiseparable mixing matrix M such that
+        `einsum('bhij,bjhp->bihp', M, X) == parallel(x)` (X = the head-split input). This is
+        the matrix the SSD scan applies; the distillation `mixing-match` stage (#100) matches
+        it against the teacher's attention matrix. Folds in the per-step `delta` scaling and
+        the per-head `D` skip, so it maps the RAW (unscaled) input. Dense O(L^2) — used only
+        as a training-time auxiliary at modest L, not in the chunked training path."""
+        B_, L, _ = x.shape
+        H, N = self.config.n_heads, self.config.d_state
+        delta, a, Bm, Cm = self._project(x)        # delta (B,L,H); Bm,Cm (B,L,N) — fp32
+        gh = (delta * a).transpose(0, 2, 1)        # (B,H,L) log-decay (<= 0)
+        decay = mx.exp(_segsum(gh))                # (B,H,L,L): exp(cumA_i-cumA_j), causal
+        CB = mx.einsum("bin,bjn->bij", Cm, Bm)     # (B,L,L) shared B/C group
+        delta_col = delta.transpose(0, 2, 1)[:, :, None, :]          # (B,H,1,L) delta_j
+        M = decay * CB[:, None] * delta_col                          # (B,H,L,L)
+        eye = mx.eye(L, dtype=M.dtype)
+        return M + self.D[None, :, None, None] * eye[None, None]     # + D skip on the diagonal
+
     def recurrence(self, x: Array, state: State) -> Tuple[Array, State]:
         """One timestep. x: (B, d_inner), state h: (B, H, P, N) -> y: (B, d_inner)."""
         B_ = x.shape[0]
@@ -338,6 +356,17 @@ class MambaBlock(nn.Module):
         y = self.ssm.parallel(xc, seg_ids)
         y = y * _silu(z)
         return x + _linear(self.out_proj, y, cd)
+
+    def mixing_matrix(self, x: Array) -> Array:
+        """This block's head-split SSM mixing matrix (B, H, L, L), for distillation
+        `mixing-match` (#100). Runs the block front-end (norm -> in_proj main -> causal conv
+        -> SiLU) then materializes the SSM matrix on that input."""
+        L = x.shape[1]
+        cd = _DTYPES[self.config.precision]
+        xn = self.norm(x)
+        x_main, _ = mx.split(_linear(self.in_proj, xn, cd), 2, axis=-1)
+        xc = _silu(self._conv_seq(x_main, cd)[:, :L])
+        return self.ssm.mixing_matrix(xc)
 
     def step(self, x: Array, state: State) -> Tuple[Array, State]:
         conv_state, ssm_state = state                        # (B,k-1,di), (B,di,ds)
@@ -510,6 +539,30 @@ class MLXMambaModel(ModelInterface, nn.Module):
             h, st2 = layer.step(h, st)
             new_state.append(st2)
         return self._head(self.norm_f(h)), new_state
+
+    # --- distillation matching accessors (#100) ------------------------------
+    def hidden_states(self, token_batch: Array) -> Tuple[Array, ...]:
+        """Per-layer hidden states for the `hidden-align` stage: the embedding output
+        followed by each layer's output (length n_layers + 1) — the HF/teacher convention
+        (`mlx_teacher.MLXConversionTeacher.forward(return_hidden=True)`)."""
+        h = _cast(self.embedding(mx.array(token_batch)), self._cd)
+        hs = [h]
+        for layer in self.layers:
+            h = layer.forward_seq(h)
+            hs.append(h)
+        return tuple(hs)
+
+    def mixing_matrices(self, token_batch: Array) -> List[Tuple[int, Array]]:
+        """For the `mixing-match` stage: each Mamba layer's head-averaged mixing matrix
+        `(B, L, L)` paired with its layer index. Attention layers are skipped (their mixer is
+        the teacher's attention they were matched against)."""
+        h = _cast(self.embedding(mx.array(token_batch)), self._cd)
+        out: List[Tuple[int, Array]] = []
+        for i, layer in enumerate(self.layers):
+            if not self.config.is_attention_layer(i):
+                out.append((i, layer.mixing_matrix(h).mean(axis=1)))    # head-average -> (B,L,L)
+            h = layer.forward_seq(h)
+        return out
 
     def init_state(self, batch_size: int) -> State:
         c = self.config

--- a/src/model/mlx_distill.py
+++ b/src/model/mlx_distill.py
@@ -1,0 +1,143 @@
+"""MLX distillation train steps (Apple Silicon, below the seam — may import mlx).
+
+The staged distillation matching (#100): a student is trained against the frozen teacher (#93)
+through the manifest's `stages` (`mixing-match -> hidden-align -> logit-distill`, #99). Each stage
+is a different `TrainStepFn` built by `make_distill_train_step(..., stage=...)`; the driver loops
+the stages (via `train.distill_manifest.distill_stages`) swapping the step. The backend-free loop
+(`train.loop`) is unchanged — this mirrors SFT/DPO/GRPO and funnels through the shared
+`_accumulate_and_step` (grad-accum, fp16 unscale + overflow-skip, clip, optimizer update) from
+`mlx_train_step`.
+
+The compound loss is a single scalar, so the existing `train.loss_scale.DynamicLossScaler` covers
+it unchanged: the loss is scaled before backprop and the backend's inf/nan check skips overflowing
+steps.
+
+Stage micro-batch tuples:
+  * logit-distill : (inputs, targets, topk_vals, topk_idx)  — cached teacher top-k (#94).
+  * hidden-align  : (inputs, teacher_hidden) cached, OR (inputs,) on-the-fly (teacher recompute).
+  * mixing-match  : (inputs,) on-the-fly (teacher attention matrices recomputed).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .mlx_train_step import _accumulate_and_step
+from ..train.distill_manifest import DistillStage
+
+
+def _align(i: int, n_src: int, n_dst: int) -> int:
+    """Map index `i` in a depth-`n_src` stack onto the nearest index in a depth-`n_dst` one."""
+    return min(n_dst - 1, max(0, int(round(i * n_dst / max(1, n_src)))))
+
+
+def _kl_topk(student_logits: mx.array, topk_vals: mx.array, topk_idx: mx.array,
+             temperature: float) -> mx.array:
+    """T^2-scaled KL(teacher || student) over the teacher's top-k support (Hinton scaling).
+
+    `student_logits` (B,L,V) fp32; `topk_vals`/`topk_idx` (B,L,k). Teacher and student are each
+    softmaxed over the SAME k indices at temperature T, so the KL is computed on the shared
+    support the cached signal (#94) provides."""
+    T = temperature
+    p = mx.softmax(topk_vals.astype(mx.float32) / T, axis=-1)            # teacher over support
+    sg = mx.take_along_axis(student_logits, topk_idx.astype(mx.int32), axis=-1) / T
+    logq = sg - mx.logsumexp(sg, axis=-1, keepdims=True)                 # student log-softmax/k
+    kl = (p * (mx.log(p + 1e-9) - logq)).sum(axis=-1)                    # (B,L)
+    return (T * T) * kl.mean()
+
+
+def _ce(logits: mx.array, targets) -> mx.array:
+    V = logits.shape[-1]
+    t = mx.array(targets).reshape(-1).astype(mx.int32)
+    return nn.losses.cross_entropy(logits.reshape(-1, V), t, reduction="mean")
+
+
+def _hidden_mse(student_hs, teacher_hs, layers: List[int], n_s: int, n_t: int) -> mx.array:
+    """Mean MSE between aligned student/teacher hidden states, over the overlapping channels
+    (the teacher and student widths differ; compare the shared `min(d)` — a documented POC
+    handling of the mismatch). `student_hs`/`teacher_hs` are (n+1)-length tuples (embedding +
+    each layer); `layers` are student hidden indices to match."""
+    terms = []
+    for s in layers:
+        th = teacher_hs[min(n_t, max(0, round(s * n_t / n_s)))]   # align embedding(0)+layers(1..n)
+        sh = student_hs[s]
+        m = min(sh.shape[-1], th.shape[-1])
+        diff = sh[..., :m].astype(mx.float32) - th[..., :m].astype(mx.float32)
+        terms.append(mx.mean(diff * diff))
+    return mx.stack(terms).mean()
+
+
+def _mixing_mse(student_mats, teacher_mats, n_s: int, n_t: int) -> mx.array:
+    """Mean MSE between each student Mamba layer's head-averaged mixing matrix and the
+    depth-aligned teacher attention matrix (both (B,L,L))."""
+    terms = []
+    for (i, sm) in student_mats:
+        tm = teacher_mats[_align(i, n_s, n_t)]
+        diff = sm.astype(mx.float32) - tm.astype(mx.float32)
+        terms.append(mx.mean(diff * diff))
+    return mx.stack(terms).mean()
+
+
+def make_distill_train_step(model, optimizer, *, stage, teacher=None,
+                            ce_weight: float = 0.1, kl_weight: float = 0.9,
+                            temperature: float = 2.0, hidden_layers: Optional[List[int]] = None,
+                            grad_clip: float = 1.0, scaler=None) -> Callable:
+    """Build a distillation `train_step(model, micro_batches, lr) -> dict` for one `stage`.
+
+    `stage` is a `DistillStage` (or its string). `teacher` (a frozen `ConversionTeacher`) is
+    required for on-the-fly `hidden-align`/`mixing-match`; `logit-distill` and cached
+    `hidden-align` need no teacher. Accumulation / fp16 scaling / clipping are shared via
+    `_accumulate_and_step`.
+    """
+    if not isinstance(stage, DistillStage):
+        stage = DistillStage.from_str(str(stage))
+    n_s = model.config.n_layers
+
+    if stage == DistillStage.LOGIT_DISTILL:
+        def loss_fn(model, inputs, targets, tv, ti):
+            logits = model.forward(inputs).astype(mx.float32)           # (B,L,V)
+            loss = ce_weight * _ce(logits, targets) + kl_weight * _kl_topk(
+                logits, mx.array(tv), mx.array(ti), temperature)
+            return loss * scaler.scale if scaler else loss
+
+    elif stage == DistillStage.HIDDEN_ALIGN:
+        n_t = teacher.n_layers if teacher is not None else None
+        layers = hidden_layers if hidden_layers is not None else list(range(1, n_s + 1))
+        if teacher is not None:                                          # on-the-fly recompute
+            def loss_fn(model, inputs):
+                t_hs = [mx.stop_gradient(h)
+                        for h in teacher.forward(inputs, return_hidden=True).hidden_states]
+                loss = _hidden_mse(model.hidden_states(inputs), t_hs, layers, n_s, n_t)
+                return loss * scaler.scale if scaler else loss
+        else:                                                           # cached teacher hidden
+            def loss_fn(model, inputs, teacher_hidden):
+                t_hs = [mx.array(h) for h in teacher_hidden]
+                nt = len(t_hs) - 1
+                loss = _hidden_mse(model.hidden_states(inputs), t_hs, layers, n_s, nt)
+                return loss * scaler.scale if scaler else loss
+
+    elif stage == DistillStage.MIXING_MATCH:
+        if teacher is None:
+            raise ValueError("mixing-match requires a teacher (on-the-fly attention matrices)")
+        n_t = teacher.n_layers
+
+        def loss_fn(model, inputs):
+            t_mats = [mx.stop_gradient(m) for m in teacher.attention_matrices(inputs)]
+            loss = _mixing_mse(model.mixing_matrices(inputs), t_mats, n_s, n_t)
+            return loss * scaler.scale if scaler else loss
+    else:                                                               # unreachable
+        raise ValueError(f"unknown distill stage {stage!r}")
+
+    value_and_grad = nn.value_and_grad(model, loss_fn)
+
+    def loss_and_grad(model, mb):
+        return value_and_grad(model, *mb)
+
+    def train_step(model, micro_batches, lr: float) -> dict:
+        return _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches,
+                                    lr, grad_clip, scaler)
+
+    return train_step

--- a/src/model/mlx_student_init.py
+++ b/src/model/mlx_student_init.py
@@ -1,0 +1,127 @@
+"""MLX student initialization from a frozen teacher (Apple Silicon, below the seam).
+
+Phase 2 of the distillation (#99): turn the transformer teacher (#93) into the Mamba-2 hybrid
+student by one of two methods (`docs/design/10-distillation.md`):
+
+  * **Mamba-in-the-Llama** (`InitMethod.MAMBA_IN_THE_LLAMA`): initialize the Mamba layers from the
+    teacher's attention projections — Q -> C, K -> B (the two d_state slices of `x_proj`),
+    V -> input (`in_proj` main half), O -> `out_proj` — copy the kept attention layers from the
+    teacher, and FREEZE them. The student is a pure Mamba+attention hybrid with no MLP blocks, so
+    the retained attention layers play the role the paper's frozen MLPs play (the trainable set is
+    the new Mamba layers). Reference: arXiv:2408.15237.
+  * **MOHAWK** (`InitMethod.MOHAWK`): a lighter init (copy attention layers where present, leave
+    Mamba at its default init, freeze nothing); the real work is the progressive matching the
+    distill loss runs per `stages` (#100). Reference: arXiv:2408.10189.
+
+Because the teacher (e.g. d_model 1536) and the swept student (e.g. 2048) differ in width, the
+mapping is **adaptive**: exact copy where dims align, otherwise copy the overlapping block and
+zero-pad/truncate to the student's shape (`_fit`). Init quality is validated downstream by the
+distillation curve, not by exactness.
+
+Freezing uses MLX's native `nn.Module.freeze`, which `nn.value_and_grad` already honors (it only
+differentiates `trainable_parameters()`), so the #100 train step needs no change. This file
+imports `mlx`; it lives below the seam and nothing portable imports it.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+from ..train.distill_manifest import InitMethod, InitReport
+
+
+def _fit(src: mx.array, shape: Tuple[int, ...]) -> mx.array:
+    """Adaptive copy of `src` into an array of `shape`: keep the overlapping region per axis,
+    zero-pad/truncate the rest. Exact (returns `src`'s values) when shapes already match."""
+    crop = src[tuple(slice(0, min(s, d)) for s, d in zip(src.shape, shape))]
+    pad = [(0, d - c) for d, c in zip(shape, crop.shape)]
+    return mx.pad(crop, pad)
+
+
+def _expand_kv(w: mx.array, n_heads: int, n_kv_heads: int, head_dim: int) -> mx.array:
+    """Expand a GQA key/value projection (n_kv_heads*head_dim, d) to full MHA width
+    (n_heads*head_dim, d) by repeating each kv head's block, matching inference-time repeat."""
+    if n_kv_heads == n_heads:
+        return w
+    rep = n_heads // n_kv_heads
+    d = w.shape[-1]
+    return mx.repeat(w.reshape(n_kv_heads, head_dim, d), rep, axis=0).reshape(n_heads * head_dim, d)
+
+
+def _set(param_owner, name: str, value: mx.array) -> None:
+    setattr(param_owner, name, value)
+
+
+def _teacher_layer_for(i: int, n_student: int, n_teacher: int) -> int:
+    """Align student depth onto teacher depth (evenly spaced)."""
+    return min(n_teacher - 1, int(round(i * n_teacher / max(1, n_student))))
+
+
+def _init_attention_layer(layer, proj, tcfg) -> None:
+    """Copy a teacher attention layer's Q/K/V/O onto a student attention block (`qkv_proj`,
+    `o_proj`), expanding GQA to full heads and adaptively fitting to the student's width."""
+    q = proj.q
+    k = _expand_kv(proj.k, tcfg.n_heads, tcfg.n_kv_heads, tcfg.head_dim)
+    v = _expand_kv(proj.v, tcfg.n_heads, tcfg.n_kv_heads, tcfg.head_dim)
+    d_attn, d_model = layer.qkv_proj.weight.shape[0] // 3, layer.qkv_proj.weight.shape[1]
+    blocks = [_fit(w, (d_attn, d_model)) for w in (q, k, v)]
+    _set(layer.qkv_proj, "weight", mx.concatenate(blocks, axis=0))   # (3*d_attn, d_model)
+    _set(layer.o_proj, "weight", _fit(proj.o, layer.o_proj.weight.shape))
+
+
+def _init_mamba_layer(layer, proj, dt_rank: int, d_state: int) -> None:
+    """Mamba-in-the-Llama mapping onto one Mamba block: Q->C, K->B (the d_state slices of
+    `x_proj`), V->input (`in_proj` main half), O->`out_proj`. Untouched rows keep their init."""
+    d_inner = layer.out_proj.weight.shape[1]
+    # x_proj: rows are [dt(dt_rank) | B(d_state) | C(d_state)] -> set B from K, C from Q.
+    xw = layer.ssm.x_proj.weight
+    B_new = _fit(proj.k, (d_state, d_inner))
+    C_new = _fit(proj.q, (d_state, d_inner))
+    _set(layer.ssm.x_proj, "weight",
+         mx.concatenate([xw[:dt_rank], B_new, C_new], axis=0))
+    # in_proj: rows are [main(d_inner) | gate(d_inner)] -> set main from V, keep gate.
+    iw = layer.in_proj.weight
+    main_new = _fit(proj.v, (d_inner, iw.shape[1]))
+    _set(layer.in_proj, "weight", mx.concatenate([main_new, iw[d_inner:]], axis=0))
+    # out_proj <- O.
+    _set(layer.out_proj, "weight", _fit(proj.o, layer.out_proj.weight.shape))
+
+
+def init_student(student, teacher, method: InitMethod) -> InitReport:
+    """Initialize `student` (an `MLXMambaModel`) from `teacher` (a `ConversionTeacher`).
+
+    Returns an `InitReport`. For Mamba-in-the-Llama the kept attention layers are frozen; for
+    MOHAWK nothing is frozen.
+    """
+    cfg = student.config
+    tcfg = teacher.config
+    S, T = cfg.n_layers, teacher.n_layers
+    dt_rank, d_state = cfg.dt_rank_resolved, cfg.d_state
+
+    frozen_layers: List[int] = []
+    n_mapped = 0
+    for i in range(S):
+        proj = teacher.attention_projection(_teacher_layer_for(i, S, T))
+        is_attn = cfg.is_attention_layer(i)
+        if is_attn:
+            _init_attention_layer(student.layers[i], proj, tcfg)
+            n_mapped += 1
+            if method == InitMethod.MAMBA_IN_THE_LLAMA:
+                student.layers[i].freeze()
+                frozen_layers.append(i)
+        elif method == InitMethod.MAMBA_IN_THE_LLAMA:
+            _init_mamba_layer(student.layers[i], proj, dt_rank, d_state)
+            n_mapped += 1
+        # MOHAWK leaves Mamba layers at their default init (refined by progressive matching #100).
+
+    mx.eval(student.parameters())
+    total = sum(v.size for _, v in tree_flatten(student.parameters()))
+    trainable = sum(v.size for _, v in tree_flatten(student.trainable_parameters()))
+    return InitReport(
+        method=method.value, n_layers_mapped=n_mapped,
+        n_frozen_params=total - trainable, n_trainable_params=trainable,
+        frozen_layers=frozen_layers,
+    )

--- a/src/model/mlx_teacher.py
+++ b/src/model/mlx_teacher.py
@@ -144,6 +144,42 @@ class MLXConversionTeacher(ConversionTeacher):
         vals = mx.take_along_axis(logits, idx, axis=-1)
         return mx.stop_gradient(vals), idx
 
+    def attention_matrices(self, token_batch) -> Tuple[mx.array, ...]:
+        """Per-layer head-averaged causal attention matrices `softmax(QK^T/sqrt(Dh))`, each
+        `(B, L, L)`, for the distillation `mixing-match` stage (#100). Stop-gradient wrapped
+        (the teacher is frozen)."""
+        c = self.config
+        h = self._w["embed"][mx.array(token_batch)]
+        L = h.shape[1]
+        cos, sin = _rope_cos_sin(mx.arange(L), c.head_dim, c.rope_theta)
+        mats = []
+        for i in range(c.n_layers):
+            mats.append(mx.stop_gradient(self._attn_probs(h, i, cos, sin)))
+            h = h + self._attn(h, i, cos, sin)
+            h = h + self._mlp(h, i)
+        return tuple(mats)
+
+    def _attn_probs(self, x: mx.array, i: int, cos: mx.array, sin: mx.array) -> mx.array:
+        """Head-averaged causal attention probabilities for layer `i` -> (B, L, L)."""
+        c = self.config
+        p = f"layer.{i}."
+        B, L, _ = x.shape
+        Hq, Hkv, Dh = c.n_heads, c.n_kv_heads, c.head_dim
+        xn = _rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps)
+        q = xn @ self._w[p + "q_w"].T + self._w[p + "q_b"]
+        k = xn @ self._w[p + "k_w"].T + self._w[p + "k_b"]
+
+        def heads(t, H):
+            return t.reshape(B, L, H, Dh).transpose(0, 2, 1, 3)
+        q, k = heads(q, Hq), heads(k, Hkv)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        if Hkv != Hq:
+            k = mx.repeat(k, Hq // Hkv, axis=1)
+        scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(Dh)       # (B,Hq,L,L)
+        causal = mx.tril(mx.ones((L, L), dtype=mx.bool_))
+        scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        return _softmax_lastdim(scores).mean(axis=1)                 # head-average -> (B,L,L)
+
     def attention_projection(self, layer: int) -> AttnProjections:
         p = f"layer.{layer}."
         g = lambda s: mx.stop_gradient(self._w[p + s])

--- a/src/model/mlx_teacher.py
+++ b/src/model/mlx_teacher.py
@@ -1,0 +1,222 @@
+"""MLX conversion teacher (Apple Silicon, below the seam — may import mlx).
+
+A frozen, forward-only **Qwen2** decoder (the DeepSeek-R1-Distill-Qwen-1.5B family) used
+as the distillation conversion teacher. It implements the portable `ConversionTeacher`
+protocol (`src/model/teacher.py`) so the precompute (#94) and the distill loss (#100) see
+only opaque arrays + a `to_numpy` converter, and the student init (#99) can read the
+attention Q/K/V/O projections.
+
+The weights are held as a plain `dict[str, mx.array]` rather than an `nn.Module`, so the
+teacher exposes **no** parameter tree — it can never be handed to an optimizer, and
+`trainable_parameters()` is empty. Forward outputs are wrapped in `mx.stop_gradient`, so
+even when the teacher's logits/hidden states are composed into a student loss, no gradient
+flows back into the teacher. `mlx-lm` is not a dependency; this is a minimal self-contained
+forward pass, reusing the RoPE/softmax idioms from `mlx_backend`.
+
+This file imports `mlx`, so it does NOT import on Linux/CUDA hosts — intentional and
+allowed: it lives below the seam and nothing portable imports it.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import numpy as np
+
+from .teacher import (AttnProjections, ConversionTeacher, TeacherConfig,
+                      TeacherForward)
+from .mlx_backend import _rotate_half, _silu, _softmax_lastdim
+
+
+def _rms_norm(x: mx.array, weight: mx.array, eps: float) -> mx.array:
+    """RMSNorm in fp32 (matches `mlx_backend.RMSNorm`)."""
+    xf = x.astype(mx.float32)
+    norm = mx.rsqrt(mx.mean(xf * xf, axis=-1, keepdims=True) + eps)
+    return weight * (xf * norm)
+
+
+def _rope_cos_sin(positions: mx.array, head_dim: int, theta: float) -> Tuple[mx.array, mx.array]:
+    """RoPE cos/sin for absolute `positions` (fp32), theta-configurable (Qwen2 rope_theta).
+    Generalizes `mlx_backend._rope_cos_sin` (which hardcodes theta=10000). (T, head_dim)."""
+    half = head_dim // 2
+    inv_freq = mx.exp(-math.log(theta) * mx.arange(0, half, dtype=mx.float32) / half)
+    ang = positions.astype(mx.float32)[:, None] * inv_freq[None, :]   # (T, half)
+    cos = mx.concatenate([mx.cos(ang), mx.cos(ang)], axis=-1)         # (T, head_dim)
+    sin = mx.concatenate([mx.sin(ang), mx.sin(ang)], axis=-1)
+    return cos, sin
+
+
+def _apply_rope(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    # x: (B, H, T, Dh); cos/sin: (T, Dh) broadcast over (B, H).
+    return x * cos[None, None] + _rotate_half(x) * sin[None, None]
+
+
+class MLXConversionTeacher(ConversionTeacher):
+    """Frozen Qwen2 conversion teacher on MLX. See module docstring."""
+
+    def __init__(self, config: TeacherConfig, weights: Dict[str, mx.array]):
+        config.validate()
+        self.config = config
+        # All compute in fp32: teacher logits feed a KL term, so stability beats speed at
+        # POC scale and the teacher forward is a one-time precompute (#94) anyway.
+        self._w = {k: v.astype(mx.float32) for k, v in weights.items()}
+
+    # --- constructors --------------------------------------------------------
+    @classmethod
+    def from_config(cls, config: TeacherConfig, *, seed: int = 0) -> "MLXConversionTeacher":
+        """Random-init synthetic teacher (offline tests / small local checks)."""
+        config.validate()
+        key = mx.random.key(seed)
+        c = config
+        scale = 1.0 / math.sqrt(c.d_model)
+
+        def rand(shape, k):
+            return mx.random.normal(shape, key=k) * scale
+
+        keys = mx.random.split(key, 4 + c.n_layers * 9)
+        ki = iter(keys)
+        w: Dict[str, mx.array] = {"embed": rand((c.vocab_size, c.d_model), next(ki))}
+        for i in range(c.n_layers):
+            p = f"layer.{i}."
+            w[p + "input_ln"] = mx.ones((c.d_model,))
+            w[p + "q_w"] = rand((c.q_dim, c.d_model), next(ki))
+            w[p + "q_b"] = mx.zeros((c.q_dim,))
+            w[p + "k_w"] = rand((c.kv_dim, c.d_model), next(ki))
+            w[p + "k_b"] = mx.zeros((c.kv_dim,))
+            w[p + "v_w"] = rand((c.kv_dim, c.d_model), next(ki))
+            w[p + "v_b"] = mx.zeros((c.kv_dim,))
+            w[p + "o_w"] = rand((c.d_model, c.q_dim), next(ki))
+            w[p + "post_ln"] = mx.ones((c.d_model,))
+            w[p + "gate_w"] = rand((c.intermediate_size, c.d_model), next(ki))
+            w[p + "up_w"] = rand((c.intermediate_size, c.d_model), next(ki))
+            w[p + "down_w"] = rand((c.d_model, c.intermediate_size), next(ki))
+        w["final_ln"] = mx.ones((c.d_model,))
+        if not c.tie_embeddings:
+            w["lm_head"] = rand((c.vocab_size, c.d_model), next(ki))
+        mx.eval(list(w.values()))
+        return cls(config, w)
+
+    @classmethod
+    def from_pretrained(cls, path, config: Optional[TeacherConfig] = None
+                        ) -> "MLXConversionTeacher":
+        """Load a local HuggingFace Qwen2 checkpoint directory (config.json + safetensors).
+
+        If `path` does not exist locally and `config.model_id` is set, the weights are
+        fetched lazily via `huggingface_hub.snapshot_download` (guarded — never reached in
+        offline tests). HF row-major projection weights are mapped onto the internal dict."""
+        p = Path(path)
+        if not p.exists():
+            if config is None or not config.model_id:
+                raise FileNotFoundError(
+                    f"teacher path {p} not found and no config.model_id to download from")
+            from huggingface_hub import snapshot_download   # lazy: optional dep, not in tests
+            p = Path(snapshot_download(config.model_id))
+        if config is None:
+            with open(p / "config.json") as f:
+                config = TeacherConfig.from_hf_dict(json.load(f))
+        hf = _load_safetensors_dir(p)
+        return cls(config, _hf_to_internal(hf, config))
+
+    # --- ConversionTeacher ---------------------------------------------------
+    def forward(self, token_batch, *, return_hidden: bool = False) -> TeacherForward:
+        tokens = mx.array(token_batch)
+        c = self.config
+        h = self._w["embed"][tokens]                          # (B, L, D)
+        L = h.shape[1]
+        cos, sin = _rope_cos_sin(mx.arange(L), c.head_dim, c.rope_theta)
+        hidden: List[mx.array] = [h] if return_hidden else []
+        for i in range(c.n_layers):
+            h = h + self._attn(h, i, cos, sin)
+            h = h + self._mlp(h, i)
+            if return_hidden:
+                hidden.append(h)
+        logits = _rms_norm(h, self._w["final_ln"], c.rms_norm_eps) @ self._lm_head().T
+        hs = tuple(mx.stop_gradient(t) for t in hidden) if return_hidden else None
+        return TeacherForward(logits=mx.stop_gradient(logits), hidden_states=hs)
+
+    def topk_logits(self, token_batch, k: int) -> Tuple[mx.array, mx.array]:
+        logits = self.forward(token_batch).logits             # (B, L, V)
+        idx = mx.argsort(-logits, axis=-1)[..., :k]            # descending, (B, L, k)
+        vals = mx.take_along_axis(logits, idx, axis=-1)
+        return mx.stop_gradient(vals), idx
+
+    def attention_projection(self, layer: int) -> AttnProjections:
+        p = f"layer.{layer}."
+        g = lambda s: mx.stop_gradient(self._w[p + s])
+        return AttnProjections(q=g("q_w"), k=g("k_w"), v=g("v_w"), o=g("o_w"),
+                               q_bias=g("q_b"), k_bias=g("k_b"), v_bias=g("v_b"))
+
+    def to_numpy(self, array) -> np.ndarray:
+        return np.array(array)
+
+    # --- internals -----------------------------------------------------------
+    def _lm_head(self) -> mx.array:
+        return self._w["embed"] if self.config.tie_embeddings else self._w["lm_head"]
+
+    def _attn(self, x: mx.array, i: int, cos: mx.array, sin: mx.array) -> mx.array:
+        c = self.config
+        p = f"layer.{i}."
+        B, L, _ = x.shape
+        Hq, Hkv, Dh = c.n_heads, c.n_kv_heads, c.head_dim
+        xn = _rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps)
+        q = xn @ self._w[p + "q_w"].T + self._w[p + "q_b"]    # (B,L,q_dim)
+        k = xn @ self._w[p + "k_w"].T + self._w[p + "k_b"]    # (B,L,kv_dim)
+        v = xn @ self._w[p + "v_w"].T + self._w[p + "v_b"]
+
+        def heads(t, H):
+            return t.reshape(B, L, H, Dh).transpose(0, 2, 1, 3)   # (B,H,L,Dh)
+        q, k, v = heads(q, Hq), heads(k, Hkv), heads(v, Hkv)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        if Hkv != Hq:                                         # GQA: repeat kv across groups
+            rep = Hq // Hkv
+            k, v = mx.repeat(k, rep, axis=1), mx.repeat(v, rep, axis=1)
+        scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(Dh)   # (B,Hq,L,L)
+        causal = mx.tril(mx.ones((L, L), dtype=mx.bool_))
+        scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        out = _softmax_lastdim(scores) @ v                   # (B,Hq,L,Dh)
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, Hq * Dh)
+        return out @ self._w[p + "o_w"].T                    # (B,L,D), o has no bias
+
+    def _mlp(self, x: mx.array, i: int) -> mx.array:
+        c = self.config
+        p = f"layer.{i}."
+        xn = _rms_norm(x, self._w[p + "post_ln"], c.rms_norm_eps)
+        gate = _silu(xn @ self._w[p + "gate_w"].T)
+        up = xn @ self._w[p + "up_w"].T
+        return (gate * up) @ self._w[p + "down_w"].T
+
+
+# --- HuggingFace checkpoint loading ------------------------------------------
+def _load_safetensors_dir(p: Path) -> Dict[str, mx.array]:
+    """Load + merge every `*.safetensors` shard in a directory into one dict."""
+    files = sorted(p.glob("*.safetensors"))
+    if not files:
+        raise FileNotFoundError(f"no .safetensors found in {p}")
+    out: Dict[str, mx.array] = {}
+    for f in files:
+        out.update(mx.load(str(f)))
+    return out
+
+
+def _hf_to_internal(hf: Dict[str, mx.array], cfg: TeacherConfig) -> Dict[str, mx.array]:
+    """Map HuggingFace Qwen2 parameter names onto the internal weight-dict layout."""
+    w: Dict[str, mx.array] = {"embed": hf["model.embed_tokens.weight"]}
+    for i in range(cfg.n_layers):
+        hp, p = f"model.layers.{i}.", f"layer.{i}."
+        w[p + "input_ln"] = hf[hp + "input_layernorm.weight"]
+        w[p + "post_ln"] = hf[hp + "post_attention_layernorm.weight"]
+        for proj, dst in (("q_proj", "q"), ("k_proj", "k"), ("v_proj", "v")):
+            w[p + dst + "_w"] = hf[hp + f"self_attn.{proj}.weight"]
+            w[p + dst + "_b"] = hf[hp + f"self_attn.{proj}.bias"]
+        w[p + "o_w"] = hf[hp + "self_attn.o_proj.weight"]
+        w[p + "gate_w"] = hf[hp + "mlp.gate_proj.weight"]
+        w[p + "up_w"] = hf[hp + "mlp.up_proj.weight"]
+        w[p + "down_w"] = hf[hp + "mlp.down_proj.weight"]
+    w["final_ln"] = hf["model.norm.weight"]
+    if not cfg.tie_embeddings:
+        w["lm_head"] = hf["lm_head.weight"]
+    return w

--- a/src/model/teacher.py
+++ b/src/model/teacher.py
@@ -1,0 +1,192 @@
+"""The conversion-teacher seam: a frozen, forward-only teacher protocol.
+
+THIS MODULE MUST NOT IMPORT ANY BACKEND (no `mlx`, no `torch`/CUDA). Like
+`interface.ModelInterface`, it is the portable contract that the distillation
+stages depend on; each backend provides a concrete `ConversionTeacher` (the MLX
+one is `mlx_teacher.MLXConversionTeacher`).
+
+The conversion teacher is the transformer the student is *built from*
+(DeepSeek-R1-Distill-Qwen-1.5B by default — see `docs/design/10-distillation.md`).
+It is run **forward only** — never trained — so it follows the same frozen-reference
+pattern DPO already uses (`mlx_train_step.make_dpo_train_step` holds a distinct
+`ref_model` the optimizer never touches). Two distillation issues consume it:
+
+  * student init (#99) maps the teacher's attention Q/K/V/O onto the student SSM's
+    C/B/input/output projections — hence `attention_projection`.
+  * the distill loss (#100) matches the student against the teacher's top-k logits
+    and optional hidden states — hence `forward(return_hidden=...)` / `topk_logits`.
+
+Per the seam, portable code sees only opaque arrays plus a `to_numpy` converter and
+these accessors — never the backend array type. The teacher reports **no** trainable
+parameters (`trainable_parameters() == {}`), so it is structurally excluded from any
+optimizer / resume bundle.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+# Opaque, backend-defined arrays (an MLX array, a torch tensor, ...). Code above the
+# seam treats these as blobs it converts with `to_numpy`.
+Array = Any
+
+
+@dataclass
+class TeacherConfig:
+    """Architecture of a Qwen2-family conversion teacher.
+
+    Defaults describe DeepSeek-R1-Distill-Qwen-1.5B (a Qwen2 decoder). The fields are
+    exactly what the MLX forward pass and the #99 projection mapping need; nothing here
+    imports a backend, so the config is shared across backends like `MambaConfig`.
+    """
+
+    vocab_size: int
+    d_model: int                 # hidden_size
+    n_layers: int                # num_hidden_layers
+    n_heads: int                 # num_attention_heads (query heads)
+    n_kv_heads: int              # num_key_value_heads (GQA groups; == n_heads if MHA)
+    head_dim: int                # per-head width (Qwen2-1.5B: 128, not d_model//n_heads)
+    intermediate_size: int       # SwiGLU MLP inner width
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 10000.0
+    tie_embeddings: bool = True
+    model_id: Optional[str] = None   # HF repo id, for from_pretrained / provenance
+
+    @classmethod
+    def qwen_1_5b(cls) -> "TeacherConfig":
+        """DeepSeek-R1-Distill-Qwen-1.5B (== Qwen2.5-Math-1.5B architecture).
+
+        Note vocab 151936 is the *model* embedding width (padded); the Qwen2.5
+        tokenizer vocab is 151646 (`docs/design/10-distillation.md`). The student
+        config uses 151646; the distill loss (#100) matches on top-k indices, which
+        fall inside the shared lower range.
+        """
+        return cls(
+            vocab_size=151936, d_model=1536, n_layers=28, n_heads=12, n_kv_heads=2,
+            head_dim=128, intermediate_size=8960, rms_norm_eps=1e-6, rope_theta=10000.0,
+            tie_embeddings=True, model_id="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+        )
+
+    @classmethod
+    def tiny(cls) -> "TeacherConfig":
+        """A toy Qwen2 teacher for offline tests / small local checks (byte vocab)."""
+        return cls(
+            vocab_size=256, d_model=64, n_layers=2, n_heads=4, n_kv_heads=2,
+            head_dim=16, intermediate_size=128, rms_norm_eps=1e-6, rope_theta=10000.0,
+            tie_embeddings=True, model_id=None,
+        )
+
+    @classmethod
+    def from_hf_dict(cls, hf: Dict[str, Any]) -> "TeacherConfig":
+        """Build from a HuggingFace Qwen2 `config.json` dict."""
+        n_heads = int(hf["num_attention_heads"])
+        d_model = int(hf["hidden_size"])
+        head_dim = int(hf.get("head_dim", d_model // n_heads))
+        return cls(
+            vocab_size=int(hf["vocab_size"]),
+            d_model=d_model,
+            n_layers=int(hf["num_hidden_layers"]),
+            n_heads=n_heads,
+            n_kv_heads=int(hf.get("num_key_value_heads", n_heads)),
+            head_dim=head_dim,
+            intermediate_size=int(hf["intermediate_size"]),
+            rms_norm_eps=float(hf.get("rms_norm_eps", 1e-6)),
+            rope_theta=float(hf.get("rope_theta", 10000.0)),
+            tie_embeddings=bool(hf.get("tie_word_embeddings", True)),
+            model_id=hf.get("_name_or_path"),
+        )
+
+    @property
+    def q_dim(self) -> int:
+        """Width of the concatenated query projection (n_heads * head_dim)."""
+        return self.n_heads * self.head_dim
+
+    @property
+    def kv_dim(self) -> int:
+        """Width of each of the key/value projections (n_kv_heads * head_dim)."""
+        return self.n_kv_heads * self.head_dim
+
+    def validate(self) -> None:
+        if self.n_kv_heads <= 0 or self.n_heads % self.n_kv_heads != 0:
+            raise ValueError(
+                f"n_kv_heads={self.n_kv_heads} must divide n_heads={self.n_heads} (GQA)."
+            )
+        if self.head_dim <= 0 or self.head_dim % 2 != 0:
+            raise ValueError(f"head_dim={self.head_dim} must be positive and even (RoPE).")
+        for name in ("vocab_size", "d_model", "n_layers", "intermediate_size"):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive")
+
+
+@dataclass
+class AttnProjections:
+    """One layer's attention projection weights, for the #99 init mapping.
+
+    Weights are opaque backend arrays in the HF row-major convention (`y = x @ W.T`):
+    `q` is (q_dim, d_model), `k`/`v` are (kv_dim, d_model), `o` is (d_model, q_dim).
+    Qwen2 has biases on q/k/v and none on o. The #99 init maps Q/K/V/O onto the
+    student SSM's C/B/input/output projections.
+    """
+
+    q: Array
+    k: Array
+    v: Array
+    o: Array
+    q_bias: Optional[Array] = None
+    k_bias: Optional[Array] = None
+    v_bias: Optional[Array] = None
+
+
+@dataclass
+class TeacherForward:
+    """Result of a teacher forward pass. `logits` is (batch, seq, vocab).
+
+    `hidden_states`, when requested, is a tuple of length `n_layers + 1`: the embedding
+    output followed by each decoder layer's output, each (batch, seq, d_model) — the HF
+    `output_hidden_states` convention MOHAWK hidden-alignment (#100) consumes.
+    """
+
+    logits: Array
+    hidden_states: Optional[Tuple[Array, ...]] = None
+
+
+class ConversionTeacher(ABC):
+    """Frozen forward-only teacher contract. Concrete impls live below the seam."""
+
+    #: Architecture, the single source of truth for the teacher's shapes.
+    config: TeacherConfig
+
+    @property
+    def n_layers(self) -> int:
+        return self.config.n_layers
+
+    @abstractmethod
+    def forward(self, token_batch: Array, *, return_hidden: bool = False) -> TeacherForward:
+        """Forward over `token_batch` (batch, seq) ids. Returns logits (+ hidden states).
+
+        No gradient flows into the teacher's weights: the implementation wraps its
+        outputs in the backend's stop-gradient so the teacher stays frozen even when
+        its logits/hidden states are composed into a student loss.
+        """
+
+    @abstractmethod
+    def topk_logits(self, token_batch: Array, k: int) -> Tuple[Array, Array]:
+        """Top-`k` logits over the vocab. Returns (values, indices), each (batch, seq, k),
+        values descending. This is the per-token teacher signal cached by the precompute
+        (#94) and matched with KL by the distill loss (#100)."""
+
+    @abstractmethod
+    def attention_projection(self, layer: int) -> AttnProjections:
+        """The Q/K/V/O projection weights of decoder `layer` (0-indexed), for #99."""
+
+    @abstractmethod
+    def to_numpy(self, array: Array) -> Any:
+        """Convert an opaque teacher array to a numpy array (the seam converter)."""
+
+    def trainable_parameters(self) -> Dict[str, Array]:
+        """The frozen contract: a conversion teacher has NO trainable parameters, so it
+        is excluded from the optimizer and the resume bundle. Overridable, but the empty
+        default is what makes the freeze structural rather than merely conventional."""
+        return {}

--- a/src/train/distill_manifest.py
+++ b/src/train/distill_manifest.py
@@ -39,6 +39,22 @@ class InitMethod(Enum):
             raise ValueError(f"unknown init method {value!r}; expected one of: {allowed}")
 
 
+class DistillStage(Enum):
+    """The progressive distillation-matching stages (#100), in their natural run order.
+
+    A manifest's `stages:` may also list post-training stages (SFT/RL, #11/#78); these three
+    are the distillation ones the distill train step (`model.mlx_distill`) implements.
+    """
+
+    MIXING_MATCH = "mixing-match"      # MOHAWK stage 1: orient the SSM mixer like attention
+    HIDDEN_ALIGN = "hidden-align"      # MOHAWK stage 2: match per-layer hidden states
+    LOGIT_DISTILL = "logit-distill"    # KL(top-k) + CE on the final logits
+
+    @classmethod
+    def from_str(cls, value: str) -> "DistillStage":
+        return cls(value)
+
+
 # Canonical distillation + post-training stages, in their natural run order. The manifest's
 # `stages:` is a subset/ordering of these; #100 runs the distill stages, post-training (#11)
 # runs the SFT/RL ones.
@@ -155,3 +171,16 @@ def manifest_to_config(manifest: DistillManifest) -> MambaConfig:
 
 def _opt_int(value: Any) -> Any:
     return None if value is None else int(value)
+
+
+_DISTILL_STAGE_VALUES = {s.value for s in DistillStage}
+
+
+def distill_stages(manifest: DistillManifest) -> List[DistillStage]:
+    """The manifest's distillation stages, in manifest order (SFT/RL stages dropped).
+
+    The distill train step (#100) loops over these, swapping the objective per stage:
+    `mixing-match -> hidden-align -> logit-distill`. Post-training stages (instruct-sft,
+    reasoning-sft, tool-sft, grpo) are handled elsewhere (#11/#78).
+    """
+    return [DistillStage.from_str(s) for s in manifest.stages if s in _DISTILL_STAGE_VALUES]

--- a/src/train/distill_manifest.py
+++ b/src/train/distill_manifest.py
@@ -1,0 +1,157 @@
+"""Distillation manifest resolver (portable — NO backend import).
+
+A student trial (#65/#98) is a lightweight **manifest** naming the frozen teacher artifacts
+plus the student layout and the conversion method (`docs/design/10-distillation.md`). A sweep is
+a set of sibling manifests pointing at the *same* teacher signal; only `layout` changes.
+`config/manifests/*.yaml` are the seed manifests.
+
+This module parses a manifest into a `DistillManifest`, validates the `init:` method and the
+`stages:` list, and resolves the `layout` sweep-schema onto a `MambaConfig` (the model's single
+source of truth). The student-init step (#99, `model.mlx_student_init`) consumes `init`; the
+distill loss (#100) consumes `stages` to run mixing-match -> hidden-align -> logit-distill in
+order. Nothing here imports a backend, so it stays above the seam.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import yaml
+
+from ..model.blocks import MambaConfig
+
+
+class InitMethod(Enum):
+    """Teacher -> student conversion method, selected per manifest by `init:`."""
+
+    MAMBA_IN_THE_LLAMA = "mamba-in-the-llama"
+    MOHAWK = "mohawk"
+
+    @classmethod
+    def from_str(cls, value: str) -> "InitMethod":
+        try:
+            return cls(value)
+        except ValueError:
+            allowed = ", ".join(m.value for m in cls)
+            raise ValueError(f"unknown init method {value!r}; expected one of: {allowed}")
+
+
+# Canonical distillation + post-training stages, in their natural run order. The manifest's
+# `stages:` is a subset/ordering of these; #100 runs the distill stages, post-training (#11)
+# runs the SFT/RL ones.
+CANONICAL_STAGES = (
+    "mixing-match", "hidden-align", "logit-distill",     # distillation matching (#100)
+    "instruct-sft", "reasoning-sft", "tool-sft",         # supervised fine-tuning (#11)
+    "grpo",                                              # verifiable RL (#78)
+)
+
+# Tokenizer name -> vocab size. Qwen2.5 is fixed by the conversion teacher (#90); the value
+# matches config/student-1b.yaml (151646, the tokenizer vocab, < the teacher's padded 151936).
+_TOKENIZER_VOCAB = {"qwen25": 151646}
+
+
+@dataclass
+class DistillManifest:
+    """A parsed student-trial manifest. `init` is an `InitMethod`; `stages` is validated."""
+
+    student: str
+    conversion_teacher: str
+    tokenizer: str
+    seq_len: int
+    init: InitMethod
+    stages: List[str]
+    layout: Dict[str, Any]
+    corpus: str = ""
+    teacher_outputs: str = ""
+    sft: str = ""
+    rl: str = ""
+    schedule: Dict[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if self.tokenizer not in _TOKENIZER_VOCAB:
+            raise ValueError(
+                f"unknown tokenizer {self.tokenizer!r}; known: {sorted(_TOKENIZER_VOCAB)}")
+        unknown = [s for s in self.stages if s not in CANONICAL_STAGES]
+        if unknown:
+            raise ValueError(
+                f"unknown stage(s) {unknown}; expected from: {list(CANONICAL_STAGES)}")
+        if not self.stages:
+            raise ValueError("manifest `stages` must be non-empty")
+
+    @property
+    def vocab_size(self) -> int:
+        return _TOKENIZER_VOCAB[self.tokenizer]
+
+
+@dataclass
+class InitReport:
+    """Summary of a student-init run (#99), returned by the backend `init_student`.
+
+    Portable (plain ints/strings) so a driver can log it without importing a backend.
+    `frozen_layers` lists the student layer indices whose params were frozen (the kept
+    attention layers under Mamba-in-the-Llama); `n_frozen_params + n_trainable_params`
+    equals the student's total parameter count.
+    """
+
+    method: str
+    n_layers_mapped: int
+    n_frozen_params: int
+    n_trainable_params: int
+    frozen_layers: List[int] = field(default_factory=list)
+
+
+def load_manifest(path: Union[str, Path]) -> DistillManifest:
+    """Load + validate a manifest YAML (`config/manifests/*.yaml`)."""
+    with open(path, "r") as f:
+        raw = yaml.safe_load(f) or {}
+    m = DistillManifest(
+        student=str(raw["student"]),
+        conversion_teacher=str(raw["conversion_teacher"]),
+        tokenizer=str(raw["tokenizer"]),
+        seq_len=int(raw["seq_len"]),
+        init=InitMethod.from_str(str(raw["init"])),
+        stages=list(raw.get("stages", [])),
+        layout=dict(raw.get("layout", {})),
+        corpus=str(raw.get("corpus", "")),
+        teacher_outputs=str(raw.get("teacher_outputs", "")),
+        sft=str(raw.get("sft", "")),
+        rl=str(raw.get("rl", "")),
+        schedule=dict(raw.get("schedule", {})),
+    )
+    m.validate()
+    return m
+
+
+def manifest_to_config(manifest: DistillManifest) -> MambaConfig:
+    """Resolve a manifest's `layout` sweep-schema onto a `MambaConfig`.
+
+    The manifest's layout keys are sweep-schema names; map them onto model fields:
+      `d_model`, `n_layers`, `attention_every` -> `attn_every`, `state_size` -> `d_state`.
+    `vocab_size`/`seq_len` come from the manifest; `precision`/`grad_checkpoint`/`head_dim`
+    mirror `config/student-1b.yaml` (bf16 CUDA training at this depth). Optional layout keys
+    `head_dim`, `expand`, `n_attn_heads` override the student defaults when present.
+    """
+    layout = manifest.layout
+    cfg = MambaConfig(
+        d_model=int(layout["d_model"]),
+        n_layers=int(layout["n_layers"]),
+        d_state=int(layout.get("state_size", layout.get("d_state", 128))),
+        expand=int(layout.get("expand", 2)),
+        head_dim=int(layout.get("head_dim", 64)),
+        attn_every=_opt_int(layout.get("attention_every", layout.get("attn_every"))),
+        n_attn_heads=_opt_int(layout.get("n_attn_heads")),
+        vocab_size=manifest.vocab_size,
+        seq_len=manifest.seq_len,
+        tie_embeddings=True,
+        precision="bf16",
+        grad_checkpoint=True,
+    )
+    cfg.validate()
+    return cfg
+
+
+def _opt_int(value: Any) -> Any:
+    return None if value is None else int(value)

--- a/tests/test_distill_manifest.py
+++ b/tests/test_distill_manifest.py
@@ -1,0 +1,59 @@
+"""Distillation manifest resolver (#99). Portable — runs without a backend."""
+
+import pytest
+
+from src.train.distill_manifest import (CANONICAL_STAGES, DistillManifest, InitMethod,
+                                        load_manifest, manifest_to_config)
+
+MANIFESTS = ["config/manifests/student-1b-attn12pct.yaml",
+             "config/manifests/student-1b-attn8pct.yaml"]
+
+
+@pytest.mark.parametrize("path", MANIFESTS)
+def test_real_manifests_load(path):
+    m = load_manifest(path)
+    assert m.init == InitMethod.MAMBA_IN_THE_LLAMA       # both seeds default to MiL
+    assert m.tokenizer == "qwen25" and m.vocab_size == 151646
+    assert m.stages and all(s in CANONICAL_STAGES for s in m.stages)
+    assert m.stages[:3] == ["mixing-match", "hidden-align", "logit-distill"]
+
+
+@pytest.mark.parametrize("path", MANIFESTS)
+def test_manifest_to_config(path):
+    m = load_manifest(path)
+    cfg = manifest_to_config(m)
+    cfg.validate()
+    assert cfg.d_model == m.layout["d_model"]
+    assert cfg.n_layers == m.layout["n_layers"]
+    assert cfg.attn_every == m.layout["attention_every"]    # sweep-schema -> model field
+    assert cfg.d_state == m.layout["state_size"]
+    assert cfg.vocab_size == 151646 and cfg.seq_len == m.seq_len
+
+
+def test_init_method_from_str():
+    assert InitMethod.from_str("mamba-in-the-llama") == InitMethod.MAMBA_IN_THE_LLAMA
+    assert InitMethod.from_str("mohawk") == InitMethod.MOHAWK
+    with pytest.raises(ValueError):
+        InitMethod.from_str("nope")
+
+
+def _manifest(**over):
+    base = dict(student="s", conversion_teacher="t", tokenizer="qwen25", seq_len=128,
+                init=InitMethod.MOHAWK, stages=["mixing-match"], layout={})
+    base.update(over)
+    return DistillManifest(**base)
+
+
+def test_validate_rejects_unknown_stage():
+    with pytest.raises(ValueError):
+        _manifest(stages=["mixing-match", "bogus-stage"]).validate()
+
+
+def test_validate_rejects_empty_stages():
+    with pytest.raises(ValueError):
+        _manifest(stages=[]).validate()
+
+
+def test_validate_rejects_unknown_tokenizer():
+    with pytest.raises(ValueError):
+        _manifest(tokenizer="gpt2").validate()

--- a/tests/test_distill_manifest.py
+++ b/tests/test_distill_manifest.py
@@ -2,8 +2,9 @@
 
 import pytest
 
-from src.train.distill_manifest import (CANONICAL_STAGES, DistillManifest, InitMethod,
-                                        load_manifest, manifest_to_config)
+from src.train.distill_manifest import (CANONICAL_STAGES, DistillManifest, DistillStage,
+                                        InitMethod, distill_stages, load_manifest,
+                                        manifest_to_config)
 
 MANIFESTS = ["config/manifests/student-1b-attn12pct.yaml",
              "config/manifests/student-1b-attn8pct.yaml"]
@@ -28,6 +29,16 @@ def test_manifest_to_config(path):
     assert cfg.attn_every == m.layout["attention_every"]    # sweep-schema -> model field
     assert cfg.d_state == m.layout["state_size"]
     assert cfg.vocab_size == 151646 and cfg.seq_len == m.seq_len
+
+
+@pytest.mark.parametrize("path", MANIFESTS)
+def test_distill_stages_order_and_filter(path):
+    m = load_manifest(path)
+    stages = distill_stages(m)
+    # the three distillation stages, in manifest order; SFT/RL stages dropped
+    assert stages == [DistillStage.MIXING_MATCH, DistillStage.HIDDEN_ALIGN,
+                      DistillStage.LOGIT_DISTILL]
+    assert all(isinstance(s, DistillStage) for s in stages)
 
 
 def test_init_method_from_str():

--- a/tests/test_distill_train_step.py
+++ b/tests/test_distill_train_step.py
@@ -1,0 +1,169 @@
+"""Distillation loss + train step (#100). MLX-only; skipped where mlx is unavailable.
+
+Covers the materialized mixing matrix (vs the scan), the compound KL(top-k)+CE logit-distill
+step, hidden-align (cached == on-the-fly), mixing-match, and the fp16 dynamic-scaler integration
+(clean step + clean overflow-skip on the compound term). Tiny synthetic teacher + tiny hybrid
+student, all offline.
+"""
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+import mlx.nn as nn
+
+from src.model.backend import get_backend
+from src.model.blocks import MambaConfig
+from src.model.mlx_backend import MLXMambaModel, SelectiveSSM
+from src.model.mlx_teacher import MLXConversionTeacher
+from src.model.teacher import TeacherConfig
+from src.model.mlx_distill import make_distill_train_step, _kl_topk
+from src.train.distill_manifest import DistillStage
+from src.train.loss_scale import DynamicLossScaler
+
+VOCAB = 256
+
+
+def _teacher(n_layers=3):
+    cfg = TeacherConfig(vocab_size=VOCAB, d_model=64, n_layers=n_layers, n_heads=4,
+                        n_kv_heads=2, head_dim=16, intermediate_size=128)
+    return MLXConversionTeacher.from_config(cfg, seed=0)
+
+
+def _student(precision="fp32", seed=0):
+    cfg = MambaConfig(d_model=48, n_layers=4, d_state=16, expand=2, d_conv=4, head_dim=16,
+                      vocab_size=VOCAB, seq_len=16, attn_every=2, n_attn_heads=4,
+                      precision=precision)
+    get_backend("mlx").seed(seed)
+    return MLXMambaModel(cfg)
+
+
+def _tokens(B=2, L=8):
+    rng = np.random.default_rng(0)
+    return rng.integers(0, VOCAB, size=(B, L)).astype(np.int32)
+
+
+def _opt(model, lr=1e-2):
+    return get_backend("mlx").make_optimizer(model, lr)
+
+
+# --- mixing matrix materialization vs the scan -------------------------------
+def test_mixing_matrix_reproduces_parallel_scan():
+    cfg = MambaConfig(d_model=32, n_layers=1, d_state=16, head_dim=16, vocab_size=64,
+                      seq_len=12, precision="fp32")
+    ssm = SelectiveSSM(cfg)
+    mx.random.seed(0)
+    x = mx.random.normal((2, 12, cfg.d_inner))
+    Y = ssm.parallel(x)
+    M = ssm.mixing_matrix(x)                                  # (B,H,L,L)
+    Xh = x.reshape(2, 12, cfg.n_heads, cfg.head_dim)
+    Ym = mx.einsum("bhij,bjhp->bihp", M, Xh).reshape(2, 12, cfg.d_inner)
+    assert float(mx.max(mx.abs(Y - Ym))) < 1e-4
+
+
+# --- KL on top-k -------------------------------------------------------------
+def test_kl_topk_nonneg_and_zero_at_match():
+    rng = np.random.default_rng(1)
+    logits = mx.array(rng.normal(size=(2, 4, VOCAB)).astype(np.float32))
+    k = 8
+    idx = mx.argsort(-logits, axis=-1)[..., :k]
+    vals = mx.take_along_axis(logits, idx, axis=-1)
+    # student == teacher on the support -> KL == 0
+    assert abs(float(_kl_topk(logits, vals, idx, 2.0))) < 1e-4
+    # a mismatched teacher distribution -> KL > 0
+    assert float(_kl_topk(logits, vals + 1.0 * mx.arange(k).astype(mx.float32), idx, 2.0)) > 0
+
+
+# --- logit-distill -----------------------------------------------------------
+def _logit_batch(teacher, tokens, k=16):
+    vals, idx = teacher.topk_logits(tokens, k)
+    targets = np.roll(tokens, -1, axis=1)
+    return (tokens, targets, np.array(vals), np.array(idx))
+
+
+def test_logit_distill_step_and_decreases():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.LOGIT_DISTILL)
+    mb = _logit_batch(teacher, _tokens())
+    losses = [step(student, [mb], 1e-2)["loss"] for _ in range(4)]
+    assert all(np.isfinite(losses))
+    assert losses[-1] < losses[0]                            # compound loss decreases
+
+
+def test_logit_distill_accepts_string_stage():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage="logit-distill")
+    out = step(student, [_logit_batch(teacher, _tokens())], 1e-2)
+    assert "loss" in out and "grad_norm" in out
+
+
+# --- hidden-align: cached == on-the-fly --------------------------------------
+def test_hidden_align_cached_matches_on_the_fly():
+    teacher = _teacher()
+    tokens = _tokens()
+    # two identically-seeded students so the first-step losses are comparable
+    s1, s2 = _student(seed=7), _student(seed=7)
+    on_fly = make_distill_train_step(s1, _opt(s1), stage=DistillStage.HIDDEN_ALIGN,
+                                     teacher=teacher)
+    cached_hs = [np.array(h) for h in teacher.forward(tokens, return_hidden=True).hidden_states]
+    cached = make_distill_train_step(s2, _opt(s2), stage=DistillStage.HIDDEN_ALIGN)
+    l_fly = on_fly(s1, [(tokens,)], 0.0)["loss"]             # lr 0 -> loss is pre-update
+    l_cached = cached(s2, [(tokens, cached_hs)], 0.0)["loss"]
+    assert l_fly >= 0 and abs(l_fly - l_cached) < 1e-4
+
+
+def test_hidden_align_decreases():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.HIDDEN_ALIGN,
+                                   teacher=teacher)
+    losses = [step(student, [(_tokens(),)], 1e-2)["loss"] for _ in range(4)]
+    assert losses[-1] < losses[0]
+
+
+# --- mixing-match ------------------------------------------------------------
+def test_mixing_match_runs_and_decreases():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH,
+                                   teacher=teacher)
+    # the matrix-matching objective is stiff; a small lr decreases it smoothly
+    losses = [step(student, [(_tokens(),)], 5e-3)["loss"] for _ in range(6)]
+    assert losses[0] >= 0 and losses[-1] < losses[0]
+
+
+def test_mixing_match_requires_teacher():
+    student = _student()
+    with pytest.raises(ValueError):
+        make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH)
+
+
+# --- fp16 dynamic-scaler integration (compound term) -------------------------
+def test_compound_loss_with_scaler_clean_step():
+    teacher, student = _teacher(), _student()
+    scaler = DynamicLossScaler(init_scale=2.0 ** 12)
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.LOGIT_DISTILL,
+                                   scaler=scaler)
+    out = step(student, [_logit_batch(teacher, _tokens())], 1e-3)
+    assert out["skipped"] is False and "loss_scale" in out and np.isfinite(out["grad_norm"])
+
+
+def test_compound_loss_overflow_skips_cleanly():
+    teacher, student = _teacher(), _student()
+    scaler = DynamicLossScaler(init_scale=2.0 ** 12)
+    before = scaler.scale
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.LOGIT_DISTILL,
+                                   scaler=scaler)
+    inputs, targets, vals, idx = _logit_batch(teacher, _tokens())
+    vals = vals.copy()
+    vals[0, 0, 0] = np.float32("nan")                        # poison -> non-finite gradient
+    out = step(student, [(inputs, targets, vals, idx)], 1e-3)
+    assert out["skipped"] is True
+    assert scaler.scale < before                             # scale backed off, step dropped
+
+
+# --- backend seam ------------------------------------------------------------
+def test_make_distill_train_step_via_backend():
+    teacher, student = _teacher(), _student()
+    step = get_backend("mlx").make_distill_train_step(
+        student, _opt(student), stage=DistillStage.LOGIT_DISTILL)
+    out = step(student, [_logit_batch(teacher, _tokens())], 1e-3)
+    assert "loss" in out

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -52,6 +52,7 @@ PORTABLE_MODULES = [
     "src.data.dpo_loader",
     "src.data.dpo_sources",
     "src.train.dpo_math",
+    "src.train.distill_manifest",
     "src.train.grpo",
     "src.train.verifiers",
     "src.train.schedule",

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -33,6 +33,7 @@ PORTABLE_MODULES = [
     "src.model.interface",
     "src.model.blocks",
     "src.model.backend",
+    "src.model.teacher",
     "src.model.sizing",
     "src.data.loader",
     "src.data.corpus",

--- a/tests/test_student_init.py
+++ b/tests/test_student_init.py
@@ -1,0 +1,131 @@
+"""Student init from a frozen teacher (#99). MLX-only; skipped where mlx is unavailable.
+
+Exercises Mamba-in-the-Llama + MOHAWK with a synthetic teacher and a tiny hybrid student:
+exact Q/K/V/O copy when dims align, the adaptive-fit path when the student is wider, the
+frozen/trainable split, and an end-to-end manifest -> config -> build -> init -> forward.
+"""
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+from mlx.utils import tree_flatten
+
+from src.model.mlx_backend import MLXMambaModel
+from src.model.blocks import MambaConfig
+from src.model.mlx_teacher import MLXConversionTeacher
+from src.model.teacher import TeacherConfig
+from src.model.mlx_student_init import init_student
+from src.train.distill_manifest import InitMethod, InitReport
+
+
+def _teacher(d_model=64, n_layers=4, n_heads=4, n_kv_heads=2, head_dim=16):
+    cfg = TeacherConfig(vocab_size=256, d_model=d_model, n_layers=n_layers, n_heads=n_heads,
+                        n_kv_heads=n_kv_heads, head_dim=head_dim, intermediate_size=128)
+    return MLXConversionTeacher.from_config(cfg, seed=0)
+
+
+def _student(d_model=64, n_attn_heads=4):
+    cfg = MambaConfig(d_model=d_model, n_layers=4, d_state=16, expand=2, d_conv=4, head_dim=16,
+                      vocab_size=256, seq_len=32, attn_every=2, n_attn_heads=n_attn_heads,
+                      precision="fp32")
+    return MLXMambaModel(cfg)
+
+
+def _total(model):
+    return sum(v.size for _, v in tree_flatten(model.parameters()))
+
+
+# --- Mamba-in-the-Llama: exact copy on matched dims --------------------------
+def test_mil_attention_exact_copy_when_dims_match():
+    teacher, student = _teacher(), _student()        # student d_attn 64 == teacher q_dim 64
+    rep = init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    assert isinstance(rep, InitReport) and rep.method == "mamba-in-the-llama"
+    # layer 1 is an attention layer (attn_every 2); teacher_layer_for(1,4,4) == 1.
+    proj = teacher.attention_projection(1)
+    qkv = student.layers[1].qkv_proj.weight          # (3*d_attn, d_model)
+    assert mx.allclose(qkv[:64], proj.q).item()      # Q block exact
+    assert mx.allclose(student.layers[1].o_proj.weight, proj.o).item()
+
+
+def test_mil_mamba_layer_gets_teacher_projection():
+    teacher, student = _teacher(), _student()
+    proj = teacher.attention_projection(0)           # layer 0 is a Mamba layer
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    cfg = student.config
+    dt_rank, N = cfg.dt_rank_resolved, cfg.d_state
+    xw = student.layers[0].ssm.x_proj.weight
+    # C slice (rows dt_rank+N : dt_rank+2N) is Q fitted into (N, d_inner): top-left overlaps Q.
+    C = xw[dt_rank + N:dt_rank + 2 * N]
+    assert mx.allclose(C[:, :proj.q.shape[1]][:N], proj.q[:N]).item()
+
+
+# --- adaptive fit when the student is wider than the teacher -----------------
+def test_mil_adaptive_fit_wider_student_shapes_finite():
+    teacher = _teacher(d_model=64)
+    student = _student(d_model=128, n_attn_heads=8)   # wider: d_attn 128 > teacher q_dim 64
+    before = {k: v.shape for k, v in tree_flatten(student.parameters())}
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    after = {k: v.shape for k, v in tree_flatten(student.parameters())}
+    assert before == after                            # every param keeps its correct shape
+    for _, v in tree_flatten(student.parameters()):
+        assert mx.all(mx.isfinite(v)).item()
+    assert student.forward(mx.zeros((1, 8), dtype=mx.int32)).shape == (1, 8, 256)
+
+
+# --- freeze gating -----------------------------------------------------------
+def test_mil_freezes_kept_attention_layers():
+    teacher, student = _teacher(), _student()
+    rep = init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    assert rep.frozen_layers == [1, 3]                # the attention layers (attn_every 2)
+    trainable = {k for k, _ in tree_flatten(student.trainable_parameters())}
+    assert not any(k.startswith("layers.1.") for k in trainable)   # frozen
+    assert any(k.startswith("layers.0.") for k in trainable)       # Mamba trainable
+    assert rep.n_frozen_params > 0
+    assert rep.n_frozen_params + rep.n_trainable_params == _total(student)
+
+
+def test_mil_no_grad_to_frozen_layers():
+    teacher, student = _teacher(), _student()
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+
+    def loss(model):
+        return model.forward(mx.zeros((1, 6), dtype=mx.int32)).sum()
+
+    import mlx.nn as nn
+    grads = nn.value_and_grad(student, loss)(student)[1]
+    flat = dict(tree_flatten(grads))
+    # frozen attention layers contribute no gradient entries; Mamba layers do.
+    assert not any(k.startswith("layers.1.") for k in flat)
+    assert any(k.startswith("layers.0.") for k in flat)
+
+
+# --- MOHAWK ------------------------------------------------------------------
+def test_mohawk_freezes_nothing():
+    teacher, student = _teacher(), _student()
+    rep = init_student(student, teacher, InitMethod.MOHAWK)
+    assert rep.method == "mohawk" and rep.frozen_layers == []
+    assert rep.n_frozen_params == 0
+    assert rep.n_trainable_params == _total(student)
+    # attention layers are still copied from the teacher
+    proj = teacher.attention_projection(1)
+    assert mx.allclose(student.layers[1].qkv_proj.weight[:64], proj.q).item()
+
+
+# --- end to end via the manifest resolver ------------------------------------
+def test_end_to_end_manifest_to_student():
+    from src.train.distill_manifest import DistillManifest, manifest_to_config
+    man = DistillManifest(
+        student="tiny", conversion_teacher="t", tokenizer="qwen25", seq_len=32,
+        init=InitMethod.MAMBA_IN_THE_LLAMA, stages=["mixing-match"],
+        layout={"d_model": 64, "n_layers": 4, "attention_every": 2, "state_size": 16,
+                "head_dim": 16, "n_attn_heads": 4},
+    )
+    cfg = manifest_to_config(man)
+    cfg.vocab_size = 256                              # shrink vocab for the offline test
+    cfg.precision, cfg.grad_checkpoint = "fp32", False
+    student = MLXMambaModel(cfg)
+    teacher = _teacher()
+    rep = init_student(student, teacher, man.init)
+    assert rep.n_layers_mapped == cfg.n_layers
+    assert mx.all(mx.isfinite(student.forward(mx.zeros((1, 8), dtype=mx.int32)))).item()

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -1,0 +1,165 @@
+"""Conversion-teacher loader (#93). MLX-only; skipped where mlx is unavailable.
+
+Exercises the frozen, forward-only teacher behind the seam with the tiny synthetic
+teacher (offline): output shapes (logits / hidden states / top-k), the Q/K/V/O
+projection accessor the #99 init consumes, the frozen contract (no trainable params,
+no gradient flow), determinism, and the real HF-safetensors loader path via an
+offline synthetic checkpoint round-trip.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from src.model.teacher import TeacherConfig
+from src.model.mlx_teacher import MLXConversionTeacher
+
+
+def _tiny():
+    return MLXConversionTeacher.from_config(TeacherConfig.tiny(), seed=0)
+
+
+def _tokens(B, L, vocab):
+    rng = np.random.default_rng(0)
+    return rng.integers(0, vocab, size=(B, L)).astype(np.int32)
+
+
+# --- config ------------------------------------------------------------------
+def test_qwen_1_5b_config_shape():
+    c = TeacherConfig.qwen_1_5b()
+    assert (c.vocab_size, c.d_model, c.n_layers) == (151936, 1536, 28)
+    assert (c.n_heads, c.n_kv_heads, c.head_dim) == (12, 2, 128)
+    assert c.intermediate_size == 8960 and c.tie_embeddings
+    assert c.q_dim == 1536 and c.kv_dim == 256
+    assert c.model_id == "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+    c.validate()
+
+
+def test_config_validate_rejects_bad_gqa():
+    with pytest.raises(ValueError):
+        TeacherConfig(vocab_size=8, d_model=16, n_layers=1, n_heads=4, n_kv_heads=3,
+                      head_dim=4, intermediate_size=16).validate()
+
+
+# --- forward / shapes --------------------------------------------------------
+def test_forward_logits_shape():
+    t = _tiny()
+    c = t.config
+    out = t.forward(_tokens(2, 5, c.vocab_size))
+    assert out.logits.shape == (2, 5, c.vocab_size)
+    assert out.hidden_states is None
+    assert mx.all(mx.isfinite(out.logits)).item()
+
+
+def test_forward_hidden_states():
+    t = _tiny()
+    c = t.config
+    out = t.forward(_tokens(2, 5, c.vocab_size), return_hidden=True)
+    assert len(out.hidden_states) == c.n_layers + 1        # embedding + each layer
+    for h in out.hidden_states:
+        assert h.shape == (2, 5, c.d_model)
+
+
+def test_topk_logits():
+    t = _tiny()
+    c = t.config
+    k = 8
+    vals, idx = t.topk_logits(_tokens(2, 5, c.vocab_size), k)
+    assert vals.shape == (2, 5, k) and idx.shape == (2, 5, k)
+    # descending values, indices in range, and equal to a gather of the full logits
+    diffs = vals[..., :-1] - vals[..., 1:]
+    assert mx.all(diffs >= -1e-5).item()
+    assert mx.all(idx >= 0).item() and mx.all(idx < c.vocab_size).item()
+    full = t.forward(_tokens(2, 5, c.vocab_size)).logits
+    gathered = mx.take_along_axis(full, idx, axis=-1)
+    assert mx.allclose(gathered, vals, atol=1e-5).item()
+
+
+# --- projection accessor (#99) ----------------------------------------------
+def test_attention_projection_shapes_gqa():
+    t = _tiny()
+    c = t.config
+    pr = t.attention_projection(0)
+    assert pr.q.shape == (c.q_dim, c.d_model)
+    assert pr.k.shape == (c.kv_dim, c.d_model)
+    assert pr.v.shape == (c.kv_dim, c.d_model)
+    assert pr.o.shape == (c.d_model, c.q_dim)
+    assert c.n_kv_heads < c.n_heads                        # exercising the GQA path
+    assert pr.q_bias.shape == (c.q_dim,)
+    assert pr.k_bias.shape == (c.kv_dim,) and pr.v_bias.shape == (c.kv_dim,)
+
+
+# --- frozen contract ---------------------------------------------------------
+def test_no_trainable_parameters():
+    assert _tiny().trainable_parameters() == {}
+
+
+def test_no_gradient_flows_to_teacher():
+    """A loss on the teacher's logits must produce zero gradient w.r.t. its weights:
+    forward wraps its outputs in stop_gradient, so the teacher stays frozen even when
+    composed into a student objective."""
+    t = _tiny()
+    toks = _tokens(1, 4, t.config.vocab_size)
+    embed = t._w["embed"]
+
+    def loss(w):
+        t._w["embed"] = w
+        return t.forward(toks).logits.sum()
+
+    g = mx.grad(loss)(embed)
+    t._w["embed"] = embed                                  # restore
+    assert mx.all(g == 0).item()
+
+
+def test_deterministic_forward():
+    t = _tiny()
+    toks = _tokens(2, 6, t.config.vocab_size)
+    a = t.forward(toks).logits
+    b = t.forward(toks).logits
+    assert mx.array_equal(a, b).item()
+
+
+# --- real HF loader path (offline synthetic checkpoint) ----------------------
+def _write_hf_checkpoint(t: MLXConversionTeacher, path):
+    """Serialize a teacher to an HF-named safetensors checkpoint + config.json, so the
+    `from_pretrained` name-mapping is exercised without a multi-GB download."""
+    c = t.config
+    w = t._w
+    hf = {"model.embed_tokens.weight": w["embed"], "model.norm.weight": w["final_ln"]}
+    for i in range(c.n_layers):
+        ip, p = f"model.layers.{i}.", f"layer.{i}."
+        hf[ip + "input_layernorm.weight"] = w[p + "input_ln"]
+        hf[ip + "post_attention_layernorm.weight"] = w[p + "post_ln"]
+        for proj, src in (("q_proj", "q"), ("k_proj", "k"), ("v_proj", "v")):
+            hf[ip + f"self_attn.{proj}.weight"] = w[p + src + "_w"]
+            hf[ip + f"self_attn.{proj}.bias"] = w[p + src + "_b"]
+        hf[ip + "self_attn.o_proj.weight"] = w[p + "o_w"]
+        hf[ip + "mlp.gate_proj.weight"] = w[p + "gate_w"]
+        hf[ip + "mlp.up_proj.weight"] = w[p + "up_w"]
+        hf[ip + "mlp.down_proj.weight"] = w[p + "down_w"]
+    path.mkdir(parents=True, exist_ok=True)
+    mx.save_safetensors(str(path / "model.safetensors"), hf)
+    hf_cfg = {
+        "vocab_size": c.vocab_size, "hidden_size": c.d_model,
+        "num_hidden_layers": c.n_layers, "num_attention_heads": c.n_heads,
+        "num_key_value_heads": c.n_kv_heads, "head_dim": c.head_dim,
+        "intermediate_size": c.intermediate_size, "rms_norm_eps": c.rms_norm_eps,
+        "rope_theta": c.rope_theta, "tie_word_embeddings": c.tie_embeddings,
+    }
+    (path / "config.json").write_text(json.dumps(hf_cfg))
+
+
+def test_from_pretrained_roundtrip(tmp_path):
+    src = MLXConversionTeacher.from_config(TeacherConfig.tiny(), seed=3)
+    _write_hf_checkpoint(src, tmp_path / "ckpt")
+    loaded = MLXConversionTeacher.from_pretrained(tmp_path / "ckpt")
+    # config recovered from config.json
+    assert loaded.config.vocab_size == src.config.vocab_size
+    assert loaded.config.n_layers == src.config.n_layers
+    # identical logits => name-mapping + IO are correct
+    toks = _tokens(2, 5, src.config.vocab_size)
+    assert mx.allclose(loaded.forward(toks).logits, src.forward(toks).logits,
+                       atol=1e-5).item()


### PR DESCRIPTION
Closes #100. Part of #65 (M10 distillation).

> **Stacked PR** — base is `feature/99-student-init` (#113), which is itself stacked on `feature/93-conversion-teacher-loader` (#112). Merge order: #112 → #113 → #100; the base retargets automatically as each parent merges.

## Summary
Train the hybrid student (#99) against the **cached** teacher signal (#93) through the manifest's distillation stages — a new injected `TrainStepFn` mirroring SFT/DPO/GRPO, so the backend-free training loop is unchanged.

- **`src/train/distill_manifest.py`**: `DistillStage` enum + `distill_stages(manifest)` (the manifest's distillation stages in order; SFT/RL stages dropped).
- **`src/model/mlx_distill.py`** (below seam): `make_distill_train_step` dispatching over the three stages, funnelled through the shared `_accumulate_and_step`:
  - **`logit-distill`** — compound `ce_weight·CE + kl_weight·KL_topk`, where `KL_topk` is the `T²`-scaled KL between the teacher's cached **top-k** distribution and the student's logits renormalized over the same support. No teacher inference in the loop.
  - **`hidden-align`** — per-layer hidden-state MSE, with **cached** teacher hidden states *or* **on-the-fly** recompute (`stop_gradient`), compared over the overlapping `min(d)` channels (width mismatch).
  - **`mixing-match`** — MSE between the student's head-averaged SSM **mixing matrix** and the teacher's head-averaged causal attention matrix (a tractable simplification of MOHAWK's per-layer teacher-forced orientation).
- **`src/model/mlx_backend.py`**: `SelectiveSSM.mixing_matrix` (the materialized 1-semiseparable matrix, **verified to reproduce the chunked scan to ~2e-7**), `MambaBlock.mixing_matrix`, and `MLXMambaModel.hidden_states` / `mixing_matrices` accessors.
- **`src/model/mlx_teacher.py`**: `attention_matrices` (per-layer head-averaged causal `softmax(QK^T)`, `stop_gradient`).
- **`src/model/backend.py`**: `Backend.make_distill_train_step` — MLX factory; CUDA stub (deferred).
- The compound loss is a single scalar, so the existing `DynamicLossScaler` covers it unchanged — overflow steps skip cleanly (tested by poisoning the cached top-k with a NaN).

## Testing
- `tests/test_distill_train_step.py`: mixing-matrix parity vs the scan, `KL_topk` (≥0, and 0 at exact match), logit-distill compound loss decreases, **hidden-align cached == on-the-fly**, mixing-match decreases, fp16 scaler clean step + **clean overflow-skip on the compound term**, and the backend-seam factory.
- `tests/test_distill_manifest.py`: `distill_stages` returns the three stages in manifest order.
- Full suite: **325 passed, 1 skipped**. M4 smoke gate exact (resume max|diff| 1.2e-7). Import guard intact.

## Acceptance
- [x] A student trains from cached teacher top-k logits with a KL+CE compound loss.
- [x] Stages run in manifest order; hidden-align works with cached or on-the-fly hidden states.
- [x] fp16 loss scaling handles the compound term; overflow steps skip cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)