### PR TITLE
feat(train): [M10] distillation loss + staged train step (KL top-k + CE) (#100)

### DIFF
--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -88,6 +88,32 @@ init quality is judged by the downstream distillation curve, not by exactness. F
 native `nn.Module.freeze`, which `nn.value_and_grad` already honors, so the train step is
 unchanged. The CUDA initializer is deferred.
 
+### The staged distillation loss + train step (#100)
+
+The student trains against the **cached** teacher signal through the manifest's distillation
+stages (`distill_stages(manifest)` → `mixing-match → hidden-align → logit-distill`, in order).
+Each stage is a separate injected `TrainStepFn` from
+`get_backend(...).make_distill_train_step(model, opt, stage=...)`
+(`src/model/mlx_distill.py`), mirroring SFT/DPO/GRPO and funnelling through the shared
+`_accumulate_and_step`, so the backend-free loop is unchanged:
+
+- **`logit-distill`** — compound `ce_weight·CE + kl_weight·KL_topk`, where `KL_topk` is the
+  `T²`-scaled KL between the teacher's cached **top-k** distribution and the student's logits
+  renormalized over the same support. No teacher inference in the loop (acceptance: KL+CE from
+  cached top-k).
+- **`hidden-align`** — MSE between per-layer hidden states, with **cached** teacher hidden states
+  in the micro-batch *or* **on-the-fly** recompute (`teacher.forward(return_hidden=True)`,
+  stop-gradient); compared over the overlapping `min(d)` channels (the width mismatch).
+- **`mixing-match`** — MSE between the student's head-averaged SSM **mixing matrix**
+  (`SelectiveSSM.mixing_matrix`, the materialized 1-semiseparable matrix, verified to reproduce
+  the scan) and the teacher's head-averaged causal attention matrix. A tractable simplification of
+  MOHAWK's strict per-layer teacher-forced orientation (each runs on its own forward, since the
+  widths differ).
+
+The compound loss is a single scalar, so the dynamic fp16 loss scaler
+(`train.loss_scale.DynamicLossScaler`) covers it unchanged — the combined term is scaled before
+backprop and overflowing steps skip cleanly. The CUDA distill step is deferred.
+
 ## The tokenizer is fixed by the conversion teacher (#90, #91)
 
 The student must **share a vocabulary with the conversion teacher** for logit and hidden-state

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -46,6 +46,9 @@ class Backend:
     # Distillation (M10/#99): initialize a student model from a teacher (Mamba-in-the-Llama /
     # MOHAWK), returning an `InitReport`. MLX-only for now; CUDA raises NotImplementedError.
     init_student: Callable[..., Any]
+    # Distillation (M10/#100): staged distill train-step factory (mixing-match / hidden-align /
+    # logit-distill), mirroring make_*_train_step. MLX-only; CUDA raises NotImplementedError.
+    make_distill_train_step: Callable[..., Callable]
 
 
 def get_backend(name: str = "auto") -> Backend:
@@ -112,6 +115,10 @@ def _mlx_backend() -> Backend:
         from .mlx_student_init import init_student
         return init_student(student, teacher, method)
 
+    def _make_distill_train_step(*args, **kwargs):
+        from .mlx_distill import make_distill_train_step
+        return make_distill_train_step(*args, **kwargs)
+
     return Backend(
         name="mlx",
         model_cls=MLXMambaModel,
@@ -128,6 +135,7 @@ def _mlx_backend() -> Backend:
         make_grpo_train_step=_make_grpo_train_step,
         make_teacher=_make_teacher,
         init_student=_init_student,
+        make_distill_train_step=_make_distill_train_step,
     )
 
 
@@ -177,6 +185,11 @@ def _cuda_backend() -> Backend:
             "Student init (M10/#99) is implemented on the MLX dev backend only; "
             "the CUDA initializer is deferred.")
 
