### PR TITLE
distill: switch conversion teacher to fully-open open-r1/OpenR1-Distill-7B

### DIFF
--- a/config/manifests/student-1b-attn12pct.yaml
+++ b/config/manifests/student-1b-attn12pct.yaml
@@ -3,8 +3,8 @@
 # SAME teacher_outputs/corpus; only `layout` changes. Changing layout invalidates nothing
 # upstream (docs/design/10-distillation.md). Resolves to a student config via the harness (#98).
 student: 1b-attn12pct
-conversion_teacher: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B   # #91/#93
-tokenizer: qwen25                # Qwen2.5 vocab 151646 (#90)
+conversion_teacher: open-r1/OpenR1-Distill-7B   # fully-open Open-R1 teacher (#91/#93)
+tokenizer: qwen25                # Qwen2.5 vocab 151646 (#90) — unchanged; teacher shares it
 seq_len: 8192
 layout:
   d_model: 2048

--- a/config/manifests/student-1b-attn8pct.yaml
+++ b/config/manifests/student-1b-attn8pct.yaml
@@ -2,7 +2,7 @@
 # only the layout differs (lower attention fraction, larger state). Demonstrates that a sweep
 # reuses corpus + teacher_outputs unchanged; the student layout is the only free variable.
 student: 1b-attn8pct
-conversion_teacher: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+conversion_teacher: open-r1/OpenR1-Distill-7B
 tokenizer: qwen25
 seq_len: 8192
 layout:

--- a/config/student-1b.yaml
+++ b/config/student-1b.yaml
@@ -1,7 +1,7 @@
 # ~1-1.5B Mamba-2 HYBRID student — distillation sweep seed (epic #65, distillation-first).
 # This is the seed layout the student sweep (#98) searches over: attention fraction,
 # layer placement, and state size are the FREE variables (see docs/design/10-distillation.md).
-# Distilled from DeepSeek-R1-Distill-Qwen-1.5B (#91/#93), NOT pretrained from scratch.
+# Distilled from open-r1/OpenR1-Distill-7B (#91/#93), NOT pretrained from scratch.
 #
 # NOTE: vocab_size 151646 (Qwen2.5) exceeds the uint16 ceiling; it packs as uint32 and
 # MambaConfig.validate() accepts it now that #90 (dtype-aware packing) has landed.

