### PR TITLE
feat(data): [M10] instruct SFT corpus under Qwen ChatML (#95)

### DIFF
--- a/docs/design/11-post-training.md
+++ b/docs/design/11-post-training.md
@@ -68,7 +68,10 @@ References: ReAct, Toolformer, TinyAgent.
 
 The Qwen base defines **`<|im_end|>`** as the chat EOS. Keep it **identical across SFT, RL, and
 serving** — a mismatch degrades the model at serving time. This is a cross-cutting invariant for
-all three layers and the GRPO pass.
+all three layers and the GRPO pass. `src/data/chat_template.py` is the single source of truth for
+the ChatML render + assistant-span masking (the assistant turn is trained up to and including its
+trailing `<|im_end|>`, so the model learns to stop on it); the shared instruct corpus under
+`shared/sft/` is produced by `src/data/instruct_sft.py` (#95).
 
 ## Shared with production
 

--- a/src/data/chat_template.py
+++ b/src/data/chat_template.py
@@ -1,0 +1,96 @@
+"""Qwen ChatML template — the single source of truth for the distillation student's chat
+format (#95), mirroring the role `instruct_format.py` plays for the OLMo POC.
+
+The student shares the **Qwen2.5 tokenizer** with the conversion teacher, so its chat format is
+Qwen **ChatML**:
+
+    <|im_start|>system\\n{system}<|im_end|>\\n
+    <|im_start|>user\\n{user}<|im_end|>\\n
+    <|im_start|>assistant\\n{response}<|im_end|>\\n
+
+**The detail that bites (docs/design/11-post-training.md):** the Qwen base defines `<|im_end|>`
+as the chat EOS. It MUST be identical across SFT, RL, and serving — a mismatch degrades the model
+at serving time. So this module is the one place the format is defined, both the data builders
+(#95/#96) and (later) serving import it, and `response_spans` trains the assistant turn **up to
+and including its trailing `<|im_end|>`** so the model learns to stop on it. No separate
+`eos_token_id` is appended — `<|im_end|>` already plays that role (and for Qwen2.5 it *is* the
+`eos_token_id`, id 151645).
+
+Unlike `instruct_format` (newline-free, because the pretraining corpus is one-doc-per-line and
+appends EOS per line), ChatML is multi-line — that is fine here because SFT records are stored as
+token-id lists (`src/data/sft_loader.py`), not as corpus text lines, so internal newlines are
+encoded into ids rather than read back as document boundaries.
+
+Portable: pure string formatting + the injected tokenizer's `encode`; no `mlx`/`torch`, no HF
+dependency (works with `tokenize.ByteTokenizer` offline).
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+IM_START = "<|im_start|>"
+IM_END = "<|im_end|>"
+#: The Qwen chat EOS — the cross-cutting SFT == RL == serving invariant (see module docstring).
+CHAT_EOS = IM_END
+
+_ROLES = ("system", "user", "assistant")
+
+
+def _render_turn(role: str, content: str) -> str:
+    """One ChatML turn: `<|im_start|>{role}\\n{content}<|im_end|>` (content stripped)."""
+    if role not in _ROLES:
+        raise ValueError(f"unknown chat role {role!r} (expected one of {_ROLES})")
+    return f"{IM_START}{role}\n{content.strip()}{IM_END}"
+
+
+def render(messages: List[dict], *, add_generation_prompt: bool = False) -> str:
+    """Render a conversation to one ChatML string.
+
+    `messages` is `[{"role": "system"|"user"|"assistant", "content": str}, ...]`; turns are joined
+    by newlines. With `add_generation_prompt=True` the string ends at `<|im_start|>assistant\\n`
+    (the open turn the model continues from at serving time) — the exact prefix that the matching
+    `response_spans` assistant span begins after.
+    """
+    parts = [_render_turn(m["role"], m["content"]) for m in messages]
+    text = "\n".join(parts)
+    if add_generation_prompt:
+        text = (text + "\n" if text else text) + f"{IM_START}assistant\n"
+    return text
+
+
+def _encode(tokenizer, text: str) -> List[int]:
+    """Encode without auto-added specials (HF appends BOS/EOS otherwise); `ByteTokenizer.encode`
+    takes no kwargs, hence the fallback. Literal `<|im_*|>` strings still map to their special
+    token ids on a real Qwen tokenizer (that flag governs auto-added specials, not recognition)."""
+    try:
+        return tokenizer.encode(text, add_special_tokens=False)
+    except TypeError:
+        return tokenizer.encode(text)
+
+
+def response_spans(messages: List[dict], tokenizer) -> Tuple[List[int], List[Tuple[int, int]]]:
+    """Tokenize `render(messages)` and return `(full_ids, spans)` where each span is a half-open
+    `[start, end)` token range covering one assistant turn's **content plus its trailing
+    `<|im_end|>`** — so SFT trains the answer *and* the stop token, but never the
+    `<|im_start|>assistant\\n` header or any user/system text.
+
+    Spans are found by tokenizing growing prefixes of the *same* rendered string and diffing their
+    lengths, so the indices line up with `full_ids` even though BPE boundaries do not coincide with
+    character boundaries (the same technique as `instruct_format.response_spans`).
+    """
+    full = render(messages)
+    full_ids = _encode(tokenizer, full)
+    spans: List[Tuple[int, int]] = []
+    prefix = ""
+    for m in messages:
+        turn = _render_turn(m["role"], m["content"])
+        sep = "\n" if prefix else ""
+        if m["role"] == "assistant" and m["content"].strip():
+            # Span starts after the `<|im_start|>assistant\n` header, ends after `<|im_end|>`.
+            header = prefix + sep + f"{IM_START}assistant\n"
+            start = len(_encode(tokenizer, header))
+            end = len(_encode(tokenizer, prefix + sep + turn))
+            spans.append((start, end))
+        prefix = prefix + sep + turn
+    return full_ids, spans

--- a/src/data/instruct_sft.py
+++ b/src/data/instruct_sft.py
@@ -1,0 +1,196 @@
+"""Build the shared **instruct SFT corpus** under the Qwen chat template (#95).
+
+Phase-1 shared artifact (docs/design/11-post-training.md): general instruction->response pairs
+rendered under Qwen **ChatML** (`src/data/chat_template.py`) with the assistant spans masked for
+loss, written as the two-artifact `shared/sft/` layout the student manifests reference:
+
+    <out_root>/sft/
+        cleaned/instruct/records.jsonl              # tokenizer-agnostic {messages,source,license}
+        tokenized/qwen25-8k/instruct.jsonl          # response-masked {input_ids,target_ids,loss_mask}
+        tokenized/qwen25-8k/manifest.json           # tokenizer, template, chat_eos, counts
+
+The cleaned rows are durable + re-tokenizable; the tokenized records drop straight into the M9
+`SFTLoader` / `make_sft_train_step` the instruct SFT layer (#101) reuses. The chat EOS is
+`<|im_end|>`, trained as the stop token and kept identical to serving (the invariant in
+`chat_template`).
+
+ABOVE THE SEAM — no `mlx`/`torch`. Reuses the clean-license loaders in `sft_sources` and the
+message-normalizer in `sft_data`; `datasets` is imported lazily by those loaders. Offline path:
+the checked-in `handauthored` set + `--byte-fallback`.
+
+CLI (mirrors sft_sources):
+    # offline smoke:
+    python -m src.data.instruct_sft --sources handauthored --byte-fallback --out-root /tmp/shared
+    # real run (HF Qwen2.5 tokenizer + datasets):
+    python -m src.data.instruct_sft --sources oasst1 flan handauthored --tokenizer qwen25
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional
+
+from . import chat_template
+from .distill_corpus import tokenized_subdir
+from .sft_data import _messages_of
+
+
+def build_chat_sft_records(rows: Iterable[dict], tokenizer, *, max_seq_len: Optional[int] = 8192,
+                           stats: Optional[dict] = None) -> Iterator[dict]:
+    """Yield `{input_ids, target_ids, loss_mask}` records from chat rows, masked to the assistant
+    turns under the Qwen chat template. Mirrors `sft_data.build_sft_records` but renders ChatML and
+    appends **no** extra EOS — `<|im_end|>` is already the last token of each assistant span and is
+    trained as the stop token. Rows whose tokenized length exceeds `max_seq_len` are dropped
+    (truncating a response would teach the model to stop mid-answer)."""
+    vocab = getattr(tokenizer, "vocab_size", None)
+    for rec in rows:
+        messages = _messages_of(rec)
+        out = _record_from_messages(messages, tokenizer, max_seq_len, vocab)
+        if out is None:
+            if stats is not None:
+                stats["skipped"] = stats.get("skipped", 0) + 1
+            continue
+        if stats is not None:
+            stats["kept"] = stats.get("kept", 0) + 1
+        yield out
+
+
+def _record_from_messages(messages: List[dict], tokenizer, max_seq_len: Optional[int],
+                          vocab: Optional[int]) -> Optional[dict]:
+    """One masked record, or None to skip (no assistant content / over length)."""
+    if not messages or messages[-1]["role"] != "assistant":
+        return None
+    seq, spans = chat_template.response_spans(messages, tokenizer)
+    if not spans:
+        return None
+    if max_seq_len is not None and len(seq) - 1 > max_seq_len:
+        return None
+    if vocab is not None and seq and max(seq) >= vocab:
+        raise ValueError(
+            f"token id {max(seq)} >= tokenizer vocab_size {vocab} — wrong tokenizer?")
+
+    # mask[j] == 1 iff target_ids[j] (= seq[j+1]) is an assistant-span token (content + <|im_end|>).
+    mask = [0] * (len(seq) - 1)
+    for s, e in spans:
+        for j in range(max(0, s - 1), min(e - 1, len(mask))):
+            mask[j] = 1
+    if not any(mask):
+        return None
+    return {"input_ids": seq[:-1], "target_ids": seq[1:], "loss_mask": mask}
+
+
+def _write_cleaned(rows: Iterable[dict], path: Path) -> List[dict]:
+    """Write the tokenizer-agnostic `{messages, source, license}` rows as JSONL; return them
+    (materialized so they can be re-iterated for tokenization)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    kept: List[dict] = []
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        for rec in rows:
+            messages = _messages_of(rec)
+            if not messages or messages[-1]["role"] != "assistant":
+                continue
+            row = {"messages": messages, "source": rec.get("source", "unknown"),
+                   "license": rec.get("license", "unknown")}
+            f.write(json.dumps(row) + "\n")
+            kept.append(row)
+    return kept
+
+
+def _load_tokenizer(tokenizer: str, model_id: Optional[str], byte_fallback: bool):
+    from .tokenize import (ByteTokenizer, load_olmo_tokenizer, load_qwen25_tokenizer,
+                           load_starcoder2_tokenizer)
+    if byte_fallback:
+        return ByteTokenizer()
+    loaders = {"qwen25": load_qwen25_tokenizer, "olmo": load_olmo_tokenizer,
+               "starcoder2": load_starcoder2_tokenizer}
+    return loaders[tokenizer](model_id)
+
+
+def build_instruct_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwen25",
+                       model_id: Optional[str] = None, seq_len: int = 8192,
+                       byte_fallback: bool = False, max_seq_len: int = 8192) -> dict:
+    """Build the shared instruct SFT corpus end to end: write cleaned chat rows, then tokenize +
+    response-mask them under the Qwen chat template into the `shared/sft/tokenized/<tok>-<k>` prefix
+    with a manifest. Returns the manifest dict."""
+    out_root = Path(out_root)
+    sft_root = out_root / "sft"
+    cleaned_path = sft_root / "cleaned" / "instruct" / "records.jsonl"
+    tok_dir = sft_root / "tokenized" / tokenized_subdir(tokenizer, seq_len)
+    tokenized_path = tok_dir / "instruct.jsonl"
+
+    cleaned_rows = _write_cleaned(rows, cleaned_path)
+
+    tok = _load_tokenizer(tokenizer, model_id, byte_fallback)
+    tok_dir.mkdir(parents=True, exist_ok=True)
+    stats: dict = {}
+    n_tokens = 0
+    sources: dict = {}
+    with open(tokenized_path, "w", encoding="utf-8", newline="\n") as f:
+        for row, out in _records_with_source(cleaned_rows, tok, max_seq_len, stats):
+            f.write(json.dumps(out) + "\n")
+            n_tokens += len(out["input_ids"])
+            sources[row["source"]] = sources.get(row["source"], 0) + 1
+
+    manifest = {
+        "tokenizer": tokenizer,
+        "model_id": getattr(tok, "name_or_path", None) if not byte_fallback else None,
+        "byte_fallback": byte_fallback,
+        "template": "qwen-chatml",
+        "chat_eos": chat_template.CHAT_EOS,
+        "seq_len": seq_len,
+        "max_seq_len": max_seq_len,
+        "n_records": stats.get("kept", 0),
+        "n_skipped": stats.get("skipped", 0),
+        "n_tokens": n_tokens,
+        "sources": sources,
+        "cleaned_path": str(cleaned_path),
+        "tokenized_path": str(tokenized_path),
+    }
+    (tok_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return manifest
+
+
+def _records_with_source(cleaned_rows: List[dict], tok, max_seq_len: int, stats: dict):
+    """Yield `(cleaned_row, masked_record)` for rows that survive masking — pairs the kept record
+    with its source row so per-source counts stay accurate."""
+    vocab = getattr(tok, "vocab_size", None)
+    for row in cleaned_rows:
+        out = _record_from_messages(row["messages"], tok, max_seq_len, vocab)
+        if out is None:
+            stats["skipped"] = stats.get("skipped", 0) + 1
+            continue
+        stats["kept"] = stats.get("kept", 0) + 1
+        yield row, out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    from .sft_sources import iter_clean_sft, _LOADERS
+    ap.add_argument("--sources", nargs="+", default=["handauthored"],
+                    choices=tuple(_LOADERS), help="clean-license SFT sources to include")
+    ap.add_argument("--out-root", type=Path, default=Path("data/shared"),
+                    help="root for the shared prefix (writes <root>/sft/...)")
+    ap.add_argument("--tokenizer", choices=("qwen25", "olmo", "starcoder2"), default="qwen25")
+    ap.add_argument("--model-id", default=None)
+    ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--seq-len", type=int, default=8192, help="tokenized-prefix dir width (qwen25-8k)")
+    ap.add_argument("--max-seq-len", type=int, default=8192,
+                    help="drop examples longer than this (truncation would teach mid-answer stops)")
+    ap.add_argument("--max-per-source", type=int, default=None)
+    args = ap.parse_args()
+
+    rows = iter_clean_sft(args.sources, max_per_source=args.max_per_source)
+    manifest = build_instruct_sft(rows, args.out_root, tokenizer=args.tokenizer,
+                                  model_id=args.model_id, seq_len=args.seq_len,
+                                  byte_fallback=args.byte_fallback, max_seq_len=args.max_seq_len)
+    print(f"instruct sft: {manifest['n_records']} records ({manifest['n_skipped']} skipped, "
+          f"{manifest['n_tokens']} tokens, template={manifest['template']}, "
+          f"chat_eos={manifest['chat_eos']}, sources={manifest['sources']}) "
+          f"-> {manifest['tokenized_path']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -46,6 +46,8 @@ PORTABLE_MODULES = [
     "src.data.split",
     "src.data.download",
     "src.data.instruct_format",
+    "src.data.chat_template",
+    "src.data.instruct_sft",
     "src.data.sft_data",
     "src.data.sft_loader",
     "src.data.sft_sources",

--- a/tests/test_instruct_sft.py
+++ b/tests/test_instruct_sft.py
@@ -1,0 +1,62 @@
+"""Shared instruct SFT corpus driver (#95): builds the response-masked Qwen-ChatML records under
+the `shared/sft/` prefix. Offline via the checked-in handauthored set + ByteTokenizer (no backend,
+no network).
+"""
+
+import json
+
+from src.data.chat_template import IM_END
+from src.data.instruct_sft import build_chat_sft_records, build_instruct_sft
+from src.data.sft_sources import handauthored_records
+from src.data.sft_loader import SFTLoader
+from src.data.tokenize import ByteTokenizer
+
+
+def test_build_chat_sft_records_masks_only_assistant():
+    tok = ByteTokenizer()
+    rows = [{"messages": [{"role": "user", "content": "ping"},
+                          {"role": "assistant", "content": "pong"}]}]
+    recs = list(build_chat_sft_records(rows, tok))
+    assert len(recs) == 1
+    rec = recs[0]
+    assert len(rec["input_ids"]) == len(rec["target_ids"]) == len(rec["loss_mask"])
+    # The trained targets decode to exactly the assistant content + <|im_end|> (no extra EOS).
+    trained = [rec["target_ids"][j] for j in range(len(rec["loss_mask"])) if rec["loss_mask"][j]]
+    # Includes the trailing <|im_end|> (the chat EOS) so the model learns to stop, and no extra EOS.
+    assert tok.decode(trained) == f"pong{IM_END}"
+
+
+def test_over_length_examples_dropped():
+    tok = ByteTokenizer()
+    rows = [{"messages": [{"role": "user", "content": "x"},
+                          {"role": "assistant", "content": "y" * 500}]}]
+    assert list(build_chat_sft_records(rows, tok, max_seq_len=50)) == []
+
+
+def test_build_instruct_sft_end_to_end(tmp_path):
+    manifest = build_instruct_sft(handauthored_records(), tmp_path,
+                                  tokenizer="qwen25", byte_fallback=True, seq_len=8192)
+
+    # Two-artifact layout under shared/sft/.
+    cleaned = tmp_path / "sft" / "cleaned" / "instruct" / "records.jsonl"
+    tok_dir = tmp_path / "sft" / "tokenized" / "qwen25-8k"
+    assert cleaned.exists()
+    assert (tok_dir / "instruct.jsonl").exists() and (tok_dir / "manifest.json").exists()
+
+    # Cleaned rows are tokenizer-agnostic {messages, source, license}.
+    first = json.loads(cleaned.read_text().splitlines()[0])
+    assert "messages" in first and "source" in first and "license" in first
+
+    # Manifest records the documented fields incl. the chat-EOS convention.
+    assert manifest["template"] == "qwen-chatml"
+    assert manifest["chat_eos"] == IM_END
+    assert manifest["tokenizer"] == "qwen25"
+    assert manifest["n_records"] == len(list(handauthored_records()))
+    assert manifest["n_tokens"] > 0
+    assert manifest["sources"].get("handauthored") == manifest["n_records"]
+
+    # Tokenized records drop straight into the M9 SFTLoader (same shape).
+    loader = SFTLoader(tok_dir / "instruct.jsonl", seq_len=8192, batch_size=2)
+    inputs, targets, mask = next(loader.epoch())
+    assert inputs.shape == targets.shape == mask.shape
+    assert mask.sum() > 0

--- a/tests/test_qwen_chat_template.py
+++ b/tests/test_qwen_chat_template.py
@@ -1,0 +1,72 @@
+"""Qwen ChatML template (#95): render + response-span masking — the single source of truth for
+the distillation student's chat format (distinct from the OLMo `instruct_format` covered by
+tests/test_chat_template.py). Pure stdlib + the offline ByteTokenizer (no backend).
+"""
+
+from src.data import chat_template
+from src.data.chat_template import IM_END, IM_START, render, response_spans
+from src.data.tokenize import ByteTokenizer
+
+
+def test_render_chatml_shape():
+    msgs = [{"role": "system", "content": "be terse"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"}]
+    out = render(msgs)
+    assert out == (f"{IM_START}system\nbe terse{IM_END}\n"
+                   f"{IM_START}user\nhi{IM_END}\n"
+                   f"{IM_START}assistant\nhello{IM_END}")
+
+
+def test_render_generation_prompt():
+    out = render([{"role": "user", "content": "hi"}], add_generation_prompt=True)
+    assert out.endswith(f"{IM_START}assistant\n")
+    assert IM_END in out and out.count(f"{IM_START}assistant") == 1
+
+
+def test_response_span_covers_content_and_im_end_only():
+    tok = ByteTokenizer()
+    msgs = [{"role": "user", "content": "ping"},
+            {"role": "assistant", "content": "pong"}]
+    full_ids, spans = response_spans(msgs, tok)
+    assert len(spans) == 1
+    s, e = spans[0]
+    # The span decodes to exactly the assistant content + its trailing <|im_end|> stop token —
+    # nothing else (no <|im_start|>assistant header, no user text).
+    assert tok.decode(full_ids[s:e]) == f"pong{IM_END}"
+    assert e == len(full_ids)
+
+
+def test_full_ids_reconstruct_the_render():
+    tok = ByteTokenizer()
+    msgs = [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}]
+    full_ids, _ = response_spans(msgs, tok)
+    assert tok.decode(full_ids) == render(msgs)
+
+
+def test_multi_turn_spans_line_up_and_exclude_user():
+    tok = ByteTokenizer()
+    msgs = [{"role": "user", "content": "a"},
+            {"role": "assistant", "content": "b"},
+            {"role": "user", "content": "c"},
+            {"role": "assistant", "content": "d"}]
+    full_ids, spans = response_spans(msgs, tok)
+    assert len(spans) == 2
+    assert tok.decode(full_ids[spans[0][0]:spans[0][1]]) == f"b{IM_END}"
+    assert tok.decode(full_ids[spans[1][0]:spans[1][1]]) == f"d{IM_END}"
+    assert spans[0][1] <= spans[1][0]                 # disjoint; "c" falls between them
+    # No user content is ever inside a span.
+    off = [full_ids[i] for i in range(len(full_ids))
+           if not any(s <= i < e for s, e in spans)]
+    assert "c" in tok.decode(off) and "a" in tok.decode(off)
+
+
+def test_empty_assistant_turn_yields_no_span():
+    tok = ByteTokenizer()
+    _, spans = response_spans([{"role": "user", "content": "hi"},
+                               {"role": "assistant", "content": ""}], tok)
+    assert spans == []
+
+
+def test_chat_eos_is_im_end():
+    assert chat_template.CHAT_EOS == IM_END == "<|im_end|>"


### PR DESCRIPTION
Closes #95

## Summary
- New `src/data/chat_template.py` — the **single source of truth** for the distillation student's Qwen **ChatML** format. `render()` emits `<|im_start|>{role}\n{content}<|im_end|>`; `response_spans()` masks each assistant turn **up to and including its trailing `<|im_end|>`**, so the model learns to stop on the chat EOS. No separate `eos_token_id` is appended — `<|im_end|>` *is* the chat EOS (the cross-cutting SFT == RL == serving invariant in `docs/design/11-post-training.md`). Mirrors the anti-drift pattern of `instruct_format.py` (OLMo) and is offline-testable via `ByteTokenizer`.
- New `src/data/instruct_sft.py` — driver writing the two-artifact `shared/sft/` layout: `cleaned/instruct/records.jsonl` (tokenizer-agnostic `{messages}`) + `tokenized/qwen25-8k/instruct.jsonl` (`{input_ids,target_ids,loss_mask}`, drop-in for the M9 `SFTLoader`) + `manifest.json` (tokenizer / template / chat_eos / counts). Reuses the `sft_sources` clean-license loaders and `sft_data._messages_of`.
- Both modules stay above the hardware seam (lazy `datasets`/`transformers` imports; added to import-guard `PORTABLE_MODULES`).
- This is the reusable Qwen chat substrate that **#96** (reasoning-trace `<think>`/`<answer>` SFT, next in queue) extends.

Scope excludes the instruct SFT *training run* (**#101**), serving-side template migration, and real HF dataset curation (user-driven) — this lands the buildable + unit-tested pipeline with the checked-in `handauthored` set as the offline default.

## Testing
- [x] Tests added — `tests/test_qwen_chat_template.py` (render + span masking; distinct from the existing OLMo `test_chat_template.py`) and `tests/test_instruct_sft.py` (masking + end-to-end + `SFTLoader` drop-in); import guard extended.
- [x] All tests passing — full suite **379 passed, 1 skipped**.
- [x] Manual testing — `python -m src.data.instruct_sft --sources handauthored --byte-fallback ...` produces the full `shared/sft/` layout + manifest offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)