### PR TITLE
feat(model): [M10] student init — Mamba-in-the-Llama + MOHAWK + manifest resolver (#99)

### DIFF
--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -66,6 +66,28 @@ HF repo id) and builds a tiny **synthetic** teacher via `from_config` for offlin
 local checks. Build one through `get_backend(...).make_teacher(...)`; the CUDA teacher is deferred
 (the branch raises `NotImplementedError`).
 
+### Student init from the teacher (#99)
+
+A trial is a **manifest** (`config/manifests/*.yaml`); `src/train/distill_manifest.py` parses it
+(portable, above the seam): `init:` resolves to an `InitMethod`, `stages:` is validated against
+the canonical list (the distill stages `mixing-match → hidden-align → logit-distill` plus the
+post-training ones), and `manifest_to_config` resolves the `layout` sweep-schema
+(`d_model`, `n_layers`, `attention_every → attn_every`, `state_size → d_state`) + `tokenizer →
+vocab_size` onto a `MambaConfig`.
+
+`get_backend(...).init_student(student, teacher, method)`
+(`src/model/mlx_student_init.py`) then performs the conversion. **Mamba-in-the-Llama** maps the
+teacher attention onto the student SSM — **Q → C**, **K → B** (the two `d_state` slices of the SSM
+`x_proj`), **V → input** (`in_proj` main half), **O → output** (`out_proj`) — copies the kept
+attention layers from the teacher and **freezes** them (the student has no MLP blocks, so the
+retained attention plays the role the paper's frozen MLPs do; the trainable set is the new Mamba
+layers). **MOHAWK** is a lighter init (copy attention, leave Mamba at default, freeze nothing);
+the matching happens in the staged distill loss (#100). Because teacher and student widths differ,
+the mapping is **adaptive** (exact copy where dims align, else copy-overlap + zero-pad/truncate);
+init quality is judged by the downstream distillation curve, not by exactness. Freezing uses MLX's
+native `nn.Module.freeze`, which `nn.value_and_grad` already honors, so the train step is
+unchanged. The CUDA initializer is deferred.
+
 ## The tokenizer is fixed by the conversion teacher (#90, #91)
 
 The student must **share a vocabulary with the conversion teacher** for logit and hidden-state

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -43,6 +43,9 @@ class Backend:
     # Distillation (M10): build a frozen, forward-only conversion teacher behind the seam
     # (`ConversionTeacher`). MLX-only for now; the CUDA branch raises NotImplementedError.
     make_teacher: Callable[..., Any]
+    # Distillation (M10/#99): initialize a student model from a teacher (Mamba-in-the-Llama /
+    # MOHAWK), returning an `InitReport`. MLX-only for now; CUDA raises NotImplementedError.
+    init_student: Callable[..., Any]
 
 
 def get_backend(name: str = "auto") -> Backend:
@@ -104,6 +107,11 @@ def _mlx_backend() -> Backend:
                              "(pass `config=...`), or `pretrained=<dir/repo>` for real weights")
         return MLXConversionTeacher.from_config(config, seed=seed)
 
+    def _init_student(student, teacher, method):
+        """Initialize a student from a teacher (#99); `method` is an `InitMethod`."""
+        from .mlx_student_init import init_student
+        return init_student(student, teacher, method)
+
     return Backend(
         name="mlx",
         model_cls=MLXMambaModel,
@@ -119,6 +127,7 @@ def _mlx_backend() -> Backend:
         make_dpo_train_step=_make_dpo_train_step,
         make_grpo_train_step=_make_grpo_train_step,
         make_teacher=_make_teacher,
+        init_student=_init_student,
     )
 
 
@@ -163,6 +172,11 @@ def _cuda_backend() -> Backend:
             "The conversion teacher (M10/#93) is implemented on the MLX dev backend only; "
             "the CUDA teacher loader is deferred.")
 
