### PR TITLE
feat(eval): [#51] post-training quantization of portable weights (W8/W4)

### DIFF
--- a/scripts/quantize.py
+++ b/scripts/quantize.py
@@ -159,6 +159,9 @@ def main() -> None:
               f"model size {report['model_compression']:.2f}x smaller "
               f"({report['model_orig_bytes']/2**20:.2f}→"
               f"{report['model_packed_bytes']/2**20:.2f} MiB at fp16 baseline)")
+        print("[note] the size figure is the THEORETICAL packed size (bit-packed codes + "
+              "group scales/zeros); the round-trip safetensors written above holds "
+              "fake-quant float32 weights and is not that size.")
 
 
 if __name__ == "__main__":

--- a/scripts/quantize.py
+++ b/scripts/quantize.py
@@ -1,0 +1,165 @@
+"""Post-training quantization measurement driver (Apple Silicon / MLX) — issue #51.
+
+Quantizes the heavy weights of a portable checkpoint with group-wise affine W8/W4
+(`src/eval/quantize.py`), then reports the held-out perplexity delta and the
+model-size delta — the #65 Phase-4 "quantize" numbers. Weight-only (activations stay
+float); true activation quant (the "A8" in W8A8) is not done here.
+
+    # Real numbers need a trained checkpoint (a smoke/poc run's portable weights):
+    .venv/bin/python scripts/quantize.py \\
+        --config config/toy.yaml --weights run/weights.safetensors \\
+        --data data/<toy split> --bits 8
+
+    # Self-contained demo: briefly train a toy model on the split, then quantize it:
+    .venv/bin/python scripts/quantize.py \\
+        --config config/toy.yaml --data data/<toy split> --train-steps 60 --bits 8
+
+The portable numeric core (`src.eval.quantize`) carries the actual quantization math
+and is unit-tested without a backend; this driver only wires it to a real model + the
+real eval path. MLX imports are kept local so `--help` works on any host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/toy.yaml"))
+    ap.add_argument("--data", type=Path, required=True,
+                    help="split dir with val.bin (and train.bin if --train-steps > 0)")
+    ap.add_argument("--weights", type=Path, default=None,
+                    help="portable safetensors to quantize (omit with --train-steps)")
+    ap.add_argument("--train-steps", type=int, default=0,
+                    help="if no --weights, train a toy checkpoint this many steps first")
+    ap.add_argument("--bits", type=int, default=8, help="weight bit-width (8, then 4 as stretch)")
+    ap.add_argument("--group-size", type=int, default=64, help="affine group size along the last axis")
+    ap.add_argument("--symmetric", action="store_true", help="symmetric (zero-point-free) quant")
+    ap.add_argument("--max-batches", type=int, default=8, help="held-out batches per eval")
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--lr", type=float, default=3e-4)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+    if args.weights is None and args.train_steps < 1:
+        ap.error("pass --weights <safetensors>, or --train-steps N to build a toy checkpoint")
+    if args.bits < 1 or args.bits > 16:
+        ap.error("--bits must be in [1, 16]")
+    return args
+
+
+def _train_toy_checkpoint(cfg, data_dir, steps, batch_size, lr, seed, out_path, mx):
+    """Briefly train a toy model on the split so the perplexity delta is meaningful
+    (a random-init model sits at ~uniform and the delta says nothing). Mirrors the
+    production wiring (model + AdamW + make_train_step), kept tiny on purpose."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    from src.train.loss_scale import scaler_for_precision
+    from src.data.loader import PackedLoader
+    import mlx.optimizers as optim
+
+    mx.random.seed(seed)
+    model = MLXMambaModel(cfg)
+    opt = optim.AdamW(learning_rate=lr)
+    train_step = make_train_step(model, opt, grad_clip=1.0,
+                                 scaler=scaler_for_precision(cfg.precision))
+    loader = PackedLoader(data_dir / "train.bin", cfg.seq_len, batch_size,
+                          shuffle=True, drop_last=True)
+    done = 0
+    while done < steps:
+        for inp, tgt in loader.epoch():
+            out = train_step(model, [(inp, tgt)], lr)
+            done += 1
+            if done % 20 == 0 or done == steps:
+                print(f"  [train] step {done}/{steps}  loss {out['loss']:.4f}")
+            if done >= steps:
+                break
+    model.save(str(out_path))
+    return out_path
+
+
+def _eval_ppl(model, data_dir, batch_size, max_batches, to_numpy):
+    from src.data.loader import PackedLoader
+    from src.eval.val_loss import evaluate
+    loader = PackedLoader(data_dir / "val.bin", model.config.seq_len, batch_size,
+                          shuffle=False, drop_last=False)
+    return evaluate(model, loader, max_batches=max_batches, to_numpy=to_numpy)
+
+
+def main() -> None:
+    args = _parse_args()
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/quantize.py ...")
+
+    import numpy as np
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+    from src.train.checkpoint import load_weights_dict, save_weights
+    from src.eval.quantize import quantize_state_dict
+
+    cfg = load_config(str(args.config))
+    to_numpy = lambda a: np.array(a)
+    print(f"[quantize] config={args.config}  d_model={cfg.d_model}  n_layers={cfg.n_layers}  "
+          f"vocab={cfg.vocab_size}  W{args.bits} g{args.group_size}"
+          f"{' symmetric' if args.symmetric else ''}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        # 1) obtain a checkpoint (given, or a quick toy train so ppl is meaningful)
+        weights_path = args.weights
+        if weights_path is None:
+            print(f"[quantize] no --weights; training a toy checkpoint ({args.train_steps} steps)")
+            weights_path = _train_toy_checkpoint(
+                cfg, args.data, args.train_steps, args.batch_size, args.lr,
+                args.seed, tmp / "weights.safetensors", mx)
+
+        # 2) baseline perplexity
+        base = MLXMambaModel(cfg)
+        base.load(str(weights_path))
+        base_eval = _eval_ppl(base, args.data, args.batch_size, args.max_batches, to_numpy)
+        print(f"[baseline] val_loss={base_eval['val_loss']:.4f}  "
+              f"val_perplexity={base_eval['val_perplexity']:.4f}")
+
+        # 3) quantize the portable weights (fake quant) + size accounting
+        sd = load_weights_dict(str(weights_path))
+        qsd, report = quantize_state_dict(sd, args.bits, args.group_size, args.symmetric)
+        print(f"[quantize] quantized {report['n_quantized']}/{report['n_total']} tensors; "
+              f"targeted {report['quantized_orig_bytes']/2**20:.3f}→"
+              f"{report['quantized_packed_bytes']/2**20:.3f} MiB "
+              f"({report['quantized_compression']:.2f}x); "
+              f"whole model {report['model_compression']:.2f}x "
+              f"(fp16 baseline)")
+        worst = max(report["per_tensor"], key=lambda t: t["rel_rms"], default=None)
+        if worst:
+            print(f"[quantize] worst rel_rms error: {worst['name']} "
+                  f"rel_rms={worst['rel_rms']:.4f} rel_max={worst['rel_max']:.4f}")
+
+        # 4) reload the quantized weights through the portable bridge + re-eval
+        qpath = tmp / "weights.q.safetensors"
+        save_weights(qsd, str(qpath), config=cfg)
+        qmodel = MLXMambaModel(cfg)
+        qmodel.load(str(qpath))                       # proves the bridge round-trips
+        q_eval = _eval_ppl(qmodel, args.data, args.batch_size, args.max_batches, to_numpy)
+        print(f"[quantized] val_loss={q_eval['val_loss']:.4f}  "
+              f"val_perplexity={q_eval['val_perplexity']:.4f}")
+
+        d_ppl = q_eval["val_perplexity"] - base_eval["val_perplexity"]
+        rel = d_ppl / base_eval["val_perplexity"] * 100 if base_eval["val_perplexity"] else 0.0
+        print(f"\n[result] W{args.bits} g{args.group_size}: "
+              f"Δperplexity {d_ppl:+.4f} ({rel:+.2f}%)  |  "
+              f"model size {report['model_compression']:.2f}x smaller "
+              f"({report['model_orig_bytes']/2**20:.2f}→"
+              f"{report['model_packed_bytes']/2**20:.2f} MiB at fp16 baseline)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/quantize.py
+++ b/src/eval/quantize.py
@@ -1,0 +1,181 @@
+"""Post-training quantization of portable weights (#51 / #65 Phase 4 — Quantize).
+
+A MEASUREMENT spike, not a serving feature: it answers "what does W8/W4 weight
+quantization cost in held-out perplexity, and what does it save in model size?" on
+the portable safetensors produced by `src/train/checkpoint.py` (the cross-backend
+bridge). The production inference path (serving #15) and CUDA (#16) are out of scope.
+
+This module is the PORTABLE numeric core — pure numpy, importable on any host and
+testable without a backend (it never imports `mlx`/`torch`). The MLX driver
+`scripts/quantize.py` applies `quantize_state_dict` to a real checkpoint and runs
+`src/eval/val_loss.evaluate` before/after.
+
+Method: group-wise AFFINE quantization (the de-facto scheme behind MambaQuant /
+LightMamba / MLX's own `mx.quantize`). Each weight matrix is grouped along its last
+axis; within a group the values map linearly to `bits`-bit integers via a per-group
+scale (and zero point, unless `symmetric`). "Fake quantization" — we quantize then
+dequantize back to float — measures the *quality* cost exactly (the round-tripped
+weight carries the true quantization error), while `packed_bytes` accounts the *size*
+the genuinely-packed representation would occupy. Weight-only (the activations stay
+float); true activation quant (the "A8" in W8A8) is a later step, not done here.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------- #
+# Group-wise affine quantization (the numeric core)
+# --------------------------------------------------------------------------- #
+def _effective_group_size(cols: int, group_size: int) -> int:
+    """Group along the last axis; fall back to whole-row groups when `group_size`
+    does not divide the row width (keeps the grouping exact rather than ragged)."""
+    if group_size <= 0:
+        raise ValueError(f"group_size must be positive, got {group_size}")
+    return group_size if cols % group_size == 0 else cols
+
+
+def quantize_dequantize(w: np.ndarray, bits: int, group_size: int,
+                        symmetric: bool = False) -> np.ndarray:
+    """Round-trip `w` through `bits`-bit group-wise affine quantization (fake quant).
+
+    Returns a float32 array of `w`'s shape carrying the quantization error — feed it
+    back into the model to measure the perplexity cost. Groups run along the last
+    axis (`_effective_group_size`). `symmetric` centres the range on zero (no zero
+    point), which is what weight-quant schemes typically use for signed weights.
+    """
+    if bits < 1 or bits > 16:
+        raise ValueError(f"bits must be in [1, 16], got {bits}")
+    w64 = np.asarray(w, dtype=np.float64)
+    if w64.ndim < 1 or w64.size == 0:
+        return w64.astype(np.float32)
+    cols = w64.shape[-1]
+    g = _effective_group_size(cols, group_size)
+    groups = w64.reshape(-1, g)
+    qmax = float(2 ** bits - 1)
+
+    if symmetric:
+        absmax = np.abs(groups).max(axis=1, keepdims=True)
+        scale = np.where(absmax == 0.0, 1.0, absmax / (qmax / 2.0))
+        q = np.clip(np.round(groups / scale), -(qmax // 2), qmax // 2)
+        deq = q * scale
+    else:
+        lo = groups.min(axis=1, keepdims=True)
+        hi = groups.max(axis=1, keepdims=True)
+        scale = np.where(hi == lo, 1.0, (hi - lo) / qmax)
+        q = np.clip(np.round((groups - lo) / scale), 0.0, qmax)
+        deq = q * scale + lo
+
+    return deq.reshape(w64.shape).astype(np.float32)
+
+
+def quant_error(w: np.ndarray, w_hat: np.ndarray) -> Dict[str, float]:
+    """Relative quantization error of a round-trip: rms and max-abs, each normalised
+    by the rms magnitude of `w` (so it is scale-free and comparable across tensors)."""
+    w = np.asarray(w, dtype=np.float64)
+    w_hat = np.asarray(w_hat, dtype=np.float64)
+    denom = float(np.sqrt(np.mean(w * w))) or 1.0
+    err = w_hat - w
+    return {
+        "rel_rms": float(np.sqrt(np.mean(err * err)) / denom),
+        "rel_max": float(np.abs(err).max() / denom),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Size accounting
+# --------------------------------------------------------------------------- #
+def packed_bytes(shape: Tuple[int, ...], bits: int, group_size: int,
+                 symmetric: bool = False, meta_bits: int = 16) -> float:
+    """Bytes a genuinely-packed group affine tensor would occupy: the `bits`-bit
+    codes plus per-group metadata (a `meta_bits` scale, and a zero point unless
+    `symmetric`). The fake-quant float array is NOT this size — this is the figure a
+    real packed export (e.g. `mx.quantize`) would write."""
+    n = int(np.prod(shape)) if shape else 0
+    cols = shape[-1] if shape else 1
+    g = _effective_group_size(cols, group_size)
+    n_groups = n // g if g else 0
+    meta_per_group = (meta_bits if symmetric else 2 * meta_bits) / 8.0
+    return n * bits / 8.0 + n_groups * meta_per_group
+
+
+def original_bytes(shape: Tuple[int, ...], dtype_bytes: int = 2) -> float:
+    """Reference size of an unquantized tensor. Defaults to fp16 (2 bytes) — the
+    realistic deployment baseline for the portable weights, so W8/W4 deltas read as
+    the genuine saving rather than an inflated one against fp32 masters."""
+    return float(int(np.prod(shape)) if shape else 0) * dtype_bytes
+
+
+# --------------------------------------------------------------------------- #
+# Picking which params to quantize
+# --------------------------------------------------------------------------- #
+def is_quantizable(name: str, arr: np.ndarray, min_elems: int = 1) -> bool:
+    """Quantize the heavy 2-D GEMM/embedding weights; leave 1-D params (RMSNorm
+    weights, the SSM `A_log`/`D`, biases) and floating-point-sensitive tiny tensors in
+    full precision — the standard weight-only PTQ rule. Non-float arrays are skipped.
+    """
+    if not np.issubdtype(np.asarray(arr).dtype, np.floating):
+        return False
+    if arr.ndim != 2:
+        return False
+    return int(np.prod(arr.shape)) >= min_elems
+
+
+def quantize_state_dict(
+    state_dict: Dict[str, np.ndarray], bits: int, group_size: int,
+    symmetric: bool = False, min_elems: int = 1,
+    baseline_dtype_bytes: int = 2,
+    keys: Optional[Iterable[str]] = None,
+) -> Tuple[Dict[str, np.ndarray], dict]:
+    """Fake-quantize the eligible tensors of a portable weight dict.
+
+    Returns `(new_state_dict, report)`. `new_state_dict` is the input with each
+    targeted tensor replaced by its round-tripped (error-carrying) version — load it
+    into the model to measure perplexity. `report` carries per-tensor error/size and
+    totals (original vs packed bytes over the *targeted* tensors, plus the whole-model
+    size with untouched tensors counted at `baseline_dtype_bytes`).
+
+    `keys`, if given, restricts quantization to those names (others pass through);
+    otherwise `is_quantizable` decides.
+    """
+    selected = set(keys) if keys is not None else None
+    out: Dict[str, np.ndarray] = {}
+    per_tensor: List[dict] = []
+    q_orig = q_packed = 0.0
+    model_orig = model_after = 0.0
+
+    for name, arr in state_dict.items():
+        arr = np.asarray(arr)
+        full = original_bytes(arr.shape, baseline_dtype_bytes)
+        model_orig += full
+        target = name in selected if selected is not None else is_quantizable(
+            name, arr, min_elems)
+        if not target:
+            out[name] = arr
+            model_after += full
+            continue
+        w_hat = quantize_dequantize(arr, bits, group_size, symmetric)
+        out[name] = w_hat
+        pk = packed_bytes(arr.shape, bits, group_size, symmetric)
+        q_orig += full
+        q_packed += pk
+        model_after += pk
+        per_tensor.append({
+            "name": name, "shape": tuple(int(s) for s in arr.shape),
+            "orig_bytes": full, "packed_bytes": pk,
+            **quant_error(arr, w_hat),
+        })
+
+    report = {
+        "bits": bits, "group_size": group_size, "symmetric": symmetric,
+        "n_quantized": len(per_tensor), "n_total": len(state_dict),
+        "quantized_orig_bytes": q_orig, "quantized_packed_bytes": q_packed,
+        "quantized_compression": (q_orig / q_packed) if q_packed else 0.0,
+        "model_orig_bytes": model_orig, "model_packed_bytes": model_after,
+        "model_compression": (model_orig / model_after) if model_after else 0.0,
+        "per_tensor": per_tensor,
+    }
+    return out, report

--- a/src/eval/quantize.py
+++ b/src/eval/quantize.py
@@ -58,9 +58,13 @@ def quantize_dequantize(w: np.ndarray, bits: int, group_size: int,
     qmax = float(2 ** bits - 1)
 
     if symmetric:
+        # Signed range [-qhalf, qhalf] (e.g. ±127 at 8-bit). Scale and clip MUST use the
+        # same qhalf, else a group's max-magnitude value can't be represented (it would
+        # clip below its own level), inflating symmetric-mode error.
+        qhalf = qmax // 2
         absmax = np.abs(groups).max(axis=1, keepdims=True)
-        scale = np.where(absmax == 0.0, 1.0, absmax / (qmax / 2.0))
-        q = np.clip(np.round(groups / scale), -(qmax // 2), qmax // 2)
+        scale = np.where(absmax == 0.0, 1.0, absmax / qhalf)
+        q = np.clip(np.round(groups / scale), -qhalf, qhalf)
         deq = q * scale
     else:
         lo = groups.min(axis=1, keepdims=True)
@@ -138,8 +142,10 @@ def quantize_state_dict(
     totals (original vs packed bytes over the *targeted* tensors, plus the whole-model
     size with untouched tensors counted at `baseline_dtype_bytes`).
 
-    `keys`, if given, restricts quantization to those names (others pass through);
-    otherwise `is_quantizable` decides.
+    `keys`, if given, further restricts quantization to those names — but only tensors
+    that ALSO satisfy `is_quantizable` are quantized (the allow-list narrows the eligible
+    set, it never overrides the eligibility rules). Without `keys`, `is_quantizable`
+    alone decides.
     """
     selected = set(keys) if keys is not None else None
     out: Dict[str, np.ndarray] = {}
@@ -151,8 +157,11 @@ def quantize_state_dict(
         arr = np.asarray(arr)
         full = original_bytes(arr.shape, baseline_dtype_bytes)
         model_orig += full
-        target = name in selected if selected is not None else is_quantizable(
-            name, arr, min_elems)
+        # `keys` is an allow-list WITHIN the eligibility rules: a named tensor is
+        # quantized only if it is also quantizable (a 2-D float weight). This prevents an
+        # explicit key from silently casting a non-float/1-D tensor through fake-quant.
+        target = is_quantizable(name, arr, min_elems) and (
+            selected is None or name in selected)
         if not target:
             out[name] = arr
             model_after += full

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -67,6 +67,7 @@ PORTABLE_MODULES = [
     "src.train.loss_scale",
     "src.train.loop",
     "src.eval.val_loss",
+    "src.eval.quantize",
     "src.eval.olmes_adapter",
     "src.eval.retrieval_probe",
     "src.eval.probes",

--- a/tests/test_quantize.py
+++ b/tests/test_quantize.py
@@ -1,0 +1,117 @@
+"""Portable tests for the PTQ numeric core (#51) — no backend required.
+
+Validates the group-wise affine quant round-trip, the size accounting, and the
+state-dict selection rules in `src.eval.quantize`. The MLX driver (`scripts/quantize.py`)
+wires this to a real model + the eval path; the quality/size math is proven here.
+"""
+
+import numpy as np
+import pytest
+
+from src.eval.quantize import (
+    is_quantizable,
+    original_bytes,
+    packed_bytes,
+    quant_error,
+    quantize_dequantize,
+    quantize_state_dict,
+)
+
+
+def test_roundtrip_is_lossless_at_high_bits():
+    # 16-bit affine over a small range reconstructs to ~float precision.
+    rng = np.random.default_rng(0)
+    w = rng.standard_normal((8, 64)).astype(np.float32)
+    w_hat = quantize_dequantize(w, bits=16, group_size=64)
+    assert quant_error(w, w_hat)["rel_rms"] < 1e-3
+
+
+def test_error_decreases_monotonically_with_bits():
+    rng = np.random.default_rng(1)
+    w = rng.standard_normal((16, 128)).astype(np.float32)
+    errs = [quant_error(w, quantize_dequantize(w, b, 64))["rel_rms"]
+            for b in (2, 4, 8)]
+    assert errs[0] > errs[1] > errs[2]
+
+
+def test_smaller_groups_reduce_error():
+    # Finer grouping tracks local scale better, so error drops as the group shrinks.
+    rng = np.random.default_rng(2)
+    w = rng.standard_normal((4, 256)).astype(np.float32)
+    e_coarse = quant_error(w, quantize_dequantize(w, 4, 256))["rel_rms"]
+    e_fine = quant_error(w, quantize_dequantize(w, 4, 32))["rel_rms"]
+    assert e_fine < e_coarse
+
+
+def test_constant_group_has_zero_error():
+    # A degenerate (hi == lo) group must not divide by zero and must reconstruct exactly.
+    w = np.full((3, 32), 0.7, dtype=np.float32)
+    w_hat = quantize_dequantize(w, bits=4, group_size=32)
+    assert np.allclose(w_hat, w)
+
+
+def test_symmetric_roundtrip_runs_and_is_reasonable():
+    rng = np.random.default_rng(3)
+    w = rng.standard_normal((8, 64)).astype(np.float32)
+    e = quant_error(w, quantize_dequantize(w, 8, 64, symmetric=True))["rel_rms"]
+    assert 0.0 < e < 0.1
+
+
+def test_non_divisible_group_falls_back_to_whole_row():
+    # 100 is not divisible by 64 -> whole-row groups; must still round-trip cleanly at 16 bits.
+    rng = np.random.default_rng(4)
+    w = rng.standard_normal((5, 100)).astype(np.float32)
+    w_hat = quantize_dequantize(w, bits=16, group_size=64)
+    assert w_hat.shape == w.shape
+    assert quant_error(w, w_hat)["rel_rms"] < 1e-2
+
+
+def test_packed_bytes_below_fp16_for_w8_and_w4():
+    shape = (512, 512)
+    fp16 = original_bytes(shape, dtype_bytes=2)
+    assert packed_bytes(shape, bits=8, group_size=64) < fp16
+    assert packed_bytes(shape, bits=4, group_size=64) < packed_bytes(shape, 8, 64)
+
+
+def test_packed_bytes_accounts_group_metadata():
+    # Two scale+zero fp16 per group on top of the bit-packed codes.
+    shape = (64, 64)
+    n, g = 64 * 64, 64
+    expected = n * 8 / 8.0 + (n // g) * (2 * 16) / 8.0
+    assert packed_bytes(shape, bits=8, group_size=64) == pytest.approx(expected)
+
+
+def test_is_quantizable_targets_only_2d_float_weights():
+    assert is_quantizable("layers.0.in_proj.weight", np.zeros((16, 16), np.float32))
+    assert not is_quantizable("norm.weight", np.zeros((16,), np.float32))      # 1-D
+    assert not is_quantizable("ssm.A_log", np.zeros((8,), np.float32))         # 1-D
+    assert not is_quantizable("idx", np.zeros((16, 16), np.int64))             # non-float
+    assert not is_quantizable("tiny", np.zeros((2, 2), np.float32), min_elems=100)
+
+
+def test_quantize_state_dict_selects_and_reports():
+    sd = {
+        "embedding.weight": np.random.default_rng(5).standard_normal((128, 64)).astype(np.float32),
+        "layers.0.in_proj.weight": np.random.default_rng(6).standard_normal((128, 64)).astype(np.float32),
+        "norm.weight": np.ones((64,), np.float32),                # 1-D, untouched
+        "layers.0.ssm.A_log": np.zeros((8,), np.float32),         # 1-D, untouched
+    }
+    qsd, report = quantize_state_dict(sd, bits=8, group_size=64)
+    assert report["n_quantized"] == 2 and report["n_total"] == 4
+    # untouched tensors pass through byte-identical
+    assert np.array_equal(qsd["norm.weight"], sd["norm.weight"])
+    # targeted tensors changed (carry quant error) but keep shape/dtype
+    assert qsd["embedding.weight"].shape == sd["embedding.weight"].shape
+    assert not np.array_equal(qsd["layers.0.in_proj.weight"], sd["layers.0.in_proj.weight"])
+    assert report["model_compression"] > 1.0
+    assert report["quantized_compression"] > 1.0
+
+
+def test_quantize_state_dict_honours_explicit_keys():
+    sd = {
+        "a.weight": np.ones((16, 16), np.float32),
+        "b.weight": np.ones((16, 16), np.float32),
+    }
+    qsd, report = quantize_state_dict(sd, 8, 16, keys=["a.weight"])
+    assert report["n_quantized"] == 1
+    assert "a.weight" in {t["name"] for t in report["per_tensor"]}


### PR DESCRIPTION
## What

Post-training quantization **measurement spike** for #51 — the #65 Phase-4 "quantize" deliverable for the local-inference student. Group-wise affine W8/W4 over the portable safetensors, reporting held-out **perplexity delta** and **model-size delta**.

- `src/eval/quantize.py` — **portable** numpy core (no backend): group affine fake-quant round-trip, relative-error metrics, packed-size accounting, and the weight-only selection rule (2-D float GEMM/embedding weights; 1-D norms / `A_log` / `D` / biases stay full precision). Added to `test_import_guard.PORTABLE_MODULES`.
- `scripts/quantize.py` — MLX driver: load a checkpoint (or `--train-steps` a quick toy one), eval baseline, quantize, reload through the checkpoint bridge, re-eval. Weight-only (activations stay float; "A8" activation quant is a later step, called out in the docstring).
- `tests/test_quantize.py` — portable unit tests for the core (monotonic error vs bits, finer groups ⇒ less error, size accounting, selection rules).

## Numbers (toy split, 80-step toy model)

| variant | Δ perplexity | model size |
|---|--:|--:|
| W8 g64 | +0.00% | **1.85× smaller** |
| W4 g64 | +0.33% | **3.38× smaller** |
| W4 g32 | +0.09% | 3.06× smaller |

MambaQuant-style <1% loss. Real numbers want a poc-scale trained checkpoint (`--weights`); posting to #65.

## Test

- `.venv/bin/python -m pytest` → 410 passed, 1 skipped.
- Seam intact (only the script imports mlx). Model code untouched, so the smoke gate is not implicated.

Part of #65 (Phase 4 — Quantize). Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)