--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -31,22 +31,33 @@ Reference: [Mamba in the Llama](https://arxiv.org/abs/2408.15237),
 the mixing matrices, then hidden states, then final logits. Reference:
 [MOHAWK](https://arxiv.org/abs/2408.10189).
 
-Both reuse the teacher's attention projections and layer structure, which is why the **conversion
-teacher must be close to the student's size (~1.5B)** and **fixes the tokenizer**. The matching
-runs as the distillation loss + train step (#100): KL on the teacher's top-k logits combined with
-cross-entropy, staged per the manifest's `stages` list.
+Both reuse the teacher's attention projections and layer structure, so a conversion teacher
+**close to the student's size is ideal** and it **fixes the tokenizer**. We trade exact size-match
+for full openness: the chosen teacher is the 7B `open-r1/OpenR1-Distill-7B`, and the 7B→~1B gap is
+bridged by the adaptive `_fit` cropping in student init (`src/model/mlx_student_init.py`) — watch
+the early distillation curve for init quality. The matching runs as the distillation loss + train
+step (#100): KL on the teacher's top-k logits combined with cross-entropy, staged per the
+manifest's `stages` list.
 
 ## Two teacher roles — keep them separate
 
 | Role | Used for | Constrained by | Choice |
 |---|---|---|---|
-| **Conversion teacher** | init + matching (the student is built from it) | **must** be ~student size + fix the tokenizer | **DeepSeek-R1-Distill-Qwen-1.5B** (MIT, already reasoning, Qwen tokenizer) |
+| **Conversion teacher** | init + matching (the student is built from it) | ideally ~student size + fix the tokenizer | **`open-r1/OpenR1-Distill-7B`** (fully open: SFT of Qwen2.5-Math-7B on open R1 traces, Apache-2.0; already reasoning, Qwen tokenizer) |
 | **Trace-generation teacher** | producing reasoning traces in post-training | **unconstrained** — traces are re-tokenized | the strongest Qwen-tokenizer R1 distill you can run (14B/32B) |
 
-Code/math conversion alternatives on the same tokenizer: Qwen2.5-Coder-1.5B, Qwen2.5-Math-1.5B
-(Apache-2.0). Avoid Qwen2.5 3B/72B (Qwen license, not Apache-2.0) and Llama / StarCoder2 as a
-tokenizer source (use restrictions). The MOHAWK lineage's demonstrated teacher family was Phi
-(Phi-4-mini, MIT) — usable, but on a different tokenizer.
+**Why fully open:** OpenR1-Distill-7B is HuggingFace's Open-R1 reproduction of R1 distillation —
+the reasoning training data and recipe DeepSeek kept closed are openly released here
+(Mixture-of-Thoughts ~350k verified traces, OpenR1-Math-220k, CodeForces-CoTs), Apache-2.0. It
+keeps the Qwen2 architecture and Qwen2.5 tokenizer, so it is a drop-in for the existing teacher
+forward — no re-tokenization, no new architecture. (It does not open Qwen's *pretraining* corpus;
+OLMo 2 would, but as a non-reasoning teacher needing a tokenizer + architecture rewrite.)
+
+Smaller / alternative conversion teachers on the same tokenizer: the original
+DeepSeek-R1-Distill-Qwen-1.5B (MIT, weights-only), Qwen2.5-Coder/-Math-1.5B (Apache-2.0). Avoid
+Qwen2.5 3B/72B (Qwen license, not Apache-2.0) and Llama / StarCoder2 as a tokenizer source (use
+restrictions). The MOHAWK lineage's demonstrated teacher family was Phi (Phi-4-mini, MIT) —
+usable, but on a different tokenizer.
 
 ### The teacher loader behind the seam (#93)
 
@@ -117,8 +128,9 @@ backprop and overflowing steps skip cleanly. The CUDA distill step is deferred.
 ## The tokenizer is fixed by the conversion teacher (#90, #91)
 
 The student must **share a vocabulary with the conversion teacher** for logit and hidden-state
-matching, so the tokenizer is **Qwen2.5 (vocab 151,646)** — shared across Qwen2.5/-Coder/-Math and
-every DeepSeek-R1-Distill-Qwen variant, so those teachers are interchangeable. Adopted for the
+matching, so the tokenizer is **Qwen2.5 (vocab 151,646)** — shared across Qwen2.5/-Coder/-Math,
+OpenR1-Distill-7B, and every DeepSeek-R1-Distill-Qwen variant, so those teachers are
+interchangeable without re-tokenizing. Adopted for the
 production model too, which collapses the POC-to-production tokenizer question (no re-tokenization).
 This exceeds the uint16 bound → **uint32 packing** (#90); see
 [corpus pipeline](08-corpus-pipeline.md).
@@ -137,7 +149,7 @@ Each student trial is then a lightweight **manifest** naming the frozen artifact
 
 ```yaml
 student: 1b-attn12pct
-conversion_teacher: deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+conversion_teacher: open-r1/OpenR1-Distill-7B
 tokenizer: qwen25               # Qwen2.5 vocab, 151646
 seq_len: 8192
 layout: { d_model: 2048, n_layers: 48, attention_every: 8, state_size: 128 }

--- a/docs/design/11-post-training.md
+++ b/docs/design/11-post-training.md
@@ -21,7 +21,7 @@ SFT and GRPO refines it.
 **What.** Turn a text-continuer into a model that follows instructions, adopts a chat template,
 and respects a system prompt — the foundation every later layer assumes.
 
-**Why a stage at all.** The conversion teacher (DeepSeek-R1-Distill-Qwen-1.5B) is already
+**Why a stage at all.** The conversion teacher (`open-r1/OpenR1-Distill-7B`) is already
 instruction-tuned, so the hybrid inherits much of this through the matching — but the architecture
 conversion can blur instruction-following, so an explicit instruct SFT stage re-establishes it.
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -36,7 +36,7 @@ Every claim here is sourced from a docstring or config comment in the code, with
 9. [Hybrid architectures](09-hybrid-architectures.md) — why the model is a Mamba-2
    hybrid (config-gated attention) and how it sizes.
 10. [Distillation (teacher → hybrid student)](10-distillation.md) — the **distillation-first
-    pivot**: distil a compact (~1–1.5B) hybrid from a frozen DeepSeek-R1-Distill-Qwen-1.5B
+    pivot**: distil a compact (~1–1.5B) hybrid from a frozen, fully-open `open-r1/OpenR1-Distill-7B`
     teacher (Qwen2.5 tokenizer → uint32 packing, #90), precompute teacher artifacts once,
     sweep student layouts cheaply (#98).
 11. [Post-training](11-post-training.md) — instruct SFT → reasoning-trace SFT → optional
@@ -69,6 +69,6 @@ Every claim here is sourced from a docstring or config comment in the code, with
 | OLMES / lm-eval | deferred (Tier-2) | its own milestone-sized task; not needed for the POC | `src/eval/olmes_adapter.py` |
 | Build method | **distillation** from a frozen teacher (not pretrain) | reaches capability at <1% of from-scratch tokens; cheap layout sweep | `docs/design/10-distillation.md` |
 | Scale-up tokenizer | **Qwen2.5** (vocab 151,646) | fixed by the conversion teacher for logit/hidden matching; uint32 packing (#90). POC stays OLMo. StarCoder2 (the old uint16 pick) superseded. | `docs/design/10-distillation.md` |
-| Conversion teacher | DeepSeek-R1-Distill-Qwen-1.5B (MIT) | reasoning-ready, Qwen tokenizer, ~student size | `docs/design/10-distillation.md` |
+| Conversion teacher | `open-r1/OpenR1-Distill-7B` (Apache-2.0) | fully open (open R1 traces + recipe), reasoning-ready, Qwen2.5 tokenizer; 7B→~1B size gap bridged by adaptive init | `docs/design/10-distillation.md` |
 | Scale-up model | compact ~1–1.5B Mamba-2 hybrid reasoning student | attention layers close the SSM retrieval gap; no-KV-cache local inference | `docs/design/10-distillation.md` |
 | Data framework | `datatrove` + R2 + RunPod | builds the teacher corpus + production-reserve from-scratch data (#75) | `docs/design/08-corpus-pipeline.md` |

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -4,7 +4,7 @@ The packed token dtype follows the tokenizer vocab (`pack.packing_dtype_for`):
 - **OLMo** (``allenai/OLMo-7B-hf``, vocab 50280 < 65536) — the original POC tokenizer,
   packs as uint16. (``allenai/OLMo-2-1124-7B`` at 100278 was rejected at POC scale.)
 - **Qwen2.5** (vocab 151,646) — fixed by the distillation conversion teacher
-  (DeepSeek-R1-Distill-Qwen-1.5B); exceeds uint16, so it packs as **uint32** (#90, see
+  (open-r1/OpenR1-Distill-7B); exceeds uint16, so it packs as **uint32** (#90, see
   docs/design/10-distillation.md). This is the scale-up / distillation default.
 - **StarCoder2** (vocab ~49,152) — a legacy code-corpus tokenizer (the old uint16 scale
   pick, now superseded by Qwen2.5).

--- a/src/model/teacher.py
+++ b/src/model/teacher.py
@@ -6,7 +6,8 @@ stages depend on; each backend provides a concrete `ConversionTeacher` (the MLX
 one is `mlx_teacher.MLXConversionTeacher`).
 
 The conversion teacher is the transformer the student is *built from*
-(DeepSeek-R1-Distill-Qwen-1.5B by default — see `docs/design/10-distillation.md`).
+(`open-r1/OpenR1-Distill-7B` by default — a fully-open R1 reproduction on the
+Qwen2.5 tokenizer; see `docs/design/10-distillation.md`).
 It is run **forward only** — never trained — so it follows the same frozen-reference
 pattern DPO already uses (`mlx_train_step.make_dpo_train_step` holds a distinct
 `ref_model` the optimizer never touches). Two distillation issues consume it:
@@ -37,9 +38,11 @@ Array = Any
 class TeacherConfig:
     """Architecture of a Qwen2-family conversion teacher.
 
-    Defaults describe DeepSeek-R1-Distill-Qwen-1.5B (a Qwen2 decoder). The fields are
-    exactly what the MLX forward pass and the #99 projection mapping need; nothing here
-    imports a backend, so the config is shared across backends like `MambaConfig`.
+    The default teacher is `open-r1/OpenR1-Distill-7B` (a Qwen2 decoder built on
+    Qwen2.5-Math-7B — see `openr1_distill_7b`). `qwen_1_5b` is retained as a
+    smaller, back-compat fixture. The fields are exactly what the MLX forward pass
+    and the #99 projection mapping need; nothing here imports a backend, so the
+    config is shared across backends like `MambaConfig`.
     """
 
     vocab_size: int              # MODEL embedding width (may be padded above the tokenizer vocab)
@@ -58,6 +61,28 @@ class TeacherConfig:
     # logits/indices over `effective_vocab_size`, so a student with the tokenizer vocab can
     # consume them — the padded rows are never emitted as teacher targets.
     tokenizer_vocab_size: Optional[int] = None
+
+    @classmethod
+    def openr1_distill_7b(cls) -> "TeacherConfig":
+        """`open-r1/OpenR1-Distill-7B` — the default, fully-open conversion teacher.
+
+        HuggingFace's Open-R1 reproduction of R1 distillation: SFT of
+        Qwen2.5-Math-7B on the openly released Mixture-of-Thoughts / OpenR1-Math-220k
+        / CodeForces-CoTs reasoning traces (open data + recipe, Apache-2.0). It keeps
+        the Qwen2 architecture and Qwen2.5 tokenizer, so it is a drop-in for the MLX
+        Qwen2 forward; Open-R1 extends RoPE theta to 300k for a 32k context.
+
+        Dims are the Qwen2.5-Math-7B architecture (vocab 152064 is the padded *model*
+        embedding; the Qwen2.5 tokenizer vocab is 151646). `from_hf_dict` reads the
+        authoritative values from the checkpoint's `config.json` at load time; these
+        match that config and serve as the offline fixture.
+        """
+        return cls(
+            vocab_size=152064, d_model=3584, n_layers=28, n_heads=28, n_kv_heads=4,
+            head_dim=128, intermediate_size=18944, rms_norm_eps=1e-6, rope_theta=300000.0,
+            tie_embeddings=False, model_id="open-r1/OpenR1-Distill-7B",
+            tokenizer_vocab_size=151646,   # student/tokenizer vocab; padded rows 151646..152064 unused
+        )
 
     @classmethod
     def qwen_1_5b(cls) -> "TeacherConfig":

--- a/src/model/teacher.py
+++ b/src/model/teacher.py
@@ -76,6 +76,13 @@ class TeacherConfig:
         embedding; the Qwen2.5 tokenizer vocab is 151646). `from_hf_dict` reads the
         authoritative values from the checkpoint's `config.json` at load time; these
         match that config and serve as the offline fixture.
+
+        NOTE: HF `config.json` carries no `tokenizer_vocab_size`, so a teacher built
+        via `from_pretrained(..., config=None)` gets `from_hf_dict`'s default
+        (`tokenizer_vocab_size=None` -> `effective_vocab_size == vocab_size`, 152064)
+        and would emit logits/top-k over the padded rows the student vocab (151646)
+        cannot represent. When loading real weights, pass this config (or otherwise set
+        `tokenizer_vocab_size`) so outputs are sliced to the tokenizer vocab.
         """
         return cls(
             vocab_size=152064, d_model=3584, n_layers=28, n_heads=28, n_kv_heads=4,

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -28,6 +28,18 @@ def _tokens(B, L, vocab):
 
 
 # --- config ------------------------------------------------------------------
+def test_openr1_distill_7b_config_shape():
+    c = TeacherConfig.openr1_distill_7b()
+    assert (c.vocab_size, c.d_model, c.n_layers) == (152064, 3584, 28)
+    assert (c.n_heads, c.n_kv_heads, c.head_dim) == (28, 4, 128)
+    assert c.intermediate_size == 18944 and not c.tie_embeddings
+    assert c.rope_theta == 300000.0          # Open-R1 extends RoPE base for 32k context
+    assert c.q_dim == 3584 and c.kv_dim == 512
+    assert c.model_id == "open-r1/OpenR1-Distill-7B"
+    assert c.tokenizer_vocab_size == 151646 and c.effective_vocab_size == 151646
+    c.validate()
+
+
 def test_qwen_1_5b_config_shape():
     c = TeacherConfig.qwen_1_5b()
     assert (c.vocab_size, c.d_model, c.n_layers) == (151936, 1536, 28)

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -27,40 +27,8 @@ def _tokens(B, L, vocab):
     return rng.integers(0, vocab, size=(B, L)).astype(np.int32)
 
 
-# --- config ------------------------------------------------------------------
-def test_openr1_distill_7b_config_shape():
-    c = TeacherConfig.openr1_distill_7b()
-    assert (c.vocab_size, c.d_model, c.n_layers) == (152064, 3584, 28)
-    assert (c.n_heads, c.n_kv_heads, c.head_dim) == (28, 4, 128)
-    assert c.intermediate_size == 18944 and not c.tie_embeddings
-    assert c.rope_theta == 300000.0          # Open-R1 extends RoPE base for 32k context
-    assert c.q_dim == 3584 and c.kv_dim == 512
-    assert c.model_id == "open-r1/OpenR1-Distill-7B"
-    assert c.tokenizer_vocab_size == 151646 and c.effective_vocab_size == 151646
-    c.validate()
-
-
-def test_qwen_1_5b_config_shape():
-    c = TeacherConfig.qwen_1_5b()
-    assert (c.vocab_size, c.d_model, c.n_layers) == (151936, 1536, 28)
-    assert (c.n_heads, c.n_kv_heads, c.head_dim) == (12, 2, 128)
-    assert c.intermediate_size == 8960 and c.tie_embeddings
-    assert c.q_dim == 1536 and c.kv_dim == 256
-    assert c.model_id == "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-    assert c.tokenizer_vocab_size == 151646 and c.effective_vocab_size == 151646
-    c.validate()
-
-
-def test_config_validate_rejects_bad_gqa():
-    with pytest.raises(ValueError):
-        TeacherConfig(vocab_size=8, d_model=16, n_layers=1, n_heads=4, n_kv_heads=3,
-                      head_dim=4, intermediate_size=16).validate()
-
-
-def test_config_rejects_tokenizer_vocab_above_model_vocab():
-    with pytest.raises(ValueError):
-        TeacherConfig(vocab_size=256, d_model=16, n_layers=1, n_heads=2, n_kv_heads=1,
-                      head_dim=8, intermediate_size=16, tokenizer_vocab_size=300).validate()
+# Portable `TeacherConfig` shape/validate tests live in `test_teacher_config.py` (no MLX
+# import), so they run on non-Apple/CI hosts where this MLX-guarded module is skipped.
 
 
 def test_make_teacher_requires_config_for_synthetic_path():

--- a/tests/test_teacher_config.py
+++ b/tests/test_teacher_config.py
@@ -1,0 +1,56 @@
+"""Portable `TeacherConfig` tests (#93). NO backend import — `teacher.py` is above the
+seam, so these run on non-Apple/CI hosts where the MLX-guarded `test_teacher.py` is skipped,
+and they actually protect the conversion-teacher fixtures (`openr1_distill_7b`, `qwen_1_5b`)
+and the cross-cutting `validate()` invariants.
+"""
+
+import pytest
+
+from src.model.teacher import TeacherConfig
+
+
+def test_openr1_distill_7b_config_shape():
+    c = TeacherConfig.openr1_distill_7b()
+    assert (c.vocab_size, c.d_model, c.n_layers) == (152064, 3584, 28)
+    assert (c.n_heads, c.n_kv_heads, c.head_dim) == (28, 4, 128)
+    assert c.intermediate_size == 18944 and not c.tie_embeddings
+    assert c.rope_theta == 300000.0          # Open-R1 extends RoPE base for 32k context
+    assert c.q_dim == 3584 and c.kv_dim == 512
+    assert c.model_id == "open-r1/OpenR1-Distill-7B"
+    assert c.tokenizer_vocab_size == 151646 and c.effective_vocab_size == 151646
+    c.validate()
+
+
+def test_qwen_1_5b_config_shape():
+    c = TeacherConfig.qwen_1_5b()
+    assert (c.vocab_size, c.d_model, c.n_layers) == (151936, 1536, 28)
+    assert (c.n_heads, c.n_kv_heads, c.head_dim) == (12, 2, 128)
+    assert c.intermediate_size == 8960 and c.tie_embeddings
+    assert c.q_dim == 1536 and c.kv_dim == 256
+    assert c.model_id == "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+    assert c.tokenizer_vocab_size == 151646 and c.effective_vocab_size == 151646
+    c.validate()
+
+
+def test_from_hf_dict_omits_tokenizer_vocab():
+    # HF config.json has no tokenizer_vocab_size, so a config built from it alone emits over the
+    # full (padded) model vocab — the gotcha openr1_distill_7b's docstring warns about.
+    c = TeacherConfig.from_hf_dict({
+        "vocab_size": 152064, "hidden_size": 3584, "num_hidden_layers": 28,
+        "num_attention_heads": 28, "num_key_value_heads": 4, "head_dim": 128,
+        "intermediate_size": 18944, "tie_word_embeddings": False,
+    })
+    assert c.tokenizer_vocab_size is None
+    assert c.effective_vocab_size == c.vocab_size == 152064
+
+
+def test_config_validate_rejects_bad_gqa():
+    with pytest.raises(ValueError):
+        TeacherConfig(vocab_size=8, d_model=16, n_layers=1, n_heads=4, n_kv_heads=3,
+                      head_dim=4, intermediate_size=16).validate()
+
+
+def test_config_rejects_tokenizer_vocab_above_model_vocab():
+    with pytest.raises(ValueError):
+        TeacherConfig(vocab_size=256, d_model=16, n_layers=1, n_heads=2, n_kv_heads=1,
+                      head_dim=8, intermediate_size=16, tokenizer_vocab_size=300).validate()


### PR DESCRIPTION
Replace the weights-only DeepSeek-R1-Distill-Qwen-1.5B conversion teacher with
HuggingFace's fully-open Open-R1 reproduction (SFT of Qwen2.5-Math-7B on the
openly released Mixture-of-Thoughts / OpenR1-Math-220k / CodeForces-CoTs
reasoning data + recipe, Apache-2.0).

It keeps the Qwen2 architecture and Qwen2.5 tokenizer (151,646), so the
tokenizer, student vocab, uint32 packing, chat-template <|im_end|> EOS, and the
MLX Qwen2 teacher forward are all unchanged — this is a drop-in teacher swap.

- teacher.py: add TeacherConfig.openr1_distill_7b() (Qwen2.5-Math-7B dims,
  rope_theta=300000 for Open-R1's 32k context, untied embeddings); keep
  qwen_1_5b() as a back-compat fixture; refresh docstrings.
- manifests: point conversion_teacher at open-r1/OpenR1-Distill-7B.
- docs 10/11 + README decision table: new teacher identity + fully-open
  rationale; note the 7B->~1B size gap is bridged by adaptive init.
- tests: add test_openr1_distill_7b_config_shape.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016hRdgn1U9mNz8Dfw1yaHAZ