+    def _student_init_unsupported(*args, **kwargs):
+        raise NotImplementedError(
+            "Student init (M10/#99) is implemented on the MLX dev backend only; "
+            "the CUDA initializer is deferred.")
+
     return Backend(
         name="cuda",
         model_cls=CUDAMambaModel,
@@ -177,4 +191,5 @@ def _cuda_backend() -> Backend:
         make_dpo_train_step=_post_training_unsupported,
         make_grpo_train_step=_post_training_unsupported,
         make_teacher=_teacher_unsupported,
+        init_student=_student_init_unsupported,
     )

--- a/src/model/mlx_student_init.py
+++ b/src/model/mlx_student_init.py
@@ -56,8 +56,11 @@ def _set(param_owner, name: str, value: mx.array) -> None:
 
 
 def _teacher_layer_for(i: int, n_student: int, n_teacher: int) -> int:
-    """Align student depth onto teacher depth (evenly spaced)."""
-    return min(n_teacher - 1, int(round(i * n_teacher / max(1, n_student))))
+    """Align student depth onto teacher depth, endpoint-to-endpoint (evenly spaced): student
+    layer 0 -> teacher 0 and the last student layer -> the last teacher layer."""
+    if n_student <= 1:
+        return 0
+    return min(n_teacher - 1, int(round(i * (n_teacher - 1) / (n_student - 1))))
 
 
 def _init_attention_layer(layer, proj, tcfg) -> None:

