### PR TITLE
feat(model): [#53] config-gated sparse MoE-Mamba block + capacity experiment

### DIFF
--- a/config/toy-moe.yaml
+++ b/config/toy-moe.yaml
@@ -1,0 +1,29 @@
+# Toy MoE config (#53): tiny Mamba-2 with config-gated sparse-MoE FFN layers.
+# Used by the parity + sizing tests so they exercise a model with the MoE block type.
+# moe_every 2 over 4 layers -> blocks [Mamba, MoE, Mamba, MoE]. fp32 for exact parity.
+d_model: 64
+n_layers: 4
+d_state: 16            # SSM state width N (per head)
+expand: 2              # d_inner = 128
+d_conv: 4
+head_dim: 16           # Mamba-2/SSD: 128/16 = 8 SSM heads (scalar A per head)
+dt_rank: auto
+
+# Sparse MoE: every 2nd block is a SwiGLU MoE FFN instead of a Mamba block.
+moe_every: 2           # layers 1 and 3 (0-indexed (i+1)%2==0) are MoE
+n_experts: 4           # route each token to top_k of these
+top_k: 2               # 2/4 experts active per token (sparse)
+moe_d_ff: null         # expert hidden width (null -> d_inner = 128)
+
+vocab_size: 256        # byte-fallback tokenizer for offline tests
+seq_len: 64
+tie_embeddings: true
+
+precision: fp32        # correctness first; fp32 makes forward/step parity exact
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false # tiny; keep tests cheap
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/scripts/moe_experiment.py
+++ b/scripts/moe_experiment.py
@@ -1,0 +1,116 @@
+"""MoE-Mamba capacity experiment (Apple Silicon / MLX) — issue #53.
+
+Trains a dense (pure-Mamba) baseline and a sparse-MoE variant on the same toy split for
+the same steps, then reports held-out loss alongside each model's TOTAL params (capacity)
+and ACTIVE params per token (a FLOP proxy: MoE counts only the top_k routed experts). The
+question MoE-Mamba/ME-Mamba pose: does sparse routing buy better loss-vs-active-FLOPs?
+
+    .venv/bin/python scripts/moe_experiment.py \\
+        --data data/<toy split> --moe-config config/toy-moe.yaml \\
+        --dense-config config/toy.yaml --steps 300
+
+The dense and MoE configs should share dims; only the MoE block placement differs. MLX
+imports are local so `--help` works on any host. Numbers post to #30.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--data", type=Path, required=True, help="split dir (train.bin, val.bin)")
+    ap.add_argument("--moe-config", type=Path, default=Path("config/toy-moe.yaml"))
+    ap.add_argument("--dense-config", type=Path, default=None,
+                    help="dense baseline config; default = the MoE config's pure-Mamba "
+                         "twin (same dims, moe_every=None) for a matched-depth comparison")
+    ap.add_argument("--steps", type=int, default=300)
+    ap.add_argument("--max-batches", type=int, default=8)
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--lr", type=float, default=3e-4)
+    ap.add_argument("--seed", type=int, default=0)
+    return ap.parse_args()
+
+
+def _train_and_eval(cfg, args, mx, np):
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    from src.train.loss_scale import scaler_for_precision
+    from src.data.loader import PackedLoader
+    from src.eval.val_loss import evaluate
+    import mlx.optimizers as optim
+
+    mx.random.seed(args.seed)
+    model = MLXMambaModel(cfg)
+    opt = optim.AdamW(learning_rate=args.lr)
+    train_step = make_train_step(model, opt, grad_clip=1.0,
+                                 scaler=scaler_for_precision(cfg.precision))
+    loader = PackedLoader(args.data / "train.bin", cfg.seq_len, args.batch_size,
+                          shuffle=True, drop_last=True)
+    done = 0
+    while done < args.steps:
+        for inp, tgt in loader.epoch():
+            train_step(model, [(inp, tgt)], args.lr)
+            done += 1
+            if done >= args.steps:
+                break
+    val_loader = PackedLoader(args.data / "val.bin", cfg.seq_len, args.batch_size,
+                              shuffle=False, drop_last=False)
+    res = evaluate(model, val_loader, max_batches=args.max_batches,
+                   to_numpy=lambda a: np.array(a))
+    return res
+
+
+def main() -> None:
+    args = _parse_args()
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/moe_experiment.py ...")
+
+    import dataclasses
+    import numpy as np
+    from src.model.blocks import load_config
+
+    moe_cfg = load_config(str(args.moe_config))
+    # Default dense baseline: the SAME config with MoE off (pure-Mamba twin) — identical
+    # depth/dims, so the comparison isolates the MoE block rather than confounding depth.
+    dense_cfg = (load_config(str(args.dense_config)) if args.dense_config is not None
+                 else dataclasses.replace(moe_cfg, moe_every=None, n_experts=0))
+    dense_cfg.validate()
+
+    rows = []
+    for label, cfg in (("dense", dense_cfg), ("moe", moe_cfg)):
+        print(f"[moe-exp] training {label} "
+              f"(n_layers={cfg.n_layers}, n_moe_layers={cfg.n_moe_layers}, "
+              f"experts={cfg.n_experts} top_k={cfg.top_k})")
+        res = _train_and_eval(cfg, args, mx, np)
+        rows.append((label, cfg, res))
+        print(f"[moe-exp] {label}: val_loss={res['val_loss']:.4f}  "
+              f"val_perplexity={res['val_perplexity']:.4f}")
+
+    print(f"\n[result] after {args.steps} steps (lower loss / fewer active params is better):")
+    print(f"  {'model':<6} {'val_loss':>9} {'perplexity':>11} "
+          f"{'total params':>13} {'active params':>14}")
+    for label, cfg, res in rows:
+        print(f"  {label:<6} {res['val_loss']:>9.4f} {res['val_perplexity']:>11.4f} "
+              f"{cfg.num_parameters():>13,} {cfg.active_num_parameters():>14,}")
+
+    dense, moe = rows[0][2], rows[1][2]
+    d_total, m_total = rows[0][1].num_parameters(), rows[1][1].num_parameters()
+    d_act, m_act = rows[0][1].active_num_parameters(), rows[1][1].active_num_parameters()
+    print(f"\n[result] MoE adds {m_total - d_total:+,} total params "
+          f"({m_total / d_total:.2f}x capacity) for {m_act - d_act:+,} active params "
+          f"({m_act / d_act:.2f}x active compute); "
+          f"val_loss {dense['val_loss']:.4f} (dense) -> {moe['val_loss']:.4f} (moe).")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -88,6 +88,19 @@ class MambaConfig:
     # Must divide d_model. Unused when attn_every is None.
     n_attn_heads: Optional[int] = None
 
+    # --- sparse Mixture-of-Experts (#53) ---
+    # Make every Mth block a sparse-MoE FFN block INSTEAD OF a Mamba block (the same
+    # interleave the hybrid uses for attention). MoE-Mamba/ME-Mamba: route each token to
+    # `top_k` of `n_experts` SwiGLU experts, adding capacity (params) at ~constant active
+    # compute. None = OFF (pure Mamba / hybrid; dense path byte-identical). Layer i is MoE
+    # iff `moe_every and (i+1) % moe_every == 0` AND it is not already an attention layer
+    # (attention takes precedence on a collision).
+    moe_every: Optional[int] = None
+    n_experts: int = 0          # experts per MoE block (>= 2 when MoE is on)
+    top_k: int = 2              # experts routed per token (1 <= top_k <= n_experts)
+    # Expert FFN hidden width. None => d_inner (the Mamba inner width), a natural scale.
+    moe_d_ff: Optional[int] = None
+
     # --- dt-projection bias init (LOAD-BEARING) ---
     # Inverse-softplus of a sample in [dt_min, dt_max] initializes the dt bias.
     # Without this the model fails to learn recall. Carry these into every backend.
@@ -132,6 +145,23 @@ class MambaConfig:
             return 0
         return self.n_layers // self.attn_every
 
+    # --- MoE derived params (#53) ---
+    @property
+    def moe_d_ff_resolved(self) -> int:
+        return int(self.moe_d_ff) if self.moe_d_ff is not None else self.d_inner
+
+    def is_moe_layer(self, i: int) -> bool:
+        """True if block `i` is a sparse-MoE FFN block. Attention takes precedence, so a
+        layer the hybrid claims is never also MoE."""
+        return (bool(self.moe_every) and (i + 1) % self.moe_every == 0
+                and not self.is_attention_layer(i))
+
+    @property
+    def n_moe_layers(self) -> int:
+        if not self.moe_every:
+            return 0
+        return sum(self.is_moe_layer(i) for i in range(self.n_layers))
+
     def parameter_breakdown(self) -> dict:
         """Closed-form trainable-parameter count, broken out by named term.
 
@@ -165,7 +195,8 @@ class MambaConfig:
         )
 
         n_attn = self.n_attention_layers
