### PR TITLE
feat(data): [M10] three-class storage layout authority (#97)

### DIFF
--- a/docs/design/08-corpus-pipeline.md
+++ b/docs/design/08-corpus-pipeline.md
@@ -94,15 +94,27 @@ it early (only the IDs stream from the Hub; the blobs come from SWH S3).
 
 ## R2 storage layout
 
+The distillation pivot adopts a **three-class** layout (#97), so the student layout stays
+downstream of every frozen artifact. `src/data/storage.py` is the single source of truth for these
+prefixes; the data drivers (`distill_corpus.py`, `instruct_sft.py`, `reasoning_sft.py`) build their
+paths through it, and #80 points the R2 `s3fs` readers/writers at the same prefixes.
+
 ```
 r2://<bucket>/
-  cleaned/   <source>/*.parquet   # Stage-4/5 output: durable, re-mixable text shards
-  tokens/    <tokenizer>/<seqlen>/*.bin   # Stage-6 output: training shards (uint16, or uint32 for Qwen2.5)
-  ckpt/      <run>/...            # checkpoints synced from RunPod (RunPod is not durable)
+  poc-distill/      corpus/{cleaned, tokenized/<tok>-<k>}/   # distillation corpus (#92)
+                    teacher-outputs/{topk-logits, hidden-states}/   # precomputed teacher signal (#94)
+                    manifests/
+  shared/           sft/{cleaned/<kind>, tokenized/<tok>-<k>}/   # instruct/reasoning/tool SFT (#95/#96/#102)
+                    rl/{math-verifiable, code-verifiable}/   # verifiable RL sets (#103)
+                    eval/
+  reserve-pretrain/ cleaned/  tokenized/<ver>-<tok>-<k>/  manifests/   # from-scratch corpus (#70/#71)
+  ckpt/             <run>/...            # checkpoints synced from RunPod (RunPod is not durable)
 ```
 
-Dedup/decontam produce `cleaned/` once; `tokens/` is cheap to regenerate when the blend,
-tokenizer, or sequence length changes.
+Two rules the layout enforces: **cleaned text and RL problems stay tokenizer-agnostic and durable**
+(re-tokenize cheaply when the blend/tokenizer/seq_len changes), and **every tokenized folder
+name-pins tokenizer + seq_len** (`<tok>-<k>`, e.g. `qwen25-8k`) so multiple tokenized views coexist.
+Dedup/decontam produce `cleaned/` once; the tokenized views are cheap to regenerate.
 
 ## Training flow (Phases 4–5, #81 / #75)
 

--- a/src/data/distill_corpus.py
+++ b/src/data/distill_corpus.py
@@ -37,18 +37,16 @@ from pathlib import Path
 from typing import Iterable
 
 from . import corpus
+from . import storage
 from .corpus import Record, ingest_dummy, ingest_text_file, iter_shard_texts
 
-#: Default local root for the distillation-corpus prefix. The three-class storage layout
-#: (poc-distill / shared / reserve-pretrain) is formalized separately in #97; here the prefix
-#: is just this default, kept deliberately minimal.
-DEFAULT_OUT_ROOT = Path("data/poc-distill")
+#: Default local root for the distillation-corpus prefix (the `poc-distill` class of the #97
+#: three-class layout, under the default `data/` base).
+DEFAULT_OUT_ROOT = storage.class_root("data", storage.POC_DISTILL)
 
-
-def tokenized_subdir(tokenizer: str, seq_len: int) -> str:
-    """Directory name for the tokenized shards: `<tokenizer>-<seqlen_k>` (e.g. `qwen25-8k`),
-    the exact path the student sweep manifests reference."""
-    return f"{tokenizer}-{seq_len // 1024}k"
+#: Tokenized-folder name-pin (`<tokenizer>-<seqlen_k>`). Canonical definition lives in `storage`
+#: (#97); kept here as an alias because the student sweep manifests + tests reference this name.
+tokenized_subdir = storage.tokenized_dir_name
 
 
 def _load_tokenizer(tokenizer: str, model_id: str | None, byte_fallback: bool):
@@ -83,8 +81,8 @@ def build_distill_corpus(records: Iterable[Record], out_root, *, tokenizer: str 
 
     out_root = Path(out_root)
     corpus_root = out_root / "corpus"
-    cleaned_dir = corpus_root / "cleaned"
-    tokenized_dir = corpus_root / "tokenized" / tokenized_subdir(tokenizer, seq_len)
+    cleaned_dir = storage.corpus_cleaned_dir(out_root)
+    tokenized_dir = storage.corpus_tokenized_dir(out_root, tokenizer, seq_len)
 
     # Stage 1 — cleaned, re-mixable text shards (durable artifact).
     cleaned_shards = corpus.build_corpus(records, cleaned_dir,

--- a/src/data/instruct_sft.py
+++ b/src/data/instruct_sft.py
@@ -32,8 +32,7 @@ import json
 from pathlib import Path
 from typing import Iterable, Iterator, List, Optional
 
-from . import chat_template
-from .distill_corpus import tokenized_subdir
+from . import chat_template, storage
 from .sft_data import _messages_of
 
 
@@ -115,9 +114,8 @@ def build_instruct_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwen
     response-mask them under the Qwen chat template into the `shared/sft/tokenized/<tok>-<k>` prefix
     with a manifest. Returns the manifest dict."""
     out_root = Path(out_root)
-    sft_root = out_root / "sft"
-    cleaned_path = sft_root / "cleaned" / "instruct" / "records.jsonl"
-    tok_dir = sft_root / "tokenized" / tokenized_subdir(tokenizer, seq_len)
+    cleaned_path = storage.sft_cleaned_dir(out_root, "instruct") / "records.jsonl"
+    tok_dir = storage.sft_tokenized_dir(out_root, tokenizer, seq_len)
     tokenized_path = tok_dir / "instruct.jsonl"
 
     cleaned_rows = _write_cleaned(rows, cleaned_path)

--- a/src/data/reasoning_sft.py
+++ b/src/data/reasoning_sft.py
@@ -41,8 +41,7 @@ import json
 from pathlib import Path
 from typing import Iterable, List, Optional
 
-from . import chat_template
-from .distill_corpus import tokenized_subdir
+from . import chat_template, storage
 
 
 def _valid_rows(rows: Iterable[dict]) -> List[dict]:
@@ -79,9 +78,8 @@ def build_reasoning_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwe
     from .shard import pack_atomic
 
     out_root = Path(out_root)
-    sft_root = out_root / "sft"
-    cleaned_path = sft_root / "cleaned" / "reasoning-traces" / "records.jsonl"
-    tok_dir = sft_root / "tokenized" / tokenized_subdir(tokenizer, seq_len)
+    cleaned_path = storage.sft_cleaned_dir(out_root, "reasoning-traces") / "records.jsonl"
+    tok_dir = storage.sft_tokenized_dir(out_root, tokenizer, seq_len)
     masked_path = tok_dir / "reasoning.jsonl"
     packed_dir = tok_dir / "reasoning-packed"
 

--- a/src/data/storage.py
+++ b/src/data/storage.py
@@ -1,0 +1,109 @@
+"""Three-class artifact storage layout (#97) — the single source of truth for where every frozen
+artifact lives, so the student layout stays downstream of all of them and #80's R2 readers/writers
+point at one canonical prefix scheme (docs/design/08-corpus-pipeline.md, #65).
+
+    poc-distill/      corpus/{cleaned,tokenized/<tok>-<k>}/  teacher-outputs/{topk-logits,hidden-states}/  manifests/
+    shared/           sft/{cleaned/<kind>,tokenized/<tok>-<k>}/  rl/{math-verifiable,code-verifiable}/  eval/
+    reserve-pretrain/ cleaned/  tokenized/<ver>-<tok>-<k>/  manifests/
+
+The three classes:
+- **poc-distill** — the tokenized distillation corpus (#92) + teacher outputs (#94); drives the
+  distillation matching only. Invalidated only by a teacher/tokenizer change, never by the student.
+- **shared** — the instruct (#95) / reasoning-trace (#96) / tool-use (#102) SFT corpora + the
+  verifiable RL sets (#103). Curated once (much of it teacher inference) and reused unchanged by
+  both the POC and the production-reserve run.
+- **reserve-pretrain** — the full from-scratch corpus (#70/#71), built only after a layout validates.
+
+Rules this module encodes:
+- **Cleaned text and RL problems are tokenizer-agnostic and durable** — their helpers take no
+  tokenizer (re-tokenize cheaply when the tokenizer/seq_len changes).
+- **Every tokenized folder name-pins tokenizer + seq_len** (`tokenized_dir_name`), so the same
+  cleaned source can produce several tokenized views side by side without collision.
+
+Portable: pure path joining, no `mlx`/`torch`, no deps. Helpers return `pathlib.Path` for the
+local builds today; the same names are valid R2 prefixes, so #80 reuses them through `s3fs`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# The three artifact classes (top-level prefixes).
+POC_DISTILL = "poc-distill"
+SHARED = "shared"
+RESERVE_PRETRAIN = "reserve-pretrain"
+CLASSES = (POC_DISTILL, SHARED, RESERVE_PRETRAIN)
+
+
+def class_root(base, cls: str) -> Path:
+    """The root of one artifact class under a bucket/local `base` (e.g. `data/poc-distill`)."""
+    if cls not in CLASSES:
+        raise ValueError(f"unknown storage class {cls!r} (have {CLASSES})")
+    return Path(base) / cls
+
+
+def tokenized_dir_name(tokenizer: str, seq_len: int) -> str:
+    """The name-pin for a tokenized folder: `<tokenizer>-<seqlen_k>` (e.g. `qwen25-8k`). This is the
+    one place the tokenizer + seq_len naming convention is defined."""
+    return f"{tokenizer}-{seq_len // 1024}k"
+
+
+# --------------------------------------------------------------------------- #
+# poc-distill/ — distillation corpus (#92) + teacher outputs (#94)
+# --------------------------------------------------------------------------- #
+def corpus_cleaned_dir(poc_distill_root) -> Path:
+    """Tokenizer-agnostic cleaned distillation text."""
+    return Path(poc_distill_root) / "corpus" / "cleaned"
+
+
+def corpus_tokenized_dir(poc_distill_root, tokenizer: str, seq_len: int) -> Path:
+    """Tokenized distillation shards, name-pinned by tokenizer + seq_len."""
+    return Path(poc_distill_root) / "corpus" / "tokenized" / tokenized_dir_name(tokenizer, seq_len)
+
+
+def teacher_outputs_dir(poc_distill_root, kind: str = "topk-logits") -> Path:
+    """Precomputed teacher outputs (#94): `topk-logits` or `hidden-states`."""
+    return Path(poc_distill_root) / "teacher-outputs" / kind
+
+
+def manifests_dir(poc_distill_root) -> Path:
+    return Path(poc_distill_root) / "manifests"
+
+
+# --------------------------------------------------------------------------- #
+# shared/ — SFT corpora (#95/#96/#102) + verifiable RL sets (#103) + eval
+# --------------------------------------------------------------------------- #
+def sft_cleaned_dir(shared_root, kind: str) -> Path:
+    """Tokenizer-agnostic cleaned SFT rows for one `kind` (instruct / reasoning-traces / tool)."""
+    return Path(shared_root) / "sft" / "cleaned" / kind
+
+
+def sft_tokenized_dir(shared_root, tokenizer: str, seq_len: int) -> Path:
+    """Tokenized SFT artifacts, name-pinned by tokenizer + seq_len (shared across SFT kinds)."""
+    return Path(shared_root) / "sft" / "tokenized" / tokenized_dir_name(tokenizer, seq_len)
+
+
+def rl_dir(shared_root, kind: str) -> Path:
+    """Tokenizer-agnostic verifiable RL problems for one `kind` (math-verifiable / code-verifiable)."""
+    return Path(shared_root) / "rl" / kind
+
+
+def eval_dir(shared_root) -> Path:
+    return Path(shared_root) / "eval"
+
+
+# --------------------------------------------------------------------------- #
+# reserve-pretrain/ — full from-scratch corpus (#70/#71), built post-validation
+# --------------------------------------------------------------------------- #
+def reserve_cleaned_dir(reserve_root) -> Path:
+    return Path(reserve_root) / "cleaned"
+
+
+def reserve_tokenized_dir(reserve_root, tokenizer: str, seq_len: int, version: str = "v1") -> Path:
+    """Tokenized reserve shards, name-pinned by corpus version + tokenizer + seq_len
+    (e.g. `tokenized/v1-qwen25-8k`)."""
+    return Path(reserve_root) / "tokenized" / f"{version}-{tokenized_dir_name(tokenizer, seq_len)}"
+
+
+def reserve_manifests_dir(reserve_root) -> Path:
+    return Path(reserve_root) / "manifests"

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -37,6 +37,7 @@ PORTABLE_MODULES = [
     "src.model.sizing",
     "src.data.loader",
     "src.data.corpus",
+    "src.data.storage",
     "src.data.distill_corpus",
     "src.data.filters",
     "src.data.dedup",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,89 @@
+"""Three-class storage layout (#97): the single source of truth for artifact prefixes.
+Pure path logic (no backend); the driver-integration test uses the offline byte fallback.
+"""
+
+import pytest
+
+from src.data import storage
+from src.data.storage import (CLASSES, POC_DISTILL, RESERVE_PRETRAIN, SHARED, class_root,
+                              tokenized_dir_name)
+
+
+def test_classes_and_class_root():
+    assert CLASSES == (POC_DISTILL, SHARED, RESERVE_PRETRAIN)
+    assert class_root("data", POC_DISTILL).as_posix() == "data/poc-distill"
+    assert class_root("data", SHARED).as_posix() == "data/shared"
+    with pytest.raises(ValueError):
+        class_root("data", "nope")
+
+
+def test_tokenized_dir_name_pins_tokenizer_and_seqlen():
+    assert tokenized_dir_name("qwen25", 8192) == "qwen25-8k"
+    assert tokenized_dir_name("olmo", 1024) == "olmo-1k"
+
+
+def test_poc_distill_layout():
+    r = class_root("data", POC_DISTILL)
+    assert storage.corpus_cleaned_dir(r).as_posix() == "data/poc-distill/corpus/cleaned"
+    assert storage.corpus_tokenized_dir(r, "qwen25", 8192).as_posix() == \
+        "data/poc-distill/corpus/tokenized/qwen25-8k"
+    assert storage.teacher_outputs_dir(r).as_posix() == \
+        "data/poc-distill/teacher-outputs/topk-logits"
+    assert storage.teacher_outputs_dir(r, "hidden-states").as_posix() == \
+        "data/poc-distill/teacher-outputs/hidden-states"
+    assert storage.manifests_dir(r).as_posix() == "data/poc-distill/manifests"
+
+
+def test_shared_layout():
+    r = class_root("data", SHARED)
+    assert storage.sft_cleaned_dir(r, "instruct").as_posix() == "data/shared/sft/cleaned/instruct"
+    assert storage.sft_cleaned_dir(r, "reasoning-traces").as_posix() == \
+        "data/shared/sft/cleaned/reasoning-traces"
+    assert storage.sft_tokenized_dir(r, "qwen25", 8192).as_posix() == \
+        "data/shared/sft/tokenized/qwen25-8k"
+    assert storage.rl_dir(r, "math-verifiable").as_posix() == "data/shared/rl/math-verifiable"
+    assert storage.eval_dir(r).as_posix() == "data/shared/eval"
+
+
+def test_reserve_pretrain_layout():
+    r = class_root("data", RESERVE_PRETRAIN)
+    assert storage.reserve_cleaned_dir(r).as_posix() == "data/reserve-pretrain/cleaned"
+    assert storage.reserve_tokenized_dir(r, "qwen25", 8192).as_posix() == \
+        "data/reserve-pretrain/tokenized/v1-qwen25-8k"
+    assert storage.reserve_manifests_dir(r).as_posix() == "data/reserve-pretrain/manifests"
+
+
+def test_cleaned_and_rl_are_tokenizer_free():
+    # The tokenizer-agnostic rule: cleaned text + RL problem paths never embed a tokenizer name.
+    r_pd, r_sh = class_root("d", POC_DISTILL), class_root("d", SHARED)
+    for p in (storage.corpus_cleaned_dir(r_pd), storage.sft_cleaned_dir(r_sh, "instruct"),
+              storage.rl_dir(r_sh, "code-verifiable"), storage.reserve_cleaned_dir(
+                  class_root("d", RESERVE_PRETRAIN))):
+        assert "qwen25" not in p.as_posix() and "-8k" not in p.as_posix()
+    # ...while tokenized folders always name-pin it.
+    assert "qwen25-8k" in storage.sft_tokenized_dir(r_sh, "qwen25", 8192).as_posix()
+
+
+def test_drivers_write_under_the_right_class_prefixes(tmp_path):
+    # End-to-end: one base, the drivers land artifacts under base/poc-distill and base/shared.
+    from src.data.corpus import ingest_dummy
+    from src.data.distill_corpus import build_distill_corpus
+    from src.data.instruct_sft import build_instruct_sft
+    from src.data.reasoning_sft import build_reasoning_sft
+    from src.data.sft_sources import handauthored_records
+    from src.data.reasoning_traces import handauthored_trace_records
+
+    pytest.importorskip("pyarrow")
+    build_distill_corpus(ingest_dummy(300, seed=3), class_root(tmp_path, POC_DISTILL),
+                         tokenizer="qwen25", byte_fallback=True, seq_len=1024)
+    build_instruct_sft(handauthored_records(), class_root(tmp_path, SHARED),
+                       tokenizer="qwen25", byte_fallback=True, seq_len=1024)
+    build_reasoning_sft(handauthored_trace_records(), class_root(tmp_path, SHARED),
+                        tokenizer="qwen25", byte_fallback=True, seq_len=1024, chunk_align=64)
+
+    assert (tmp_path / "poc-distill" / "corpus" / "tokenized" / "qwen25-1k" / "manifest.json").exists()
+    assert (tmp_path / "shared" / "sft" / "tokenized" / "qwen25-1k" / "instruct.jsonl").exists()
+    assert (tmp_path / "shared" / "sft" / "tokenized" / "qwen25-1k" / "reasoning.jsonl").exists()
+    # The two SFT kinds share the tokenized prefix but split cleaned by kind.
+    assert (tmp_path / "shared" / "sft" / "cleaned" / "instruct" / "records.jsonl").exists()
+    assert (tmp_path / "shared" / "sft" / "cleaned" / "reasoning-traces" / "records.jsonl").exists()


### PR DESCRIPTION
Closes #97

## Summary
Adopt the **three-class artifact layout** (poc-distill / shared / reserve-pretrain) as a single source of truth, so the student layout stays downstream of every frozen artifact and #80's R2 readers/writers point at one canonical prefix scheme.

- **`src/data/storage.py`** (new) — the layout authority: class constants + `class_root(base, cls)`, the `tokenized_dir_name(tokenizer, seq_len)` name-pin (moved here; `distill_corpus.tokenized_subdir` kept as an alias), and pure path-builder helpers for every prefix in the issue's diagram (`poc-distill/`, `shared/`, `reserve-pretrain/`). Helpers return `Path` locally and the same names are valid R2 prefixes (the #80 seam).
- Encodes the two rules: **cleaned text + RL problems stay tokenizer-agnostic** (those helpers take no tokenizer), **every tokenized folder name-pins tokenizer + seq_len** (e.g. `qwen25-8k`).
- Routes the #92/#95/#96 drivers (`distill_corpus`, `instruct_sft`, `reasoning_sft`) through these helpers — **on-disk paths are byte-identical**, so no behavior change, but the layout now lives in one place instead of inline in each driver.
- Docs: `08-corpus-pipeline.md` "R2 storage layout" updated from the pre-pivot two-class scheme (`cleaned/ tokens/ ckpt/`) to the three-class layout, pointing at `storage.py`.

Scope excludes the actual R2 bucket + `s3fs`/datatrove wiring (**#80**, pod-gated) — this defines the prefixes those readers/writers will target.

## Testing
- [x] Tests added — `tests/test_storage.py` (layout matches the diagram, name-pinning, tokenizer-free cleaned/RL rule, and a driver-integration test proving the writers land artifacts under the right class prefixes); import guard extended.
- [x] All tests passing — full suite **399 passed, 1 skipped**.
- [x] Manual testing — the three driver CLIs emit byte-identical layouts via `storage` (verified `data/poc-distill/...` and `data/shared/sft/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)