### PR TITLE
feat(data): [M10] reasoning-trace SFT corpus (<think>/<answer>) (#96)

### DIFF
--- a/docs/design/11-post-training.md
+++ b/docs/design/11-post-training.md
@@ -38,7 +38,14 @@ FLAN, DPO.
 (#96), then GRPO with verifiable rewards as polish (#103). The primary trace corpus is open-r1
 **Mixture-of-Thoughts** (~350k verified math/code/science traces distilled from R1, already on the
 Qwen tokenizer), topped up from a larger R1 distill (14B/32B) only where coverage is thin. **Trace
-SFT is the main event.** GSM8K + MATH and code-with-executable-tests supply the GRPO rewards and
+SFT is the main event.**
+
+`src/data/reasoning_sft.py` builds the corpus under `shared/sft/cleaned/reasoning-traces/` +
+`shared/sft/tokenized/qwen25-8k/` (`reasoning_traces.py` does the `<think>/<answer>` formatting and
+the Mixture-of-Thoughts / `load_topup` sources). It writes **two** forms: `reasoning.jsonl`
+(response-masked records for `SFTLoader`) and `reasoning-packed/` — the long 8K packing where each
+trace is one chunk-aligned document, so **no trace spans a sequence boundary** and `.bounds` marks
+each start for the SSM reset (#68); over-length traces are dropped, never split. GSM8K + MATH and code-with-executable-tests supply the GRPO rewards and
 evaluation; the [open-r1](https://github.com/huggingface/open-r1) harness provides GRPO with
 code-execution rewards and 1.5B configs that adapt directly. References: Chain-of-Thought,
 DeepSeek-R1.

--- a/src/data/reasoning_sft.py
+++ b/src/data/reasoning_sft.py
@@ -1,0 +1,196 @@
+"""Build the shared **reasoning-trace SFT corpus** (#96) — the thinking layer's data.
+
+`<think>`/`<answer>`-formatted traces (`src/data/reasoning_traces.py`) rendered under the Qwen
+chat template, written as the `shared/sft/` layout, in two complementary forms:
+
+    <out_root>/sft/
+        cleaned/reasoning-traces/records.jsonl        # tokenizer-agnostic {messages,source,license}
+        tokenized/qwen25-8k/
+            reasoning.jsonl                           # masked {input_ids,target_ids,loss_mask} (SFTLoader)
+            reasoning-packed/                         # the atomic 8K packing (the #96 deliverable)
+                part-*.bin   uint32 trace tokens
+                part-*.bounds  doc-start flags (SSM reset, #68)
+                manifest.json
+            reasoning-manifest.json                   # summary across both forms
+
+The **masked JSONL** is the trainable artifact (drop-in for the M9 `SFTLoader` /
+`make_sft_train_step`); the **packed** form is the "long 8K packing with document boundaries
+marked for reset" #96 asks to store: each trace is one document, padded to a `chunk_align`
+multiple so it starts on a chunk boundary and **no trace spans a sequence boundary** — verifiable
+via `n_documents == kept traces` and chunk-aligned `.bounds`. Over-length traces (> `seq_len`) are
+**dropped, never truncated** (truncating teaches mid-reasoning stops).
+
+Unlike the instruct corpus, reasoning content is **not** whitespace-collapsed — the `<think>`
+trace keeps its internal newlines (SFT records store token ids, so newlines are encoded, not read
+back as document boundaries). It therefore masks the already-clean `reasoning_traces` messages
+directly via `chat_template.response_spans` (the same assistant-span masking as #95), computing the
+spans once and reusing them for both the masked record and the packed document.
+
+ABOVE THE SEAM — no `mlx`/`torch`. Reuses `chat_template`, `instruct_sft`, and `shard`; `datasets`
+is lazy inside the loaders. Offline path: the checked-in handauthored traces + `--byte-fallback`.
+
+CLI:
+    python -m src.data.reasoning_sft --sources handauthored --byte-fallback --out-root /tmp/shared
+    python -m src.data.reasoning_sft --sources mot --tokenizer qwen25         # real run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from . import chat_template
+from .distill_corpus import tokenized_subdir
+
+
+def _valid_rows(rows: Iterable[dict]) -> List[dict]:
+    """Keep `{messages, source, license}` rows ending in a non-empty assistant turn (no whitespace
+    collapse — reasoning traces keep their newlines)."""
+    out: List[dict] = []
+    for rec in rows:
+        messages = rec.get("messages")
+        if not messages or messages[-1].get("role") != "assistant" \
+                or not (messages[-1].get("content") or "").strip():
+            continue
+        out.append({"messages": [dict(m) for m in messages],
+                    "source": rec.get("source", "unknown"),
+                    "license": rec.get("license", "unknown")})
+    return out
+
+
+def _load_tokenizer(tokenizer: str, model_id: Optional[str], byte_fallback: bool):
+    from .tokenize import (ByteTokenizer, load_olmo_tokenizer, load_qwen25_tokenizer,
+                           load_starcoder2_tokenizer)
+    if byte_fallback:
+        return ByteTokenizer()
+    loaders = {"qwen25": load_qwen25_tokenizer, "olmo": load_olmo_tokenizer,
+               "starcoder2": load_starcoder2_tokenizer}
+    return loaders[tokenizer](model_id)
+
+
+def build_reasoning_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwen25",
+                        model_id: Optional[str] = None, seq_len: int = 8192,
+                        chunk_align: int = 64, byte_fallback: bool = False) -> dict:
+    """Build the reasoning-trace SFT corpus: cleaned rows, masked JSONL records, and the atomic
+    chunk-aligned packed `.bin`/`.bounds` artifact. Returns the summary manifest dict."""
+    from .pack import packing_dtype_for
+    from .shard import pack_atomic
+
+    out_root = Path(out_root)
+    sft_root = out_root / "sft"
+    cleaned_path = sft_root / "cleaned" / "reasoning-traces" / "records.jsonl"
+    tok_dir = sft_root / "tokenized" / tokenized_subdir(tokenizer, seq_len)
+    masked_path = tok_dir / "reasoning.jsonl"
+    packed_dir = tok_dir / "reasoning-packed"
+
+    valid = _valid_rows(rows)
+
+    # Cleaned (tokenizer-agnostic) — newlines preserved.
+    cleaned_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(cleaned_path, "w", encoding="utf-8", newline="\n") as f:
+        for row in valid:
+            f.write(json.dumps(row) + "\n")
+
+    tok = _load_tokenizer(tokenizer, model_id, byte_fallback)
+    dtype = packing_dtype_for(tok.vocab_size)          # uint16 (byte) / uint32 (Qwen2.5)
+    vocab = getattr(tok, "vocab_size", None)
+
+    # Masked JSONL records + the per-trace token streams for atomic packing (kept in lockstep, so
+    # the packed documents are exactly the traces that survived masking + the length cap).
+    tok_dir.mkdir(parents=True, exist_ok=True)
+    n_records = n_tokens = 0
+    n_overlength = 0
+    sources: dict = {}
+    trace_id_lists: List[List[int]] = []
+    with open(masked_path, "w", encoding="utf-8", newline="\n") as f:
+        for row in valid:
+            # Tokenize + find assistant spans once; reuse for the masked record AND the packed doc.
+            full_ids, spans = chat_template.response_spans(row["messages"], tok)
+            if not spans:
+                continue
+            # A trace must fit in one sequence to be packed atomically. Use the SAME chunk-aligned
+            # length the packer will use, so the masked and packed sets are identical (dropped, not
+            # split, when over length — truncating would teach mid-reasoning stops).
+            padded_len = -(-len(full_ids) // chunk_align) * chunk_align
+            if padded_len > seq_len:
+                n_overlength += 1
+                continue
+            if vocab is not None and full_ids and max(full_ids) >= vocab:
+                raise ValueError(
+                    f"token id {max(full_ids)} >= tokenizer vocab_size {vocab} — wrong tokenizer?")
+            mask = [0] * (len(full_ids) - 1)
+            for s, e in spans:
+                for j in range(max(0, s - 1), min(e - 1, len(mask))):
+                    mask[j] = 1
+            if not any(mask):
+                continue
+            rec = {"input_ids": full_ids[:-1], "target_ids": full_ids[1:], "loss_mask": mask}
+            f.write(json.dumps(rec) + "\n")
+            n_records += 1
+            n_tokens += len(rec["input_ids"])
+            sources[row["source"]] = sources.get(row["source"], 0) + 1
+            # One document per trace = the full rendered ChatML ids (atomic unit for packing).
+            trace_id_lists.append(full_ids)
+
+    # Atomic packed artifact: each trace a chunk-aligned document that fits in one sequence, so
+    # none spans a sequence boundary (every kept trace was pre-filtered to padded_len <= seq_len,
+    # so pack_atomic drops nothing -> n_documents == n_masked_records).
+    pack_manifest = pack_atomic(trace_id_lists, packed_dir, seq_len=seq_len,
+                                chunk_align=chunk_align, tokenizer=tokenizer, dtype=dtype)
+
+    manifest = {
+        "tokenizer": tokenizer,
+        "model_id": getattr(tok, "name_or_path", None) if not byte_fallback else None,
+        "byte_fallback": byte_fallback,
+        "template": "qwen-chatml",
+        "format": "think-answer",
+        "chat_eos": chat_template.CHAT_EOS,
+        "seq_len": seq_len,
+        "chunk_align": chunk_align,
+        "n_traces": len(valid),
+        "n_masked_records": n_records,
+        "n_overlength_dropped": n_overlength,
+        "n_tokens": n_tokens,
+        "packed_n_documents": pack_manifest["n_documents"],
+        "packed_n_sequences": pack_manifest["n_sequences"],
+        "sources": sources,
+        "cleaned_path": str(cleaned_path),
+        "masked_path": str(masked_path),
+        "packed_dir": str(packed_dir),
+    }
+    (tok_dir / "reasoning-manifest.json").write_text(json.dumps(manifest, indent=2))
+    return manifest
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    from .reasoning_traces import _LOADERS, iter_reasoning_traces
+    ap.add_argument("--sources", nargs="+", default=["handauthored"],
+                    choices=tuple(_LOADERS), help="reasoning-trace sources (handauthored / mot)")
+    ap.add_argument("--out-root", type=Path, default=Path("data/shared"))
+    ap.add_argument("--tokenizer", choices=("qwen25", "olmo", "starcoder2"), default="qwen25")
+    ap.add_argument("--model-id", default=None)
+    ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
+    ap.add_argument("--seq-len", type=int, default=8192,
+                    help="atomic-packing sequence length; traces longer than this are dropped")
+    ap.add_argument("--chunk-align", type=int, default=64,
+                    help="pad each trace to this multiple (the model chunk_size) so it starts on a "
+                         "chunk boundary for the SSM reset (#68)")
+    ap.add_argument("--max-per-source", type=int, default=None)
+    args = ap.parse_args()
+
+    rows = iter_reasoning_traces(args.sources, max_per_source=args.max_per_source)
+    m = build_reasoning_sft(rows, args.out_root, tokenizer=args.tokenizer, model_id=args.model_id,
+                            seq_len=args.seq_len, chunk_align=args.chunk_align,
+                            byte_fallback=args.byte_fallback)
+    print(f"reasoning sft: {m['n_masked_records']} masked records "
+          f"({m['n_overlength_dropped']} over-length dropped, {m['n_tokens']} tokens), "
+          f"packed {m['packed_n_documents']} traces atomically x{m['seq_len']} "
+          f"(chunk_align={m['chunk_align']}, sources={m['sources']}) -> {m['masked_path']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/reasoning_traces.py
+++ b/src/data/reasoning_traces.py
@@ -1,0 +1,157 @@
+"""Reasoning-trace sources + `<think>`/`<answer>` formatting (#96) — the headline skill's data.
+
+A reasoning trace is rendered as an assistant turn whose content is the chain of thought wrapped
+in `<think>...</think>` followed by the final `<answer>...</answer>` (docs/design/11-post-training.md).
+The trace is the assistant *content*, so it flows through the Qwen ChatML masker
+(`src/data/chat_template.py` / `src/data/instruct_sft.build_chat_sft_records`) unchanged — the
+`<think>`/`<answer>` spans are trained and the turn ends on `<|im_end|>`.
+
+Primary corpus: open-r1 **Mixture-of-Thoughts** (~350k verified math/code/science traces distilled
+from R1, already on the Qwen tokenizer). **Top-up path:** where coverage is thin, generate more
+traces with a larger DeepSeek-R1-Distill-Qwen model (14B/32B — the trace-generation teacher) and
+ingest them through `load_topup`; traces are re-tokenized, so the generator is unconstrained.
+
+ABOVE THE SEAM — stdlib only; `datasets` is imported lazily inside the HF loaders. Offline path:
+the checked-in `handauthored` trace set (always available, no network).
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator, List, Optional
+
+THINK_OPEN, THINK_CLOSE = "<think>", "</think>"
+ANSWER_OPEN, ANSWER_CLOSE = "<answer>", "</answer>"
+
+# Source -> license (clean-license accounting; MoT is ODC-BY / Apache-mixed, flagged).
+SOURCE_LICENSES = {"mot": "odc-by", "topup": "generated", "handauthored": "cc0"}
+
+
+def format_trace(reasoning: str, answer: str) -> str:
+    """The assistant content for one reasoning trace:
+    `<think>\\n{reasoning}\\n</think>\\n<answer>\\n{answer}\\n</answer>`."""
+    reasoning, answer = reasoning.strip(), answer.strip()
+    return (f"{THINK_OPEN}\n{reasoning}\n{THINK_CLOSE}\n"
+            f"{ANSWER_OPEN}\n{answer}\n{ANSWER_CLOSE}")
+
+
+def _tag(messages: List[dict], source: str) -> dict:
+    return {"messages": messages, "source": source,
+            "license": SOURCE_LICENSES.get(source, "unknown")}
+
+
+def trace_to_messages(question: str, reasoning: str, answer: str, *,
+                      system: Optional[str] = None, source: str = "handauthored") -> dict:
+    """A `{messages, source, license}` row: optional system, the user `question`, and an assistant
+    turn whose content is `format_trace(reasoning, answer)`. The chat-template masker then trains
+    only that assistant turn."""
+    messages: List[dict] = []
+    if system:
+        messages.append({"role": "system", "content": system.strip()})
+    messages.append({"role": "user", "content": question.strip()})
+    messages.append({"role": "assistant", "content": format_trace(reasoning, answer)})
+    return _tag(messages, source)
+
+
+def mot_row_to_messages(row: dict, source: str = "mot") -> Optional[dict]:
+    """Map a Mixture-of-Thoughts row into a tagged trace row, or None to skip.
+
+    MoT rows carry a chat `messages` list (the assistant turn already contains the R1-style
+    `<think>...</think>` trace); we pass those through, normalizing roles/content and tagging the
+    source. Falls back to a `problem`/`solution` (or `question`/`answer`) pair, wrapping the
+    solution as the answer when no explicit reasoning field is present."""
+    msgs = row.get("messages")
+    if isinstance(msgs, (list, tuple)):
+        out: List[dict] = []
+        for m in msgs:
+            role = m.get("role")
+            content = (m.get("content") or "").strip()
+            if role in ("system", "user", "assistant") and content:
+                out.append({"role": role, "content": content})
+        if out and out[0]["role"] in ("system", "user") and out[-1]["role"] == "assistant":
+            return _tag(out, source)
+        return None
+    question = (row.get("problem") or row.get("question") or "").strip()
+    reasoning = (row.get("reasoning") or row.get("think") or "").strip()
+    answer = (row.get("solution") or row.get("answer") or "").strip()
+    if not question or not answer:
+        return None
+    return trace_to_messages(question, reasoning, answer, source=source)
+
+
+def load_mixture_of_thoughts(split: str = "train", max_examples: Optional[int] = None,
+                             config: Optional[str] = None) -> Iterator[dict]:
+    """Stream open-r1/Mixture-of-Thoughts and map rows to tagged trace rows (lazy `datasets`)."""
+    from datasets import load_dataset  # pragma: no cover - network/optional extra
+
+    ds = load_dataset("open-r1/Mixture-of-Thoughts", config, split=split, streaming=True)
+    n = 0
+    for row in ds:
+        rec = mot_row_to_messages(row, source="mot")
+        if rec is None:
+            continue
+        yield rec
+        n += 1
+        if max_examples is not None and n >= max_examples:
+            break
+
+
+def load_topup(dataset: str, split: str = "train",
+               max_examples: Optional[int] = None) -> Iterator[dict]:
+    """Top-up path: stream additional traces from a larger R1-distill trace set (e.g. generated by
+    DeepSeek-R1-Distill-Qwen-14B/32B and uploaded as an HF dataset). Same row mapping as MoT; tagged
+    `topup`. Traces are re-tokenized under Qwen2.5, so the generating model is unconstrained."""
+    from datasets import load_dataset  # pragma: no cover - network/optional extra
+
+    ds = load_dataset(dataset, split=split, streaming=True)
+    n = 0
+    for row in ds:
+        rec = mot_row_to_messages(row, source="topup")
+        if rec is None:
+            continue
+        yield rec
+        n += 1
+        if max_examples is not None and n >= max_examples:
+            break
+
+
+# --------------------------------------------------------------------------- #
+# Hand-authored in-format trace set (checked in, CC0) — offline coverage
+# --------------------------------------------------------------------------- #
+_HANDAUTHORED_TRACES = [
+    ("What is 17 + 25?",
+     "Add the ones: 7 + 5 = 12, write 2 carry 1. Add the tens: 1 + 2 + 1 = 4.",
+     "42"),
+    ("A train travels 60 km in 45 minutes. What is its speed in km/h?",
+     "45 minutes is 0.75 hours. Speed = distance / time = 60 / 0.75 = 80.",
+     "80 km/h"),
+    ("Write a Python function that returns the maximum of two numbers.",
+     "Use a conditional: if a is greater than b return a, otherwise return b.",
+     "def maximum(a, b): return a if a > b else b"),
+    ("Is 91 a prime number?",
+     "Check small factors: 91 = 7 * 13, so it has a divisor other than 1 and itself.",
+     "No, 91 = 7 x 13."),
+]
+
+
+def handauthored_trace_records() -> Iterator[dict]:
+    """The checked-in hand-authored reasoning traces (always available, offline)."""
+    for question, reasoning, answer in _HANDAUTHORED_TRACES:
+        yield trace_to_messages(question, reasoning, answer, source="handauthored")
+
+
+# --------------------------------------------------------------------------- #
+# Aggregator
+# --------------------------------------------------------------------------- #
+_LOADERS = {
+    "handauthored": lambda n: handauthored_trace_records(),
+    "mot": lambda n: load_mixture_of_thoughts(max_examples=n),
+}
+
+
+def iter_reasoning_traces(sources: Iterable[str],
+                          max_per_source: Optional[int] = None) -> Iterator[dict]:
+    """Concatenate tagged trace rows from the named sources (`handauthored` / `mot`)."""
+    for name in sources:
+        if name not in _LOADERS:
+            raise ValueError(f"unknown reasoning source {name!r} (have {sorted(_LOADERS)})")
+        yield from _LOADERS[name](max_per_source)

--- a/src/data/shard.py
+++ b/src/data/shard.py
@@ -113,6 +113,102 @@ def pack_sequences(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int
     return manifest
 
 
+def pack_atomic(token_docs: Iterable[Sequence[int]], out_dir, *, seq_len: int = 8192,
+                shard_size_mb: int = 512, prefix: str = "part", tokenizer: str = "",
+                chunk_align: int | None = None, pad_id: int = 0, dtype=DTYPE) -> dict:
+    """Pack per-document token lists into fixed `seq_len` sequences such that **no document spans a
+    sequence boundary** — the atomic-packing guarantee #96 needs for reasoning traces.
+
+    Unlike `pack_sequences` (which concatenates docs into a flat stream, so a doc can straddle a
+    `seq_len` edge and be split across two training rows), this greedily bin-packs: a document that
+    will not fit in the current sequence's remaining space pads that sequence to its end with
+    `pad_id` and starts the document at the head of the next sequence. Documents whose
+    (chunk-aligned) length exceeds `seq_len` cannot be packed atomically and are **dropped**
+    (counted in `n_dropped_overlength`); the final partial sequence is padded out and kept (no
+    document is lost to a dropped tail). `chunk_align` still pads each document to a chunk multiple
+    so it starts on a chunk boundary for the SSM reset (#68); writes the same
+    `.bin`/`.bounds`/`manifest.json` artifacts as `pack_sequences`."""
+    dtype = np.dtype(dtype)
+    hi = int(np.iinfo(dtype).max)
+    if chunk_align is not None:
+        if chunk_align <= 0:
+            raise ValueError(f"chunk_align must be positive, got {chunk_align}")
+        if seq_len % chunk_align:
+            raise ValueError(
+                f"seq_len {seq_len} must be a multiple of chunk_align {chunk_align}")
+    if not 0 <= pad_id <= hi:
+        raise ValueError(f"pad_id {pad_id} out of {dtype.name} range [0, {hi}]")
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    bytes_per_token = dtype.itemsize
+    budget = max(seq_len, (shard_size_mb * (1 << 20)) // bytes_per_token)
+    budget -= budget % seq_len
+
+    tok_buf = array(typecode_for(dtype))
+    bnd_buf = bytearray()
+    cur: List[int] = []                 # the in-progress sequence (< seq_len until flushed)
+    cur_bnd: List[int] = []
+    shards: List[dict] = []
+    state = {"idx": 0, "docs": 0, "seqs": 0, "tokens": 0, "dropped": 0}
+
+    def flush_seq() -> None:
+        """Pad the in-progress sequence out to `seq_len` and append it to the shard buffers."""
+        nonlocal cur, cur_bnd
+        if not cur:
+            return
+        pad = seq_len - len(cur)
+        tok_buf.extend(cur + [pad_id] * pad)         # OverflowError if any id exceeds the dtype
+        bnd_buf.extend(bytes(cur_bnd) + b"\x00" * pad)
+        cur, cur_bnd = [], []
+
+    def emit(n_tokens: int) -> None:
+        name = f"{prefix}-{state['idx']:05d}"
+        toks = np.frombuffer(tok_buf, dtype=dtype, count=n_tokens)
+        toks.tofile(out_dir / f"{name}.bin")
+        del toks
+        (out_dir / f"{name}.bounds").write_bytes(bytes(bnd_buf[:n_tokens]))
+        n_seq = n_tokens // seq_len
+        shards.append({"name": name, "n_sequences": n_seq, "n_tokens": n_tokens})
+        state["idx"] += 1
+        state["seqs"] += n_seq
+        state["tokens"] += n_tokens
+        state["docs"] += int(sum(bnd_buf[:n_tokens]))
+        del tok_buf[:n_tokens]
+        del bnd_buf[:n_tokens]
+
+    for doc in token_docs:
+        ids = list(doc)
+        if not ids:
+            continue
+        if chunk_align is not None:
+            rem = len(ids) % chunk_align
+            if rem:
+                ids = ids + [pad_id] * (chunk_align - rem)
+        if len(ids) > seq_len:                       # cannot fit atomically -> drop
+            state["dropped"] += 1
+            continue
+        if len(cur) + len(ids) > seq_len:            # won't fit -> pad current seq, start a new one
+            flush_seq()
+        cur.extend(ids)
+        cur_bnd.append(1)
+        cur_bnd.extend([0] * (len(ids) - 1))
+        while len(tok_buf) >= budget:
+            emit(budget)
+    flush_seq()                                      # pad + keep the final partial sequence
+    while len(tok_buf) >= budget:
+        emit(budget)
+    if len(tok_buf):                                 # remaining whole sequences (< one shard)
+        emit(len(tok_buf))
+
+    manifest = {"seq_len": seq_len, "dtype": dtype.name, "tokenizer": tokenizer,
+                "n_documents": state["docs"], "n_sequences": state["seqs"],
+                "n_tokens": state["tokens"], "n_dropped_overlength": state["dropped"],
+                "shards": shards}
+    (out_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return manifest
+
+
 def open_shard(out_dir, name: str) -> Tuple[np.memmap, np.memmap]:
     """Memory-map a shard's (tokens, boundaries uint8) pair, read-only. Token dtype comes
     from the manifest (uint16 / uint32; fallback uint16 for legacy shards)."""

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -48,6 +48,8 @@ PORTABLE_MODULES = [
     "src.data.instruct_format",
     "src.data.chat_template",
     "src.data.instruct_sft",
+    "src.data.reasoning_traces",
+    "src.data.reasoning_sft",
     "src.data.sft_data",
     "src.data.sft_loader",
     "src.data.sft_sources",

--- a/tests/test_reasoning_sft.py
+++ b/tests/test_reasoning_sft.py
@@ -1,0 +1,73 @@
+"""Reasoning-trace SFT driver (#96): masked JSONL + atomic packed .bounds artifact.
+Offline via the handauthored trace set + ByteTokenizer (no backend, no network)."""
+
+import json
+
+from src.data.chat_template import IM_END
+from src.data.distill_corpus import tokenized_subdir
+from src.data.reasoning_sft import build_reasoning_sft
+from src.data.reasoning_traces import handauthored_trace_records, trace_to_messages
+from src.data.shard import doc_start_offsets, open_shard, read_manifest
+from src.data.sft_loader import SFTLoader
+
+
+def test_build_reasoning_sft_end_to_end(tmp_path):
+    m = build_reasoning_sft(handauthored_trace_records(), tmp_path, tokenizer="qwen25",
+                            byte_fallback=True, seq_len=1024, chunk_align=64)
+
+    cleaned = tmp_path / "sft" / "cleaned" / "reasoning-traces" / "records.jsonl"
+    tok_dir = tmp_path / "sft" / "tokenized" / tokenized_subdir("qwen25", 1024)
+    packed_dir = tok_dir / "reasoning-packed"
+    assert cleaned.exists()
+    assert (tok_dir / "reasoning.jsonl").exists()
+    assert (tok_dir / "reasoning-manifest.json").exists()
+    assert (packed_dir / "manifest.json").exists()
+
+    # Manifest summary: think-answer format, chat EOS, atomic-packing invariant.
+    assert m["format"] == "think-answer" and m["chat_eos"] == IM_END
+    assert m["n_masked_records"] == len(list(handauthored_trace_records()))
+    assert m["packed_n_documents"] == m["n_masked_records"]   # every trace packed atomically
+
+    # Atomic packing: each trace starts on a chunk boundary; #docs == kept traces; none split.
+    pack_manifest = read_manifest(packed_dir)
+    assert pack_manifest["n_documents"] == m["n_masked_records"]
+    name = pack_manifest["shards"][0]["name"]
+    _, bnds = open_shard(packed_dir, name)
+    starts = doc_start_offsets(bnds)
+    assert all(off % m["chunk_align"] == 0 for off in starts)  # chunk-aligned -> no mid-seq trace
+    assert len(starts) == m["packed_n_documents"]
+
+
+def test_masked_records_train_only_the_trace(tmp_path):
+    tok_dir = tmp_path / "sft" / "tokenized" / tokenized_subdir("qwen25", 1024)
+    build_reasoning_sft(handauthored_trace_records(), tmp_path, tokenizer="qwen25",
+                        byte_fallback=True, seq_len=1024, chunk_align=64)
+    recs = [json.loads(line) for line in (tok_dir / "reasoning.jsonl").read_text().splitlines()]
+    assert recs
+    from src.data.tokenize import ByteTokenizer
+    tok = ByteTokenizer()
+    rec = recs[0]
+    trained = [rec["target_ids"][j] for j in range(len(rec["loss_mask"])) if rec["loss_mask"][j]]
+    decoded = tok.decode(trained)
+    # The trained span is the assistant trace ending on <|im_end|>; the user question is excluded.
+    assert decoded.endswith(IM_END) and "<think>" in decoded and "<answer>" in decoded
+
+
+def test_over_length_trace_dropped_from_both_artifacts(tmp_path):
+    # One short trace + one trace longer than seq_len: the long one is dropped, never split.
+    rows = [trace_to_messages("hi", "short", "ok"),
+            trace_to_messages("big", "y " * 2000, "done")]
+    m = build_reasoning_sft(rows, tmp_path, tokenizer="qwen25", byte_fallback=True,
+                            seq_len=256, chunk_align=64)
+    assert m["n_traces"] == 2
+    assert m["n_masked_records"] == 1 and m["n_overlength_dropped"] == 1
+    assert m["packed_n_documents"] == 1               # dropped trace absent from the packing too
+
+
+def test_records_load_through_sft_loader(tmp_path):
+    tok_dir = tmp_path / "sft" / "tokenized" / tokenized_subdir("qwen25", 1024)
+    build_reasoning_sft(handauthored_trace_records(), tmp_path, tokenizer="qwen25",
+                        byte_fallback=True, seq_len=1024, chunk_align=64)
+    loader = SFTLoader(tok_dir / "reasoning.jsonl", seq_len=1024, batch_size=2)
+    inputs, targets, mask = next(loader.epoch())
+    assert inputs.shape == targets.shape == mask.shape and mask.sum() > 0

--- a/tests/test_reasoning_traces.py
+++ b/tests/test_reasoning_traces.py
@@ -1,0 +1,49 @@
+"""Reasoning-trace sources + <think>/<answer> formatting (#96). Pure stdlib (no backend/network)."""
+
+from src.data.reasoning_traces import (ANSWER_CLOSE, ANSWER_OPEN, THINK_CLOSE, THINK_OPEN,
+                                       format_trace, handauthored_trace_records,
+                                       iter_reasoning_traces, mot_row_to_messages,
+                                       trace_to_messages)
+
+
+def test_format_trace_wraps_think_then_answer():
+    out = format_trace("step one\nstep two", "42")
+    assert out == (f"{THINK_OPEN}\nstep one\nstep two\n{THINK_CLOSE}\n"
+                   f"{ANSWER_OPEN}\n42\n{ANSWER_CLOSE}")
+    # think precedes answer; both tag pairs present.
+    assert out.index(THINK_OPEN) < out.index(ANSWER_OPEN)
+
+
+def test_trace_to_messages_assistant_carries_tags():
+    rec = trace_to_messages("What is 2+2?", "add them", "4", system="be terse")
+    roles = [m["role"] for m in rec["messages"]]
+    assert roles == ["system", "user", "assistant"]
+    content = rec["messages"][-1]["content"]
+    assert THINK_OPEN in content and ANSWER_OPEN in content and "4" in content
+    assert rec["source"] == "handauthored" and rec["license"] == "cc0"
+
+
+def test_mot_row_messages_passthrough():
+    row = {"messages": [{"role": "user", "content": "Q"},
+                        {"role": "assistant", "content": f"{THINK_OPEN}\nthink\n{THINK_CLOSE}\nA"}]}
+    rec = mot_row_to_messages(row)
+    assert rec is not None and rec["source"] == "mot"
+    assert rec["messages"][-1]["role"] == "assistant"
+
+
+def test_mot_row_problem_solution_fallback():
+    rec = mot_row_to_messages({"problem": "2+2?", "reasoning": "add", "solution": "4"})
+    assert rec is not None
+    content = rec["messages"][-1]["content"]
+    assert THINK_OPEN in content and "4" in content
+
+
+def test_mot_row_skips_incomplete():
+    assert mot_row_to_messages({"problem": "only a question"}) is None
+    assert mot_row_to_messages({"messages": [{"role": "user", "content": "no answer"}]}) is None
+
+
+def test_iter_reasoning_traces_handauthored():
+    rows = list(iter_reasoning_traces(["handauthored"]))
+    assert rows == list(handauthored_trace_records())
+    assert len(rows) >= 4 and all(r["messages"][-1]["role"] == "assistant" for r in rows)

--- a/tests/test_shard.py
+++ b/tests/test_shard.py
@@ -6,8 +6,8 @@ Pure numpy + stdlib. The boundary sidecar (consumed by #68) is the contract here
 import numpy as np
 import pytest
 
-from src.data.shard import (doc_start_offsets, open_shard, pack_sequences, read_manifest,
-                            segment_ids)
+from src.data.shard import (doc_start_offsets, open_shard, pack_atomic, pack_sequences,
+                            read_manifest, segment_ids)
 
 
 def test_pack_sequences_boundaries_and_roundtrip(tmp_path):
@@ -77,6 +77,36 @@ def test_chunk_align_requires_divisible_seq_len(tmp_path):
 def test_pack_sequences_validates_inputs(tmp_path):
     with pytest.raises(ValueError):
         pack_sequences([[1, 2]], tmp_path, seq_len=4, chunk_align=0)   # not ZeroDivisionError
+
+
+def test_pack_atomic_no_doc_spans_a_sequence_boundary(tmp_path):
+    # Two docs of 6 and 4 with seq_len 8: the 6-doc fills seq 0 (padded to 8); the 4-doc would
+    # straddle the seq-0/seq-1 edge under pack_sequences, so it starts seq 1 instead. No split.
+    manifest = pack_atomic([[1, 2, 3, 4, 5, 6], [7, 8, 9, 10]], tmp_path, seq_len=8, pad_id=0)
+    assert manifest["n_documents"] == 2 and manifest["n_sequences"] == 2
+    toks, bnds = open_shard(tmp_path, manifest["shards"][0]["name"])
+    assert list(toks) == [1, 2, 3, 4, 5, 6, 0, 0,   # doc A + pad to seq_len
+                          7, 8, 9, 10, 0, 0, 0, 0]   # doc B starts at the next sequence boundary
+    assert doc_start_offsets(bnds) == [0, 8]          # neither doc crosses the seq_len-8 boundary
+    assert int(np.asarray(bnds).sum()) == 2
+
+
+def test_pack_atomic_drops_overlength_and_keeps_final_partial(tmp_path):
+    # A doc longer than seq_len can't be packed atomically -> dropped; the short doc is kept and
+    # its final partial sequence is padded out (not dropped, unlike pack_sequences).
+    manifest = pack_atomic([[1, 2], [1, 2, 3, 4, 5]], tmp_path, seq_len=4, pad_id=0)
+    assert manifest["n_dropped_overlength"] == 1       # the 5-token doc
+    assert manifest["n_documents"] == 1 and manifest["n_sequences"] == 1
+    toks, _ = open_shard(tmp_path, manifest["shards"][0]["name"])
+    assert list(toks) == [1, 2, 0, 0]                  # kept doc + padding
+
+
+def test_pack_atomic_chunk_align(tmp_path):
+    # chunk_align keeps doc starts on chunk boundaries within the sequence.
+    manifest = pack_atomic([[1, 2, 3], [4, 5]], tmp_path, seq_len=8, chunk_align=4, pad_id=0)
+    toks, bnds = open_shard(tmp_path, manifest["shards"][0]["name"])
+    assert doc_start_offsets(bnds) == [0, 4]           # second doc padded to start at chunk 4
+    assert list(toks) == [1, 2, 3, 0, 4, 5, 0, 0]
     with pytest.raises(ValueError):
         pack_sequences([[1, 2]], tmp_path, seq_len=4, pad_id=70000)    # out of uint16 range
 


### PR DESCRIPTION
Closes #96

## Summary
The thinking layer's data — the headline-skill corpus, built on the #95 Qwen-ChatML substrate.

- **`src/data/reasoning_traces.py`** — `<think>`/`<answer>` formatting + sources. `format_trace()` wraps reasoning+answer as the assistant content; `trace_to_messages`/`mot_row_to_messages` build tagged chat rows; lazy loaders for open-r1 **Mixture-of-Thoughts** and the larger R1-distill **top-up path**; a checked-in handauthored trace set for the offline gate.
- **`src/data/reasoning_sft.py`** — driver writing `shared/sft/cleaned/reasoning-traces/` + `tokenized/qwen25-8k/{reasoning.jsonl, reasoning-packed/}`. `reasoning.jsonl` is the response-masked trainable artifact (reuses the #95 `chat_template` masking; reasoning newlines preserved). `reasoning-packed/` is the long 8K packing with doc boundaries marked for the SSM reset (#68).
- **`src/data/shard.py::pack_atomic`** — new greedy bin-packer that **guarantees no document spans a sequence boundary** (a doc that won't fit pads the current sequence and starts the next), drops docs longer than `seq_len`, and keeps the final partial. `pack_sequences` only *chunk*-aligns, so a trace could straddle a `seq_len` edge and be split across training rows — `pack_atomic` is what satisfies #96's "atomic trace packing (no trace spans a boundary)" acceptance.

The masked and packed sets are kept identical (same chunk-aligned over-length criterion), so `n_documents == n_masked_records`. All modules stay above the hardware seam (lazy `datasets` imports; added to import-guard `PORTABLE_MODULES`).

Scope excludes the reasoning-SFT *training run* / GRPO (#103) and real Mixture-of-Thoughts download (user-driven) — this lands the buildable + unit-tested pipeline with handauthored traces offline.

## Testing
- [x] Tests added — `tests/test_reasoning_traces.py`, `tests/test_reasoning_sft.py` (atomic packing verified: `n_documents == kept traces`, chunk-aligned `.bounds`, over-length dropped from both artifacts, `SFTLoader` drop-in), and `pack_atomic` cases in `tests/test_shard.py`; import guard extended.
- [x] All tests passing — full suite **392 passed, 1 skipped**.
- [x] Manual testing — `python -m src.data.reasoning_sft --sources handauthored --byte-fallback ...` produces the masked JSONL + atomic packed `.bin`/`.bounds` + manifests offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)