-        n_mamba = self.n_layers - n_attn
+        n_moe = self.n_moe_layers
+        n_mamba = self.n_layers - n_attn - n_moe
 
         bd = {
             "embedding": self.vocab_size * d_model,
@@ -179,14 +210,42 @@ class MambaConfig:
             d_attn = self.n_attn_heads_resolved * self.attn_head_dim
             attn_per_layer = d_model + 3 * d_model * d_attn + d_attn * d_model
             bd["attention"] = n_attn * attn_per_layer
+        # MoE (#53): sparse-FFN blocks REPLACE that many Mamba blocks. Each is a pre-norm
+        # + a bias-free router (d_model -> n_experts) + n_experts SwiGLU experts (gate, up:
+        # d_model -> d_ff; down: d_ff -> d_model; all bias-free). ALL expert params count
+        # toward capacity here; `active_parameter_breakdown` counts only the top_k routed.
+        if n_moe:
+            bd["moe"] = n_moe * self._moe_layer_params(self.n_experts)
         # Tied embedding reuses the input matrix as the LM head -> no extra params.
         if not self.tie_embeddings:
             bd["lm_head"] = self.vocab_size * d_model
         return bd
 
+    def _moe_layer_params(self, n_active_experts: int) -> int:
+        """Params of one MoE block counting `n_active_experts` experts: pre-norm + router
+        + experts (SwiGLU gate+up+down, bias-free). Used both for total capacity
+        (n_active_experts = n_experts) and active compute (= top_k)."""
+        d_model, d_ff = self.d_model, self.moe_d_ff_resolved
+        expert = 3 * d_model * d_ff
+        return d_model + self.n_experts * d_model + n_active_experts * expert
+
     def num_parameters(self) -> int:
         """Total trainable parameters (sum of `parameter_breakdown()`)."""
         return sum(self.parameter_breakdown().values())
+
+    def active_parameter_breakdown(self) -> dict:
+        """Per-token ACTIVE parameters — a FLOP proxy for the MoE capacity experiment
+        (#53). Identical to `parameter_breakdown()` except MoE blocks count only the
+        `top_k` routed experts (the conditional compute), not all `n_experts`. With MoE
+        off this equals `parameter_breakdown()`."""
+        bd = dict(self.parameter_breakdown())
+        if self.n_moe_layers:
+            bd["moe"] = self.n_moe_layers * self._moe_layer_params(self.top_k)
+        return bd
+
+    def active_num_parameters(self) -> int:
+        """Per-token active parameter count (sum of `active_parameter_breakdown()`)."""
+        return sum(self.active_parameter_breakdown().values())
 
     @property
     def packing_dtype(self) -> str:
@@ -222,6 +281,25 @@ class MambaConfig:
                 raise ValueError(
                     f"n_attn_heads={nah} must divide d_model={self.d_model} "
                     "(attn_head_dim = d_model // n_attn_heads)."
+                )
+        if self.moe_every is not None:
+            if self.moe_every <= 0:
+                raise ValueError("moe_every must be a positive int or None")
+            if self.n_experts < 2:
+                raise ValueError(
+                    f"n_experts={self.n_experts} must be >= 2 when moe_every is set "
+                    "(a sparse MoE needs at least two experts to route between)."
+                )
+            if not (1 <= self.top_k <= self.n_experts):
+                raise ValueError(
+                    f"top_k={self.top_k} must be in [1, n_experts={self.n_experts}]."
+                )
+            if self.moe_d_ff_resolved <= 0:
+                raise ValueError("moe_d_ff must be positive or None")
+            if self.n_moe_layers == 0:
+                raise ValueError(
+                    f"moe_every={self.moe_every} selects no layer at n_layers="
+                    f"{self.n_layers} (after attention precedence)."
                 )
 
     def to_dict(self) -> dict:

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -424,6 +424,15 @@ class CUDAMambaModel(ModelInterface, nn.Module):
     def __init__(self, config: MambaConfig, device: str = "cpu"):
         nn.Module.__init__(self)
         config.validate()
+        # Fail fast rather than silently build a DENSE model: the sparse-MoE block (#53) is
+        # MLX-only for now, but MambaConfig.num_parameters()/parameter_breakdown() already
+        # account for MoE capacity — so a `moe_every` config here would disagree with the
+        # formula and skew any cross-backend sizing/comparison.
+        if config.n_moe_layers > 0:
+            raise NotImplementedError(
+                "MoE-Mamba (#53) is not implemented in the CUDA backend; "
+                "build a config without `moe_every` (it is an MLX-only experiment)."
+            )
         self.config = config
         self._cd = _DTYPES[config.precision]         # compute dtype for the heavy GEMMs
         self._device = torch.device(device)

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -489,6 +489,69 @@ class AttentionBlock(nn.Module):
 
 
 # --------------------------------------------------------------------------- #
+# Sparse Mixture-of-Experts FFN block (#53)
+# --------------------------------------------------------------------------- #
+class _Expert(nn.Module):
+    """A SwiGLU FFN expert: down(silu(gate(x)) * up(x)). Bias-free, matmuls in `cd`."""
+
+    def __init__(self, d_model: int, d_ff: int):
+        super().__init__()
+        self.gate = nn.Linear(d_model, d_ff, bias=False)
+        self.up = nn.Linear(d_model, d_ff, bias=False)
+        self.down = nn.Linear(d_ff, d_model, bias=False)
+
+    def __call__(self, xn: Array, cd) -> Array:
+        return _linear(self.down, _silu(_linear(self.gate, xn, cd)) * _linear(self.up, xn, cd), cd)
+
+
+class MoEBlock(nn.Module):
+    """Sparse Mixture-of-Experts FFN block (#53), interleaved like `AttentionBlock`.
+
+    pre-norm -> router (softmax over n_experts) -> keep the top_k experts per token,
+    renormalize their gates -> weighted sum of those experts' SwiGLU outputs, with a
+    residual. Same `forward_seq(x)->x` / `step(x, state)->(x, state)` contract as the
+    other blocks; because it is POINTWISE over the sequence (no temporal mixing), forward
+    and step compute the same function by construction (parity is trivial), and it carries
+    no recurrent state (a placeholder state passes through `step` unchanged).
+
+    Toy-scale routing: all experts are evaluated and the top_k gates select the
+    combination (a dense compute, sparse *combination*). This is exact and FLOP-accountable
+    (the active-FLOP count is top_k via `MambaConfig.active_num_parameters`) but does not
+    yet realize the wall-clock saving of a true gathered/grouped matmul — fine for a
+    capacity experiment measuring loss vs active-FLOPs, called out so it is not mistaken
+    for a production MoE kernel."""
+
+    def __init__(self, config: MambaConfig):
+        super().__init__()
+        self.config = config
+        self.norm = RMSNorm(config.d_model)
+        self.router = nn.Linear(config.d_model, config.n_experts, bias=False)
+        d_ff = config.moe_d_ff_resolved
+        self.experts = [_Expert(config.d_model, d_ff) for _ in range(config.n_experts)]
+
+    def _moe(self, xn: Array) -> Array:
+        cd = _DTYPES[self.config.precision]
+        E, k = self.config.n_experts, self.config.top_k
+        logits = _f32(_linear(self.router, xn, cd))          # (..., E) — route in fp32
+        probs = mx.softmax(logits, axis=-1)
+        if k < E:                                            # keep top_k, zero the rest
+            kth = mx.sort(probs, axis=-1)[..., -k][..., None]
+            gate = mx.where(probs >= kth, probs, mx.zeros_like(probs))
+        else:
+            gate = probs
+        gate = gate / mx.sum(gate, axis=-1, keepdims=True)   # renormalize the kept gates
+        outs = mx.stack([e(xn, cd) for e in self.experts], axis=-2)   # (..., E, d_model)
+        y = mx.sum(gate[..., None] * _f32(outs), axis=-2)    # combine in fp32
+        return _cast(y, cd)
+
+    def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:
+        return x + self._moe(self.norm(x))                   # pointwise: seg_ids irrelevant
+
+    def step(self, x: Array, state: State) -> Tuple[Array, State]:
+        return x + self._moe(self.norm(x)), state            # stateless: pass state through
+
+
+# --------------------------------------------------------------------------- #
 # Top-level model implementing the seam
 # --------------------------------------------------------------------------- #
 class MLXMambaModel(ModelInterface, nn.Module):
@@ -498,9 +561,10 @@ class MLXMambaModel(ModelInterface, nn.Module):
         self.config = config
         self._cd = _DTYPES[config.precision]         # compute dtype for the heavy GEMMs
         self.embedding = nn.Embedding(config.vocab_size, config.d_model)
-        # Hybrid (#67): attention blocks replace Mamba blocks at the gated positions.
-        self.layers = [AttentionBlock(config) if config.is_attention_layer(i)
-                       else MambaBlock(config) for i in range(config.n_layers)]
+        # Hybrid (#67): attention blocks replace Mamba blocks at the gated positions;
+        # MoE (#53): sparse-FFN blocks replace Mamba blocks at their gated positions
+        # (attention takes precedence on a collision, matching `is_moe_layer`).
+        self.layers = [self._make_layer(config, i) for i in range(config.n_layers)]
         self.norm_f = RMSNorm(config.d_model)
         self._tie_embeddings = config.tie_embeddings
         if not config.tie_embeddings:
@@ -513,6 +577,14 @@ class MLXMambaModel(ModelInterface, nn.Module):
             self._layer_fns = [_checkpoint(l, l.forward_seq) for l in self.layers]
         else:
             self._layer_fns = [l.forward_seq for l in self.layers]
+
+    @staticmethod
+    def _make_layer(config: MambaConfig, i: int):
+        if config.is_attention_layer(i):
+            return AttentionBlock(config)
+        if config.is_moe_layer(i):
+            return MoEBlock(config)
+        return MambaBlock(config)
 
     def _head(self, h: Array) -> Array:
         # Logits + cross-entropy run in fp32 (wide-vocab softmax stability); h is
@@ -577,6 +649,9 @@ class MLXMambaModel(ModelInterface, nn.Module):
             if c.is_attention_layer(i):
                 z = mx.zeros((batch_size, Ha, 0, Dh))
                 return (z, z)
+            if c.is_moe_layer(i):
+                z = mx.zeros((batch_size, 0))     # MoE FFN is stateless; placeholder pair
+                return (z, z)                     # (keeps clone_state's (a, b) unpack valid)
             return (mx.zeros((batch_size, k - 1, di)), mx.zeros((batch_size, H, P, N)))
         return [layer_state(i) for i in range(self.config.n_layers)]
 

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -539,9 +539,13 @@ class MoEBlock(nn.Module):
         E, k = self.config.n_experts, self.config.top_k
         logits = _f32(_linear(self.router, xn, cd))          # (..., E) — route in fp32
         probs = mx.softmax(logits, axis=-1)
-        if k < E:                                            # keep top_k, zero the rest
-            kth = mx.sort(probs, axis=-1)[..., -k][..., None]
-            gate = mx.where(probs >= kth, probs, mx.zeros_like(probs))
+        if k < E:                                            # keep EXACTLY top_k per token
+            # Rank each expert by descending prob (double argsort), keep ranks < k. A plain
+            # `probs >= kth` threshold would keep MORE than k experts on ties (e.g. uniform
+            # routing early in training), breaking the top_k contract and the active-FLOP
+            # count; ranking breaks ties by index so exactly k survive.
+            ranks = mx.argsort(mx.argsort(-probs, axis=-1), axis=-1)
+            gate = mx.where(ranks < k, probs, mx.zeros_like(probs))
         else:
             gate = probs
         gate = gate / mx.sum(gate, axis=-1, keepdims=True)   # renormalize the kept gates

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -140,3 +140,21 @@ def test_router_selects_top_k():
     expert_outs = np.stack([np.array(e(xn, cd)) for e in block.experts], axis=1)  # (5,E,d)
     for i, e in enumerate(chosen):
         assert np.allclose(combined[i], expert_outs[i, e], atol=1e-5)
+
+
+def test_router_keeps_exactly_k_on_ties():
+    """A zeroed router makes all experts tie; exactly top_k must be kept (not all of
+    them), so the combination is the mean of the first k experts — not all E."""
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    block.router.weight = mx.zeros_like(block.router.weight)   # uniform routing -> ties
+    xn = mx.random.normal((3, cfg.d_model))
+    cd = mx.float32
+    combined = np.array(block._moe(xn))
+    expert_outs = np.stack([np.array(e(xn, cd)) for e in block.experts], axis=1)  # (3,E,d)
+    mean_first_k = expert_outs[:, :2, :].mean(axis=1)          # ranks break ties by index
+    assert np.allclose(combined, mean_first_k, atol=1e-5)
+    assert not np.allclose(combined, expert_outs.mean(axis=1), atol=1e-5)  # NOT all 4

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -1,0 +1,142 @@
+"""Tests for the sparse MoE-Mamba block (#53).
+
+Portable: the config selectors, validation, and total-vs-active param accounting.
+MLX-guarded: the dense path is byte-identical with MoE off, forward/step parity holds
+for the MoE block, and routing actually selects top_k experts.
+"""
+
+import numpy as np
+import pytest
+
+from src.model.blocks import MambaConfig
+
+
+def _cfg(**over):
+    base = dict(d_model=64, n_layers=4, head_dim=16, d_state=16, vocab_size=256,
+                seq_len=32, precision="fp32")
+    base.update(over)
+    return MambaConfig(**base)
+
+
+# --------------------------------------------------------------------------- #
+# Portable: selectors, validation, accounting
+# --------------------------------------------------------------------------- #
+def test_moe_off_by_default():
+    cfg = _cfg()
+    assert cfg.moe_every is None
+    assert cfg.n_moe_layers == 0
+    assert not any(cfg.is_moe_layer(i) for i in range(cfg.n_layers))
+    assert "moe" not in cfg.parameter_breakdown()
+    assert cfg.active_num_parameters() == cfg.num_parameters()   # no MoE -> identical
+
+
+def test_moe_layer_placement():
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    assert [cfg.is_moe_layer(i) for i in range(4)] == [False, True, False, True]
+    assert cfg.n_moe_layers == 2
+
+
+def test_attention_takes_precedence_over_moe():
+    # Layer 1 and 3 selected by both; attention wins, so neither is MoE.
+    cfg = _cfg(attn_every=2, n_attn_heads=4, moe_every=2, n_experts=4, top_k=2)
+    assert cfg.n_attention_layers == 2
+    assert cfg.n_moe_layers == 0
+    assert all(not cfg.is_moe_layer(i) for i in range(4))
+
+
+def test_moe_breakdown_sums_and_adds_capacity():
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    bd = cfg.parameter_breakdown()
+    assert "moe" in bd and bd["moe"] > 0
+    assert cfg.num_parameters() == sum(bd.values())
+    # MoE blocks replace Mamba blocks but add expert capacity -> more total params than
+    # the pure-Mamba twin at these toy dims.
+    pure = MambaConfig(**{**cfg.to_dict(), "moe_every": None})
+    assert cfg.num_parameters() > pure.num_parameters()
+
+
+def test_active_params_below_total_and_matches_top_k():
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    assert cfg.active_num_parameters() < cfg.num_parameters()    # sparse: top_k < n_experts
+    # active MoE term uses top_k experts; total uses n_experts.
+    full = _cfg(moe_every=2, n_experts=4, top_k=4)               # dense routing
+    assert full.active_num_parameters() == full.num_parameters()
+
+
+def test_moe_validation():
+    with pytest.raises(ValueError, match="n_experts"):
+        _cfg(moe_every=2, n_experts=1, top_k=1).validate()
+    with pytest.raises(ValueError, match="top_k"):
+        _cfg(moe_every=2, n_experts=4, top_k=5).validate()
+    with pytest.raises(ValueError, match="moe_every"):
+        _cfg(moe_every=0, n_experts=4, top_k=2).validate()
+    _cfg(moe_every=2, n_experts=4, top_k=2).validate()           # valid: no raise
+
+
+# --------------------------------------------------------------------------- #
+# MLX-guarded: dense path unchanged, parity, routing
+# --------------------------------------------------------------------------- #
+mx = pytest.importorskip("mlx.core")
+
+
+def test_dense_path_byte_identical_with_moe_off():
+    """A model built with MoE off must be byte-for-byte the pre-#53 model: same layer
+    types, same params, same logits."""
+    from src.model.mlx_backend import MLXMambaModel, MambaBlock
+    cfg = _cfg()                                  # moe off
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    assert all(isinstance(l, MambaBlock) for l in model.layers)
+    tokens = mx.array(np.arange(2 * 32).reshape(2, 32) % 256)
+    y = np.array(model.forward(tokens))
+    assert np.all(np.isfinite(y))
+    assert np.array_equal(y, np.array(model.forward(tokens)))    # deterministic
+
+
+def test_moe_model_builds_with_expected_block_types():
+    from src.model.mlx_backend import MLXMambaModel, MambaBlock, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    types = [type(l).__name__ for l in model.layers]
+    assert types == ["MambaBlock", "MoEBlock", "MambaBlock", "MoEBlock"]
+    # param-count formula holds against the real tensors
+    actual = sum(int(v.size) for v in model._portable_state_dict().values())
+    assert cfg.num_parameters() == actual
+
+
+def test_moe_forward_step_parity():
+    """MoE is pointwise, so the chunked forward and the one-step recurrence must agree
+    (fp32 ~1e-4), like the Mamba/attention blocks."""
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    tokens = np.arange(32).reshape(1, 32) % 256
+
+    seq = np.array(model.forward(mx.array(tokens)))[0]
+    state = model.init_state(1)
+    step = []
+    for t in range(tokens.shape[1]):
+        logit, state = model.step(mx.array(tokens[:, t]), state)
+        step.append(np.array(logit)[0])
+    step = np.stack(step)
+    rel = np.abs(seq - step).max() / (np.abs(seq).max() + 1e-6)
+    assert rel < 1e-4
+
+
+def test_router_selects_top_k():
+    """With top_k=1 the combined output must equal the single argmax-routed expert."""
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=1)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    xn = mx.random.normal((5, cfg.d_model))
+    cd = mx.float32
+    logits = np.array(block.router(xn))
+    chosen = logits.argmax(axis=-1)
+    combined = np.array(block._moe(xn))
+    expert_outs = np.stack([np.array(e(xn, cd)) for e in block.experts], axis=1)  # (5,E,d)
+    for i, e in enumerate(chosen):
+        assert np.allclose(combined[i], expert_outs[i, e], atol=1e-5)

