### PR TITLE
feat(model): [M10] transfer teacher embeddings + lm_head in student init (#99)

### DIFF
--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -34,8 +34,17 @@ the mixing matrices, then hidden states, then final logits. Reference:
 Both reuse the teacher's attention projections and layer structure, so a conversion teacher
 **close to the student's size is ideal** and it **fixes the tokenizer**. We trade exact size-match
 for full openness: the chosen teacher is the 7B `open-r1/OpenR1-Distill-7B`, and the 7B→~1B gap is
-bridged by the adaptive `_fit` cropping in student init (`src/model/mlx_student_init.py`) — watch
-the early distillation curve for init quality. The matching runs as the distillation loss + train
+bridged by the adaptive `_fit` cropping in student init (`src/model/mlx_student_init.py`).
+
+To keep that cropping coherent, the init also **transfers the teacher's token embedding and
+lm_head** (`_init_embeddings`, cropped with the same `_fit`), so the student's residual stream *is*
+the teacher's first-`d_model` residual coordinates end-to-end — the per-layer corner-crop becomes a
+subspace restriction rather than an arbitrary slice, and it matches the first-`min(d)` channel
+alignment the hidden-state matching loss already uses (`mlx_distill._hidden_mse`). The subspace is
+the **first** `d_model` coordinates; if the early distillation curve shows that is a poor warm
+start, the alternative is a PCA-of-activations basis (keep the highest-variance directions and apply
+that change of basis consistently across embeddings, every projection, and the matching loss) —
+deferred until the first-k baseline is measured. The matching runs as the distillation loss + train
 step (#100): KL on the teacher's top-k logits combined with cross-entropy, staged per the
 manifest's `stages` list.
 

--- a/src/model/mlx_student_init.py
+++ b/src/model/mlx_student_init.py
@@ -63,6 +63,21 @@ def _teacher_layer_for(i: int, n_student: int, n_teacher: int) -> int:
     return min(n_teacher - 1, int(round(i * (n_teacher - 1) / (n_student - 1))))
 
 
+def _init_embeddings(student, teacher) -> None:
+    """Copy the teacher's token embedding (and, for an untied student, the lm_head) onto the
+    student, cropping with `_fit`. This makes the per-layer projection transfer coherent: the
+    student's residual stream becomes the teacher's first-`d_model` residual coordinates, so the
+    corner-crop in `_init_attention_layer`/`_init_mamba_layer` is a subspace restriction rather
+    than an arbitrary slice. `_fit`'s row-crop drops the teacher's padded vocab rows (they sit
+    above the tokenizer vocab); its column-crop selects the residual subspace. Used by both
+    init methods — embedding transfer helps regardless of which layers are frozen."""
+    cfg = student.config
+    shape = (cfg.vocab_size, cfg.d_model)
+    _set(student.embedding, "weight", _fit(teacher.embedding_matrix(), shape))
+    if not cfg.tie_embeddings:    # student.lm_head exists only when untied (mlx_backend)
+        _set(student.lm_head, "weight", _fit(teacher.lm_head_matrix(), shape))
+
+
 def _init_attention_layer(layer, proj, tcfg) -> None:
     """Copy a teacher attention layer's Q/K/V/O onto a student attention block (`qkv_proj`,
     `o_proj`), expanding GQA to full heads and adaptively fitting to the student's width."""
@@ -103,6 +118,8 @@ def init_student(student, teacher, method: InitMethod) -> InitReport:
     tcfg = teacher.config
     S, T = cfg.n_layers, teacher.n_layers
     dt_rank, d_state = cfg.dt_rank_resolved, cfg.d_state
+
+    _init_embeddings(student, teacher)
 
     frozen_layers: List[int] = []
     n_mapped = 0

--- a/src/model/mlx_teacher.py
+++ b/src/model/mlx_teacher.py
@@ -1,7 +1,7 @@
 """MLX conversion teacher (Apple Silicon, below the seam — may import mlx).
 
-A frozen, forward-only **Qwen2** decoder (the DeepSeek-R1-Distill-Qwen-1.5B family) used
-as the distillation conversion teacher. It implements the portable `ConversionTeacher`
+A frozen, forward-only **Qwen2** decoder (open-r1/OpenR1-Distill-7B by default, a
+Qwen2-family R1 reproduction) used as the distillation conversion teacher. It implements the portable `ConversionTeacher`
 protocol (`src/model/teacher.py`) so the precompute (#94) and the distill loss (#100) see
 only opaque arrays + a `to_numpy` converter, and the student init (#99) can read the
 attention Q/K/V/O projections.
@@ -200,6 +200,12 @@ class MLXConversionTeacher(ConversionTeacher):
         g = lambda s: mx.stop_gradient(self._w[p + s])
         return AttnProjections(q=g("q_w"), k=g("k_w"), v=g("v_w"), o=g("o_w"),
                                q_bias=g("q_b"), k_bias=g("k_b"), v_bias=g("v_b"))
+
+    def embedding_matrix(self) -> mx.array:
+        return mx.stop_gradient(self._w["embed"])
+
+    def lm_head_matrix(self) -> mx.array:
+        return mx.stop_gradient(self._lm_head())   # == embed when tied (see _lm_head)
 
     def to_numpy(self, array) -> np.ndarray:
         return np.array(array)

--- a/src/model/teacher.py
+++ b/src/model/teacher.py
@@ -231,6 +231,22 @@ class ConversionTeacher(ABC):
         """The Q/K/V/O projection weights of decoder `layer` (0-indexed), for #99."""
 
     @abstractmethod
+    def embedding_matrix(self) -> Array:
+        """The token-embedding matrix `(vocab_size, d_model)`, for the #99 init.
+
+        Returned over the *padded* model vocab (padded rows are at the end, above
+        `effective_vocab_size`); the student init crops it to the student shape with
+        `_fit`, so the row-crop drops exactly the padding and the column-crop selects
+        the student's residual subspace. Opaque, stop-gradient-wrapped (frozen teacher)."""
+
+    @abstractmethod
+    def lm_head_matrix(self) -> Array:
+        """The output (unembedding) matrix `(vocab_size, d_model)`, for the #99 init.
+
+        Equals `embedding_matrix()` when the teacher ties embeddings. Same convention and
+        cropping contract as `embedding_matrix`."""
+
+    @abstractmethod
     def to_numpy(self, array: Array) -> Any:
         """Convert an opaque teacher array to a numpy array (the seam converter)."""
 

--- a/src/model/teacher.py
+++ b/src/model/teacher.py
@@ -234,10 +234,12 @@ class ConversionTeacher(ABC):
     def embedding_matrix(self) -> Array:
         """The token-embedding matrix `(vocab_size, d_model)`, for the #99 init.
 
-        Returned over the *padded* model vocab (padded rows are at the end, above
-        `effective_vocab_size`); the student init crops it to the student shape with
-        `_fit`, so the row-crop drops exactly the padding and the column-crop selects
-        the student's residual subspace. Opaque, stop-gradient-wrapped (frozen teacher)."""
+        Shape is `(vocab_size, d_model)` — the *full padded* model vocab, NOT pre-clipped
+        to `effective_vocab_size` (padded rows are at the end, above the tokenizer vocab).
+        The student init crops it to the student shape with `_fit`, so the row-crop drops
+        exactly the padding and the column-crop selects the student's residual subspace;
+        an impl that pre-clipped would make `_fit` crop live rows. Opaque,
+        stop-gradient-wrapped (frozen teacher)."""
 
     @abstractmethod
     def lm_head_matrix(self) -> Array:

--- a/tests/test_student_init.py
+++ b/tests/test_student_init.py
@@ -15,7 +15,7 @@ from src.model.mlx_backend import MLXMambaModel
 from src.model.blocks import MambaConfig
 from src.model.mlx_teacher import MLXConversionTeacher
 from src.model.teacher import TeacherConfig
-from src.model.mlx_student_init import init_student, _teacher_layer_for
+from src.model.mlx_student_init import init_student, _teacher_layer_for, _fit
 from src.train.distill_manifest import InitMethod, InitReport
 
 
@@ -78,6 +78,34 @@ def test_mil_adaptive_fit_wider_student_shapes_finite():
     for _, v in tree_flatten(student.parameters()):
         assert mx.all(mx.isfinite(v)).item()
     assert student.forward(mx.zeros((1, 8), dtype=mx.int32)).shape == (1, 8, 256)
+
+
+# --- embedding / lm_head transfer --------------------------------------------
+def test_embedding_transferred_exact_when_dims_match():
+    teacher, student = _teacher(), _student()         # both d_model 64, vocab 256
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    assert mx.array_equal(student.embedding.weight, teacher.embedding_matrix()).item()
+
+
+def test_embedding_transferred_adaptive_fit_wider_student():
+    teacher = _teacher(d_model=64)
+    student = _student(d_model=128, n_attn_heads=8)   # student wider than teacher
+    init_student(student, teacher, InitMethod.MOHAWK)
+    e = student.embedding.weight
+    assert e.shape == (256, 128) and mx.all(mx.isfinite(e)).item()
+    # the overlapping block is the teacher embedding; the widened columns are zero-padded
+    assert mx.array_equal(e, _fit(teacher.embedding_matrix(), (256, 128))).item()
+    assert mx.array_equal(e[:, :64], teacher.embedding_matrix()).item()
+
+
+def test_lm_head_transferred_when_student_untied():
+    teacher = _teacher()
+    cfg = MambaConfig(d_model=64, n_layers=4, d_state=16, expand=2, d_conv=4, head_dim=16,
+                      vocab_size=256, seq_len=32, attn_every=2, n_attn_heads=4,
+                      precision="fp32", tie_embeddings=False)
+    student = MLXMambaModel(cfg)
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    assert mx.array_equal(student.lm_head.weight, _fit(teacher.lm_head_matrix(), (256, 64))).item()
 
 
 # --- freeze gating -----------------------------------------------------------

--- a/tests/test_student_init.py
+++ b/tests/test_student_init.py
@@ -26,9 +26,11 @@ def test_teacher_layer_alignment_maps_endpoints():
     assert [_teacher_layer_for(i, 4, 4) for i in range(4)] == [0, 1, 2, 3]   # identity
 
 
-def _teacher(d_model=64, n_layers=4, n_heads=4, n_kv_heads=2, head_dim=16):
-    cfg = TeacherConfig(vocab_size=256, d_model=d_model, n_layers=n_layers, n_heads=n_heads,
-                        n_kv_heads=n_kv_heads, head_dim=head_dim, intermediate_size=128)
+def _teacher(d_model=64, n_layers=4, n_heads=4, n_kv_heads=2, head_dim=16, vocab=256,
+             tie_embeddings=True):
+    cfg = TeacherConfig(vocab_size=vocab, d_model=d_model, n_layers=n_layers, n_heads=n_heads,
+                        n_kv_heads=n_kv_heads, head_dim=head_dim, intermediate_size=128,
+                        tie_embeddings=tie_embeddings)
     return MLXConversionTeacher.from_config(cfg, seed=0)
 
 
@@ -85,6 +87,7 @@ def test_embedding_transferred_exact_when_dims_match():
     teacher, student = _teacher(), _student()         # both d_model 64, vocab 256
     init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
     assert mx.array_equal(student.embedding.weight, teacher.embedding_matrix()).item()
+    assert not hasattr(student, "lm_head")            # tied student: no separate head set
 
 
 def test_embedding_transferred_adaptive_fit_wider_student():
@@ -98,14 +101,28 @@ def test_embedding_transferred_adaptive_fit_wider_student():
     assert mx.array_equal(e[:, :64], teacher.embedding_matrix()).item()
 
 
+def test_embedding_row_crop_when_teacher_vocab_larger():
+    # The production case: teacher padded vocab (300) > student vocab (256). The student keeps
+    # the first 256 teacher rows (the tokenizer vocab); the padded rows 256..299 are dropped.
+    teacher = _teacher(vocab=300)                     # student vocab is 256
+    student = _student()
+    init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    e = student.embedding.weight
+    assert e.shape == (256, 64)
+    assert mx.array_equal(e, teacher.embedding_matrix()[:256]).item()   # surviving rows, not zeros
+
+
 def test_lm_head_transferred_when_student_untied():
-    teacher = _teacher()
+    teacher = _teacher(vocab=300, tie_embeddings=False)   # untied + larger vocab exercises the row-crop
     cfg = MambaConfig(d_model=64, n_layers=4, d_state=16, expand=2, d_conv=4, head_dim=16,
                       vocab_size=256, seq_len=32, attn_every=2, n_attn_heads=4,
                       precision="fp32", tie_embeddings=False)
     student = MLXMambaModel(cfg)
     init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
     assert mx.array_equal(student.lm_head.weight, _fit(teacher.lm_head_matrix(), (256, 64))).item()
+    assert mx.array_equal(student.lm_head.weight, teacher.lm_head_matrix()[:256]).item()
+    # the untied head actually drives output: forward runs and is finite
+    assert mx.all(mx.isfinite(student.forward(mx.zeros((1, 8), dtype=mx.int32)))).item()
 
 
 # --- freeze gating -----------------------------------------------------------

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -97,6 +97,24 @@ def test_attention_projection_shapes_gqa():
     assert pr.k_bias.shape == (c.kv_dim,) and pr.v_bias.shape == (c.kv_dim,)
 
 
+def test_embedding_and_lm_head_matrices_tied():
+    t = _tiny()                                            # TeacherConfig.tiny() ties embeddings
+    c = t.config
+    assert t.config.tie_embeddings
+    e, lm = t.embedding_matrix(), t.lm_head_matrix()
+    assert e.shape == (c.vocab_size, c.d_model) and lm.shape == (c.vocab_size, c.d_model)
+    assert mx.array_equal(e, lm).item()                   # tied -> same matrix
+
+
+def test_embedding_and_lm_head_matrices_untied():
+    cfg = TeacherConfig(vocab_size=256, d_model=64, n_layers=2, n_heads=4, n_kv_heads=2,
+                        head_dim=16, intermediate_size=128, tie_embeddings=False)
+    t = MLXConversionTeacher.from_config(cfg, seed=0)
+    e, lm = t.embedding_matrix(), t.lm_head_matrix()
+    assert e.shape == (256, 64) and lm.shape == (256, 64)
+    assert not mx.array_equal(e, lm).item()               # untied -> distinct lm_head
+
+
 # --- frozen contract ---------------------------------------------------------
 def test_no_trainable_parameters():
     assert _tiny().trainable_parameters() == {}


### PR DESCRIPTION
Follow-on to #117 (now merged). Makes the teacher→student init coherent after the 7B teacher swap. (Supersedes #118, which GitHub auto-closed when #117's branch was deleted; rebased onto main.)

## Problem
`init_student` mapped the teacher's per-layer attention projections onto the student via the adaptive `_fit` crop, but never transferred the teacher's **token embedding or lm_head** — they kept the student's random init. So the projections landed on a residual stream whose basis had no relation to the one the teacher was trained on. After #117 (`_fit` now crops the 7B teacher's 3584→2048 instead of zero-padding a smaller one), that incoherence matters more.

## Change (Stage 1 — "first-k" baseline)
- `init_student` now copies the teacher embedding (and lm_head, when the student is untied) cropped with the same `_fit`. The student residual stream becomes the teacher's first-`d_model` coordinates **end-to-end**, so the per-layer corner-crop is a coherent subspace restriction.
- Already matches the first-`min(d)` channel alignment the hidden-state matching loss uses (`mlx_distill._hidden_mse`), so **no matching-loss change needed**.
- New `embedding_matrix()` / `lm_head_matrix()` accessors on the `ConversionTeacher` seam (mirror `attention_projection`); MLX impls reuse the existing private `_lm_head()`. Applied for both MOHAWK and Mamba-in-the-Llama.

## Deferred (Stage 2 — gated)
If the early distillation curve shows the first-k subspace is a poor warm start, the alternative is a **PCA-of-activations basis** (highest-variance directions, applied consistently across embeddings, every projection, and the matching loss). Not built yet — larger blast radius (`_hidden_mse` + the #94 cached-hidden precompute would need the basis applied). Documented in `docs/design/10-distillation.md`.

## Tests
Teacher accessor shapes (tied → identical, untied → distinct); embedding transferred exactly on matched dims, adaptive-fit when wider, lm_head set for an untied student. Full suite green (338 passed, 1 skipped); changes are below the seam so the import guard is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSMoaQw3LFaABpsomsigWE