+    def _distill_unsupported(*args, **kwargs):
+        raise NotImplementedError(
+            "The distillation train step (M10/#100) is implemented on the MLX dev backend "
+            "only; the CUDA distill step is deferred.")
+
     return Backend(
         name="cuda",
         model_cls=CUDAMambaModel,
@@ -192,4 +205,5 @@ def _cuda_backend() -> Backend:
         make_grpo_train_step=_post_training_unsupported,
         make_teacher=_teacher_unsupported,
         init_student=_student_init_unsupported,
+        make_distill_train_step=_distill_unsupported,
     )

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -256,11 +256,13 @@ class SelectiveSSM(nn.Module):
 
     def mixing_matrix(self, x: Array) -> Array:
         """Materialize the dense (B, H, L, L) 1-semiseparable mixing matrix M such that
-        `einsum('bhij,bjhp->bihp', M, X) == parallel(x)` (X = the head-split input). This is
-        the matrix the SSD scan applies; the distillation `mixing-match` stage (#100) matches
-        it against the teacher's attention matrix. Folds in the per-step `delta` scaling and
-        the per-head `D` skip, so it maps the RAW (unscaled) input. Dense O(L^2) — used only
-        as a training-time auxiliary at modest L, not in the chunked training path."""
+        `einsum('bhij,bjhp->bihp', M, X) == parallel(x)` (X = the head-split input) **in the
+        single-segment case** (`seg_ids=None`). This is the matrix the SSD scan applies; the
+        distillation `mixing-match` stage (#100) matches it against the teacher's attention
+        matrix. Folds in the per-step `delta` scaling and the per-head `D` skip, so it maps the
+        RAW (unscaled) input. It does NOT model the packing-aware `seg_ids` path (#68), whose
+        masked inter-chunk carry changes the scan; the equality holds only without `seg_ids`.
+        Dense O(L^2) — a training-time auxiliary at modest L, not the chunked training path."""
         B_, L, _ = x.shape
         H, N = self.config.n_heads, self.config.d_state
         delta, a, Bm, Cm = self._project(x)        # delta (B,L,H); Bm,Cm (B,L,N) — fp32

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -254,6 +254,24 @@ class SelectiveSSM(nn.Module):
         Y = Y + X[:, :L] * self.D[None, None, :, None]             # skip
         return _cast(Y.reshape(B_, L, d_inner), cd)                # back to compute dtype
 
+    def mixing_matrix(self, x: Array) -> Array:
+        """Materialize the dense (B, H, L, L) 1-semiseparable mixing matrix M such that
+        `einsum('bhij,bjhp->bihp', M, X) == parallel(x)` (X = the head-split input). This is
+        the matrix the SSD scan applies; the distillation `mixing-match` stage (#100) matches
+        it against the teacher's attention matrix. Folds in the per-step `delta` scaling and
+        the per-head `D` skip, so it maps the RAW (unscaled) input. Dense O(L^2) — used only
+        as a training-time auxiliary at modest L, not in the chunked training path."""
+        B_, L, _ = x.shape
+        H, N = self.config.n_heads, self.config.d_state
+        delta, a, Bm, Cm = self._project(x)        # delta (B,L,H); Bm,Cm (B,L,N) — fp32
+        gh = (delta * a).transpose(0, 2, 1)        # (B,H,L) log-decay (<= 0)
+        decay = mx.exp(_segsum(gh))                # (B,H,L,L): exp(cumA_i-cumA_j), causal
+        CB = mx.einsum("bin,bjn->bij", Cm, Bm)     # (B,L,L) shared B/C group
+        delta_col = delta.transpose(0, 2, 1)[:, :, None, :]          # (B,H,1,L) delta_j
+        M = decay * CB[:, None] * delta_col                          # (B,H,L,L)
+        eye = mx.eye(L, dtype=M.dtype)
+        return M + self.D[None, :, None, None] * eye[None, None]     # + D skip on the diagonal
+
     def recurrence(self, x: Array, state: State) -> Tuple[Array, State]:
         """One timestep. x: (B, d_inner), state h: (B, H, P, N) -> y: (B, d_inner)."""
         B_ = x.shape[0]
@@ -338,6 +356,17 @@ class MambaBlock(nn.Module):
         y = self.ssm.parallel(xc, seg_ids)
         y = y * _silu(z)
         return x + _linear(self.out_proj, y, cd)
+
+    def mixing_matrix(self, x: Array) -> Array:
+        """This block's head-split SSM mixing matrix (B, H, L, L), for distillation
+        `mixing-match` (#100). Runs the block front-end (norm -> in_proj main -> causal conv
+        -> SiLU) then materializes the SSM matrix on that input."""
+        L = x.shape[1]
+        cd = _DTYPES[self.config.precision]
+        xn = self.norm(x)
+        x_main, _ = mx.split(_linear(self.in_proj, xn, cd), 2, axis=-1)
+        xc = _silu(self._conv_seq(x_main, cd)[:, :L])
+        return self.ssm.mixing_matrix(xc)
 
     def step(self, x: Array, state: State) -> Tuple[Array, State]:
         conv_state, ssm_state = state                        # (B,k-1,di), (B,di,ds)
@@ -510,6 +539,30 @@ class MLXMambaModel(ModelInterface, nn.Module):
             h, st2 = layer.step(h, st)
             new_state.append(st2)
         return self._head(self.norm_f(h)), new_state
+
+    # --- distillation matching accessors (#100) ------------------------------
+    def hidden_states(self, token_batch: Array) -> Tuple[Array, ...]:
+        """Per-layer hidden states for the `hidden-align` stage: the embedding output
+        followed by each layer's output (length n_layers + 1) — the HF/teacher convention
+        (`mlx_teacher.MLXConversionTeacher.forward(return_hidden=True)`)."""
+        h = _cast(self.embedding(mx.array(token_batch)), self._cd)
+        hs = [h]
+        for layer in self.layers:
+            h = layer.forward_seq(h)
+            hs.append(h)
+        return tuple(hs)
+
+    def mixing_matrices(self, token_batch: Array) -> List[Tuple[int, Array]]:
+        """For the `mixing-match` stage: each Mamba layer's head-averaged mixing matrix
+        `(B, L, L)` paired with its layer index. Attention layers are skipped (their mixer is
+        the teacher's attention they were matched against)."""
+        h = _cast(self.embedding(mx.array(token_batch)), self._cd)
+        out: List[Tuple[int, Array]] = []
+        for i, layer in enumerate(self.layers):
+            if not self.config.is_attention_layer(i):
+                out.append((i, layer.mixing_matrix(h).mean(axis=1)))    # head-average -> (B,L,L)
+            h = layer.forward_seq(h)
+        return out
 
     def init_state(self, batch_size: int) -> State:
         c = self.config

--- a/src/model/mlx_distill.py
+++ b/src/model/mlx_distill.py
@@ -1,0 +1,143 @@
+"""MLX distillation train steps (Apple Silicon, below the seam — may import mlx).
+
+The staged distillation matching (#100): a student is trained against the frozen teacher (#93)
+through the manifest's `stages` (`mixing-match -> hidden-align -> logit-distill`, #99). Each stage
+is a different `TrainStepFn` built by `make_distill_train_step(..., stage=...)`; the driver loops
+the stages (via `train.distill_manifest.distill_stages`) swapping the step. The backend-free loop
+(`train.loop`) is unchanged — this mirrors SFT/DPO/GRPO and funnels through the shared
+`_accumulate_and_step` (grad-accum, fp16 unscale + overflow-skip, clip, optimizer update) from
+`mlx_train_step`.
+
+The compound loss is a single scalar, so the existing `train.loss_scale.DynamicLossScaler` covers
+it unchanged: the loss is scaled before backprop and the backend's inf/nan check skips overflowing
+steps.
+
+Stage micro-batch tuples:
+  * logit-distill : (inputs, targets, topk_vals, topk_idx)  — cached teacher top-k (#94).
+  * hidden-align  : (inputs, teacher_hidden) cached, OR (inputs,) on-the-fly (teacher recompute).
+  * mixing-match  : (inputs,) on-the-fly (teacher attention matrices recomputed).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .mlx_train_step import _accumulate_and_step
+from ..train.distill_manifest import DistillStage
+
+
+def _align(i: int, n_src: int, n_dst: int) -> int:
+    """Map index `i` in a depth-`n_src` stack onto the nearest index in a depth-`n_dst` one."""
+    return min(n_dst - 1, max(0, int(round(i * n_dst / max(1, n_src)))))
+
+
+def _kl_topk(student_logits: mx.array, topk_vals: mx.array, topk_idx: mx.array,
+             temperature: float) -> mx.array:
+    """T^2-scaled KL(teacher || student) over the teacher's top-k support (Hinton scaling).
+
+    `student_logits` (B,L,V) fp32; `topk_vals`/`topk_idx` (B,L,k). Teacher and student are each
+    softmaxed over the SAME k indices at temperature T, so the KL is computed on the shared
+    support the cached signal (#94) provides."""
+    T = temperature
+    p = mx.softmax(topk_vals.astype(mx.float32) / T, axis=-1)            # teacher over support
+    sg = mx.take_along_axis(student_logits, topk_idx.astype(mx.int32), axis=-1) / T
+    logq = sg - mx.logsumexp(sg, axis=-1, keepdims=True)                 # student log-softmax/k
+    kl = (p * (mx.log(p + 1e-9) - logq)).sum(axis=-1)                    # (B,L)
+    return (T * T) * kl.mean()
+
+
+def _ce(logits: mx.array, targets) -> mx.array:
+    V = logits.shape[-1]
+    t = mx.array(targets).reshape(-1).astype(mx.int32)
+    return nn.losses.cross_entropy(logits.reshape(-1, V), t, reduction="mean")
+
+
+def _hidden_mse(student_hs, teacher_hs, layers: List[int], n_s: int, n_t: int) -> mx.array:
+    """Mean MSE between aligned student/teacher hidden states, over the overlapping channels
+    (the teacher and student widths differ; compare the shared `min(d)` — a documented POC
+    handling of the mismatch). `student_hs`/`teacher_hs` are (n+1)-length tuples (embedding +
+    each layer); `layers` are student hidden indices to match."""
+    terms = []
+    for s in layers:
+        th = teacher_hs[min(n_t, max(0, round(s * n_t / n_s)))]   # align embedding(0)+layers(1..n)
+        sh = student_hs[s]
+        m = min(sh.shape[-1], th.shape[-1])
+        diff = sh[..., :m].astype(mx.float32) - th[..., :m].astype(mx.float32)
+        terms.append(mx.mean(diff * diff))
+    return mx.stack(terms).mean()
+
+
+def _mixing_mse(student_mats, teacher_mats, n_s: int, n_t: int) -> mx.array:
+    """Mean MSE between each student Mamba layer's head-averaged mixing matrix and the
+    depth-aligned teacher attention matrix (both (B,L,L))."""
+    terms = []
+    for (i, sm) in student_mats:
+        tm = teacher_mats[_align(i, n_s, n_t)]
+        diff = sm.astype(mx.float32) - tm.astype(mx.float32)
+        terms.append(mx.mean(diff * diff))
+    return mx.stack(terms).mean()
+
+
+def make_distill_train_step(model, optimizer, *, stage, teacher=None,
+                            ce_weight: float = 0.1, kl_weight: float = 0.9,
+                            temperature: float = 2.0, hidden_layers: Optional[List[int]] = None,
+                            grad_clip: float = 1.0, scaler=None) -> Callable:
+    """Build a distillation `train_step(model, micro_batches, lr) -> dict` for one `stage`.
+
+    `stage` is a `DistillStage` (or its string). `teacher` (a frozen `ConversionTeacher`) is
+    required for on-the-fly `hidden-align`/`mixing-match`; `logit-distill` and cached
+    `hidden-align` need no teacher. Accumulation / fp16 scaling / clipping are shared via
+    `_accumulate_and_step`.
+    """
+    if not isinstance(stage, DistillStage):
+        stage = DistillStage.from_str(str(stage))
+    n_s = model.config.n_layers
+
+    if stage == DistillStage.LOGIT_DISTILL:
+        def loss_fn(model, inputs, targets, tv, ti):
+            logits = model.forward(inputs).astype(mx.float32)           # (B,L,V)
+            loss = ce_weight * _ce(logits, targets) + kl_weight * _kl_topk(
+                logits, mx.array(tv), mx.array(ti), temperature)
+            return loss * scaler.scale if scaler else loss
+
+    elif stage == DistillStage.HIDDEN_ALIGN:
+        n_t = teacher.n_layers if teacher is not None else None
+        layers = hidden_layers if hidden_layers is not None else list(range(1, n_s + 1))
+        if teacher is not None:                                          # on-the-fly recompute
+            def loss_fn(model, inputs):
+                t_hs = [mx.stop_gradient(h)
+                        for h in teacher.forward(inputs, return_hidden=True).hidden_states]
+                loss = _hidden_mse(model.hidden_states(inputs), t_hs, layers, n_s, n_t)
+                return loss * scaler.scale if scaler else loss
+        else:                                                           # cached teacher hidden
+            def loss_fn(model, inputs, teacher_hidden):
+                t_hs = [mx.array(h) for h in teacher_hidden]
+                nt = len(t_hs) - 1
+                loss = _hidden_mse(model.hidden_states(inputs), t_hs, layers, n_s, nt)
+                return loss * scaler.scale if scaler else loss
+
+    elif stage == DistillStage.MIXING_MATCH:
+        if teacher is None:
+            raise ValueError("mixing-match requires a teacher (on-the-fly attention matrices)")
+        n_t = teacher.n_layers
+
+        def loss_fn(model, inputs):
+            t_mats = [mx.stop_gradient(m) for m in teacher.attention_matrices(inputs)]
+            loss = _mixing_mse(model.mixing_matrices(inputs), t_mats, n_s, n_t)
+            return loss * scaler.scale if scaler else loss
+    else:                                                               # unreachable
+        raise ValueError(f"unknown distill stage {stage!r}")
+
+    value_and_grad = nn.value_and_grad(model, loss_fn)
+
+    def loss_and_grad(model, mb):
+        return value_and_grad(model, *mb)
+
+    def train_step(model, micro_batches, lr: float) -> dict:
+        return _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches,
+                                    lr, grad_clip, scaler)
+
+    return train_step

--- a/src/model/mlx_distill.py
+++ b/src/model/mlx_distill.py
@@ -30,8 +30,11 @@ from ..train.distill_manifest import DistillStage
 
 
 def _align(i: int, n_src: int, n_dst: int) -> int:
-    """Map index `i` in a depth-`n_src` stack onto the nearest index in a depth-`n_dst` one."""
-    return min(n_dst - 1, max(0, int(round(i * n_dst / max(1, n_src)))))
+    """Map index `i` in a depth-`n_src` stack onto a depth-`n_dst` one, endpoint-to-endpoint:
+    `0 -> 0` and `n_src-1 -> n_dst-1` (so the first/last always align), with clamping."""
+    if n_src <= 1:
+        return 0
+    return min(n_dst - 1, max(0, int(round(i * (n_dst - 1) / (n_src - 1)))))
 
 
 def _kl_topk(student_logits: mx.array, topk_vals: mx.array, topk_idx: mx.array,
@@ -62,7 +65,10 @@ def _hidden_mse(student_hs, teacher_hs, layers: List[int], n_s: int, n_t: int) -
     each layer); `layers` are student hidden indices to match."""
     terms = []
     for s in layers:
-        th = teacher_hs[min(n_t, max(0, round(s * n_t / n_s)))]   # align embedding(0)+layers(1..n)
+        # Map layer-to-layer: embedding(0)->0, and student layer s in 1..n_s -> teacher layer
+        # 1..n_t endpoint-to-endpoint (so layer 1 never collapses onto the teacher embedding).
+        th_idx = 0 if s == 0 else 1 + _align(s - 1, n_s, n_t)
+        th = teacher_hs[th_idx]
         sh = student_hs[s]
         m = min(sh.shape[-1], th.shape[-1])
         diff = sh[..., :m].astype(mx.float32) - th[..., :m].astype(mx.float32)
@@ -122,6 +128,9 @@ def make_distill_train_step(model, optimizer, *, stage, teacher=None,
     elif stage == DistillStage.MIXING_MATCH:
         if teacher is None:
             raise ValueError("mixing-match requires a teacher (on-the-fly attention matrices)")
+        if all(model.config.is_attention_layer(i) for i in range(n_s)):
+            raise ValueError("mixing-match has no Mamba layers to match in a pure-attention "
+                             "layout (attn_every covers every layer); skip this stage")
         n_t = teacher.n_layers
 
         def loss_fn(model, inputs):

--- a/src/model/mlx_teacher.py
+++ b/src/model/mlx_teacher.py
@@ -166,14 +166,16 @@ class MLXConversionTeacher(ConversionTeacher):
         h = self._w["embed"][mx.array(token_batch)]
         L = h.shape[1]
         cos, sin = _rope_cos_sin(mx.arange(L), c.head_dim, c.rope_theta)
+        mask = self._causal_mask(L)                                  # built once, shared
         mats = []
         for i in range(c.n_layers):
-            mats.append(mx.stop_gradient(self._attn_probs(h, i, cos, sin)))
-            h = h + self._attn(h, i, cos, sin)
+            mats.append(mx.stop_gradient(self._attn_probs(h, i, cos, sin, mask)))
+            h = h + self._attn(h, i, cos, sin, mask)
             h = h + self._mlp(h, i)
         return tuple(mats)
 
-    def _attn_probs(self, x: mx.array, i: int, cos: mx.array, sin: mx.array) -> mx.array:
+    def _attn_probs(self, x: mx.array, i: int, cos: mx.array, sin: mx.array,
+                    mask: mx.array) -> mx.array:
         """Head-averaged causal attention probabilities for layer `i` -> (B, L, L)."""
         c = self.config
         p = f"layer.{i}."
@@ -190,8 +192,7 @@ class MLXConversionTeacher(ConversionTeacher):
         if Hkv != Hq:
             k = mx.repeat(k, Hq // Hkv, axis=1)
         scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(Dh)       # (B,Hq,L,L)
-        causal = mx.tril(mx.ones((L, L), dtype=mx.bool_))
-        scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        scores = mx.where(mask, scores, mx.array(float("-inf"), dtype=scores.dtype))
         return _softmax_lastdim(scores).mean(axis=1)                 # head-average -> (B,L,L)
 
     def attention_projection(self, layer: int) -> AttnProjections:

--- a/src/model/mlx_teacher.py
+++ b/src/model/mlx_teacher.py
@@ -158,6 +158,42 @@ class MLXConversionTeacher(ConversionTeacher):
         vals = mx.take_along_axis(pv, order, axis=-1)
         return mx.stop_gradient(vals), idx
 
+    def attention_matrices(self, token_batch) -> Tuple[mx.array, ...]:
+        """Per-layer head-averaged causal attention matrices `softmax(QK^T/sqrt(Dh))`, each
+        `(B, L, L)`, for the distillation `mixing-match` stage (#100). Stop-gradient wrapped
+        (the teacher is frozen)."""
+        c = self.config
+        h = self._w["embed"][mx.array(token_batch)]
+        L = h.shape[1]
+        cos, sin = _rope_cos_sin(mx.arange(L), c.head_dim, c.rope_theta)
+        mats = []
+        for i in range(c.n_layers):
+            mats.append(mx.stop_gradient(self._attn_probs(h, i, cos, sin)))
+            h = h + self._attn(h, i, cos, sin)
+            h = h + self._mlp(h, i)
+        return tuple(mats)
+
+    def _attn_probs(self, x: mx.array, i: int, cos: mx.array, sin: mx.array) -> mx.array:
+        """Head-averaged causal attention probabilities for layer `i` -> (B, L, L)."""
+        c = self.config
+        p = f"layer.{i}."
+        B, L, _ = x.shape
+        Hq, Hkv, Dh = c.n_heads, c.n_kv_heads, c.head_dim
+        xn = _rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps)
+        q = xn @ self._w[p + "q_w"].T + self._w[p + "q_b"]
+        k = xn @ self._w[p + "k_w"].T + self._w[p + "k_b"]
+
+        def heads(t, H):
+            return t.reshape(B, L, H, Dh).transpose(0, 2, 1, 3)
+        q, k = heads(q, Hq), heads(k, Hkv)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        if Hkv != Hq:
+            k = mx.repeat(k, Hq // Hkv, axis=1)
+        scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(Dh)       # (B,Hq,L,L)
+        causal = mx.tril(mx.ones((L, L), dtype=mx.bool_))
+        scores = mx.where(causal, scores, mx.array(float("-inf"), dtype=scores.dtype))
+        return _softmax_lastdim(scores).mean(axis=1)                 # head-average -> (B,L,L)
+
     def attention_projection(self, layer: int) -> AttnProjections:
         p = f"layer.{layer}."
         g = lambda s: mx.stop_gradient(self._w[p + s])

--- a/src/train/distill_manifest.py
+++ b/src/train/distill_manifest.py
@@ -39,6 +39,22 @@ class InitMethod(Enum):
             raise ValueError(f"unknown init method {value!r}; expected one of: {allowed}")
 
 
+class DistillStage(Enum):
+    """The progressive distillation-matching stages (#100), in their natural run order.
+
+    A manifest's `stages:` may also list post-training stages (SFT/RL, #11/#78); these three
+    are the distillation ones the distill train step (`model.mlx_distill`) implements.
+    """
+
+    MIXING_MATCH = "mixing-match"      # MOHAWK stage 1: orient the SSM mixer like attention
+    HIDDEN_ALIGN = "hidden-align"      # MOHAWK stage 2: match per-layer hidden states
+    LOGIT_DISTILL = "logit-distill"    # KL(top-k) + CE on the final logits
+
+    @classmethod
+    def from_str(cls, value: str) -> "DistillStage":
+        return cls(value)
+
+
 # Canonical distillation + post-training stages, in their natural run order. The manifest's
 # `stages:` is a subset/ordering of these; #100 runs the distill stages, post-training (#11)
 # runs the SFT/RL ones.
@@ -155,3 +171,16 @@ def manifest_to_config(manifest: DistillManifest) -> MambaConfig:
 
 def _opt_int(value: Any) -> Any:
     return None if value is None else int(value)
+
+
+_DISTILL_STAGE_VALUES = {s.value for s in DistillStage}
+
+
+def distill_stages(manifest: DistillManifest) -> List[DistillStage]:
+    """The manifest's distillation stages, in manifest order (SFT/RL stages dropped).
+
+    The distill train step (#100) loops over these, swapping the objective per stage:
+    `mixing-match -> hidden-align -> logit-distill`. Post-training stages (instruct-sft,
+    reasoning-sft, tool-sft, grpo) are handled elsewhere (#11/#78).
+    """
+    return [DistillStage.from_str(s) for s in manifest.stages if s in _DISTILL_STAGE_VALUES]

--- a/tests/test_distill_manifest.py
+++ b/tests/test_distill_manifest.py
@@ -2,8 +2,9 @@
 
 import pytest
 
-from src.train.distill_manifest import (CANONICAL_STAGES, DistillManifest, InitMethod,
-                                        load_manifest, manifest_to_config)
+from src.train.distill_manifest import (CANONICAL_STAGES, DistillManifest, DistillStage,
+                                        InitMethod, distill_stages, load_manifest,
+                                        manifest_to_config)
 
 MANIFESTS = ["config/manifests/student-1b-attn12pct.yaml",
              "config/manifests/student-1b-attn8pct.yaml"]
@@ -28,6 +29,16 @@ def test_manifest_to_config(path):
     assert cfg.attn_every == m.layout["attention_every"]    # sweep-schema -> model field
     assert cfg.d_state == m.layout["state_size"]
     assert cfg.vocab_size == 151646 and cfg.seq_len == m.seq_len
+
+
+@pytest.mark.parametrize("path", MANIFESTS)
+def test_distill_stages_order_and_filter(path):
+    m = load_manifest(path)
+    stages = distill_stages(m)
+    # the three distillation stages, in manifest order; SFT/RL stages dropped
+    assert stages == [DistillStage.MIXING_MATCH, DistillStage.HIDDEN_ALIGN,
+                      DistillStage.LOGIT_DISTILL]
+    assert all(isinstance(s, DistillStage) for s in stages)
 
 
 def test_init_method_from_str():

--- a/tests/test_distill_train_step.py
+++ b/tests/test_distill_train_step.py
@@ -1,0 +1,169 @@
+"""Distillation loss + train step (#100). MLX-only; skipped where mlx is unavailable.
+
+Covers the materialized mixing matrix (vs the scan), the compound KL(top-k)+CE logit-distill
+step, hidden-align (cached == on-the-fly), mixing-match, and the fp16 dynamic-scaler integration
+(clean step + clean overflow-skip on the compound term). Tiny synthetic teacher + tiny hybrid
+student, all offline.
+"""
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+import mlx.nn as nn
+
+from src.model.backend import get_backend
+from src.model.blocks import MambaConfig
+from src.model.mlx_backend import MLXMambaModel, SelectiveSSM
+from src.model.mlx_teacher import MLXConversionTeacher
+from src.model.teacher import TeacherConfig
+from src.model.mlx_distill import make_distill_train_step, _kl_topk
+from src.train.distill_manifest import DistillStage
+from src.train.loss_scale import DynamicLossScaler
+
+VOCAB = 256
+
+
+def _teacher(n_layers=3):
+    cfg = TeacherConfig(vocab_size=VOCAB, d_model=64, n_layers=n_layers, n_heads=4,
+                        n_kv_heads=2, head_dim=16, intermediate_size=128)
+    return MLXConversionTeacher.from_config(cfg, seed=0)
+
+
+def _student(precision="fp32", seed=0):
+    cfg = MambaConfig(d_model=48, n_layers=4, d_state=16, expand=2, d_conv=4, head_dim=16,
+                      vocab_size=VOCAB, seq_len=16, attn_every=2, n_attn_heads=4,
+                      precision=precision)
+    get_backend("mlx").seed(seed)
+    return MLXMambaModel(cfg)
+
+
+def _tokens(B=2, L=8):
+    rng = np.random.default_rng(0)
+    return rng.integers(0, VOCAB, size=(B, L)).astype(np.int32)
+
+
+def _opt(model, lr=1e-2):
+    return get_backend("mlx").make_optimizer(model, lr)
+
+
+# --- mixing matrix materialization vs the scan -------------------------------
+def test_mixing_matrix_reproduces_parallel_scan():
+    cfg = MambaConfig(d_model=32, n_layers=1, d_state=16, head_dim=16, vocab_size=64,
+                      seq_len=12, precision="fp32")
+    ssm = SelectiveSSM(cfg)
+    mx.random.seed(0)
+    x = mx.random.normal((2, 12, cfg.d_inner))
+    Y = ssm.parallel(x)
+    M = ssm.mixing_matrix(x)                                  # (B,H,L,L)
+    Xh = x.reshape(2, 12, cfg.n_heads, cfg.head_dim)
+    Ym = mx.einsum("bhij,bjhp->bihp", M, Xh).reshape(2, 12, cfg.d_inner)
+    assert float(mx.max(mx.abs(Y - Ym))) < 1e-4
+
+
+# --- KL on top-k -------------------------------------------------------------
+def test_kl_topk_nonneg_and_zero_at_match():
+    rng = np.random.default_rng(1)
+    logits = mx.array(rng.normal(size=(2, 4, VOCAB)).astype(np.float32))
+    k = 8
+    idx = mx.argsort(-logits, axis=-1)[..., :k]
+    vals = mx.take_along_axis(logits, idx, axis=-1)
+    # student == teacher on the support -> KL == 0
+    assert abs(float(_kl_topk(logits, vals, idx, 2.0))) < 1e-4
+    # a mismatched teacher distribution -> KL > 0
+    assert float(_kl_topk(logits, vals + 1.0 * mx.arange(k).astype(mx.float32), idx, 2.0)) > 0
+
+
+# --- logit-distill -----------------------------------------------------------
+def _logit_batch(teacher, tokens, k=16):
+    vals, idx = teacher.topk_logits(tokens, k)
+    targets = np.roll(tokens, -1, axis=1)
+    return (tokens, targets, np.array(vals), np.array(idx))
+
+
+def test_logit_distill_step_and_decreases():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.LOGIT_DISTILL)
+    mb = _logit_batch(teacher, _tokens())
+    losses = [step(student, [mb], 1e-2)["loss"] for _ in range(4)]
+    assert all(np.isfinite(losses))
+    assert losses[-1] < losses[0]                            # compound loss decreases
+
+
+def test_logit_distill_accepts_string_stage():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage="logit-distill")
+    out = step(student, [_logit_batch(teacher, _tokens())], 1e-2)
+    assert "loss" in out and "grad_norm" in out
+
+
+# --- hidden-align: cached == on-the-fly --------------------------------------
+def test_hidden_align_cached_matches_on_the_fly():
+    teacher = _teacher()
+    tokens = _tokens()
+    # two identically-seeded students so the first-step losses are comparable
+    s1, s2 = _student(seed=7), _student(seed=7)
+    on_fly = make_distill_train_step(s1, _opt(s1), stage=DistillStage.HIDDEN_ALIGN,
+                                     teacher=teacher)
+    cached_hs = [np.array(h) for h in teacher.forward(tokens, return_hidden=True).hidden_states]
+    cached = make_distill_train_step(s2, _opt(s2), stage=DistillStage.HIDDEN_ALIGN)
+    l_fly = on_fly(s1, [(tokens,)], 0.0)["loss"]             # lr 0 -> loss is pre-update
+    l_cached = cached(s2, [(tokens, cached_hs)], 0.0)["loss"]
+    assert l_fly >= 0 and abs(l_fly - l_cached) < 1e-4
+
+
+def test_hidden_align_decreases():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.HIDDEN_ALIGN,
+                                   teacher=teacher)
+    losses = [step(student, [(_tokens(),)], 1e-2)["loss"] for _ in range(4)]
+    assert losses[-1] < losses[0]
+
+
+# --- mixing-match ------------------------------------------------------------
+def test_mixing_match_runs_and_decreases():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH,
+                                   teacher=teacher)
+    # the matrix-matching objective is stiff; a small lr decreases it smoothly
+    losses = [step(student, [(_tokens(),)], 5e-3)["loss"] for _ in range(6)]
+    assert losses[0] >= 0 and losses[-1] < losses[0]
+
+
+def test_mixing_match_requires_teacher():
+    student = _student()
+    with pytest.raises(ValueError):
+        make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH)
+
+
+# --- fp16 dynamic-scaler integration (compound term) -------------------------
+def test_compound_loss_with_scaler_clean_step():
+    teacher, student = _teacher(), _student()
+    scaler = DynamicLossScaler(init_scale=2.0 ** 12)
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.LOGIT_DISTILL,
+                                   scaler=scaler)
+    out = step(student, [_logit_batch(teacher, _tokens())], 1e-3)
+    assert out["skipped"] is False and "loss_scale" in out and np.isfinite(out["grad_norm"])
+
+
+def test_compound_loss_overflow_skips_cleanly():
+    teacher, student = _teacher(), _student()
+    scaler = DynamicLossScaler(init_scale=2.0 ** 12)
+    before = scaler.scale
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.LOGIT_DISTILL,
+                                   scaler=scaler)
+    inputs, targets, vals, idx = _logit_batch(teacher, _tokens())
+    vals = vals.copy()
+    vals[0, 0, 0] = np.float32("nan")                        # poison -> non-finite gradient
+    out = step(student, [(inputs, targets, vals, idx)], 1e-3)
+    assert out["skipped"] is True
+    assert scaler.scale < before                             # scale backed off, step dropped
+
+
+# --- backend seam ------------------------------------------------------------
+def test_make_distill_train_step_via_backend():
+    teacher, student = _teacher(), _student()
+    step = get_backend("mlx").make_distill_train_step(
+        student, _opt(student), stage=DistillStage.LOGIT_DISTILL)
+    out = step(student, [_logit_batch(teacher, _tokens())], 1e-3)
+    assert "loss" in out

--- a/tests/test_distill_train_step.py
+++ b/tests/test_distill_train_step.py
@@ -126,7 +126,7 @@ def test_mixing_match_runs_and_decreases():
     step = make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH,
                                    teacher=teacher)
     # the matrix-matching objective is stiff; a small lr decreases it smoothly
-    losses = [step(student, [(_tokens(),)], 5e-3)["loss"] for _ in range(6)]
+    losses = [step(student, [(_tokens(),)], 3e-3)["loss"] for _ in range(6)]
     assert losses[0] >= 0 and losses[-1] < losses[0]
 
 
@@ -134,6 +134,24 @@ def test_mixing_match_requires_teacher():
     student = _student()
     with pytest.raises(ValueError):
         make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH)
+
+
+def test_mixing_match_rejects_pure_attention_layout():
+    teacher = _teacher()
+    # attn_every 1 -> every layer is attention, so there are no Mamba mixers to match
+    cfg = MambaConfig(d_model=48, n_layers=2, d_state=16, head_dim=16, vocab_size=VOCAB,
+                      seq_len=16, attn_every=1, n_attn_heads=4, precision="fp32")
+    get_backend("mlx").seed(0)
+    student = MLXMambaModel(cfg)
+    with pytest.raises(ValueError):
+        make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH,
+                                teacher=teacher)
+
+
+def test_align_maps_endpoints():
+    from src.model.mlx_distill import _align
+    assert [_align(i, 4, 28) for i in range(4)] == [0, 9, 18, 27]   # 0->0, last->last
+    assert _align(0, 1, 28) == 0                                    # n_src <= 1 fallback
 
 
 # --- fp16 dynamic-scaler integration (compound term) -------------------------


### PR DESCRIPTION
Closes #100. Part of #65 (M10 distillation). Builds on the merged teacher (#93) + student init (#99).

> Recreated from #114 (auto-closed when the stacked base `feature/99-...` was deleted on merge of #115). Rebased onto `main`; Copilot feedback from #114 addressed.

## Summary
Train the hybrid student against the **cached** teacher signal through the manifest's distillation stages — a new injected `TrainStepFn` mirroring SFT/DPO/GRPO, so the backend-free loop is unchanged.

- **`src/train/distill_manifest.py`**: `DistillStage` enum + `distill_stages(manifest)` (distillation stages in order; SFT/RL dropped).
- **`src/model/mlx_distill.py`** (below seam): `make_distill_train_step` over three stages via the shared `_accumulate_and_step`:
  - **logit-distill** — compound `ce_weight·CE + kl_weight·KL_topk` (T²-scaled KL over the cached top-k support); no teacher in the loop.
  - **hidden-align** — per-layer hidden-state MSE, cached or on-the-fly, over the overlapping `min(d)` channels.
  - **mixing-match** — MSE between the student's head-averaged SSM mixing matrix and the teacher's attention matrix (tractable MOHAWK simplification).
- **`src/model/mlx_backend.py`**: `SelectiveSSM.mixing_matrix` (materialized 1-SS matrix, verified to reproduce the scan in the single-segment case), block + model accessors. **`mlx_teacher.py`**: `attention_matrices`. **`backend.py`**: `Backend.make_distill_train_step`.
- The compound loss is one scalar, so `DynamicLossScaler` covers it unchanged; overflow skips cleanly (tested with a NaN-poisoned top-k).

## Review feedback addressed (from #114)
- `_align` now maps depth **endpoint-to-endpoint** (over n-1, with an n_src≤1 fallback).
- **hidden-align** maps student layers 1..n_s onto teacher layers 1..n_t (embedding 0→0), so layer 1 never collapses onto the teacher embedding.
- **mixing-match** fails fast with a clear error for a pure-attention layout (no Mamba mixers), instead of `mx.stack([])` crashing.
- `mixing_matrix` docstring scopes the `== parallel(x)` equality to the single-segment case (it doesn't model the `seg_ids` #68 path).

## Testing
- `tests/test_distill_train_step.py` + `tests/test_distill_manifest.py`: mixing-matrix parity, KL top-k (≥0, 0 at match), logit-distill decreases, hidden-align cached==on-the-fly, mixing-match decreases, pure-attention guard, endpoint alignment, fp16 scaler clean step + overflow-skip, backend seam.
- Full suite (rebased on main): **331 passed, 1 skipped**. M4 smoke gate exact.

## Acceptance
- [x] A student trains from cached teacher top-k logits with a KL+CE compound loss.
- [x] Stages run in manifest order; hidden-align works with cached or on-the-fly hidden states.
- [x] fp16 loss scaling handles the compound term; overflow steps skip cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)