### PR TITLE
feat: [M8] CUDA seg_ids packing-aware doc-boundary reset

### DIFF
--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -447,7 +447,8 @@ class CUDAMambaModel(ModelInterface, nn.Module):
             return h @ self.embedding.weight.t()
         return self.lm_head(h)
 
-    def _layer_forward(self, layer: MambaBlock, h: Array, seg_ids: Array = None) -> Array:
+    def _layer_forward(self, layer: "MambaBlock | AttentionBlock", h: Array,
+                       seg_ids: Array = None) -> Array:
         # Gradient checkpointing: recompute the layer's forward in backward instead of
         # retaining its activations. Only meaningful under autograd; use_reentrant=False
         # runs normally in no-grad (eval/parity) contexts.

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -97,6 +97,25 @@ def _segsum(x: Array) -> Array:
     return seg.masked_fill(~mask, float("-inf"))
 
 
+def _chunk_seg_mask(seg_ids: Array, B: int, Q: int, nc: int, pad: int) -> Array:
+    """Boundary mask for the SSD inter-chunk decay matrix (#68) — torch port of the MLX
+    helper. Doc boundaries are chunk-aligned, so each length-Q chunk is single-document;
+    this masks the inter-chunk state carry so SSM state can't bleed past a packed boundary.
+
+    `seg_ids` (B, L) document ids -> (B, nc+1, nc+1) bool: entry [i, c] keeps the decay from
+    state c (chunk c-1's final; c=0 is the zero initial state) into entering chunk i iff
+    they share a document. Sentinels: -1 the zero-state column, -2 the dropped-output row."""
+    seg = seg_ids
+    if pad:
+        seg = torch.cat([seg, seg[:, -1:].expand(B, pad)], dim=1)
+    seg_chunks = seg.reshape(B, nc, Q)[:, :, 0]                  # (B, nc) doc id per chunk
+    sentinel_a = torch.full((B, 1), -1, dtype=seg_chunks.dtype, device=seg_chunks.device)
+    sentinel_b = torch.full((B, 1), -2, dtype=seg_chunks.dtype, device=seg_chunks.device)
+    src = torch.cat([sentinel_a, seg_chunks], dim=1)            # state c axis
+    out = torch.cat([seg_chunks, sentinel_b], dim=1)           # entering-chunk i axis
+    return out[:, :, None] == src[:, None, :]                   # (B, nc+1, nc+1) bool
+
+
 class SelectiveSSM(nn.Module):
     """Scalar-A Mamba-2 / SSD selective state space (see mlx_backend.SelectiveSSM)."""
 
@@ -146,11 +165,15 @@ class SelectiveSSM(nn.Module):
         a = -torch.exp(self.A_log)                   # (H,) scalar decay, fp32
         return delta, a, B, C
 
