### PR TITLE
feat(data): [M10] distillation corpus driver under Qwen2.5 (#92)

### DIFF
--- a/docs/design/10-distillation.md
+++ b/docs/design/10-distillation.md
@@ -149,7 +149,9 @@ This exceeds the uint16 bound → **uint32 packing** (#90); see
 Everything that depends only on the **teacher + corpus** — not the student — is computed a single
 time and reused by every trial:
 
-- The tokenized distillation corpus (#92).
+- The tokenized distillation corpus (#92): `src/data/distill_corpus.py` orchestrates the existing
+  clean → Qwen2.5-tokenize → uint32-pack stages into `poc-distill/corpus/{cleaned,tokenized/qwen25-8k}`
+  with doc-boundary sidecars and a corpus manifest — the exact path the manifests below name.
 - **Teacher outputs** over it: top-50..100 logits + indices per token (#94); optionally hidden
   states for MOHAWK matching. The teacher forward pass is the dominant cost — paid **once**.
 - The shared SFT corpora and verifiable RL sets ([post-training](11-post-training.md)).

--- a/src/data/distill_corpus.py
+++ b/src/data/distill_corpus.py
@@ -1,0 +1,172 @@
+"""Build the FROZEN distillation corpus (#92): the cleaned + Qwen2.5-tokenized,
+uint32-packed token corpus every student trial consumes.
+
+This is a thin **orchestrator** over the existing data stages — it adds no new cleaning or
+packing logic, only the `poc-distill/` prefixed layout and a corpus-level manifest tying the
+two artifacts together:
+
+    <out_root>/corpus/
+        cleaned/    part-*.parquet          # durable, re-mixable text (corpus.build_corpus)
+        tokenized/  qwen25-8k/              # training shards (shard.pack_sequences)
+            part-*.bin     uint32 tokens (Qwen2.5 vocab 151,646 -> uint32, #90)
+            part-*.bounds  uint8 doc-start flags  (SSM state reset, #68)
+            manifest.json  {seq_len, dtype, tokenizer, n_tokens, ...}
+        manifest.json       # the two-stage summary (the artifact #94 freezes against)
+
+The corpus is **precomputed once** (docs/design/10-distillation.md): the teacher logit
+precompute (#94) and every student layout sweep (#98/#100) read it unchanged. The student
+manifests (`config/manifests/student-1b-*.yaml`) already name
+`poc-distill/corpus/tokenized/qwen25-8k`; `tokenized_subdir` produces exactly that name.
+
+ABOVE THE SEAM — no `mlx`/`torch`. Heavy data deps (pyarrow via `corpus`, `transformers` via
+the tokenizer loaders) are imported LAZILY, so importing this module stays cheap and the seam
+guard (tests/test_import_guard.py) needs nothing extra.
+
+CLI (mirrors download/tokenize/pack/corpus):
+    # real run (needs the HF Qwen2.5 tokenizer): a few-B-token slice
+    python -m src.data.distill_corpus --source text --in data/raw/slice.txt --tokenizer qwen25
+    # offline smoke (no network/tokenizer; byte fallback):
+    python -m src.data.distill_corpus --source dummy --byte-fallback --out-root /tmp/pd
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+from . import corpus
+from .corpus import Record, ingest_dummy, ingest_text_file, iter_shard_texts
+
+#: Default local root for the distillation-corpus prefix. The three-class storage layout
+#: (poc-distill / shared / reserve-pretrain) is formalized separately in #97; here the prefix
+#: is just this default, kept deliberately minimal.
+DEFAULT_OUT_ROOT = Path("data/poc-distill")
+
+
+def tokenized_subdir(tokenizer: str, seq_len: int) -> str:
+    """Directory name for the tokenized shards: `<tokenizer>-<seqlen_k>` (e.g. `qwen25-8k`),
+    the exact path the student sweep manifests reference."""
+    return f"{tokenizer}-{seq_len // 1024}k"
+
+
+def _load_tokenizer(tokenizer: str, model_id: str | None, byte_fallback: bool):
+    """Resolve the tokenizer, reusing the `tokenize.py` loaders. `byte_fallback` is the
+    offline-only path (vocab 256 -> uint16); a real run uses `qwen25` (vocab 151,646 -> uint32)."""
+    from .tokenize import (ByteTokenizer, load_olmo_tokenizer, load_qwen25_tokenizer,
+                           load_starcoder2_tokenizer)
+
+    if byte_fallback:
+        return ByteTokenizer()
+    loaders = {"qwen25": load_qwen25_tokenizer, "olmo": load_olmo_tokenizer,
+               "starcoder2": load_starcoder2_tokenizer}
+    return loaders[tokenizer](model_id)
+
+
+def build_distill_corpus(records: Iterable[Record], out_root, *, tokenizer: str = "qwen25",
+                         model_id: str | None = None, seq_len: int = 8192,
+                         byte_fallback: bool = False, chunk_align: int | None = None,
+                         shard_size_mb: int = 512, clean_shard_size_mb: int = 128,
+                         **clean_kwargs) -> dict:
+    """Build the distillation corpus end to end: clean text shards, then Qwen2.5-tokenize +
+    uint32-pack into fixed `seq_len` sequences with doc-boundary sidecars, under `out_root`.
+
+    Stage 1 reuses `corpus.build_corpus` (normalize -> filter/dedup -> Parquet text shards);
+    `clean_kwargs` are forwarded to it (e.g. `quality=True`, `dedup="minhash"`). Stage 2 reuses
+    `shard.pack_sequences`; the packed dtype follows the tokenizer vocab via `packing_dtype_for`
+    (uint16 for the byte/OLMo path, uint32 for Qwen2.5). Returns the corpus-level manifest dict.
+    """
+    from .pack import packing_dtype_for
+    from .shard import pack_sequences
+    from .tokenize import tokenize_docs
+
+    out_root = Path(out_root)
+    corpus_root = out_root / "corpus"
+    cleaned_dir = corpus_root / "cleaned"
+    tokenized_dir = corpus_root / "tokenized" / tokenized_subdir(tokenizer, seq_len)
+
+    # Stage 1 — cleaned, re-mixable text shards (durable artifact).
+    cleaned_shards = corpus.build_corpus(records, cleaned_dir,
+                                         shard_size_mb=clean_shard_size_mb, **clean_kwargs)
+
+    # Stage 2 — tokenize + pack the cleaned text. Pass the short tokenizer label so the pack
+    # manifest records `tokenizer: qwen25` (the acceptance criterion), not the HF repo path.
+    tok = _load_tokenizer(tokenizer, model_id, byte_fallback)
+    dtype = packing_dtype_for(tok.vocab_size)          # uint16 (byte/OLMo) / uint32 (Qwen2.5)
+    docs = tokenize_docs(iter_shard_texts(cleaned_dir), tok)
+    pack_manifest = pack_sequences(docs, tokenized_dir, seq_len=seq_len,
+                                   shard_size_mb=shard_size_mb, tokenizer=tokenizer,
+                                   chunk_align=chunk_align, dtype=dtype)
+
+    # Corpus-level manifest — the two-stage summary the teacher precompute (#94) freezes against.
+    manifest = {
+        "tokenizer": tokenizer,
+        "model_id": getattr(tok, "name_or_path", None) if not byte_fallback else None,
+        "byte_fallback": byte_fallback,
+        "seq_len": seq_len,
+        "dtype": pack_manifest["dtype"],
+        "n_tokens": pack_manifest["n_tokens"],
+        "n_documents": pack_manifest["n_documents"],
+        "n_sequences": pack_manifest["n_sequences"],
+        "n_cleaned_shards": len(cleaned_shards),
+        "cleaned_dir": str(cleaned_dir),
+        "tokenized_dir": str(tokenized_dir),
+    }
+    (corpus_root).mkdir(parents=True, exist_ok=True)
+    (corpus_root / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return manifest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--source", choices=("dummy", "text"), default="text",
+                    help="dummy: synthetic offline docs; text: a UTF-8 text file (--in)")
+    ap.add_argument("--in", dest="inp", default=None, help="input text file (--source text)")
+    ap.add_argument("--out-root", type=Path, default=DEFAULT_OUT_ROOT,
+                    help="root for the poc-distill prefix (writes <root>/corpus/...)")
+    ap.add_argument("--source-name", default=None,
+                    help="value for the schema `source` field (default: source type / filename)")
+    ap.add_argument("--lang", default="en")
+    ap.add_argument("--license", default="unknown")
+    ap.add_argument("--max-docs", type=int, default=1000, help="--source dummy: #synthetic docs")
+    # Tokenize + pack
+    ap.add_argument("--tokenizer", choices=("qwen25", "olmo", "starcoder2"), default="qwen25",
+                    help="HF tokenizer; the packed dtype is uint16/uint32 per its vocab")
+    ap.add_argument("--model-id", default=None)
+    ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--seq-len", type=int, default=8192)
+    ap.add_argument("--chunk-align", type=int, default=None,
+                    help="pad each doc to a multiple of this (the model chunk_size) so docs "
+                         "start on a chunk boundary for the SSM reset (#68)")
+    ap.add_argument("--shard-size-mb", type=int, default=512, help="tokenized shard roll size")
+    ap.add_argument("--clean-shard-size-mb", type=int, default=128, help="cleaned shard roll size")
+    # Stage-3/4 cleaning passthrough (default-off keeps the local gate path unchanged)
+    ap.add_argument("--min-chars", type=int, default=1)
+    ap.add_argument("--quality", action="store_true", help="Stage-3 text-quality heuristics")
+    ap.add_argument("--dedup", choices=("exact", "minhash"), default=None,
+                    help="Stage-4 dedup: exact-hash, or exact+MinHash-LSH near-dedup")
+    args = ap.parse_args()
+
+    if args.source == "dummy":
+        records = ingest_dummy(args.max_docs, source=args.source_name or "dummy")
+    else:
+        if not args.inp:
+            ap.error("--in is required for --source text")
+        name = args.source_name or Path(args.inp).stem
+        records = ingest_text_file(args.inp, source=name, lang=args.lang, license=args.license)
+
+    manifest = build_distill_corpus(
+        records, args.out_root, tokenizer=args.tokenizer, model_id=args.model_id,
+        seq_len=args.seq_len, byte_fallback=args.byte_fallback, chunk_align=args.chunk_align,
+        shard_size_mb=args.shard_size_mb, clean_shard_size_mb=args.clean_shard_size_mb,
+        min_chars=args.min_chars, quality=args.quality, dedup=args.dedup)
+    print(f"distill corpus: {manifest['n_tokens']} tokens "
+          f"({manifest['dtype']}, {manifest['n_documents']} docs, "
+          f"{manifest['n_sequences']} seq x {manifest['seq_len']}, "
+          f"tokenizer={manifest['tokenizer']}) -> {manifest['tokenized_dir']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_distill_corpus.py
+++ b/tests/test_distill_corpus.py
@@ -1,0 +1,91 @@
+"""Distillation-corpus driver (#92): the clean -> Qwen2.5-tokenize -> uint32-pack orchestrator
+that produces the frozen `poc-distill/corpus/` artifact the teacher precompute (#94) and every
+student sweep (#98) consume.
+
+Pure numpy + pyarrow (no backend); fully offline via the byte-fallback tokenizer. Skips cleanly
+where pyarrow is absent, mirroring test_corpus.py.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pyarrow")
+
+from src.data.distill_corpus import build_distill_corpus, tokenized_subdir
+from src.data.corpus import ingest_dummy
+from src.data.pack import packing_dtype_for
+from src.data.shard import open_shard, read_manifest
+
+
+def test_tokenized_subdir():
+    # The exact dir name the student manifests reference (config/manifests/student-1b-*.yaml).
+    assert tokenized_subdir("qwen25", 8192) == "qwen25-8k"
+    assert tokenized_subdir("olmo", 1024) == "olmo-1k"
+
+
+def test_qwen25_packs_uint32():
+    # The Qwen2.5 vocab (151,646) exceeds the uint16 ceiling -> uint32 packing (#90). Locks the
+    # uint32 claim without needing the HF tokenizer offline.
+    assert packing_dtype_for(151646) == np.dtype(np.uint32)
+    assert packing_dtype_for(50280) == np.dtype(np.uint16)        # OLMo POC path stays uint16
+
+
+def test_build_distill_corpus_byte_fallback(tmp_path):
+    # End-to-end on synthetic docs, byte fallback (offline). The label is still "qwen25" — the
+    # manifest records the short name, not the (absent) HF repo path.
+    manifest = build_distill_corpus(ingest_dummy(400, seed=1), tmp_path,
+                                    tokenizer="qwen25", byte_fallback=True, seq_len=1024)
+
+    # Stage 1: cleaned Parquet shards exist.
+    cleaned = list((tmp_path / "corpus" / "cleaned").glob("*.parquet"))
+    assert cleaned, "no cleaned text shards written"
+
+    # Stage 2: tokenized shards + sidecars + per-dir manifest under the tokenized prefix.
+    tok_dir = tmp_path / "corpus" / "tokenized" / tokenized_subdir("qwen25", 1024)
+    assert (tok_dir / "manifest.json").exists()
+    assert list(tok_dir.glob("part-*.bin")) and list(tok_dir.glob("part-*.bounds"))
+
+    # Pack manifest records the acceptance fields: tokenizer (short), seq_len, dtype, token count.
+    pack_manifest = read_manifest(tok_dir)
+    assert pack_manifest["tokenizer"] == "qwen25"
+    assert pack_manifest["seq_len"] == 1024
+    assert pack_manifest["dtype"] == "uint16"            # byte fallback vocab 256 -> uint16
+    assert pack_manifest["n_tokens"] > 0
+
+    # Document boundaries present so a downstream reset/atomic-pack consumer can honor them.
+    name = pack_manifest["shards"][0]["name"]
+    toks, bnds = open_shard(tok_dir, name)
+    assert len(toks) == pack_manifest["shards"][0]["n_tokens"]
+    assert int(bnds.sum()) == pack_manifest["n_documents"]   # one flag per emitted doc-start
+
+    # Corpus-level manifest: the two-stage summary, pointing at the tokenized prefix.
+    assert manifest["tokenizer"] == "qwen25" and manifest["byte_fallback"] is True
+    assert manifest["seq_len"] == 1024 and manifest["dtype"] == "uint16"
+    assert manifest["n_tokens"] == pack_manifest["n_tokens"]
+    assert manifest["n_documents"] == pack_manifest["n_documents"]
+    assert manifest["n_cleaned_shards"] == len(cleaned)
+    assert manifest["tokenized_dir"].endswith(tokenized_subdir("qwen25", 1024))
+
+
+def test_seq_len_8k_subdir_matches_manifests(tmp_path):
+    # At the real seq_len the tokenized dir is exactly the path the student manifests name.
+    manifest = build_distill_corpus(ingest_dummy(2000, seed=2), tmp_path,
+                                    tokenizer="qwen25", byte_fallback=True, seq_len=8192)
+    assert manifest["tokenized_dir"].endswith("corpus/tokenized/qwen25-8k")
+
+
+def test_cli_smoke_byte_fallback(tmp_path):
+    # The `python -m src.data.distill_corpus` entrypoint runs offline end to end.
+    out_root = tmp_path / "pd"
+    r = subprocess.run(
+        [sys.executable, "-m", "src.data.distill_corpus", "--source", "dummy",
+         "--max-docs", "300", "--byte-fallback", "--tokenizer", "qwen25",
+         "--seq-len", "1024", "--out-root", str(out_root)],
+        capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    assert "distill corpus:" in r.stdout
+    assert (out_root / "corpus" / "manifest.json").exists()
+    assert (out_root / "corpus" / "tokenized" / "qwen25-1k" / "manifest.json").exists()

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -37,6 +37,7 @@ PORTABLE_MODULES = [
     "src.model.sizing",
     "src.data.loader",
     "src.data.corpus",
+    "src.data.distill_corpus",
     "src.data.filters",
     "src.data.dedup",
     "src.data.blend",


### PR DESCRIPTION
Closes #92

## Summary
- New portable module `src/data/distill_corpus.py` — orchestrates the existing clean → Qwen2.5-tokenize → uint32-pack stages into the `poc-distill/corpus/{cleaned,tokenized/qwen25-8k}` layout the student manifests (`config/manifests/student-1b-*.yaml`) already reference, plus a corpus-level `manifest.json` recording tokenizer / seq_len / dtype / token count — the artifact the teacher logit precompute (#94) freezes against.
- Reuses `corpus.build_corpus`, `shard.pack_sequences`, `tokenize.tokenize_docs`, and `pack.packing_dtype_for` — no new clean/pack logic. Qwen2.5 (vocab 151,646) packs as **uint32** (#90); document boundaries are preserved in the `.bounds` sidecars for the SSM state reset (#68).
- Stays above the hardware seam: pyarrow/transformers are lazy-imported, and the module is added to the import-guard `PORTABLE_MODULES` list.
- One-line pointer added in `docs/design/10-distillation.md` ("Precompute once") to the concrete builder.

Scope deliberately excludes the three-class storage-prefix helper (**#97**, next in queue) and the pod-gated teacher precompute (**#94**).

## Testing
- [x] Tests added/updated — `tests/test_distill_corpus.py` (offline byte-fallback end-to-end + CLI smoke + uint32/subdir unit tests); import guard extended.
- [x] All tests passing — full suite **369 passed, 1 skipped**.
- [x] Manual testing completed — `python -m src.data.distill_corpus --source dummy --byte-fallback ...` produces the full `poc-distill/corpus/` layout + manifests offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)