--- a/src/model/mlx_student_init.py
+++ b/src/model/mlx_student_init.py
@@ -1,0 +1,127 @@
+"""MLX student initialization from a frozen teacher (Apple Silicon, below the seam).
+
+Phase 2 of the distillation (#99): turn the transformer teacher (#93) into the Mamba-2 hybrid
+student by one of two methods (`docs/design/10-distillation.md`):
+
+  * **Mamba-in-the-Llama** (`InitMethod.MAMBA_IN_THE_LLAMA`): initialize the Mamba layers from the
+    teacher's attention projections — Q -> C, K -> B (the two d_state slices of `x_proj`),
+    V -> input (`in_proj` main half), O -> `out_proj` — copy the kept attention layers from the
+    teacher, and FREEZE them. The student is a pure Mamba+attention hybrid with no MLP blocks, so
+    the retained attention layers play the role the paper's frozen MLPs play (the trainable set is
+    the new Mamba layers). Reference: arXiv:2408.15237.
+  * **MOHAWK** (`InitMethod.MOHAWK`): a lighter init (copy attention layers where present, leave
+    Mamba at its default init, freeze nothing); the real work is the progressive matching the
+    distill loss runs per `stages` (#100). Reference: arXiv:2408.10189.
+
+Because the teacher (e.g. d_model 1536) and the swept student (e.g. 2048) differ in width, the
+mapping is **adaptive**: exact copy where dims align, otherwise copy the overlapping block and
+zero-pad/truncate to the student's shape (`_fit`). Init quality is validated downstream by the
+distillation curve, not by exactness.
+
+Freezing uses MLX's native `nn.Module.freeze`, which `nn.value_and_grad` already honors (it only
+differentiates `trainable_parameters()`), so the #100 train step needs no change. This file
+imports `mlx`; it lives below the seam and nothing portable imports it.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+
+from ..train.distill_manifest import InitMethod, InitReport
+
+
+def _fit(src: mx.array, shape: Tuple[int, ...]) -> mx.array:
+    """Adaptive copy of `src` into an array of `shape`: keep the overlapping region per axis,
+    zero-pad/truncate the rest. Exact (returns `src`'s values) when shapes already match."""
+    crop = src[tuple(slice(0, min(s, d)) for s, d in zip(src.shape, shape))]
+    pad = [(0, d - c) for d, c in zip(shape, crop.shape)]
+    return mx.pad(crop, pad)
+
+
+def _expand_kv(w: mx.array, n_heads: int, n_kv_heads: int, head_dim: int) -> mx.array:
+    """Expand a GQA key/value projection (n_kv_heads*head_dim, d) to full MHA width
+    (n_heads*head_dim, d) by repeating each kv head's block, matching inference-time repeat."""
+    if n_kv_heads == n_heads:
+        return w
+    rep = n_heads // n_kv_heads
+    d = w.shape[-1]
+    return mx.repeat(w.reshape(n_kv_heads, head_dim, d), rep, axis=0).reshape(n_heads * head_dim, d)
+
+
+def _set(param_owner, name: str, value: mx.array) -> None:
+    setattr(param_owner, name, value)
+
+
+def _teacher_layer_for(i: int, n_student: int, n_teacher: int) -> int:
+    """Align student depth onto teacher depth (evenly spaced)."""
+    return min(n_teacher - 1, int(round(i * n_teacher / max(1, n_student))))
+
+
+def _init_attention_layer(layer, proj, tcfg) -> None:
+    """Copy a teacher attention layer's Q/K/V/O onto a student attention block (`qkv_proj`,
+    `o_proj`), expanding GQA to full heads and adaptively fitting to the student's width."""
+    q = proj.q
+    k = _expand_kv(proj.k, tcfg.n_heads, tcfg.n_kv_heads, tcfg.head_dim)
+    v = _expand_kv(proj.v, tcfg.n_heads, tcfg.n_kv_heads, tcfg.head_dim)
+    d_attn, d_model = layer.qkv_proj.weight.shape[0] // 3, layer.qkv_proj.weight.shape[1]
+    blocks = [_fit(w, (d_attn, d_model)) for w in (q, k, v)]
+    _set(layer.qkv_proj, "weight", mx.concatenate(blocks, axis=0))   # (3*d_attn, d_model)
+    _set(layer.o_proj, "weight", _fit(proj.o, layer.o_proj.weight.shape))
+
+
+def _init_mamba_layer(layer, proj, dt_rank: int, d_state: int) -> None:
+    """Mamba-in-the-Llama mapping onto one Mamba block: Q->C, K->B (the d_state slices of
+    `x_proj`), V->input (`in_proj` main half), O->`out_proj`. Untouched rows keep their init."""
+    d_inner = layer.out_proj.weight.shape[1]
+    # x_proj: rows are [dt(dt_rank) | B(d_state) | C(d_state)] -> set B from K, C from Q.
+    xw = layer.ssm.x_proj.weight
+    B_new = _fit(proj.k, (d_state, d_inner))
+    C_new = _fit(proj.q, (d_state, d_inner))
+    _set(layer.ssm.x_proj, "weight",
+         mx.concatenate([xw[:dt_rank], B_new, C_new], axis=0))
+    # in_proj: rows are [main(d_inner) | gate(d_inner)] -> set main from V, keep gate.
+    iw = layer.in_proj.weight
+    main_new = _fit(proj.v, (d_inner, iw.shape[1]))
+    _set(layer.in_proj, "weight", mx.concatenate([main_new, iw[d_inner:]], axis=0))
+    # out_proj <- O.
+    _set(layer.out_proj, "weight", _fit(proj.o, layer.out_proj.weight.shape))
+
+
+def init_student(student, teacher, method: InitMethod) -> InitReport:
+    """Initialize `student` (an `MLXMambaModel`) from `teacher` (a `ConversionTeacher`).
+
+    Returns an `InitReport`. For Mamba-in-the-Llama the kept attention layers are frozen; for
+    MOHAWK nothing is frozen.
+    """
+    cfg = student.config
+    tcfg = teacher.config
+    S, T = cfg.n_layers, teacher.n_layers
+    dt_rank, d_state = cfg.dt_rank_resolved, cfg.d_state
+
+    frozen_layers: List[int] = []
+    n_mapped = 0
+    for i in range(S):
+        proj = teacher.attention_projection(_teacher_layer_for(i, S, T))
+        is_attn = cfg.is_attention_layer(i)
+        if is_attn:
+            _init_attention_layer(student.layers[i], proj, tcfg)
+            n_mapped += 1
+            if method == InitMethod.MAMBA_IN_THE_LLAMA:
+                student.layers[i].freeze()
+                frozen_layers.append(i)
+        elif method == InitMethod.MAMBA_IN_THE_LLAMA:
+            _init_mamba_layer(student.layers[i], proj, dt_rank, d_state)
+            n_mapped += 1
+        # MOHAWK leaves Mamba layers at their default init (refined by progressive matching #100).
+
+    mx.eval(student.parameters())
+    total = sum(v.size for _, v in tree_flatten(student.parameters()))
+    trainable = sum(v.size for _, v in tree_flatten(student.trainable_parameters()))
+    return InitReport(
+        method=method.value, n_layers_mapped=n_mapped,
+        n_frozen_params=total - trainable, n_trainable_params=trainable,
+        frozen_layers=frozen_layers,
+    )

--- a/src/train/distill_manifest.py
+++ b/src/train/distill_manifest.py
@@ -1,0 +1,157 @@
+"""Distillation manifest resolver (portable — NO backend import).
+
+A student trial (#65/#98) is a lightweight **manifest** naming the frozen teacher artifacts
+plus the student layout and the conversion method (`docs/design/10-distillation.md`). A sweep is
+a set of sibling manifests pointing at the *same* teacher signal; only `layout` changes.
+`config/manifests/*.yaml` are the seed manifests.
+
+This module parses a manifest into a `DistillManifest`, validates the `init:` method and the
+`stages:` list, and resolves the `layout` sweep-schema onto a `MambaConfig` (the model's single
+source of truth). The student-init step (#99, `model.mlx_student_init`) consumes `init`; the
+distill loss (#100) consumes `stages` to run mixing-match -> hidden-align -> logit-distill in
+order. Nothing here imports a backend, so it stays above the seam.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import yaml
+
+from ..model.blocks import MambaConfig
+
+
+class InitMethod(Enum):
+    """Teacher -> student conversion method, selected per manifest by `init:`."""
+
+    MAMBA_IN_THE_LLAMA = "mamba-in-the-llama"
+    MOHAWK = "mohawk"
+
+    @classmethod
+    def from_str(cls, value: str) -> "InitMethod":
+        try:
+            return cls(value)
+        except ValueError:
+            allowed = ", ".join(m.value for m in cls)
+            raise ValueError(f"unknown init method {value!r}; expected one of: {allowed}")
+
+
+# Canonical distillation + post-training stages, in their natural run order. The manifest's
+# `stages:` is a subset/ordering of these; #100 runs the distill stages, post-training (#11)
+# runs the SFT/RL ones.
+CANONICAL_STAGES = (
+    "mixing-match", "hidden-align", "logit-distill",     # distillation matching (#100)
+    "instruct-sft", "reasoning-sft", "tool-sft",         # supervised fine-tuning (#11)
+    "grpo",                                              # verifiable RL (#78)
+)
+
+# Tokenizer name -> vocab size. Qwen2.5 is fixed by the conversion teacher (#90); the value
+# matches config/student-1b.yaml (151646, the tokenizer vocab, < the teacher's padded 151936).
+_TOKENIZER_VOCAB = {"qwen25": 151646}
+
+
+@dataclass
+class DistillManifest:
+    """A parsed student-trial manifest. `init` is an `InitMethod`; `stages` is validated."""
+
+    student: str
+    conversion_teacher: str
+    tokenizer: str
+    seq_len: int
+    init: InitMethod
+    stages: List[str]
+    layout: Dict[str, Any]
+    corpus: str = ""
+    teacher_outputs: str = ""
+    sft: str = ""
+    rl: str = ""
+    schedule: Dict[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        if self.tokenizer not in _TOKENIZER_VOCAB:
+            raise ValueError(
+                f"unknown tokenizer {self.tokenizer!r}; known: {sorted(_TOKENIZER_VOCAB)}")
+        unknown = [s for s in self.stages if s not in CANONICAL_STAGES]
+        if unknown:
+            raise ValueError(
+                f"unknown stage(s) {unknown}; expected from: {list(CANONICAL_STAGES)}")
+        if not self.stages:
+            raise ValueError("manifest `stages` must be non-empty")
+
+    @property
+    def vocab_size(self) -> int:
+        return _TOKENIZER_VOCAB[self.tokenizer]
+
+
+@dataclass
+class InitReport:
+    """Summary of a student-init run (#99), returned by the backend `init_student`.
+
+    Portable (plain ints/strings) so a driver can log it without importing a backend.
+    `frozen_layers` lists the student layer indices whose params were frozen (the kept
+    attention layers under Mamba-in-the-Llama); `n_frozen_params + n_trainable_params`
+    equals the student's total parameter count.
+    """
+
+    method: str
+    n_layers_mapped: int
+    n_frozen_params: int
+    n_trainable_params: int
+    frozen_layers: List[int] = field(default_factory=list)
+
+
+def load_manifest(path: Union[str, Path]) -> DistillManifest:
+    """Load + validate a manifest YAML (`config/manifests/*.yaml`)."""
+    with open(path, "r") as f:
+        raw = yaml.safe_load(f) or {}
+    m = DistillManifest(
+        student=str(raw["student"]),
+        conversion_teacher=str(raw["conversion_teacher"]),
+        tokenizer=str(raw["tokenizer"]),
+        seq_len=int(raw["seq_len"]),
+        init=InitMethod.from_str(str(raw["init"])),
+        stages=list(raw.get("stages", [])),
+        layout=dict(raw.get("layout", {})),
+        corpus=str(raw.get("corpus", "")),
+        teacher_outputs=str(raw.get("teacher_outputs", "")),
+        sft=str(raw.get("sft", "")),
+        rl=str(raw.get("rl", "")),
+        schedule=dict(raw.get("schedule", {})),
+    )
+    m.validate()
+    return m
+
+
+def manifest_to_config(manifest: DistillManifest) -> MambaConfig:
+    """Resolve a manifest's `layout` sweep-schema onto a `MambaConfig`.
+
+    The manifest's layout keys are sweep-schema names; map them onto model fields:
+      `d_model`, `n_layers`, `attention_every` -> `attn_every`, `state_size` -> `d_state`.
+    `vocab_size`/`seq_len` come from the manifest; `precision`/`grad_checkpoint`/`head_dim`
+    mirror `config/student-1b.yaml` (bf16 CUDA training at this depth). Optional layout keys
+    `head_dim`, `expand`, `n_attn_heads` override the student defaults when present.
+    """
+    layout = manifest.layout
+    cfg = MambaConfig(
+        d_model=int(layout["d_model"]),
+        n_layers=int(layout["n_layers"]),
+        d_state=int(layout.get("state_size", layout.get("d_state", 128))),
+        expand=int(layout.get("expand", 2)),
+        head_dim=int(layout.get("head_dim", 64)),
+        attn_every=_opt_int(layout.get("attention_every", layout.get("attn_every"))),
+        n_attn_heads=_opt_int(layout.get("n_attn_heads")),
+        vocab_size=manifest.vocab_size,
+        seq_len=manifest.seq_len,
+        tie_embeddings=True,
+        precision="bf16",
+        grad_checkpoint=True,
+    )
+    cfg.validate()
+    return cfg
+
+
+def _opt_int(value: Any) -> Any:
+    return None if value is None else int(value)

--- a/tests/test_distill_manifest.py
+++ b/tests/test_distill_manifest.py
@@ -1,0 +1,59 @@
+"""Distillation manifest resolver (#99). Portable — runs without a backend."""
+
+import pytest
+
+from src.train.distill_manifest import (CANONICAL_STAGES, DistillManifest, InitMethod,
+                                        load_manifest, manifest_to_config)
+
+MANIFESTS = ["config/manifests/student-1b-attn12pct.yaml",
+             "config/manifests/student-1b-attn8pct.yaml"]
+
+
+@pytest.mark.parametrize("path", MANIFESTS)
+def test_real_manifests_load(path):
+    m = load_manifest(path)
+    assert m.init == InitMethod.MAMBA_IN_THE_LLAMA       # both seeds default to MiL
+    assert m.tokenizer == "qwen25" and m.vocab_size == 151646
+    assert m.stages and all(s in CANONICAL_STAGES for s in m.stages)
+    assert m.stages[:3] == ["mixing-match", "hidden-align", "logit-distill"]
+
+
+@pytest.mark.parametrize("path", MANIFESTS)
+def test_manifest_to_config(path):
+    m = load_manifest(path)
+    cfg = manifest_to_config(m)
+    cfg.validate()
+    assert cfg.d_model == m.layout["d_model"]
+    assert cfg.n_layers == m.layout["n_layers"]
+    assert cfg.attn_every == m.layout["attention_every"]    # sweep-schema -> model field
+    assert cfg.d_state == m.layout["state_size"]
+    assert cfg.vocab_size == 151646 and cfg.seq_len == m.seq_len
+
+
+def test_init_method_from_str():
+    assert InitMethod.from_str("mamba-in-the-llama") == InitMethod.MAMBA_IN_THE_LLAMA
+    assert InitMethod.from_str("mohawk") == InitMethod.MOHAWK
+    with pytest.raises(ValueError):
+        InitMethod.from_str("nope")
+
+
+def _manifest(**over):
+    base = dict(student="s", conversion_teacher="t", tokenizer="qwen25", seq_len=128,
+                init=InitMethod.MOHAWK, stages=["mixing-match"], layout={})
+    base.update(over)
+    return DistillManifest(**base)
+
+
+def test_validate_rejects_unknown_stage():
+    with pytest.raises(ValueError):
+        _manifest(stages=["mixing-match", "bogus-stage"]).validate()
+
+
+def test_validate_rejects_empty_stages():
+    with pytest.raises(ValueError):
+        _manifest(stages=[]).validate()
+
+
+def test_validate_rejects_unknown_tokenizer():
+    with pytest.raises(ValueError):
+        _manifest(tokenizer="gpt2").validate()

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -52,6 +52,7 @@ PORTABLE_MODULES = [
     "src.data.dpo_loader",
     "src.data.dpo_sources",
     "src.train.dpo_math",
+    "src.train.distill_manifest",
     "src.train.grpo",
     "src.train.verifiers",
     "src.train.schedule",

--- a/tests/test_student_init.py
+++ b/tests/test_student_init.py
@@ -15,8 +15,15 @@ from src.model.mlx_backend import MLXMambaModel
 from src.model.blocks import MambaConfig
 from src.model.mlx_teacher import MLXConversionTeacher
 from src.model.teacher import TeacherConfig
-from src.model.mlx_student_init import init_student
+from src.model.mlx_student_init import init_student, _teacher_layer_for
 from src.train.distill_manifest import InitMethod, InitReport
+
+
+def test_teacher_layer_alignment_maps_endpoints():
+    # endpoints map to endpoints (not biased toward early teacher layers)
+    assert [_teacher_layer_for(i, 4, 28) for i in range(4)] == [0, 9, 18, 27]
+    assert _teacher_layer_for(0, 1, 28) == 0          # n_student <= 1 fallback
+    assert [_teacher_layer_for(i, 4, 4) for i in range(4)] == [0, 1, 2, 3]   # identity
 
 
 def _teacher(d_model=64, n_layers=4, n_heads=4, n_kv_heads=2, head_dim=16):

--- a/tests/test_student_init.py
+++ b/tests/test_student_init.py
@@ -1,0 +1,131 @@
+"""Student init from a frozen teacher (#99). MLX-only; skipped where mlx is unavailable.
+
+Exercises Mamba-in-the-Llama + MOHAWK with a synthetic teacher and a tiny hybrid student:
+exact Q/K/V/O copy when dims align, the adaptive-fit path when the student is wider, the
+frozen/trainable split, and an end-to-end manifest -> config -> build -> init -> forward.
+"""
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+from mlx.utils import tree_flatten
+
+from src.model.mlx_backend import MLXMambaModel
+from src.model.blocks import MambaConfig
+from src.model.mlx_teacher import MLXConversionTeacher
+from src.model.teacher import TeacherConfig
+from src.model.mlx_student_init import init_student
+from src.train.distill_manifest import InitMethod, InitReport
+
+
+def _teacher(d_model=64, n_layers=4, n_heads=4, n_kv_heads=2, head_dim=16):
+    cfg = TeacherConfig(vocab_size=256, d_model=d_model, n_layers=n_layers, n_heads=n_heads,
+                        n_kv_heads=n_kv_heads, head_dim=head_dim, intermediate_size=128)
+    return MLXConversionTeacher.from_config(cfg, seed=0)
+
+
+def _student(d_model=64, n_attn_heads=4):
+    cfg = MambaConfig(d_model=d_model, n_layers=4, d_state=16, expand=2, d_conv=4, head_dim=16,
+                      vocab_size=256, seq_len=32, attn_every=2, n_attn_heads=n_attn_heads,
+                      precision="fp32")
+    return MLXMambaModel(cfg)
+
+
+def _total(model):
+    return sum(v.size for _, v in tree_flatten(model.parameters()))
+
+
+# --- Mamba-in-the-Llama: exact copy on matched dims --------------------------
+def test_mil_attention_exact_copy_when_dims_match():
+    teacher, student = _teacher(), _student()        # student d_attn 64 == teacher q_dim 64
+    rep = init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    assert isinstance(rep, InitReport) and rep.method == "mamba-in-the-llama"
+    # layer 1 is an attention layer (attn_every 2); teacher_layer_for(1,4,4) == 1.
+    proj = teacher.attention_projection(1)
+    qkv = student.layers[1].qkv_proj.weight          # (3*d_attn, d_model)
+    assert mx.allclose(qkv[:64], proj.q).item()      # Q block exact
+    assert mx.allclose(student.layers[1].o_proj.weight, proj.o).item()
+
+
+def test_mil_mamba_layer_gets_teacher_projection():
+    teacher, student = _teacher(), _student()
+    proj = teacher.attention_projection(0)           # layer 0 is a Mamba layer
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    cfg = student.config
+    dt_rank, N = cfg.dt_rank_resolved, cfg.d_state
+    xw = student.layers[0].ssm.x_proj.weight
+    # C slice (rows dt_rank+N : dt_rank+2N) is Q fitted into (N, d_inner): top-left overlaps Q.
+    C = xw[dt_rank + N:dt_rank + 2 * N]
+    assert mx.allclose(C[:, :proj.q.shape[1]][:N], proj.q[:N]).item()
+
+
+# --- adaptive fit when the student is wider than the teacher -----------------
+def test_mil_adaptive_fit_wider_student_shapes_finite():
+    teacher = _teacher(d_model=64)
+    student = _student(d_model=128, n_attn_heads=8)   # wider: d_attn 128 > teacher q_dim 64
+    before = {k: v.shape for k, v in tree_flatten(student.parameters())}
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    after = {k: v.shape for k, v in tree_flatten(student.parameters())}
+    assert before == after                            # every param keeps its correct shape
+    for _, v in tree_flatten(student.parameters()):
+        assert mx.all(mx.isfinite(v)).item()
+    assert student.forward(mx.zeros((1, 8), dtype=mx.int32)).shape == (1, 8, 256)
+
+
+# --- freeze gating -----------------------------------------------------------
+def test_mil_freezes_kept_attention_layers():
+    teacher, student = _teacher(), _student()
+    rep = init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    assert rep.frozen_layers == [1, 3]                # the attention layers (attn_every 2)
+    trainable = {k for k, _ in tree_flatten(student.trainable_parameters())}
+    assert not any(k.startswith("layers.1.") for k in trainable)   # frozen
+    assert any(k.startswith("layers.0.") for k in trainable)       # Mamba trainable
+    assert rep.n_frozen_params > 0
+    assert rep.n_frozen_params + rep.n_trainable_params == _total(student)
+
+
+def test_mil_no_grad_to_frozen_layers():
+    teacher, student = _teacher(), _student()
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+
+    def loss(model):
+        return model.forward(mx.zeros((1, 6), dtype=mx.int32)).sum()
+
+    import mlx.nn as nn
+    grads = nn.value_and_grad(student, loss)(student)[1]
+    flat = dict(tree_flatten(grads))
+    # frozen attention layers contribute no gradient entries; Mamba layers do.
+    assert not any(k.startswith("layers.1.") for k in flat)
+    assert any(k.startswith("layers.0.") for k in flat)
+
+
+# --- MOHAWK ------------------------------------------------------------------
+def test_mohawk_freezes_nothing():
+    teacher, student = _teacher(), _student()
+    rep = init_student(student, teacher, InitMethod.MOHAWK)
+    assert rep.method == "mohawk" and rep.frozen_layers == []
+    assert rep.n_frozen_params == 0
+    assert rep.n_trainable_params == _total(student)
+    # attention layers are still copied from the teacher
+    proj = teacher.attention_projection(1)
+    assert mx.allclose(student.layers[1].qkv_proj.weight[:64], proj.q).item()
+
+
+# --- end to end via the manifest resolver ------------------------------------
+def test_end_to_end_manifest_to_student():
+    from src.train.distill_manifest import DistillManifest, manifest_to_config
+    man = DistillManifest(
+        student="tiny", conversion_teacher="t", tokenizer="qwen25", seq_len=32,
+        init=InitMethod.MAMBA_IN_THE_LLAMA, stages=["mixing-match"],
+        layout={"d_model": 64, "n_layers": 4, "attention_every": 2, "state_size": 16,
+                "head_dim": 16, "n_attn_heads": 4},
+    )
+    cfg = manifest_to_config(man)
+    cfg.vocab_size = 256                              # shrink vocab for the offline test
+    cfg.precision, cfg.grad_checkpoint = "fp32", False
+    student = MLXMambaModel(cfg)
+    teacher = _teacher()
+    rep = init_student(student, teacher, man.init)
+    assert rep.n_layers_mapped == cfg.n_layers
+    assert mx.all(mx.isfinite(student.forward(mx.zeros((1, 8), dtype=mx.int32)))).item()


### PR DESCRIPTION
Closes #99. Part of #65 (M10 distillation). Builds on the merged conversion teacher (#93, PR #112).

> Recreated from #113 (auto-closed when the stacked base branch `feature/93-...` was deleted on merge). Rebased onto `main`; Copilot feedback from #113 addressed.

## Summary
Phase 2 of the distillation: convert the frozen teacher (#93) into the Mamba-2 hybrid student, selected per manifest by `init:`, and expose the `stages:` list for the distill loss (#100).

- **`src/train/distill_manifest.py`** (portable): `InitMethod` enum, `DistillManifest` + `load_manifest`, stage validation, `manifest_to_config` resolving the `layout` sweep-schema (`d_model`, `n_layers`, `attention_every → attn_every`, `state_size → d_state`) + `tokenizer → vocab_size` onto a `MambaConfig`. Adds `InitReport`.
- **`src/model/mlx_student_init.py`** (below seam): `init_student` for **Mamba-in-the-Llama** (Q→C, K→B via the SSM `x_proj` `d_state` slices, V→`in_proj` main, O→`out_proj`; copy + **freeze** kept attention layers) and **MOHAWK** (lighter init, freeze nothing). Adaptive `_fit` handles the teacher/student width mismatch; GQA k/v expanded to full heads. Freezing uses MLX `nn.Module.freeze`, honored by `nn.value_and_grad` — no train-step change.
- **`src/model/backend.py`**: `Backend.init_student` — MLX factory; CUDA stub (deferred).

## Review feedback addressed (from #113)
- `_teacher_layer_for` now maps student depth onto teacher depth **endpoint-to-endpoint** (scale over n-1, with an `n_student<=1` fallback), so the last student layer maps to the last teacher layer instead of biasing toward early teacher layers.

## Testing
- `tests/test_distill_manifest.py` + `tests/test_student_init.py`: exact Q/K/V/O copy on matched dims, adaptive-fit shapes/finite when wider, freeze gating + no-grad-to-frozen, MOHAWK, endpoint depth-alignment, end-to-end manifest → student.
- Full suite (rebased on main): **316 passed, 1 skipped**. Import guard intact.

## Acceptance
- [x] A student initializes from the teacher with the projection mapping at correct shapes.
- [x] `init: mamba-in-the-llama` and `init: mohawk` both resolve from a manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)