### PR TITLE
feat(model): [#54] training-free long-context extension (LongMamba dt-scale)

### DIFF
--- a/scripts/long_context.py
+++ b/scripts/long_context.py
@@ -1,0 +1,143 @@
+"""Training-free long-context extension driver (Apple Silicon / MLX) — issue #54.
+
+Measures perplexity vs sequence length for a model trained at `seq_len`, with the
+LongMamba-style knob OFF (the baseline degradation past the training length) and ON
+(`MambaConfig.long_ctx_factor`, the inference-time receptive-field enlargement). The
+knob is training-free: the same weights are read under both settings — only the SSM
+discretization step is rescaled at eval (see `SelectiveSSM._project`).
+
+    # Real numbers want a trained checkpoint:
+    .venv/bin/python scripts/long_context.py \\
+        --config config/toy.yaml --weights run/weights.safetensors \\
+        --data data/<toy split> --mults 1 2 4
+
+    # Self-contained demo: briefly train a toy model, then sweep lengths:
+    .venv/bin/python scripts/long_context.py \\
+        --config config/toy.yaml --data data/<toy split> --train-steps 80 --mults 1 2 4
+
+The harness (`src.eval.long_context`) is portable and unit-tested; this driver wires
+the MLX model + the knob. MLX imports are local so `--help` works on any host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import tempfile
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/toy.yaml"))
+    ap.add_argument("--data", type=Path, required=True,
+                    help="split dir with val.bin (and train.bin if --train-steps > 0)")
+    ap.add_argument("--weights", type=Path, default=None)
+    ap.add_argument("--train-steps", type=int, default=0,
+                    help="if no --weights, train a toy checkpoint this many steps first")
+    ap.add_argument("--mults", type=int, nargs="+", default=[1, 2, 4],
+                    help="evaluate at these multiples of seq_len")
+    ap.add_argument("--max-batches", type=int, default=8)
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--lr", type=float, default=3e-4)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+    if args.weights is None and args.train_steps < 1:
+        ap.error("pass --weights <safetensors>, or --train-steps N to build a toy checkpoint")
+    return args
+
+
+def _train_toy_checkpoint(cfg, data_dir, steps, batch_size, lr, seed, out_path, mx):
+    """Brief toy train so degradation/recovery is measurable (mirrors the prod wiring)."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    from src.train.loss_scale import scaler_for_precision
+    from src.data.loader import PackedLoader
+    import mlx.optimizers as optim
+
+    mx.random.seed(seed)
+    model = MLXMambaModel(cfg)
+    opt = optim.AdamW(learning_rate=lr)
+    train_step = make_train_step(model, opt, grad_clip=1.0,
+                                 scaler=scaler_for_precision(cfg.precision))
+    loader = PackedLoader(data_dir / "train.bin", cfg.seq_len, batch_size,
+                          shuffle=True, drop_last=True)
+    done = 0
+    while done < steps:
+        for inp, tgt in loader.epoch():
+            out = train_step(model, [(inp, tgt)], lr)
+            done += 1
+            if done % 20 == 0 or done == steps:
+                print(f"  [train] step {done}/{steps}  loss {out['loss']:.4f}")
+            if done >= steps:
+                break
+    model.save(str(out_path))
+    return out_path
+
+
+def main() -> None:
+    args = _parse_args()
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/long_context.py ...")
+
+    import numpy as np
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+    from src.eval.long_context import long_context_eval, format_curve
+
+    cfg = load_config(str(args.config))
+    to_numpy = lambda a: np.array(a)
+    val_path = args.data / "val.bin"
+    print(f"[long-ctx] config={args.config}  seq_len={cfg.seq_len}  "
+          f"d_model={cfg.d_model}  n_layers={cfg.n_layers}  mults={args.mults}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        weights_path = args.weights
+        if weights_path is None:
+            print(f"[long-ctx] no --weights; training a toy checkpoint ({args.train_steps} steps)")
+            weights_path = _train_toy_checkpoint(
+                cfg, args.data, args.train_steps, args.batch_size, args.lr,
+                args.seed, Path(tmp) / "weights.safetensors", mx)
+
+        # Knob OFF: factor 1.0 everywhere (baseline degradation past seq_len).
+        base = MLXMambaModel(cfg)
+        base.load(str(weights_path))
+        off = long_context_eval(base, val_path, cfg.seq_len, args.batch_size,
+                                 mults=args.mults, max_batches=args.max_batches,
+                                 to_numpy=to_numpy)
+        print(format_curve("knob OFF", off))
+
+        # Knob ON: set the dt-scale to the extension ratio at each length. The model is
+        # rebuilt per length with long_ctx_factor=mult and the SAME weights reloaded —
+        # training-free (only the inference-time discretization step changes).
+        print("\n[long-ctx] knob ON (long_ctx_factor = extension ratio per length):")
+        on = {}
+        for mult in args.mults:
+            mcfg = dataclasses.replace(cfg, long_ctx_factor=float(mult))
+            model = MLXMambaModel(mcfg)
+            model.load(str(weights_path))
+            res = long_context_eval(model, val_path, cfg.seq_len, args.batch_size,
+                                    mults=[mult], max_batches=args.max_batches,
+                                    to_numpy=to_numpy)
+            on[mult] = res[mult]
+        print(format_curve("knob ON ", on))
+
+        # Recovery summary at the extended lengths.
+        print("\n[result] perplexity at extended lengths (lower is better):")
+        for mult in args.mults:
+            if mult == 1 or off.get(mult) is None or on.get(mult) is None:
+                continue
+            po, pn = off[mult]["val_perplexity"], on[mult]["val_perplexity"]
+            print(f"  {mult}x: OFF {po:.4f}  ON {pn:.4f}  "
+                  f"({(po - pn) / po * 100:+.2f}% from the knob)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/long_context.py
+++ b/scripts/long_context.py
@@ -92,7 +92,10 @@ def main() -> None:
     from src.model.mlx_backend import MLXMambaModel
     from src.eval.long_context import long_context_eval, format_curve
 
-    cfg = load_config(str(args.config))
+    # Force the knob OFF for training and the OFF baseline regardless of what the YAML
+    # sets — long_ctx_factor is an inference-time knob the ON path applies explicitly, so
+    # a stray factor in the config must not leak into training or the baseline curve.
+    cfg = dataclasses.replace(load_config(str(args.config)), long_ctx_factor=1.0)
     to_numpy = lambda a: np.array(a)
     val_path = args.data / "val.bin"
     print(f"[long-ctx] config={args.config}  seq_len={cfg.seq_len}  "

--- a/src/eval/long_context.py
+++ b/src/eval/long_context.py
@@ -1,0 +1,66 @@
+"""Long-sequence evaluation harness (#54 / #65 Phase 4 — usable context length).
+
+Reports held-out perplexity as a function of sequence length, so the training-free
+long-context knob (`MambaConfig.long_ctx_factor`, applied in the MLX backend's
+`SelectiveSSM`) can be measured: a model trained at `seq_len` is evaluated at 1x / 2x /
+4x that length, with the knob off (baseline degradation) and on (recovery).
+
+PORTABLE: builds on `PackedLoader` + `val_loss.evaluate` and never imports a backend
+(the knob lives on the model's config; this harness only chooses the eval length). An
+SSM reads arbitrary lengths with no positional limit, so evaluating at >`seq_len` just
+means packing longer chunks — `PackedLoader(seq_len=mult*base)` does exactly that.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import numpy as np
+
+from ..data.loader import PackedLoader
+from ..eval.val_loss import evaluate
+from ..model.interface import ModelInterface
+
+
+def long_context_eval(
+    model: ModelInterface, val_packed_path, base_seq_len: int, batch_size: int,
+    mults: Iterable[int] = (1, 2, 4), max_batches: Optional[int] = None,
+    to_numpy=np.asarray,
+) -> Dict[int, Optional[dict]]:
+    """Evaluate `model` at each length `mult * base_seq_len`.
+
+    Returns `{mult: {val_loss, val_perplexity, seq_len, n_batches} | None}`; `None`
+    when the val file holds fewer than one chunk at that length (recorded, not raised —
+    no silent drop). The knob is whatever `model.config.long_ctx_factor` already is, so
+    call this twice (off vs on) to get both curves.
+    """
+    val_packed_path = Path(val_packed_path)
+    results: Dict[int, Optional[dict]] = {}
+    for mult in mults:
+        seq_len = int(base_seq_len * mult)
+        try:
+            loader = PackedLoader(val_packed_path, seq_len, batch_size,
+                                  shuffle=False, drop_last=False)
+        except ValueError:
+            results[mult] = None          # file too small for one chunk at this length
+            continue
+        res = evaluate(model, loader, max_batches=max_batches, to_numpy=to_numpy)
+        res["seq_len"] = seq_len
+        res["n_batches"] = min(len(loader), max_batches) if max_batches else len(loader)
+        results[mult] = res
+    return results
+
+
+def format_curve(label: str, results: Dict[int, Optional[dict]]) -> str:
+    """One-line-per-length perplexity-vs-length table for logging / posting to #65."""
+    lines = [f"[{label}] perplexity vs sequence length:"]
+    for mult, res in sorted(results.items()):
+        if res is None:
+            lines.append(f"  {mult}x  (skipped — val split too small for one chunk)")
+        else:
+            lines.append(f"  {mult}x  seq_len={res['seq_len']:>6}  "
+                         f"val_loss={res['val_loss']:.4f}  "
+                         f"perplexity={res['val_perplexity']:.4f}  "
+                         f"({res['n_batches']} batches)")
+    return "\n".join(lines)

--- a/src/eval/long_context.py
+++ b/src/eval/long_context.py
@@ -47,7 +47,9 @@ def long_context_eval(
             continue
         res = evaluate(model, loader, max_batches=max_batches, to_numpy=to_numpy)
         res["seq_len"] = seq_len
-        res["n_batches"] = min(len(loader), max_batches) if max_batches else len(loader)
+        # `is None` (not truthiness): max_batches=0 means 0 batches, not "the whole loader".
+        res["n_batches"] = (len(loader) if max_batches is None
+                            else min(len(loader), max_batches))
         results[mult] = res
     return results
 

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -88,6 +88,16 @@ class MambaConfig:
     # Must divide d_model. Unused when attn_every is None.
     n_attn_heads: Optional[int] = None
 
+    # --- training-free long-context extension (#54) ---
+    # INFERENCE-TIME receptive-field enlargement (LongMamba). Divides the SSM
+    # discretization step `delta` by this factor, pushing the per-step decay
+    # exp(delta*A) toward 1 so state persists over a longer horizon — the SSM analogue
+    # of RoPE position interpolation. 1.0 = OFF and byte-identical (training + smoke gate
+    # untouched); set > 1.0 only at eval to read a model trained at `seq_len` over
+    # longer sequences. Applied in `SelectiveSSM._project`, so the chunked-scan
+    # (forward) and one-step recurrence (step) stay parity-exact.
+    long_ctx_factor: float = 1.0
+
     # --- dt-projection bias init (LOAD-BEARING) ---
     # Inverse-softplus of a sample in [dt_min, dt_max] initializes the dt bias.
     # Without this the model fails to learn recall. Carry these into every backend.
@@ -207,6 +217,8 @@ class MambaConfig:
             raise ValueError(f"unknown precision {self.precision!r}")
         if self.chunk_size is not None and self.chunk_size <= 0:
             raise ValueError("chunk_size must be positive or None")
+        if self.long_ctx_factor < 1.0:
+            raise ValueError("long_ctx_factor must be >= 1.0 (1.0 = off)")
         if self.d_conv < 1:
             raise ValueError("d_conv must be >= 1")
         if self.head_dim <= 0 or self.d_inner % self.head_dim != 0:

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -187,6 +187,11 @@ class SelectiveSSM(nn.Module):
         B = _f32(proj[..., dt_rank:dt_rank + d_state])
         C = _f32(proj[..., dt_rank + d_state:])
         delta = _softplus(self.dt_proj(dt_pre))   # (..., H) per head, fp32
+        # Long-context extension (#54): divide the discretization step so per-step decay
+        # exp(delta*a) moves toward 1, enlarging the receptive field at inference. Guarded
+        # so factor 1.0 (the default) leaves delta byte-identical — training/smoke untouched.
+        if self.config.long_ctx_factor != 1.0:
+            delta = delta / self.config.long_ctx_factor
         a = -mx.exp(self.A_log)                    # (H,) scalar decay, fp32
         return delta, a, B, C
 

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -67,6 +67,7 @@ PORTABLE_MODULES = [
     "src.train.loss_scale",
     "src.train.loop",
     "src.eval.val_loss",
+    "src.eval.long_context",
     "src.eval.olmes_adapter",
     "src.eval.retrieval_probe",
     "src.eval.probes",

--- a/tests/test_long_context.py
+++ b/tests/test_long_context.py
@@ -5,14 +5,21 @@ model + a tiny packed file, no backend; the MLX-guarded checks confirm the knob 
 parity-exact when off, actually changes the scan when on, and the config validates.
 """
 
-import json
-
 import numpy as np
 import pytest
 
 from src.data.pack import pack_ids
 from src.eval.long_context import format_curve, long_context_eval
 from src.model.blocks import MambaConfig
+
+try:
+    import mlx.core as mx
+    HAVE_MLX = True
+except ImportError:                     # portable tests below must still run without mlx
+    mx = None
+    HAVE_MLX = False
+
+requires_mlx = pytest.mark.skipif(not HAVE_MLX, reason="requires mlx (Apple Silicon)")
 
 
 # --------------------------------------------------------------------------- #
@@ -87,10 +94,9 @@ def test_long_ctx_factor_default_is_off():
 
 # --------------------------------------------------------------------------- #
 # MLX-guarded: the knob is parity-exact off, and changes the scan on
+# (each test skips individually when mlx is absent, so the portable tests above
+# still run on a non-Mac host — see the `requires_mlx` marker)
 # --------------------------------------------------------------------------- #
-mx = pytest.importorskip("mlx.core")
-
-
 def _toy_cfg(**over):
     base = dict(d_model=32, n_layers=2, head_dim=16, d_state=8, vocab_size=32,
                 seq_len=16, precision="fp32")
@@ -98,6 +104,7 @@ def _toy_cfg(**over):
     return MambaConfig(**base)
 
 
+@requires_mlx
 def test_knob_off_is_byte_identical():
     from src.model.mlx_backend import MLXMambaModel
     mx.random.seed(0)
@@ -111,6 +118,7 @@ def test_knob_off_is_byte_identical():
     assert np.array_equal(y, np.array(model.forward(tokens)))
 
 
+@requires_mlx
 def test_knob_on_changes_logits_but_stays_finite():
     from src.model.mlx_backend import MLXMambaModel
     mx.random.seed(0)
@@ -124,6 +132,7 @@ def test_knob_on_changes_logits_but_stays_finite():
     assert not np.allclose(yo, yn)                  # the scan genuinely changed
 
 
+@requires_mlx
 def test_forward_step_parity_holds_with_knob_on():
     """The knob lives in `_project`, shared by parallel (forward) and recurrence (step),
     so the two paths must still agree at the fp32 ~1e-4 tolerance with the knob on."""

--- a/tests/test_long_context.py
+++ b/tests/test_long_context.py
@@ -1,0 +1,145 @@
+"""Tests for the training-free long-context extension (#54).
+
+Two layers: the PORTABLE harness logic (`src.eval.long_context`) runs with a fake
+model + a tiny packed file, no backend; the MLX-guarded checks confirm the knob is
+parity-exact when off, actually changes the scan when on, and the config validates.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from src.data.pack import pack_ids
+from src.eval.long_context import format_curve, long_context_eval
+from src.model.blocks import MambaConfig
+
+
+# --------------------------------------------------------------------------- #
+# Portable harness (no backend)
+# --------------------------------------------------------------------------- #
+class _FakeModel:
+    """Minimal ModelInterface surface: forward(inputs)->logits and a `config`."""
+
+    def __init__(self, vocab_size, seq_len):
+        self.vocab_size = vocab_size
+
+        class _Cfg:
+            pass
+        self.config = _Cfg()
+        self.config.seq_len = seq_len
+        self._rng = np.random.default_rng(0)
+
+    def forward(self, inputs):
+        b, l = np.asarray(inputs).shape
+        return self._rng.standard_normal((b, l, self.vocab_size)).astype(np.float32)
+
+
+def _make_packed(tmp_path, n_tokens, vocab=32):
+    ids = np.arange(n_tokens, dtype=np.int64) % vocab
+    path = tmp_path / "val.bin"
+    pack_ids(ids, path, dtype=np.dtype("uint16"))
+    return path
+
+
+def test_harness_reports_perplexity_per_length(tmp_path):
+    base_seq = 8
+    path = _make_packed(tmp_path, n_tokens=8 * (base_seq * 4 + 1))  # room for 4x chunks
+    model = _FakeModel(vocab_size=32, seq_len=base_seq)
+    res = long_context_eval(model, path, base_seq, batch_size=2, mults=(1, 2, 4),
+                            max_batches=2)
+    for mult in (1, 2, 4):
+        assert res[mult] is not None
+        assert res[mult]["seq_len"] == base_seq * mult
+        assert res[mult]["val_perplexity"] > 0
+
+
+def test_harness_skips_lengths_too_long_for_the_split(tmp_path):
+    base_seq = 8
+    # Only enough tokens for a single 1x chunk; 2x/4x can't form one chunk.
+    path = _make_packed(tmp_path, n_tokens=base_seq + 2)
+    model = _FakeModel(vocab_size=16, seq_len=base_seq)
+    res = long_context_eval(model, path, base_seq, batch_size=1, mults=(1, 2, 4))
+    assert res[1] is not None
+    assert res[2] is None and res[4] is None        # recorded, not raised
+
+
+def test_format_curve_handles_skips(tmp_path):
+    out = format_curve("knob OFF", {1: {"seq_len": 8, "val_loss": 1.0,
+                                        "val_perplexity": 2.7, "n_batches": 2},
+                                    2: None})
+    assert "1x" in out and "2x" in out and "skipped" in out
+
+
+# --------------------------------------------------------------------------- #
+# Config validation (portable)
+# --------------------------------------------------------------------------- #
+def test_long_ctx_factor_validates():
+    cfg = MambaConfig(d_model=64, n_layers=2, head_dim=16, vocab_size=32,
+                      seq_len=16, long_ctx_factor=0.5)
+    with pytest.raises(ValueError, match="long_ctx_factor"):
+        cfg.validate()
+
+
+def test_long_ctx_factor_default_is_off():
+    assert MambaConfig(d_model=64, n_layers=2).long_ctx_factor == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# MLX-guarded: the knob is parity-exact off, and changes the scan on
+# --------------------------------------------------------------------------- #
+mx = pytest.importorskip("mlx.core")
+
+
+def _toy_cfg(**over):
+    base = dict(d_model=32, n_layers=2, head_dim=16, d_state=8, vocab_size=32,
+                seq_len=16, precision="fp32")
+    base.update(over)
+    return MambaConfig(**base)
+
+
+def test_knob_off_is_byte_identical():
+    from src.model.mlx_backend import MLXMambaModel
+    mx.random.seed(0)
+    model = MLXMambaModel(_toy_cfg(long_ctx_factor=1.0))
+    tokens = mx.array(np.arange(2 * 16).reshape(2, 16) % 32)
+    # Default config path and an explicit factor=1.0 must agree exactly with a model
+    # that simply never sees the scaling branch — the guard keeps delta untouched.
+    y = np.array(model.forward(tokens))
+    assert np.all(np.isfinite(y))
+    # Re-run: deterministic, identical.
+    assert np.array_equal(y, np.array(model.forward(tokens)))
+
+
+def test_knob_on_changes_logits_but_stays_finite():
+    from src.model.mlx_backend import MLXMambaModel
+    mx.random.seed(0)
+    off = MLXMambaModel(_toy_cfg(long_ctx_factor=1.0))
+    weights = off._portable_state_dict()
+    on = MLXMambaModel(_toy_cfg(long_ctx_factor=4.0))
+    on._load_portable(weights)                      # same weights, knob on
+    tokens = mx.array(np.arange(2 * 16).reshape(2, 16) % 32)
+    yo, yn = np.array(off.forward(tokens)), np.array(on.forward(tokens))
+    assert np.all(np.isfinite(yn))
+    assert not np.allclose(yo, yn)                  # the scan genuinely changed
+
+
+def test_forward_step_parity_holds_with_knob_on():
+    """The knob lives in `_project`, shared by parallel (forward) and recurrence (step),
+    so the two paths must still agree at the fp32 ~1e-4 tolerance with the knob on."""
+    from src.model.mlx_backend import MLXMambaModel
+    mx.random.seed(0)
+    model = MLXMambaModel(_toy_cfg(long_ctx_factor=3.0))
+    tokens = np.arange(16).reshape(1, 16) % 32
+
+    seq_logits = np.array(model.forward(mx.array(tokens)))[0]   # (L, V)
+
+    state = model.init_state(1)
+    step_logits = []
+    for t in range(tokens.shape[1]):
+        logit, state = model.step(mx.array(tokens[:, t]), state)
+        step_logits.append(np.array(logit)[0])
+    step_logits = np.stack(step_logits)                          # (L, V)
+
+    rel = np.abs(seq_logits - step_logits).max() / (np.abs(seq_logits).max() + 1e-6)
+    assert rel < 1e-4


### PR DESCRIPTION
## What

Training-free long-context extension for #54 — the #65 Phase-4 headline metric (usable context length). A model trained at `seq_len` is read over longer sequences with **no retraining**, via an inference-time receptive-field knob, plus a harness that reports perplexity vs length.

- **`MambaConfig.long_ctx_factor`** (default `1.0` = OFF, byte-identical; `validate()` requires ≥ 1.0).
- **Backend knob** in `SelectiveSSM._project`: divides the SSM discretization step `delta` so per-step decay `exp(delta·A)` moves toward 1 — enlarging the effective memory horizon. This is the SSM analogue of RoPE position interpolation (LongMamba). Because `_project` is shared by the chunked scan (`parallel`, forward) and the one-step `recurrence` (step), **forward/step parity holds with the knob on** (tested at fp32 ~1e-4).
- **`src/eval/long_context.py`** (portable): evaluates at 1×/2×/4× `seq_len` via `PackedLoader` + `val_loss.evaluate`; records (does not raise on) lengths the split is too small for. Added to `test_import_guard.PORTABLE_MODULES`.
- **`scripts/long_context.py`**: sweeps lengths with the knob off vs on (same weights reloaded), printing the perplexity-vs-length curves.

## Correctness

- **Knob off ⇒ byte-identical**: the M4 smoke gate stays exact (`max|loss diff| = 2.4e-7`), full suite **407 passed, 1 skipped**.
- **Knob on**: forward/step parity test passes; logits genuinely change; harness runs at 2×/4×.

## Honest note on numbers

On the synthetic byte-fallback toy corpus, perplexity is ~flat with length (no long-range dependencies to lose), so the knob's recovery is near-zero **by construction** (+0.03%/+0.07% at 2×/4×). The mechanism is validated; meaningful recovery numbers want a poc-scale model on real text — posting to #65 when available.

Part of #65 (Phase 4). Closes #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)