--- a/tests/test_sizing_mlx.py
+++ b/tests/test_sizing_mlx.py
@@ -17,7 +17,7 @@ from src.model.mlx_backend import MLXMambaModel
 CONFIG_DIR = Path(__file__).resolve().parents[1] / "config"
 
 
-@pytest.mark.parametrize("name", ["toy", "poc", "toy-hybrid"])
+@pytest.mark.parametrize("name", ["toy", "poc", "toy-hybrid", "toy-moe"])
 def test_num_parameters_matches_built_model(name):
     cfg = load_config(CONFIG_DIR / f"{name}.yaml")
     model = MLXMambaModel(cfg)


### PR DESCRIPTION
## What

Config-gated sparse Mixture-of-Experts FFN blocks interleaved into the SSD stack (MoE-Mamba / ME-Mamba) for #53 — more parameter capacity at roughly constant active compute. **Off by default; the dense path is byte-identical when off.**

- **config** (`blocks.py`): `moe_every` (placement, mirrors `attn_every`), `n_experts`, `top_k`, `moe_d_ff`. Selectors `is_moe_layer`/`n_moe_layers` (attention takes precedence on a collision). `validate()` enforces `n_experts ≥ 2`, `1 ≤ top_k ≤ n_experts`. `parameter_breakdown()` gains an exact `moe` term; new `active_parameter_breakdown()` / `active_num_parameters()` count only the `top_k` routed experts (the FLOP proxy).
- **backend** (`mlx_backend.py`): `MoEBlock` — pre-norm → router → top_k SwiGLU experts → renormalized combine, residual. Same `forward_seq`/`step` contract as the Mamba/attention blocks. Pointwise ⇒ forward/step parity is exact; stateless ⇒ a placeholder state passes through `step` (keeps `clone_state`'s `(a,b)` unpack valid). Toy-scale routing computes all experts and combines the top_k — exact and FLOP-accountable, not yet a gathered-matmul kernel (called out in the docstring).
- **`config/toy-moe.yaml`** + added to the MLX param safety net (`num_parameters()` formula == built model's real tensors).

## Correctness

- **Dense path byte-identical with MoE off**: M4 smoke gate exact (`max|diff|=2.4e-7`), MLX parity green, full suite **410 passed, 1 skipped**.
- New `tests/test_moe.py`: selectors/validation/accounting (portable) + dense-unchanged, block-type wiring, **forward/step parity**, and top_k routing (MLX-guarded).

## Capacity experiment (`scripts/moe_experiment.py`)

Trains the MoE config against its **pure-Mamba twin** (matched depth/dims) and reports loss vs total/active params:

```
  model   val_loss  perplexity  total params  active params
  dense     1.2323      3.4291       136,224         136,224
  moe       1.2277      3.4133       273,584         175,280
  -> MoE: 2.01x capacity for 1.29x active compute; val_loss 1.2323 -> 1.2277
```

The toy corpus saturates, so the loss gap is small — the gated block + exact active-FLOP accounting are the deliverable; a real loss-vs-FLOPs signal wants a non-toy run. Posting to #30.

Part of #30. Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)