-    def parallel(self, x: Array) -> Array:
+    def parallel(self, x: Array, seg_ids: Array = None) -> Array:
         """SSD chunked-matmul scan. x: (B, L, d_inner) -> (B, L, d_inner).
 
         Pads L up to a multiple of the chunk length Q (padded steps carry zero input and
-        are trimmed). All decays are exp of non-positive sums, so it is overflow-safe."""
+        are trimmed). All decays are exp of non-positive sums, so it is overflow-safe.
+
+        `seg_ids` (B, L) document ids (chunk-aligned boundaries) makes the scan
+        packing-aware (#68): the inter-chunk state carry is masked so recurrent state can't
+        bleed across documents. `None` is the original single-segment scan."""
         B_, L, d_inner = x.shape
         H, P, N = self.config.n_heads, self.config.head_dim, self.config.d_state
         Q = self.config.chunk_size or 64
@@ -186,6 +209,9 @@ class SelectiveSSM(nn.Module):
             [states.new_zeros((B_, 1, H, P, N)), states], dim=1)
         chunk_tot = F.pad(Acum[..., -1], (1, 0))             # (B,H,nc+1)
         decay_chunk = torch.exp(_segsum(chunk_tot))          # (B,H,nc+1,nc+1)
+        if seg_ids is not None:                              # #68: cross-doc reset
+            seg_mask = _chunk_seg_mask(seg_ids, B_, Q, nc, pad)   # (B,nc+1,nc+1) bool
+            decay_chunk = decay_chunk * seg_mask[:, None].to(decay_chunk.dtype)
         new_states = torch.einsum("bhzc,bchpn->bzhpn", decay_chunk, states)
         S_enter = new_states[:, :-1]                         # (B,nc,H,P,N)
         # 4) off-diagonal output: entering state decayed to each position
@@ -233,15 +259,48 @@ class MambaBlock(nn.Module):
                      c.stride, c.padding, c.dilation, c.groups)
         return y.transpose(1, 2)
 
-    def forward_seq(self, x: Array) -> Array:
+    def _conv_seq_seg(self, x_main: Array, cd, seg: Array) -> Array:
+        """Boundary-aware causal depthwise conv (#68) — torch port. Taps reaching into a
+        previous document are zeroed, so the conv window can't bleed across a packed
+        boundary (the conv is part of the per-doc recurrent state). `seg` is (B, L).
+        Returns length L, matching the full conv exactly within a single document."""
+        c = self.conv
+        K = self.config.d_conv
+        B_, L, _ = x_main.shape
+        x = x_main.to(cd)
+        w = c.weight.to(cd)                         # (d_inner, 1, K) torch Conv1d layout
+        acc = None
+        for k in range(K):
+            shift = K - 1 - k                       # how far this tap reaches into the past
+            wk = w[:, 0, k]                          # (d_inner,)
+            if shift == 0:
+                xs = x
+            elif shift >= L:
+                continue                            # tap reaches entirely before the start
+            else:
+                xs = F.pad(x[:, :L - shift], (0, 0, shift, 0))   # x[t-shift]
+                same = seg[:, shift:] == seg[:, :-shift]         # (B, L-shift)
+                valid = F.pad(same, (shift, 0)).to(cd)           # 0 across boundary
+                xs = xs * valid[..., None]
+            term = xs * wk
+            acc = term if acc is None else acc + term
+        if acc is None:                             # K > L: all taps reach before the start
+            acc = torch.zeros((B_, L, x.shape[-1]), dtype=cd, device=x.device)
+        return acc + c.bias.to(cd)
+
+    def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:
         L = x.shape[1]
         cd = _DTYPES[self.config.precision]
         xn = self.norm(x)
         x_main, z = torch.chunk(_linear(self.in_proj, xn, cd), 2, dim=-1)   # (B,L,di) each
-        # Causal depthwise conv: pad both sides (d_conv-1), keep the first L outputs.
-        xc = self._conv_seq(x_main, cd)[:, :L]
+        # Causal depthwise conv: pad both sides (d_conv-1), keep the first L outputs. With
+        # seg_ids the conv is boundary-aware so its window can't cross a packed doc boundary.
+        if seg_ids is None:
+            xc = self._conv_seq(x_main, cd)[:, :L]
+        else:
+            xc = self._conv_seq_seg(x_main, cd, seg_ids)
         xc = _silu(xc)
-        y = self.ssm.parallel(xc)
+        y = self.ssm.parallel(xc, seg_ids)
         y = y * _silu(z)
         return x + _linear(self.out_proj, y, cd)
 
@@ -321,7 +380,7 @@ class AttentionBlock(nn.Module):
             return _f32(t).reshape(B, T, self.H, self.Dh).permute(0, 2, 1, 3)
         return heads(q), heads(k), heads(v)
 
-    def forward_seq(self, x: Array) -> Array:
+    def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:
         cd = _DTYPES[self.config.precision]
         L = x.shape[1]
         xn = self.norm(x)
@@ -330,7 +389,14 @@ class AttentionBlock(nn.Module):
         q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
         scores = (q @ k.transpose(-1, -2)) / math.sqrt(self.Dh)      # (B,H,L,L)
         causal = torch.tril(torch.ones((L, L), dtype=torch.bool, device=x.device))
-        scores = scores.masked_fill(~causal, float("-inf"))
+        if seg_ids is None:
+            scores = scores.masked_fill(~causal, float("-inf"))
+        else:
+            # Block-diagonal: a token only attends within its own document (#68). Exact for
+            # arbitrary boundaries (attention needs no chunk-alignment, unlike the SSM scan).
+            same = seg_ids[:, :, None] == seg_ids[:, None, :]        # (B,L,L)
+            allow = causal[None] & same                             # (B,L,L)
+            scores = scores.masked_fill(~allow[:, None], float("-inf"))
         out = _softmax_lastdim(scores) @ v                   # (B,H,L,Dh)
         out = out.permute(0, 2, 1, 3).reshape(x.shape[0], L, self.H * self.Dh)
         return x + _linear(self.o_proj, _cast(out, cd), cd)
@@ -381,26 +447,25 @@ class CUDAMambaModel(ModelInterface, nn.Module):
             return h @ self.embedding.weight.t()
         return self.lm_head(h)
 
-    def _layer_forward(self, layer: MambaBlock, h: Array) -> Array:
+    def _layer_forward(self, layer: MambaBlock, h: Array, seg_ids: Array = None) -> Array:
         # Gradient checkpointing: recompute the layer's forward in backward instead of
         # retaining its activations. Only meaningful under autograd; use_reentrant=False
         # runs normally in no-grad (eval/parity) contexts.
         if self.config.grad_checkpoint and torch.is_grad_enabled():
-            return _checkpoint(layer.forward_seq, h, use_reentrant=False)
-        return layer.forward_seq(h)
+            if seg_ids is None:
+                return _checkpoint(layer.forward_seq, h, use_reentrant=False)
+            return _checkpoint(layer.forward_seq, h, seg_ids, use_reentrant=False)
+        return layer.forward_seq(h, seg_ids)
 
     # --- ModelInterface ---
     def forward(self, token_batch: Array, seg_ids: Array = None) -> Array:
-        if seg_ids is not None:
-            # Packing-aware document boundaries (#68) are MLX-only for now; the CUDA scan
-            # would need the same inter-chunk mask. Deferred with the rest of this backend.
-            raise NotImplementedError(
-                "seg_ids (packing-aware doc boundaries, #68) is not implemented on the "
-                "CUDA backend yet — run packed-boundary training on MLX.")
         ids = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
         h = _cast(self.embedding(ids), self._cd)     # activation stream in cd
+        seg = None
+        if seg_ids is not None:                      # (B, L) document ids -> boundary-aware (#68)
+            seg = torch.as_tensor(np.asarray(seg_ids), dtype=torch.long, device=self._device)
         for layer in self.layers:
-            h = self._layer_forward(layer, h)
+            h = self._layer_forward(layer, h, seg)
         return self._head(self.norm_f(h))
 
     def step(self, token: Array, state: State) -> Tuple[Array, State]:

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -102,6 +102,40 @@ def test_backend_parity_hybrid(tmp_path):
 
 @pytest.mark.skipif(not (HAVE_MLX and HAVE_TORCH),
                     reason="needs both mlx and torch (run on a Mac)")
+def test_backend_parity_seg_ids(tmp_path):
+    """Packed multi-doc forward with seg_ids (#68/#111) agrees MLX<->torch in fp32. Proves
+    the CUDA seg_ids path (inter-chunk mask + boundary-aware conv + block-diagonal attn)
+    matches the MLX reference, not just each backend's own doc-boundary self-consistency."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.cuda_backend import CUDAMambaModel
+
+    cfg = load_config("config/toy-hybrid.yaml")        # exercises both Mamba + attention
+    Q = cfg.chunk_size or 64
+    torch.manual_seed(0)
+    src = CUDAMambaModel(cfg)
+    path = str(tmp_path / "weights.safetensors")
+    src.save(path)
+    mlx_m = MLXMambaModel(cfg); mlx_m.load(path)
+    cuda_m = CUDAMambaModel(cfg); cuda_m.load(path)
+
+    # Pack two chunk-aligned docs into one sequence with seg_ids (doc boundaries on chunks).
+    rng = np.random.default_rng(0)
+    packed, seg = [], []
+    for d, n in enumerate([Q, 2 * Q]):
+        packed.extend(rng.integers(0, cfg.vocab_size, size=n).tolist())
+        seg.extend([d] * n)
+    packed = np.asarray(packed, dtype=np.int32)[None]
+    seg = np.asarray(seg, dtype=np.int32)[None]
+
+    with torch.no_grad():
+        a = _mlx_np(mlx_m.forward(packed, seg)).astype(np.float64)
+        b = _torch_np(cuda_m.forward(packed, seg)).astype(np.float64)
+    max_abs = float(np.abs(a - b).max())
+    assert np.allclose(a, b, rtol=1e-4, atol=1e-5), f"seg_ids parity drift {max_abs:.3e}"
+
+
+@pytest.mark.skipif(not (HAVE_MLX and HAVE_TORCH),
+                    reason="needs both mlx and torch (run on a Mac)")
 def test_portable_weights_roundtrip_both_directions(tmp_path):
     """MLX save -> torch _load_portable -> torch save -> load back into MLX; the MLX
     logits are unchanged. Proves the cross-backend bridge in both directions (a

--- a/tests/test_cuda_doc_boundary_parity.py
+++ b/tests/test_cuda_doc_boundary_parity.py
@@ -1,0 +1,58 @@
+"""Packing-aware document-boundary parity (#68) on the CUDA/torch backend (#111).
+
+Mirror of tests/test_doc_boundary_parity.py: a packed multi-document forward (with
+seg_ids) must equal each document's standalone forward, proving SSM/attention state
+doesn't bleed across chunk-aligned boundaries. Runs on torch-CPU — no GPU needed — so the
+CUDA seg_ids path is verified on the Mac before it ships to a CUDA host.
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import load_config
+from src.model.cuda_backend import CUDAMambaModel
+from src.conformance.doc_boundary_parity import check_doc_boundary_parity
+
+
+def _torch_np(a):
+    return a.detach().cpu().numpy()
+
+
+def _docs(cfg, lengths, seed=0):
+    rng = np.random.default_rng(seed)
+    return [rng.integers(0, cfg.vocab_size, size=n).tolist() for n in lengths]
+
+
+def test_doc_boundary_parity_toy():
+    cfg = load_config("config/toy.yaml")
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    Q = cfg.chunk_size or 64
+    # exact chunk multiples, several chunks, and a short doc that needs padding
+    docs = _docs(cfg, [Q, 2 * Q, 5])
+    res = check_doc_boundary_parity(model, docs, Q, to_numpy=_torch_np)
+    assert res["ok"] and res["max_abs_diff"] < 1e-3
+
+
+def test_doc_boundary_parity_hybrid():
+    cfg = load_config("config/toy-hybrid.yaml")
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    Q = cfg.chunk_size or 64
+    docs = _docs(cfg, [Q, 7, Q + 3], seed=1)        # mixes attention + Mamba layers
+    res = check_doc_boundary_parity(model, docs, Q, to_numpy=_torch_np)
+    assert res["ok"] and res["max_abs_diff"] < 1e-3
+
+
+def test_grad_checkpoint_path_supports_seg_ids():
+    # poc uses grad_checkpoint=True; make sure seg_ids threads through the checkpointed
+    # layer wrappers (grad is enabled here, so _layer_forward takes the _checkpoint path).
+    cfg = load_config("config/toy.yaml")
+    cfg.grad_checkpoint = True
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    Q = cfg.chunk_size or 64
+    res = check_doc_boundary_parity(model, _docs(cfg, [Q, Q]), Q, to_numpy=_torch_np)
+    assert res["ok"]


### PR DESCRIPTION
Closes #111

## Summary
Ports the #68 document-boundary reset from the MLX backend to the CUDA/torch backend, so packed multi-document training resets SSM state at `seg_ids` boundaries instead of bleeding state across documents. The CUDA `forward(..., seg_ids=...)` `NotImplementedError` stub is removed.

- **`_chunk_seg_mask`** — torch port of the MLX inter-chunk boundary mask `(B, nc+1, nc+1)`.
- **`SelectiveSSM.parallel`** — masks the inter-chunk decay carry when `seg_ids` is given.
- **`MambaBlock._conv_seq_seg`** — boundary-aware causal depthwise conv (taps reaching across a doc boundary are zeroed).
- **`AttentionBlock.forward_seq`** — block-diagonal (same-document) attention mask.
- **`_layer_forward` / `forward`** — thread `seg_ids` through every layer, including the grad-checkpoint path.

All ops mirror the MLX implementation line-for-line; the seam rule is preserved (only `cuda_backend.py` touches torch).

## Testing
- [x] Tests added/updated — new `tests/test_cuda_doc_boundary_parity.py` (toy + toy-hybrid + grad-checkpoint), plus a cross-backend **MLX-vs-CUDA** `seg_ids` parity test in `tests/test_backend_parity.py`, all fp32 ~1e-4 on torch-CPU (no GPU).
- [x] All tests passing — full suite 355 passed, 1 opt-in skip.
- [x] Manual testing completed — MLX smoke gate (`scripts/smoke_test.py`) green; resume exact, eval runs.

Part of #16. Buildable and parity-verified on the Mac; only throughput needs a CUDA host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)