### PR TITLE
feat(serve): [#52] self-speculative decoding (prompt-lookup + batched verify)

### DIFF
--- a/scripts/spec_decode.py
+++ b/scripts/spec_decode.py
@@ -125,24 +125,34 @@ def spec_decode(model, prompt, max_new, gamma, max_n, mx):
             continue
 
         block_logits, block_states = model.verify_block(draft, state)   # one eval
-        # verifier greedy token at each draft position given the accepted prefix
-        preds = [_argmax(logits, mx)] + [_argmax(bl, mx) for bl in block_logits[:-1]]
-        m = first_mismatch(draft, preds)            # accepted count in [0, len(draft)]
+        # All greedy verifier predictions for draft positions 0..len(draft) in ONE host
+        # transfer (position i is the token after consuming draft[:i]): pred[0] from the
+        # pre-existing logits, pred[1..] from the block. Vectorized so verify_block's single
+        # eval isn't undone by per-position .item() syncs.
+        all_logits = mx.stack([logits] + block_logits, axis=0)[:, 0, :]   # (γ+1, V)
+        preds = mx.argmax(all_logits, axis=-1).tolist()
+        m = first_mismatch(draft, preds[:len(draft)])   # accepted count in [0, len(draft)]
 
-        # Roll back to the accepted prefix, then emit the verifier's own token there
-        # (a correction if m < γ, the free bonus token if m == γ).
-        base_logits = logits if m == 0 else block_logits[m - 1]
-        base_state = state if m == 0 else block_states[m - 1]
-        x = _argmax(base_logits, mx)
-        emit = draft[:m] + [x]
-
-        logits, state = model.step(mx.array([x]), base_state)
-        mx.eval(logits)
-        generated.extend(emit)
-        context.extend(emit)
+        accept = draft[:m]
         drafted += len(draft)
         accepted += m
         rounds += 1
+        if len(generated) + m >= max_new:
+            # Accepted drafts already fill the budget — stop without the extra
+            # correction/bonus token (and its extra step), so we never compute past max_new.
+            generated.extend(accept)
+            context.extend(accept)
+            break
+
+        # Roll back to the accepted prefix, then emit the verifier's own token there
+        # (a correction if m < len(draft), the free bonus token if all accepted).
+        x = preds[m]
+        base_state = state if m == 0 else block_states[m - 1]
+        logits, state = model.step(mx.array([x]), base_state)
+        mx.eval(logits)
+        emit = accept + [x]
+        generated.extend(emit)
+        context.extend(emit)
 
     elapsed = time.perf_counter() - t0
     stats = {
@@ -164,7 +174,6 @@ def main() -> None:
             "mlx not found — run with the project venv on Apple Silicon:\n"
             "    .venv/bin/python scripts/spec_decode.py ...")
 
-    import numpy as np
     from src.model.blocks import load_config
     from src.model.mlx_backend import MLXMambaModel
     from src.data.loader import PackedLoader

--- a/scripts/spec_decode.py
+++ b/scripts/spec_decode.py
@@ -1,0 +1,212 @@
+"""Self-speculative decoding spike (Apple Silicon / MLX) — issue #52.
+
+Draft-and-verify decoding over the model's `step` recurrence. A prompt-lookup drafter
+(`src.serve.spec_decode.propose`, no second model) proposes the next few tokens; the
+verifier scores them in ONE batched eval (`MLXMambaModel.verify_block`) and accepts the
+greedy-matching prefix. Greedy verification makes the output BYTE-IDENTICAL to plain
+greedy decoding — the spike asserts that — while the batched verify amortizes the
+per-token sync that bounds batch-1 SSM decode (the #30 ~94.7 tok/s record).
+
+    # Self-contained demo on a toy split:
+    .venv/bin/python scripts/spec_decode.py \\
+        --config config/toy.yaml --data data/<toy split> --train-steps 200 \\
+        --max-new 256 --gamma 4
+
+    # Real model:
+    .venv/bin/python scripts/spec_decode.py --config config/toy.yaml \\
+        --weights run/weights.safetensors --data data/<toy split> --max-new 256
+
+Numbers (tokens/s plain vs speculative, acceptance rate) post to #30. MLX imports are
+local so `--help` works on any host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/toy.yaml"))
+    ap.add_argument("--data", type=Path, required=True,
+                    help="split dir; val.bin seeds the prompt, train.bin if --train-steps")
+    ap.add_argument("--weights", type=Path, default=None)
+    ap.add_argument("--train-steps", type=int, default=0)
+    ap.add_argument("--prompt-len", type=int, default=32)
+    ap.add_argument("--max-new", type=int, default=256)
+    ap.add_argument("--gamma", type=int, default=4, help="draft length per round")
+    ap.add_argument("--max-n", type=int, default=8, help="longest prompt-lookup pattern")
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--lr", type=float, default=3e-4)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+    if args.weights is None and args.train_steps < 1:
+        ap.error("pass --weights <safetensors>, or --train-steps N to build a toy checkpoint")
+    if args.gamma < 1:
+        ap.error("--gamma must be >= 1")
+    return args
+
+
+def _train_toy_checkpoint(cfg, data_dir, steps, batch_size, lr, seed, mx):
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    from src.train.loss_scale import scaler_for_precision
+    from src.data.loader import PackedLoader
+    import mlx.optimizers as optim
+
+    mx.random.seed(seed)
+    model = MLXMambaModel(cfg)
+    opt = optim.AdamW(learning_rate=lr)
+    train_step = make_train_step(model, opt, grad_clip=1.0,
+                                 scaler=scaler_for_precision(cfg.precision))
+    loader = PackedLoader(data_dir / "train.bin", cfg.seq_len, batch_size,
+                          shuffle=True, drop_last=True)
+    done = 0
+    while done < steps:
+        for inp, tgt in loader.epoch():
+            out = train_step(model, [(inp, tgt)], lr)
+            done += 1
+            if done % 50 == 0 or done == steps:
+                print(f"  [train] step {done}/{steps}  loss {out['loss']:.4f}")
+            if done >= steps:
+                break
+    return model
+
+
+def _argmax(mx_logits, mx) -> int:
+    return int(mx.argmax(mx_logits[0]).item())
+
+
+def _prefill(model, prompt, mx):
+    """Feed the prompt through `step`; return (next-token logits, state)."""
+    state = model.init_state(1)
+    logits = None
+    for tok in prompt:
+        logits, state = model.step(mx.array([int(tok)]), state)
+    mx.eval(logits)
+    return logits, state
+
+
+def plain_decode(model, prompt, max_new, mx):
+    """Greedy one-step-at-a-time decoding (the baseline)."""
+    logits, state = _prefill(model, prompt, mx)
+    generated = []
+    t0 = time.perf_counter()
+    for _ in range(max_new):
+        x = _argmax(logits, mx)
+        generated.append(x)
+        logits, state = model.step(mx.array([x]), state)
+        mx.eval(logits)
+    return generated, time.perf_counter() - t0
+
+
+def spec_decode(model, prompt, max_new, gamma, max_n, mx):
+    """Greedy self-speculative decoding. Identical output to `plain_decode`."""
+    from src.serve.spec_decode import first_mismatch, propose
+
+    logits, state = _prefill(model, prompt, mx)
+    context = [int(t) for t in prompt]
+    generated, drafted, accepted, rounds = [], 0, 0, 0
+
+    t0 = time.perf_counter()
+    while len(generated) < max_new:
+        remaining = max_new - len(generated)
+        draft = propose(context, min(gamma, remaining), max_n)
+        if not draft:
+            # No tail recurs — take one ordinary verifier step.
+            x = _argmax(logits, mx)
+            logits, state = model.step(mx.array([x]), state)
+            mx.eval(logits)
+            generated.append(x)
+            context.append(x)
+            continue
+
+        block_logits, block_states = model.verify_block(draft, state)   # one eval
+        # verifier greedy token at each draft position given the accepted prefix
+        preds = [_argmax(logits, mx)] + [_argmax(bl, mx) for bl in block_logits[:-1]]
+        m = first_mismatch(draft, preds)            # accepted count in [0, len(draft)]
+
+        # Roll back to the accepted prefix, then emit the verifier's own token there
+        # (a correction if m < γ, the free bonus token if m == γ).
+        base_logits = logits if m == 0 else block_logits[m - 1]
+        base_state = state if m == 0 else block_states[m - 1]
+        x = _argmax(base_logits, mx)
+        emit = draft[:m] + [x]
+
+        logits, state = model.step(mx.array([x]), base_state)
+        mx.eval(logits)
+        generated.extend(emit)
+        context.extend(emit)
+        drafted += len(draft)
+        accepted += m
+        rounds += 1
+
+    elapsed = time.perf_counter() - t0
+    stats = {
+        "rounds": rounds, "drafted": drafted, "accepted": accepted,
+        "accept_rate": (accepted / drafted) if drafted else 0.0,
+        "tokens_per_round": (len(generated) / rounds) if rounds else 0.0,
+    }
+    return generated[:max_new], elapsed, stats
+
+
+def main() -> None:
+    args = _parse_args()
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/spec_decode.py ...")
+
+    import numpy as np
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+    from src.data.loader import PackedLoader
+
+    cfg = load_config(str(args.config))
+    print(f"[spec] config={args.config}  d_model={cfg.d_model}  n_layers={cfg.n_layers}  "
+          f"vocab={cfg.vocab_size}  gamma={args.gamma}  max_new={args.max_new}")
+
+    if args.weights is not None:
+        model = MLXMambaModel(cfg)
+        model.load(str(args.weights))
+    else:
+        print(f"[spec] no --weights; training a toy checkpoint ({args.train_steps} steps)")
+        model = _train_toy_checkpoint(cfg, args.data, args.train_steps,
+                                      args.batch_size, args.lr, args.seed, mx)
+    mx.eval(model.parameters())
+
+    # Prompt from real held-out tokens so the continuation is structured (the drafter
+    # needs recurring n-grams to match).
+    loader = PackedLoader(args.data / "val.bin", args.prompt_len, 1,
+                          shuffle=False, drop_last=False)
+    inputs, _ = next(iter(loader.epoch()))
+    prompt = [int(t) for t in inputs[0]]
+
+    plain, t_plain = plain_decode(model, prompt, args.max_new, mx)
+    spec, t_spec, stats = spec_decode(model, prompt, args.max_new, args.gamma, args.max_n, mx)
+
+    identical = plain == spec
+    print(f"\n[correctness] speculative == plain greedy: {identical}")
+    if not identical:
+        first = next(i for i, (a, b) in enumerate(zip(plain, spec)) if a != b)
+        raise SystemExit(f"SPEC DECODE MISMATCH at token {first}: plain={plain[first]} "
+                         f"spec={spec[first]} — verification is NOT distribution-preserving")
+
+    print(f"[accept]   {stats['accepted']}/{stats['drafted']} draft tokens accepted "
+          f"({stats['accept_rate']*100:.1f}%); {stats['tokens_per_round']:.2f} tokens/round "
+          f"over {stats['rounds']} rounds")
+    print(f"[plain]    {len(plain)/t_plain:>8.1f} tokens/s   ({t_plain:.3f}s)")
+    print(f"[spec]     {len(spec)/t_spec:>8.1f} tokens/s   ({t_spec:.3f}s)")
+    print(f"[result]   speculative is {t_plain/t_spec:.2f}x plain decode wall-clock "
+          f"(identical output)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -21,7 +21,7 @@ and allowed: it lives below the seam and nothing portable imports it.
 from __future__ import annotations
 
 import math
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -542,21 +542,23 @@ class MLXMambaModel(ModelInterface, nn.Module):
             new_state.append(st2)
         return self._head(self.norm_f(h)), new_state
 
-    def verify_block(self, tokens: Array, state: State):
-        """Speculative-decoding verify pass (#52): consume `tokens` (a 1-D id sequence)
-        through the `step` recurrence from `state`, returning the per-token next-token
-        logits and the per-token states in a SINGLE graph eval.
+    def verify_block(self, tokens: Sequence[int], state: State):
+        """Speculative-decoding verify pass (#52): consume `tokens` (a HOST-side sequence
+        of int ids) through the `step` recurrence from `state`, returning the per-token
+        next-token logits and the per-token states in a SINGLE graph eval.
 
         Identical in value to calling `step` token-by-token — but evaluating the whole
         block at once amortizes the per-token kernel-launch/sync that dominates batch-1
         decode, which is where speculative decoding's wall-clock win comes from. Returns
         `(logits_list, state_list)` of length len(tokens); `state_list[i]` is the state
         after consuming `tokens[:i+1]`, so the caller can roll back to the accepted prefix
-        without recomputing."""
+        without recomputing. `tokens` is normalized to host ints ONCE up front so a stray
+        MLX-array argument can't force a per-token host sync inside the loop."""
+        toks = [int(t) for t in tokens]
         logits_list, state_list = [], []
         h_state = state
-        for tok in tokens:
-            logit, h_state = self.step(mx.array([int(tok)]), h_state)
+        for tok in toks:
+            logit, h_state = self.step(mx.array([tok]), h_state)
             logits_list.append(logit)
             state_list.append(h_state)
         # One eval realizes the whole block (logits + every intermediate state) together.

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -542,6 +542,30 @@ class MLXMambaModel(ModelInterface, nn.Module):
             new_state.append(st2)
         return self._head(self.norm_f(h)), new_state
 
+    def verify_block(self, tokens: Array, state: State):
+        """Speculative-decoding verify pass (#52): consume `tokens` (a 1-D id sequence)
+        through the `step` recurrence from `state`, returning the per-token next-token
+        logits and the per-token states in a SINGLE graph eval.
+
+        Identical in value to calling `step` token-by-token — but evaluating the whole
+        block at once amortizes the per-token kernel-launch/sync that dominates batch-1
+        decode, which is where speculative decoding's wall-clock win comes from. Returns
+        `(logits_list, state_list)` of length len(tokens); `state_list[i]` is the state
+        after consuming `tokens[:i+1]`, so the caller can roll back to the accepted prefix
+        without recomputing."""
+        logits_list, state_list = [], []
+        h_state = state
+        for tok in tokens:
+            logit, h_state = self.step(mx.array([int(tok)]), h_state)
+            logits_list.append(logit)
+            state_list.append(h_state)
+        # One eval realizes the whole block (logits + every intermediate state) together.
+        leaves = list(logits_list)
+        for st in state_list:
+            leaves.extend(v for _, v in tree_flatten(st))
+        mx.eval(leaves)
+        return logits_list, state_list
+
     # --- distillation matching accessors (#100) ------------------------------
     def hidden_states(self, token_batch: Array) -> Tuple[Array, ...]:
         """Per-layer hidden states for the `hidden-align` stage: the embedding output

--- a/src/serve/spec_decode.py
+++ b/src/serve/spec_decode.py
@@ -1,0 +1,61 @@
+"""Self-speculative decoding primitives (#52) — portable, numpy only.
+
+Draft-and-verify decoding accelerates autoregressive generation: a cheap drafter
+proposes the next few tokens, the real model verifies them in one batched pass, and
+verification keeps the output distribution exact. This module holds the two BACKEND-FREE
+pieces — the drafter and the accept rule — so they are testable without mlx. The stateful
+verifier pass and the timing live in `scripts/spec_decode.py` (it advances the model's
+`step` recurrence on the backend).
+
+The drafter here is **prompt-lookup** (a.k.a. n-gram / self-speculative): it proposes
+continuations by finding where the current context's tail recurred earlier and copying
+what followed. It needs no second trained model — the "self-speculative variant avoids
+training a second model" the issue calls for — and any wrong guess is simply rejected by
+the verifier, so it can never change the output, only the speed.
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+
+def propose(context: Sequence[int], gamma: int, max_n: int = 8) -> List[int]:
+    """Prompt-lookup draft: up to `gamma` tokens continuing `context`.
+
+    Tries the longest tail first: for n from min(max_n, len-1) down to 1, take the last
+    n tokens as a pattern and search for its most recent EARLIER occurrence in the
+    context; on a hit, copy the up-to-`gamma` tokens that followed it. Returns `[]` when
+    no tail recurs (the caller then takes one ordinary step). Longer matched patterns are
+    preferred because they predict the continuation more reliably.
+    """
+    ctx = [int(t) for t in context]
+    L = len(ctx)
+    if L < 2 or gamma <= 0:
+        return []
+    for n in range(min(max_n, L - 1), 0, -1):
+        pattern = ctx[L - n:]
+        # Most recent earlier occurrence: scan start positions right-to-left, excluding
+        # the tail occurrence itself (search space is ctx[: L - n]).
+        for start in range(L - n - 1, -1, -1):
+            if ctx[start:start + n] == pattern:
+                draft = ctx[start + n:start + n + gamma]
+                if draft:
+                    return draft
+                break  # this pattern recurs only at the very end — try a shorter one
+    return []
+
+
+def first_mismatch(draft: Sequence[int], verifier_preds: Sequence[int]) -> int:
+    """Number of leading draft tokens the verifier agrees with (greedy acceptance).
+
+    `verifier_preds[i]` is the verifier's greedy next token at position i given the
+    accepted prefix `draft[:i]`. The accepted count is the first i where they differ
+    (or `len(draft)` if all agree) — exactly the prefix plain greedy decoding would also
+    have produced, which is what makes speculative decoding distribution-preserving.
+    """
+    m = 0
+    for d, p in zip(draft, verifier_preds):
+        if int(d) != int(p):
+            break
+        m += 1
+    return m

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -77,6 +77,7 @@ PORTABLE_MODULES = [
     "src.serve.rewind",
     "src.serve.sampling",
     "src.serve.generate",
+    "src.serve.spec_decode",
 ]
 
 FORBIDDEN_ROOTS = ("mlx", "torch")

--- a/tests/test_spec_decode.py
+++ b/tests/test_spec_decode.py
@@ -1,0 +1,115 @@
+"""Tests for self-speculative decoding (#52).
+
+Portable: the prompt-lookup drafter and the greedy accept rule. MLX-guarded: the
+batched `verify_block` matches sequential `step`, and the full speculative loop is
+byte-identical to plain greedy decoding (the distribution-preserving guarantee).
+"""
+
+import numpy as np
+import pytest
+
+from src.serve.spec_decode import first_mismatch, propose
+
+
+# --------------------------------------------------------------------------- #
+# Portable: drafter
+# --------------------------------------------------------------------------- #
+def test_propose_copies_after_recent_match():
+    # tail [1, 2] recurred earlier, followed by [3, 4]
+    ctx = [1, 2, 3, 4, 9, 9, 1, 2]
+    assert propose(ctx, gamma=2, max_n=8) == [3, 4]
+
+
+def test_propose_prefers_longer_pattern():
+    # both [2] and [1, 2] recur; the longer match [1,2]->[3] should win
+    ctx = [1, 2, 3, 7, 2, 5, 1, 2]
+    assert propose(ctx, gamma=1, max_n=8) == [3]
+
+
+def test_propose_limited_by_gamma_and_returns_empty_when_no_match():
+    assert propose([1, 2, 3, 1, 2, 3], gamma=2, max_n=8) == [1, 2]  # tail [1,2,3] recurs at 0
+    assert propose([5, 6, 7, 8], gamma=2, max_n=8) == []            # no tail recurs
+    assert propose([1], gamma=2, max_n=8) == []                     # too short
+
+
+def test_propose_respects_max_n_window():
+    ctx = list(range(10)) + [3, 4]          # tail [3,4]; earlier [3,4] at index 3
+    assert propose(ctx, gamma=2, max_n=8) == [5, 6]
+
+
+# --------------------------------------------------------------------------- #
+# Portable: accept rule
+# --------------------------------------------------------------------------- #
+def test_first_mismatch_counts_leading_agreement():
+    assert first_mismatch([1, 2, 3], [1, 2, 3]) == 3   # all accepted
+    assert first_mismatch([1, 2, 3], [1, 9, 3]) == 1   # mismatch at index 1
+    assert first_mismatch([1, 2, 3], [9, 2, 3]) == 0   # immediate mismatch
+    assert first_mismatch([], []) == 0
+
+
+# --------------------------------------------------------------------------- #
+# MLX-guarded: verifier + end-to-end equivalence
+# --------------------------------------------------------------------------- #
+mx = pytest.importorskip("mlx.core")
+
+
+def _toy_model():
+    from src.model.blocks import MambaConfig
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = MambaConfig(d_model=32, n_layers=2, head_dim=16, d_state=8,
+                      vocab_size=32, seq_len=16, precision="fp32")
+    mx.random.seed(0)
+    return MLXMambaModel(cfg)
+
+
+def test_verify_block_matches_sequential_step():
+    model = _toy_model()
+    tokens = [3, 7, 1, 4, 9]
+    state = model.init_state(1)
+
+    seq_logits = []
+    h = state
+    for t in tokens:
+        logit, h = model.step(mx.array([t]), h)
+        seq_logits.append(np.array(logit))
+
+    block_logits, block_states = model.verify_block(tokens, state)
+    for a, b in zip(seq_logits, block_logits):
+        assert np.allclose(a, np.array(b), atol=1e-5)
+    # final state from the block must equal the sequential final state
+    final_seq = np.array(h[0][1])           # layer 0 ssm state
+    final_blk = np.array(block_states[-1][0][1])
+    assert np.allclose(final_seq, final_blk, atol=1e-5)
+
+
+def _greedy_plain(model, prompt, max_new):
+    state = model.init_state(1)
+    logits = None
+    for t in prompt:
+        logits, state = model.step(mx.array([int(t)]), state)
+    out = []
+    for _ in range(max_new):
+        x = int(mx.argmax(logits[0]).item())
+        out.append(x)
+        logits, state = model.step(mx.array([x]), state)
+    return out
+
+
+def test_speculative_decode_equals_plain_greedy():
+    import scripts.spec_decode as sd
+    model = _toy_model()
+    # A structured (repeating) prompt so the prompt-lookup drafter finds matches.
+    prompt = [1, 2, 3, 4, 1, 2, 3, 4, 5, 6]
+    plain = _greedy_plain(model, prompt, max_new=40)
+    spec, _, stats = sd.spec_decode(model, prompt, max_new=40, gamma=4, max_n=8, mx=mx)
+    assert spec == plain                    # distribution-preserving (exact, greedy)
+    assert stats["rounds"] >= 1
+
+
+def test_speculative_decode_accepts_on_repetitive_text():
+    import scripts.spec_decode as sd
+    model = _toy_model()
+    prompt = [7, 7, 7, 7, 7, 7, 7, 7]       # maximally predictable -> high acceptance
+    spec, _, stats = sd.spec_decode(model, prompt, max_new=32, gamma=4, max_n=8, mx=mx)
+    assert spec == _greedy_plain(model, prompt, max_new=32)
+    assert stats["accept_rate"] > 0.0       # the drafter landed at least some tokens

--- a/tests/test_spec_decode.py
+++ b/tests/test_spec_decode.py
@@ -10,6 +10,15 @@ import pytest
 
 from src.serve.spec_decode import first_mismatch, propose
 
+try:
+    import mlx.core as mx
+    HAVE_MLX = True
+except ImportError:                     # portable drafter/accept tests must run without mlx
+    mx = None
+    HAVE_MLX = False
+
+requires_mlx = pytest.mark.skipif(not HAVE_MLX, reason="requires mlx (Apple Silicon)")
+
 
 # --------------------------------------------------------------------------- #
 # Portable: drafter
@@ -49,10 +58,9 @@ def test_first_mismatch_counts_leading_agreement():
 
 # --------------------------------------------------------------------------- #
 # MLX-guarded: verifier + end-to-end equivalence
+# (each test skips individually when mlx is absent, so the portable tests above
+# still run on a non-Mac host — see the `requires_mlx` marker)
 # --------------------------------------------------------------------------- #
-mx = pytest.importorskip("mlx.core")
-
-
 def _toy_model():
     from src.model.blocks import MambaConfig
     from src.model.mlx_backend import MLXMambaModel
@@ -62,6 +70,7 @@ def _toy_model():
     return MLXMambaModel(cfg)
 
 
+@requires_mlx
 def test_verify_block_matches_sequential_step():
     model = _toy_model()
     tokens = [3, 7, 1, 4, 9]
@@ -95,6 +104,7 @@ def _greedy_plain(model, prompt, max_new):
     return out
 
 
+@requires_mlx
 def test_speculative_decode_equals_plain_greedy():
     import scripts.spec_decode as sd
     model = _toy_model()
@@ -106,6 +116,7 @@ def test_speculative_decode_equals_plain_greedy():
     assert stats["rounds"] >= 1
 
 
+@requires_mlx
 def test_speculative_decode_accepts_on_repetitive_text():
     import scripts.spec_decode as sd
     model = _toy_model()


### PR DESCRIPTION
## What

Self-speculative draft-and-verify decoding for #52 — faster autoregressive decode with **no second trained model** and **provably unchanged output**.

- **`src/serve/spec_decode.py`** (portable): a prompt-lookup / n-gram drafter (copies continuations from recurring context) + the greedy accept rule (`first_mismatch`). Backend-free, unit-tested. Added to `test_import_guard.PORTABLE_MODULES`.
- **`MLXMambaModel.verify_block(tokens, state)`**: scores a draft block through `step` in a **single graph eval** (identical values to token-by-token `step`, verified in tests), returning per-token logits + states so the loop rolls back to the accepted prefix without recompute. Batching the verify into one `mx.eval` amortizes the per-token launch/sync that bounds batch-1 SSM decode — the source of the win.
- **`scripts/spec_decode.py`**: greedy speculative loop that **asserts byte-identical output to plain greedy decode**, then reports tokens/s + acceptance.

## Result (toy split, 200-step toy model)

```
[correctness] speculative == plain greedy: True
[accept]   201/218 draft tokens accepted (92.2%); 4.59 tokens/round over 56 rounds
[plain]       817.2 tokens/s
[spec]       1403.7 tokens/s
[result]   speculative is 1.72x plain decode wall-clock (identical output)
```

Distribution-preserving (exact, greedy) + measured **1.72× speedup**. Acceptance is high here because the synthetic corpus is repetitive; a real model's rate will differ — posting to #30.

## Test

- `.venv/bin/python -m pytest` → 407 passed, 1 skipped; `verify_block` matches sequential `step`; spec-vs-plain equality on structured and repetitive prompts.
- `verify_block` is additive — the M4 smoke gate stays exact.

Part of #30. Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)