### PR TITLE
Crash-safe resume + checkpoint durability; test-integrity hardening (audit remediation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ decision record** — read them before changing values. Key locked decisions:
 - **toy.yaml** (smoke/correctness): tiny, `fp32` for bit-exact fixed-seed resume,
   `vocab_size 256` (byte-fallback tokenizer, offline).
 - **poc.yaml** (~100M scale run): `vocab_size 50280` (OLMo-7B-hf, confirmed `<65536`, uint16),
-  `precision fp16` + (dynamic) loss scaling (~18% faster than bf16 on Metal per the M1
+  `precision fp16` + (dynamic) loss scaling (~16% faster than bf16 on Metal per the M1
   micro-benchmark — **do not assume bf16**), tied embedding **mandatory** (~38M of
   ~100M params), `grad_checkpoint: true` (required at this depth — see below).
 - **`head_dim`** is the Mamba-2 head width: `d_inner` splits into

--- a/docs/design/05-training.md
+++ b/docs/design/05-training.md
@@ -97,16 +97,21 @@ This separation is the crux of the migration story:
 
 - **`save_weights`** writes safetensors + a `<path>.config.json` sidecar — portable,
   the bridge between backends.
-- **`save_resume` / `load_resume`** write a same-backend bundle (step, RNG state,
-  optimizer state) using a backend-supplied serializer — because optimizer-state
-  layout *is* backend-specific, and you never need to resume a half-finished MLX run
-  on CUDA.
+- **`CheckpointStore`** writes the same-backend resume bundle (portable weights +
+  optimizer state + step + fp16 loss-scale state) via a backend-supplied serializer —
+  optimizer-state layout *is* backend-specific, and you never need to resume a
+  half-finished MLX run on CUDA. It is **double-buffered and crash-safe**: two slots plus
+  an atomically-flipped `LATEST` pointer, so a checkpoint interrupted mid-write (a spot
+  preemption on a multi-week run) leaves the *previous* checkpoint fully intact. The data
+  order on resume is reconstructed deterministically from `(seed, step, grad_accum)` — no
+  RNG is persisted, because the model has no train-time randomness (dropout-free; weight
+  init is overwritten by the loaded weights).
 
 `safetensors` is imported lazily so the module loads without the dependency present.
 
-The [smoke gate](06-smoke-gate-and-eval.md) exercises exactly this: save portable
-weights + a resume bundle, tear everything down, rebuild, load, and continue — then
-assert the trajectory matches bit-for-bit.
+The [smoke gate](06-smoke-gate-and-eval.md) exercises exactly this: save a full
+checkpoint, tear everything down, rebuild, load, and continue — then assert the
+trajectory matches bit-for-bit.
 
 ## The scale run (M5)
 

--- a/docs/design/08-corpus-pipeline.md
+++ b/docs/design/08-corpus-pipeline.md
@@ -136,6 +136,26 @@ Dedup/decontam produce `cleaned/` once; the tokenized views are cheap to regener
   4. Sync the ~20 GB subset from R2 to a 50 GB network volume, train via
      `scripts/train.py --backend cuda`, confirm a decreasing val-perplexity curve,
      **checkpoint back to R2** (RunPod is not durable), and run the retrieval probes (#79).
+
+  **Pod spec + fused-kernel pins (#40).** The card must be **Ampere+** for native bf16
+  (the scale configs are bf16) — *not* a T4/Turing — and the image a RunPod **`-devel`** one,
+  which ships `nvcc` so the kernels can source-compile if no prebuilt wheel matches. The fused
+  selective-scan kernels (`mamba-ssm` / `causal-conv1d`) are the #40 perf path and are
+  deliberately **not** in the `[cuda]` extra; install them by hand. The one rule that bites:
+  the torch **minor** version and the **C++-ABI flag** must match across the image and the
+  kernel wheels. Two self-consistent sets (pins as of 2026-06-20):
+  - **Recommended (known-good, what this runbook is validated around):** image
+    `runpod/pytorch:2.4.0-py3.11-cuda12.4.1-devel-ubuntu22.04` +
+    `causal-conv1d==1.5.0.post8`, `mamba-ssm==2.2.4` (wheel tag `cu12torch2.4cxx11abiFALSE-cp311`).
+  - **Newest:** image `runpod/pytorch:2.8.0-py3.11-cuda12.8.1-cudnn-devel-ubuntu22.04` +
+    `causal-conv1d==1.6.2.post1`, `mamba-ssm==2.3.2.post1` (wheel tag
+    `cu12torch2.8cxx11abiTRUE-cp311` — note the ABI flag flipped to **TRUE** at torch ≥2.7).
+
+  Install with `pip install causal-conv1d mamba-ssm --no-build-isolation` — the flag makes the
+  build see the pod's preinstalled CUDA torch instead of pulling a CPU torch, so on a `-devel`
+  image it produces a torch-matched build (~10–30 min) even when no wheel matches. Re-check the
+  latest wheel tags at launch ([state-spaces/mamba](https://github.com/state-spaces/mamba/releases),
+  [Dao-AILab/causal-conv1d](https://github.com/Dao-AILab/causal-conv1d/releases)).
 - **Phase 5 (#75):** the 1B → 2B → 4B tiers per the #65 sizing table. **8-bit Adam** when
   VRAM-tight; **spot instances + frequent checkpointing** for 2B/4B; back up intermediate
   checkpoints to R2. Reuses the portable loop + two-concern [checkpointing](05-training.md);

--- a/docs/design/08-corpus-pipeline.md
+++ b/docs/design/08-corpus-pipeline.md
@@ -118,10 +118,24 @@ Dedup/decontam produce `cleaned/` once; the tokenized views are cheap to regener
 
 ## Training flow (Phases 4–5, #81 / #75)
 
-- **Phase 4 (#81):** the 100M smoke run — sync the ~20 GB subset from R2 to a 50 GB network
-  volume on a cheap GPU pod (T4/L4), train via `scripts/train.py --backend cuda`, confirm a
-  decreasing val-perplexity curve, **checkpoint back to R2**, and run the retrieval probes
-  (#79). Validates the whole plumbing before paying for big cards.
+- **Phase 4 (#81):** the 100M smoke run on a cheap GPU pod (T4/L4). Bring the pod up in
+  this order so a config or throughput problem surfaces *before* the long run:
+  1. `pip install -e '.[cuda]'` (the `[cuda]` extra pulls torch; `mlx` is Mac-only).
+  2. **CUDA smoke gate** — build a tiny toy split on the pod and run
+     `scripts/smoke_test.py --backend cuda --data <toy split>`. This proves the torch
+     backend resumes bit-exactly through the [double-buffered `CheckpointStore`](05-training.md)
+     end to end. Use `config/toy.yaml` (a dense config) — the gate refuses a MoE config,
+     since MoE-Mamba (#53) is MLX-only.
+  3. **Train-step bench** — `scripts/bench_cuda_train_step.py --config config/poc.yaml
+     --batch 32 --grad-accum 4` reports s/step, tokens/s, and **peak GPU memory** for the
+     production path (`CUDAMambaModel` + AdamW + `make_train_step`, wired exactly as
+     `train.py --backend cuda`). Confirms the card fits the step and gives a throughput
+     baseline to plan the run against — *before paying for big cards*. The same script
+     dry-runs on the Mac via torch-CPU (`--device cpu`, slow but the identical code path),
+     so the pod run is a no-surprise repeat. The MLX counterpart is `bench_train_step.py`.
+  4. Sync the ~20 GB subset from R2 to a 50 GB network volume, train via
+     `scripts/train.py --backend cuda`, confirm a decreasing val-perplexity curve,
+     **checkpoint back to R2** (RunPod is not durable), and run the retrieval probes (#79).
 - **Phase 5 (#75):** the 1B → 2B → 4B tiers per the #65 sizing table. **8-bit Adam** when
   VRAM-tight; **spot instances + frequent checkpointing** for 2B/4B; back up intermediate
   checkpoints to R2. Reuses the portable loop + two-concern [checkpointing](05-training.md);

--- a/scripts/bench_cuda_train_step.py
+++ b/scripts/bench_cuda_train_step.py
@@ -1,0 +1,173 @@
+"""CUDA / PyTorch train-step benchmark — the torch mirror of `bench_train_step.py`.
+
+Times the *production* CUDA training path — `CUDAMambaModel` + `torch.optim.AdamW` +
+`scaler_for_precision` + the real `make_train_step` closure (including the per-step
+`.item()` overflow sync) — so a RunPod CUDA box has trustworthy s/step, tokens/s, and
+peak-GPU-memory numbers before committing to a real run. It wires the model exactly as
+`scripts/train.py --backend cuda` does, through `get_backend("cuda")`.
+
+Develop it on the Mac FIRST (`--device cpu`, the default fallback): torch-CPU is in the
+`[cuda]` extra and exercises the identical code path — slow, but it proves the script
+works so the GPU run later is a no-surprise repeat. On the pod, `--device auto` picks
+CUDA when available.
+
+    # Mac dry-run (CPU; tiny so it finishes):
+    .venv/bin/python scripts/bench_cuda_train_step.py --config config/toy.yaml \\
+        --batch 2 --grad-accum 2 --warmup 1 --iters 3
+
+    # RunPod GPU, standard protocol:
+    .venv/bin/python scripts/bench_cuda_train_step.py --config config/poc.yaml \\
+        --batch 32 --grad-accum 4 --warmup 3 --iters 10
+
+torch imports are kept local so the module stays importable for `--help` on any host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import math
+import platform
+import time
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
+    ap.add_argument("--device", choices=("auto", "cuda", "cpu"), default="auto",
+                    help="auto: cuda if available, else cpu (the Mac dev fallback)")
+    ap.add_argument("--batch", type=int, default=32, help="sequences per micro-batch")
+    ap.add_argument("--seq", type=int, default=None, help="sequence length (default: config seq_len)")
+    ap.add_argument("--grad-accum", type=int, default=4, help="micro-batches per optimizer step")
+    ap.add_argument("--warmup", type=int, default=3, help="untimed warmup steps (first reported separately)")
+    ap.add_argument("--iters", type=int, default=10, help="timed optimizer steps")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--lr", type=float, default=3e-4, help="learning rate (matches train.py --base-lr default)")
+    ap.add_argument("--chunk-size", type=int, default=None,
+                    help="override SSD scan chunk length Q (default: config value, else 64)")
+    args = ap.parse_args()
+    # Fail fast on inputs that would crash or report nonsense (same as bench_train_step).
+    if args.iters < 1:
+        ap.error("--iters must be >= 1")
+    if args.warmup < 1:
+        ap.error("--warmup must be >= 1 (the first call is always run untimed)")
+    if args.batch < 1:
+        ap.error("--batch must be >= 1")
+    if args.grad_accum < 1:
+        ap.error("--grad-accum must be >= 1")
+    if args.seq is not None and args.seq < 1:
+        ap.error("--seq must be >= 1")
+    if args.chunk_size is not None and args.chunk_size < 1:
+        ap.error("--chunk-size must be >= 1")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+
+    # torch-only imports kept local so the seam stays clean and --help works anywhere.
+    try:
+        import torch
+    except ModuleNotFoundError as e:
+        if e.name != "torch":
+            raise
+        raise SystemExit(
+            "torch not found — install the CUDA backend extra on a Linux/CUDA host:\n"
+            "    pip install -e '.[cuda]'\n"
+            "(torch is omitted from the default deps; mlx is the Apple-Silicon backend.)"
+        ) from e
+    import numpy as np
+
+    from src.model.backend import get_backend
+    from src.model.blocks import load_config
+    from src.train.loss_scale import scaler_for_precision
+
+    cfg = load_config(str(args.config))
+    if args.chunk_size is not None:
+        cfg = dataclasses.replace(cfg, chunk_size=args.chunk_size)
+        cfg.validate()
+    if cfg.n_moe_layers > 0:
+        raise SystemExit(
+            "MoE-Mamba (#53) is MLX-only; the CUDA backend can't build it. Bench a dense "
+            "config (e.g. config/poc.yaml / config/toy.yaml).")
+
+    device = ("cuda" if torch.cuda.is_available() else "cpu") if args.device == "auto" \
+        else args.device
+    if device == "cuda" and not torch.cuda.is_available():
+        raise SystemExit("--device cuda requested but torch.cuda.is_available() is False.")
+    on_cuda = device == "cuda"
+
+    seq = args.seq if args.seq is not None else cfg.seq_len
+    tokens_per_step = args.batch * seq * args.grad_accum
+
+    print(f"[bench/cuda] torch {torch.__version__}  device={device}  {platform.platform()}")
+    if on_cuda:
+        print(f"[bench/cuda] gpu={torch.cuda.get_device_name(0)}")
+    print(f"[bench/cuda] config={args.config}  d_model={cfg.d_model}  d_inner={cfg.d_inner}  "
+          f"n_layers={cfg.n_layers}  vocab={cfg.vocab_size}  precision={cfg.precision}  "
+          f"grad_checkpoint={cfg.grad_checkpoint}  chunk_size={cfg.chunk_size or 64}")
+    print(f"[bench/cuda] batch={args.batch} x seq={seq} x grad_accum={args.grad_accum} "
+          f"= {tokens_per_step} tokens/step  iters={args.iters} (+{args.warmup} warmup)\n")
+
+    # The exact wiring of scripts/train.py --backend cuda — measures the production path.
+    backend = get_backend("cuda")
+    backend.seed(args.seed)
+    model = backend.model_cls(cfg, device=device)
+    opt = backend.make_optimizer(model, args.lr)
+    scaler = scaler_for_precision(cfg.precision)
+    train_step = backend.make_train_step(model, opt, grad_clip=1.0, scaler=scaler)
+
+    rng = np.random.default_rng(args.seed)
+    # Mirror PackedLoader exactly: numpy int64 ids; the backend converts inside forward.
+    micro_batches = [
+        (rng.integers(0, cfg.vocab_size, size=(args.batch, seq)).astype(np.int64),
+         rng.integers(0, cfg.vocab_size, size=(args.batch, seq)).astype(np.int64))
+        for _ in range(args.grad_accum)
+    ]
+
+    def _sync() -> None:
+        if on_cuda:
+            torch.cuda.synchronize()  # the step queues async work; wait before stopping the clock
+
+    # First call timed separately — it includes lazy CUDA init / first-kernel compile.
+    t0 = time.perf_counter()
+    out = train_step(model, micro_batches, args.lr)
+    _sync()
+    first_call_s = time.perf_counter() - t0
+    for _ in range(args.warmup - 1):
+        out = train_step(model, micro_batches, args.lr)
+    _sync()
+
+    if on_cuda:
+        torch.cuda.reset_peak_memory_stats()
+    times = []
+    skipped = 0
+    for _ in range(args.iters):
+        t0 = time.perf_counter()
+        out = train_step(model, micro_batches, args.lr)
+        _sync()
+        times.append(time.perf_counter() - t0)
+        skipped += int(out.get("skipped", False))
+
+    if not math.isfinite(out["loss"]):
+        raise RuntimeError("non-finite loss — run is degenerate")
+
+    mean_s = sum(times) / len(times)
+    min_s = min(times)
+    print(f"first call      {first_call_s:>10.3f} s   (init/compile, excluded from stats)")
+    print(f"s/step          {mean_s:>10.3f} mean   {min_s:.3f} min   over {args.iters} iters")
+    print(f"tokens/s        {tokens_per_step / mean_s:>10,.0f}   ({tokens_per_step} tokens/step)")
+    if on_cuda:
+        print(f"peak memory     {torch.cuda.max_memory_allocated() / 2**30:>10.2f} GB")
+    else:
+        print(f"peak memory     {'n/a':>10}   (cpu dev run — GPU peak only on --device cuda)")
+    line = f"loss {out['loss']:.4f}   grad_norm {out['grad_norm']:.4f}"
+    if scaler:
+        line += f"   loss_scale {out['loss_scale']:.0f}   skipped {skipped}/{args.iters}"
+    print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_precision.py
+++ b/scripts/bench_precision.py
@@ -142,7 +142,17 @@ def _bench_model(args, cfg, mx) -> None:
 
 def main() -> None:
     args = _parse_args()
-    import mlx.core as mx
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/bench_precision.py ...\n"
+            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
+            "`python` likely points at a different interpreter.)"
+        ) from e
 
     from src.model.blocks import load_config
 

--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -71,7 +71,7 @@ def main() -> None:
     from src.train.loss_scale import scaler_for_precision
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
-    from src.train.checkpoint import save_resume, load_resume
+    from src.train.checkpoint import CheckpointStore
     from src.train.dpo_math import evaluate_dpo
 
     backend = get_backend(args.backend)
@@ -105,30 +105,29 @@ def main() -> None:
     out = args.out
     out.mkdir(parents=True, exist_ok=True)
     weights_path = str(out / "weights.safetensors")
-    bundle_dir = str(out / "resume")
-    resume_dir = args.resume if args.resume is not None else (
-        Path(bundle_dir) if Path(bundle_dir, "resume_meta.json").exists() else None)
+    store = CheckpointStore(str(args.resume) if args.resume is not None
+                            else str(out / "resume"))
+    resuming = store.has_checkpoint()
 
     start_step = 0
-    if resume_dir is not None:
-        policy.load(weights_path)                        # resume the policy
-        meta = load_resume(str(resume_dir),
-                           optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
+    if resuming:
+        meta = store.load(weights_deserializer=lambda p: policy.load(p),  # resume the policy
+                          optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
             scaler.load_state_dict(meta.get("loss_scale_state") or {})
-        print(f"[resume] from step {start_step} (out={out})")
+        print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})")
     else:
         policy.load(str(args.init))                      # init policy from SFT weights
         print(f"[init] policy + reference from {args.init}")
 
-    logger = JsonlLogger(str(out / "metrics.jsonl"), append=resume_dir is not None)
+    logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 
     def on_checkpoint(step: int) -> None:
-        policy.save(weights_path)                        # checkpoint the POLICY
-        save_resume(bundle_dir, step=step,
-                    loss_scale_state=(scaler.state_dict() if scaler else None),
-                    optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
+        store.save(step=step,
+                   loss_scale_state=(scaler.state_dict() if scaler else None),
+                   weights_serializer=lambda p: policy.save(p),  # checkpoint the POLICY
+                   optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
 
     tcfg = TrainConfig(
         total_steps=total_steps, base_lr=args.base_lr, warmup_steps=warmup,
@@ -148,6 +147,7 @@ def main() -> None:
     # Skip the terminal checkpoint if the loop already wrote one at total_steps.
     if total_steps % tcfg.ckpt_every != 0:
         on_checkpoint(total_steps)
+    policy.save(weights_path)           # canonical portable policy weights for downstream
     final = evaluate_dpo(policy, ref, val_loader, beta=args.beta, max_batches=max_b,
                          to_numpy=np_to)
     logger.close()

--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -116,7 +116,7 @@ def main() -> None:
                            optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
-            scaler.load_state_dict(meta.get("rng_state") or {})
+            scaler.load_state_dict(meta.get("loss_scale_state") or {})
         print(f"[resume] from step {start_step} (out={out})")
     else:
         policy.load(str(args.init))                      # init policy from SFT weights
@@ -127,7 +127,7 @@ def main() -> None:
     def on_checkpoint(step: int) -> None:
         policy.save(weights_path)                        # checkpoint the POLICY
         save_resume(bundle_dir, step=step,
-                    rng_state=(scaler.state_dict() if scaler else None),
+                    loss_scale_state=(scaler.state_dict() if scaler else None),
                     optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
 
     tcfg = TrainConfig(
@@ -145,7 +145,9 @@ def main() -> None:
           val_eval=val_eval, logger=logger, on_checkpoint=on_checkpoint,
           start_step=start_step)
 
-    on_checkpoint(total_steps)
+    # Skip the terminal checkpoint if the loop already wrote one at total_steps.
+    if total_steps % tcfg.ckpt_every != 0:
+        on_checkpoint(total_steps)
     final = evaluate_dpo(policy, ref, val_loader, beta=args.beta, max_batches=max_b,
                          to_numpy=np_to)
     logger.close()

--- a/scripts/moe_experiment.py
+++ b/scripts/moe_experiment.py
@@ -10,7 +10,7 @@ question MoE-Mamba/ME-Mamba pose: does sparse routing buy better loss-vs-active-
         --dense-config config/toy.yaml --steps 300
 
 The dense and MoE configs should share dims; only the MoE block placement differs. MLX
-imports are local so `--help` works on any host. Numbers post to #30.
+imports are local so `--help` works on any host. Numbers post to #53.
 """
 
 from __future__ import annotations

--- a/scripts/rlvr.py
+++ b/scripts/rlvr.py
@@ -7,7 +7,7 @@ step. The model generates the solutions; the verifier judges — so only problem
 are needed, no reference solutions (docs/design/08-corpus-pipeline.md lines 120-123).
 
   python scripts/rlvr.py --config config/poc.yaml --init runs/sft/weights.safetensors \
-      --problems math.jsonl --steps 200
+      --problems math.jsonl --steps 200 --out runs/rlvr --ckpt-every 50
 
 `--problems` is JSONL with `{"prompt": "...", "answer": "..."}` per line. `--reward math`
 (default) uses the final-number exact-match; `--reward exact` uses normalized string match.
@@ -56,6 +56,12 @@ def main() -> None:
     ap.add_argument("--init", type=Path, required=True, help="checkpoint weights (SFT base)")
     ap.add_argument("--problems", type=Path, required=True, help="JSONL {prompt, answer}")
     ap.add_argument("--reward", choices=("math", "exact"), default="math")
+    ap.add_argument("--out", type=Path, default=Path("runs/rlvr"),
+                    help="output dir for weights.safetensors (default runs/rlvr); kept "
+                         "separate from --init so the base checkpoint is never clobbered")
+    ap.add_argument("--ckpt-every", type=int, default=0,
+                    help="save intermediate weights every N steps (0 = only at the end), "
+                         "so a long run that crashes does not lose all progress")
     ap.add_argument("--steps", type=int, default=200)
     ap.add_argument("--group-size", type=int, default=8, help="K completions per problem")
     ap.add_argument("--lr", type=float, default=1e-6)
@@ -93,6 +99,10 @@ def main() -> None:
         raise SystemExit(f"no problems in {args.problems}")
     rng = np.random.default_rng(args.seed)
 
+    out = args.out
+    out.mkdir(parents=True, exist_ok=True)
+    weights_path = str(out / "weights.safetensors")
+
     for step in range(args.steps):
         prob = problems[step % len(problems)]
         prompt_ids = list(tok.encode(prob["prompt"])) or [eos or 0]
@@ -111,15 +121,17 @@ def main() -> None:
             rewards.append(reward_fn(tok.decode(gen), str(prob.get("answer", ""))))
 
         adv = group_advantages([rewards])[0]            # (K,)
-        out = grpo_step(model, [collate_rollouts(rollouts, adv)], args.lr)
+        metrics = grpo_step(model, [collate_rollouts(rollouts, adv)], args.lr)
         if step % args.log_every == 0:
             stats = reward_stats(rewards)
-            print(f"step {step:4d}  loss {out['loss']:.4f}  "
+            print(f"step {step:4d}  loss {metrics['loss']:.4f}  "
                   f"mean_reward {stats['mean_reward']:.3f}  solved {stats['frac_solved']:.3f}")
+        if args.ckpt_every and step > 0 and step % args.ckpt_every == 0:
+            model.save(weights_path)
+            print(f"  [ckpt] step {step} -> {weights_path}")
 
-    save_dir = args.init.parent
-    model.save(str(save_dir / "rlvr_weights.safetensors"))
-    print(f"done — wrote {save_dir / 'rlvr_weights.safetensors'}")
+    model.save(weights_path)
+    print(f"done — wrote {weights_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -72,7 +72,7 @@ def main() -> None:
     from src.train.loss_scale import scaler_for_precision
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
-    from src.train.checkpoint import save_resume, load_resume
+    from src.train.checkpoint import CheckpointStore
     from src.eval.val_loss import evaluate_masked
 
     backend = get_backend(args.backend)
@@ -104,30 +104,29 @@ def main() -> None:
     out = args.out
     out.mkdir(parents=True, exist_ok=True)
     weights_path = str(out / "weights.safetensors")
-    bundle_dir = str(out / "resume")
-    resume_dir = args.resume if args.resume is not None else (
-        Path(bundle_dir) if Path(bundle_dir, "resume_meta.json").exists() else None)
+    store = CheckpointStore(str(args.resume) if args.resume is not None
+                            else str(out / "resume"))
+    resuming = store.has_checkpoint()
 
     start_step = 0
-    if resume_dir is not None:
-        model.load(weights_path)                         # resume from SFT checkpoint
-        meta = load_resume(str(resume_dir),
-                           optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
+    if resuming:
+        meta = store.load(weights_deserializer=lambda p: model.load(p),
+                          optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
             scaler.load_state_dict(meta.get("loss_scale_state") or {})
-        print(f"[resume] from step {start_step} (out={out})")
+        print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})")
     else:
         model.load(str(args.init))                       # initialize from pretrained base
         print(f"[init] from pretrained base {args.init}")
 
-    logger = JsonlLogger(str(out / "metrics.jsonl"), append=resume_dir is not None)
+    logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 
     def on_checkpoint(step: int) -> None:
-        model.save(weights_path)                         # portable weights + config
-        save_resume(bundle_dir, step=step,
-                    loss_scale_state=(scaler.state_dict() if scaler else None),
-                    optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
+        store.save(step=step,
+                   loss_scale_state=(scaler.state_dict() if scaler else None),
+                   weights_serializer=lambda p: model.save(p),  # portable weights + config
+                   optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
 
     tcfg = TrainConfig(
         total_steps=total_steps, base_lr=args.base_lr, warmup_steps=warmup,
@@ -147,6 +146,7 @@ def main() -> None:
     # Skip the terminal checkpoint if the loop already wrote one at total_steps.
     if total_steps % tcfg.ckpt_every != 0:
         on_checkpoint(total_steps)
+    model.save(weights_path)            # canonical portable weights for downstream
     final = evaluate_masked(model, val_loader, max_batches=max_b, to_numpy=np_to)
     logger.close()
     print(f"[done] step={total_steps}  val_loss={final['val_loss']:.4f}  "

--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -76,7 +76,7 @@ def main() -> None:
     from src.eval.val_loss import evaluate_masked
 
     backend = get_backend(args.backend)
-    cfg = load_config(str(args.config))                 # validates (vocab < 65536, ...)
+    cfg = load_config(str(args.config))                 # validates (vocab < 2**32, head_dim | d_inner, ...)
 
     # --- data (response-masked instruction records) ----------------------------
     train_loader = SFTLoader(args.data / "train.jsonl", cfg.seq_len, args.batch_size,
@@ -115,7 +115,7 @@ def main() -> None:
                            optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
-            scaler.load_state_dict(meta.get("rng_state") or {})
+            scaler.load_state_dict(meta.get("loss_scale_state") or {})
         print(f"[resume] from step {start_step} (out={out})")
     else:
         model.load(str(args.init))                       # initialize from pretrained base
@@ -126,7 +126,7 @@ def main() -> None:
     def on_checkpoint(step: int) -> None:
         model.save(weights_path)                         # portable weights + config
         save_resume(bundle_dir, step=step,
-                    rng_state=(scaler.state_dict() if scaler else None),
+                    loss_scale_state=(scaler.state_dict() if scaler else None),
                     optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
 
     tcfg = TrainConfig(
@@ -144,7 +144,9 @@ def main() -> None:
           val_eval=val_eval, logger=logger, on_checkpoint=on_checkpoint,
           start_step=start_step)
 
-    on_checkpoint(total_steps)
+    # Skip the terminal checkpoint if the loop already wrote one at total_steps.
+    if total_steps % tcfg.ckpt_every != 0:
+        on_checkpoint(total_steps)
     final = evaluate_masked(model, val_loader, max_batches=max_b, to_numpy=np_to)
     logger.close()
     print(f"[done] step={total_steps}  val_loss={final['val_loss']:.4f}  "

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -50,6 +50,14 @@ def main() -> None:
     backend = get_backend(args.backend)
     cfg = load_config(str(args.config))
     assert cfg.precision == "fp32", "smoke test requires fp32 for exact resume"
+    # Pin the CUDA gate to a DENSE config (e.g. config/toy.yaml). MoE-Mamba (#53) is
+    # MLX-only, so CUDAMambaModel refuses to build it — fail here with that reason
+    # rather than deep inside model construction. (toy-moe.yaml is also fp32, so the
+    # precision assert above would not catch it.)
+    if backend.name == "cuda":
+        assert cfg.n_moe_layers == 0, (
+            f"CUDA smoke gate needs a dense config (got {args.config} with "
+            f"{cfg.n_moe_layers} MoE layers); MoE is MLX-only. Use config/toy.yaml.")
     N = args.steps
     half = N // 2
     np_to = backend.to_numpy

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -93,7 +93,7 @@ def main() -> None:
     model_a, opt_a, step_fn_a = fresh_model_opt()
     run_window(model_a, step_fn_a, 0, half, res)
     model_a.save(weights_path)                                  # portable weights
-    save_resume(bundle_dir, step=half, rng_state=None,
+    save_resume(bundle_dir, step=half, loss_scale_state=None,
                 optimizer_serializer=lambda p: backend.save_optimizer(opt_a, p))
     del model_a, opt_a, step_fn_a                               # "kill" the process state
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -44,7 +44,7 @@ def main() -> None:
     from src.model.blocks import load_config
     from src.data.loader import PackedLoader
     from src.train.schedule import CosineSchedule
-    from src.train.checkpoint import save_weights, save_resume, load_resume
+    from src.train.checkpoint import CheckpointStore
     from src.eval.val_loss import evaluate
 
     backend = get_backend(args.backend)
@@ -86,23 +86,21 @@ def main() -> None:
     # --- 2) interrupted run: train half, checkpoint, KILL, rebuild, resume ------
     out = args.out
     out.mkdir(parents=True, exist_ok=True)
-    weights_path = str(out / "weights.safetensors")
-    bundle_dir = str(out / "resume")
+    store = CheckpointStore(str(out / "resume"))
 
     res = {}
     model_a, opt_a, step_fn_a = fresh_model_opt()
     run_window(model_a, step_fn_a, 0, half, res)
-    model_a.save(weights_path)                                  # portable weights
-    save_resume(bundle_dir, step=half, loss_scale_state=None,
-                optimizer_serializer=lambda p: backend.save_optimizer(opt_a, p))
+    store.save(step=half, loss_scale_state=None,
+               weights_serializer=lambda p: model_a.save(p),    # portable weights
+               optimizer_serializer=lambda p: backend.save_optimizer(opt_a, p))
     del model_a, opt_a, step_fn_a                               # "kill" the process state
 
     backend.seed(args.seed + 999)              # different RNG: weights come from disk
     model_b = backend.model_cls(cfg)
-    model_b.load(weights_path)
     opt_b = backend.make_optimizer(model_b, sched.base_lr)
-    meta = load_resume(bundle_dir,
-                       optimizer_deserializer=lambda p: backend.load_optimizer(opt_b, p))
+    meta = store.load(weights_deserializer=lambda p: model_b.load(p),
+                      optimizer_deserializer=lambda p: backend.load_optimizer(opt_b, p))
     start = meta["step"]
     step_fn_b = backend.make_train_step(model_b, opt_b, grad_clip=1.0)
     run_window(model_b, step_fn_b, start, N, res)

--- a/scripts/spec_decode.py
+++ b/scripts/spec_decode.py
@@ -13,8 +13,8 @@ per-token sync that bounds batch-1 SSM decode (the #30 ~94.7 tok/s record).
         --max-new 256 --gamma 4
 
     # Real model:
-    .venv/bin/python scripts/spec_decode.py --config config/toy.yaml \\
-        --weights run/weights.safetensors --data data/<toy split> --max-new 256
+    .venv/bin/python scripts/spec_decode.py --config config/poc.yaml \\
+        --weights runs/poc/weights.safetensors --data data/split --max-new 256
 
 Numbers (tokens/s plain vs speculative, acceptance rate) post to #30. MLX imports are
 local so `--help` works on any host.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -75,7 +75,7 @@ def main() -> None:
     from src.train.loss_scale import scaler_for_precision
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
-    from src.train.checkpoint import save_resume, load_resume
+    from src.train.checkpoint import CheckpointStore
     from src.eval.val_loss import evaluate
 
     backend = get_backend(args.backend)
@@ -106,31 +106,30 @@ def main() -> None:
     max_b = args.eval_batches or None
     val_eval = lambda m: evaluate(m, val_loader, max_batches=max_b, to_numpy=np_to)
 
-    # --- resume (portable weights + within-backend bundle) ---------------------
+    # --- resume (double-buffered, crash-safe checkpoint store) -----------------
     out = args.out
     out.mkdir(parents=True, exist_ok=True)
     weights_path = str(out / "weights.safetensors")
-    bundle_dir = str(out / "resume")
-    resume_dir = args.resume if args.resume is not None else (
-        Path(bundle_dir) if Path(bundle_dir, "resume_meta.json").exists() else None)
+    store = CheckpointStore(str(args.resume) if args.resume is not None
+                            else str(out / "resume"))
+    resuming = store.has_checkpoint()
 
     start_step = 0
-    if resume_dir is not None:
-        model.load(weights_path)
-        meta = load_resume(str(resume_dir),
-                           optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
+    if resuming:
+        meta = store.load(weights_deserializer=lambda p: model.load(p),
+                          optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
             scaler.load_state_dict(meta.get("loss_scale_state") or {})
-        print(f"[resume] from step {start_step} (out={out})")
+        print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})")
 
-    logger = JsonlLogger(str(out / "metrics.jsonl"), append=resume_dir is not None)
+    logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 
     def on_checkpoint(step: int) -> None:
-        model.save(weights_path)                        # portable weights + config
-        save_resume(bundle_dir, step=step,
-                    loss_scale_state=(scaler.state_dict() if scaler else None),
-                    optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
+        store.save(step=step,
+                   loss_scale_state=(scaler.state_dict() if scaler else None),
+                   weights_serializer=lambda p: model.save(p),  # portable weights + config
+                   optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
 
     tcfg = TrainConfig(
         total_steps=total_steps, base_lr=args.base_lr, warmup_steps=warmup,
@@ -152,6 +151,9 @@ def main() -> None:
     # multiple of ckpt_every; guard so we don't write (and re-serialize) it twice.
     if total_steps % tcfg.ckpt_every != 0:
         on_checkpoint(total_steps)
+    # Materialize the portable weights at the canonical out/weights.safetensors for
+    # downstream eval/serving/distillation (the live copy otherwise lives in the slot).
+    model.save(weights_path)
     final = evaluate(model, val_loader, max_batches=max_b, to_numpy=np_to)
     logger.close()
     print(f"[done] step={total_steps}  val_loss={final['val_loss']:.4f}  "

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -80,7 +80,7 @@ def main() -> None:
 
     backend = get_backend(args.backend)
 
-    cfg = load_config(str(args.config))                 # validates (vocab < 65536, ...)
+    cfg = load_config(str(args.config))                 # validates (vocab < 2**32, head_dim | d_inner, ...)
 
     tokens_per_step = args.batch_size * cfg.seq_len * args.grad_accum
     total_steps = (args.total_steps if args.total_steps is not None
@@ -121,7 +121,7 @@ def main() -> None:
                            optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
-            scaler.load_state_dict(meta.get("rng_state") or {})
+            scaler.load_state_dict(meta.get("loss_scale_state") or {})
         print(f"[resume] from step {start_step} (out={out})")
 
     logger = JsonlLogger(str(out / "metrics.jsonl"), append=resume_dir is not None)
@@ -129,7 +129,7 @@ def main() -> None:
     def on_checkpoint(step: int) -> None:
         model.save(weights_path)                        # portable weights + config
         save_resume(bundle_dir, step=step,
-                    rng_state=(scaler.state_dict() if scaler else None),
+                    loss_scale_state=(scaler.state_dict() if scaler else None),
                     optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
 
     tcfg = TrainConfig(
@@ -148,7 +148,10 @@ def main() -> None:
           start_step=start_step)
 
     # --- final checkpoint + full eval ------------------------------------------
-    on_checkpoint(total_steps)
+    # The loop already checkpoints at `step == total_steps` when total_steps is a
+    # multiple of ckpt_every; guard so we don't write (and re-serialize) it twice.
+    if total_steps % tcfg.ckpt_every != 0:
+        on_checkpoint(total_steps)
     final = evaluate(model, val_loader, max_batches=max_b, to_numpy=np_to)
     logger.close()
     print(f"[done] step={total_steps}  val_loss={final['val_loss']:.4f}  "

--- a/src/conformance/doc_boundary_parity.py
+++ b/src/conformance/doc_boundary_parity.py
@@ -24,11 +24,12 @@ from ..model.interface import ModelInterface
 def check_doc_boundary_parity(model: ModelInterface, docs: Sequence[Sequence[int]],
                               chunk_size: int, *, to_numpy=np.asarray, pad_id: int = 0,
                               rtol: float = 1e-4, atol: float = 1e-5) -> dict:
-    """Pack `docs` chunk-aligned into one sequence with `seg_ids` and assert each document's
-    logits match its standalone forward. Returns `{max_abs_diff, ok}`; raises on mismatch.
+    """Pack `docs` chunk-aligned into one sequence with `seg_ids` and check each document's
+    logits match its standalone forward. Returns `{max_abs_diff, ok, failed_doc}`.
 
     Each doc is padded up to a multiple of `chunk_size` (padding follows the real tokens, so
-    causality keeps it from affecting them); only the real positions are compared.
+    causality keeps it from affecting them); only the real positions are compared. Returns
+    the verdict rather than raising, so the caller's `assert res["ok"]` is the real gate.
     """
     packed: List[int] = []
     seg: List[int] = []
@@ -48,6 +49,8 @@ def check_doc_boundary_parity(model: ModelInterface, docs: Sequence[Sequence[int
     packed_logits = to_numpy(model.forward(packed_arr, seg_arr))   # (1, Lp, V)
 
     max_abs = 0.0
+    ok = True
+    failed_doc = None
     for d, doc in enumerate(docs):
         solo = to_numpy(model.forward(np.asarray([list(doc)], dtype=np.int64)))  # (1, n, V)
         s, e = spans[d]
@@ -55,7 +58,8 @@ def check_doc_boundary_parity(model: ModelInterface, docs: Sequence[Sequence[int
         diff = np.abs(sub.astype(np.float64) - solo.astype(np.float64))
         max_abs = max(max_abs, float(diff.max()))
         if not np.allclose(sub, solo, rtol=rtol, atol=atol):
-            raise AssertionError(
-                f"doc-boundary parity FAILED for document {d}: max|diff|={diff.max():.3e} "
-                "— state leaked across a packed boundary")
-    return {"max_abs_diff": max_abs, "ok": True}
+            # State leaked across a packed boundary for this document.
+            ok = False
+            if failed_doc is None:
+                failed_doc = d
+    return {"max_abs_diff": max_abs, "ok": ok, "failed_doc": failed_doc}

--- a/src/conformance/forward_step_parity.py
+++ b/src/conformance/forward_step_parity.py
@@ -1,4 +1,4 @@
-"""forward vs step parity (MILESTONE 1, MLX-only) — SKELETON.
+"""forward vs step parity (MILESTONE 1).
 
 The training path (`forward`, parallel scan) and the inference path (`step`,
 recurrence) are two SEPARATE code paths and must produce the same logits for the
@@ -38,7 +38,8 @@ def check_forward_step_parity(model: ModelInterface, token_batch: np.ndarray,
 
     diff = np.abs(parallel_logits.astype(np.float64) - step_logits.astype(np.float64))
     max_abs = float(diff.max())
-    ok = np.allclose(parallel_logits, step_logits, rtol=rtol, atol=atol)
-    if not ok:
-        raise AssertionError(f"forward/step parity FAILED: max|diff|={max_abs:.3e}")
+    # Return the verdict (don't raise) so the CALLER's `assert result["ok"]` is the
+    # actual gate — otherwise the assertion is decorative (the result could only ever
+    # be ok=True if a raise gated it first).
+    ok = bool(np.allclose(parallel_logits, step_logits, rtol=rtol, atol=atol))
     return {"max_abs_diff": max_abs, "ok": ok}

--- a/src/conformance/forward_step_parity.py
+++ b/src/conformance/forward_step_parity.py
@@ -7,8 +7,11 @@ scan check does NOT catch (that check validates only the scan, not train/infer
 equivalence).
 
 Run in fp32, ~1e-4 relative tolerance. Build the model, run a fixed batch through
-`forward`, then feed the same tokens one at a time through `step` carrying state,
-and assert the per-position logits agree.
+`forward`, then feed the same tokens one at a time through `step` carrying state, and
+compare the per-position logits. The check RETURNS the verdict (`{max_abs_diff, ok}`);
+the caller asserts on `result["ok"]` (so that assertion is the real gate). Backend-
+agnostic — drives the model only through `ModelInterface`, so it runs on MLX and the
+torch/CUDA backend alike (see `tests/test_mlx_parity.py` / `tests/test_cuda_parity.py`).
 """
 
 from __future__ import annotations
@@ -21,10 +24,11 @@ from ..model.interface import ModelInterface
 def check_forward_step_parity(model: ModelInterface, token_batch: np.ndarray,
                               to_numpy=np.asarray, rtol: float = 1e-4,
                               atol: float = 1e-5) -> dict:
-    """Assert forward (parallel) and step (recurrence) agree. Returns max abs diff.
+    """Check forward (parallel) and step (recurrence) agree. Returns `{max_abs_diff, ok}`
+    (does NOT raise) — the caller asserts on `ok`.
 
     `to_numpy` converts backend logits to numpy (identity by default; on MLX pass a
-    converter). Requires a working backend model -> run on Apple Silicon.
+    converter). Requires a working backend model (MLX or torch/CUDA).
     """
     batch, seq_len = token_batch.shape
     parallel_logits = to_numpy(model.forward(token_batch))  # (B, T, V)

--- a/src/data/dpo_loader.py
+++ b/src/data/dpo_loader.py
@@ -43,12 +43,16 @@ class DPOLoader:
         full = n // self.batch_size
         return full if self.drop_last else (n + self.batch_size - 1) // self.batch_size
 
-    def epoch(self, reseed: Optional[int] = None) -> Iterator[tuple[np.ndarray, ...]]:
+    def epoch(self, reseed: Optional[int] = None,
+              skip_batches: int = 0) -> Iterator[tuple[np.ndarray, ...]]:
+        """Yield one pass; `skip_batches` fast-forwards on resume (shuffle runs first)."""
         if reseed is not None:
             self.rng = np.random.default_rng(reseed)
         order = np.arange(len(self.records))
         if self.shuffle:
             self.rng.shuffle(order)
+        if skip_batches:
+            order = order[skip_batches * self.batch_size:]
 
         batch: List[dict] = []
         for idx in order:

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -45,13 +45,22 @@ class PackedLoader:
         full = self.n_chunks // self.batch_size
         return full if self.drop_last else (self.n_chunks + self.batch_size - 1) // self.batch_size
 
-    def epoch(self, reseed: Optional[int] = None) -> Iterator[tuple[np.ndarray, np.ndarray]]:
-        """Yield (inputs, targets), each (batch, seq_len), for one pass over the data."""
+    def epoch(self, reseed: Optional[int] = None,
+              skip_batches: int = 0) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Yield (inputs, targets), each (batch, seq_len), for one pass over the data.
+
+        `skip_batches` drops that many leading batches WITHOUT reading their chunks
+        — used on resume to fast-forward into a partial epoch. The shuffle is still
+        run first (so the order, and the rng state, are identical to an unskipped
+        epoch); only the already-consumed prefix of `order` is sliced off.
+        """
         if reseed is not None:
             self.rng = np.random.default_rng(reseed)
         order = np.arange(self.n_chunks)
         if self.shuffle:
             self.rng.shuffle(order)
+        if skip_batches:
+            order = order[skip_batches * self.batch_size:]
 
         batch = []
         for idx in order:

--- a/src/data/sft_loader.py
+++ b/src/data/sft_loader.py
@@ -44,14 +44,20 @@ class SFTLoader:
         full = n // self.batch_size
         return full if self.drop_last else (n + self.batch_size - 1) // self.batch_size
 
-    def epoch(self, reseed: Optional[int] = None
+    def epoch(self, reseed: Optional[int] = None, skip_batches: int = 0
               ) -> Iterator[tuple[np.ndarray, np.ndarray, np.ndarray]]:
-        """Yield `(inputs, targets, mask)` for one pass; shuffles per epoch if enabled."""
+        """Yield `(inputs, targets, mask)` for one pass; shuffles per epoch if enabled.
+
+        `skip_batches` drops that many leading batches (resume fast-forward); the
+        shuffle still runs first so the order and rng state are unchanged.
+        """
         if reseed is not None:
             self.rng = np.random.default_rng(reseed)
         order = np.arange(len(self.records))
         if self.shuffle:
             self.rng.shuffle(order)
+        if skip_batches:
+            order = order[skip_batches * self.batch_size:]
 
         batch: List[dict] = []
         for idx in order:

--- a/src/eval/val_loss.py
+++ b/src/eval/val_loss.py
@@ -72,7 +72,11 @@ def evaluate(model: ModelInterface, loader: PackedLoader,
         n_tokens = int(np.asarray(targets).size)
         total_ce += cross_entropy(logits, targets) * n_tokens
         total_tokens += n_tokens
-    mean_ce = total_ce / max(1, total_tokens)
+    if total_tokens == 0:
+        # Otherwise mean_ce=0 -> perplexity=1.0, a false "perfect model" that silently
+        # masks a misconfigured eval (empty/missing val split, wrong path).
+        raise ValueError("evaluate(): no tokens evaluated — val loader is empty")
+    mean_ce = total_ce / total_tokens
     return {"val_loss": mean_ce, "val_perplexity": perplexity(mean_ce)}
 
 
@@ -94,5 +98,9 @@ def evaluate_masked(model: ModelInterface, loader,
         logits = to_numpy(model.forward(inputs))
         total_ce += masked_cross_entropy(logits, targets, mask) * n_tokens
         total_tokens += n_tokens
-    mean_ce = total_ce / max(1.0, total_tokens)
+    if total_tokens == 0:
+        # No response tokens at all -> a false perplexity=1.0; fail loudly instead.
+        raise ValueError("evaluate_masked(): no response tokens evaluated — "
+                         "val loader is empty or fully masked")
+    mean_ce = total_ce / total_tokens
     return {"val_loss": mean_ce, "val_perplexity": perplexity(mean_ce)}

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -59,11 +59,14 @@ def get_backend(name: str = "auto") -> Backend:
     in a hardware library.
     """
     if name == "auto":
-        try:
+        # Decide by whether mlx is importable, NOT by catching SystemExit from
+        # `_mlx_backend()` — that would also swallow an unrelated SystemExit raised
+        # while mlx IS present and mis-route to the torch backend (a confusing
+        # "torch not found" on an Apple-Silicon box).
+        import importlib.util
+        if importlib.util.find_spec("mlx") is not None:
             return _mlx_backend()
-        except SystemExit:
-            # mlx absent on this host — fall back to the torch backend.
-            return _cuda_backend()
+        return _cuda_backend()
     if name == "mlx":
         return _mlx_backend()
     if name == "cuda":

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -162,6 +162,11 @@ class SelectiveSSM(nn.Module):
         B = _f32(proj[..., dt_rank:dt_rank + d_state])
         C = _f32(proj[..., dt_rank + d_state:])
         delta = _softplus(self.dt_proj(dt_pre))      # (..., H) per head, fp32
+        # Long-context extension (#54): mirror mlx_backend — divide the discretization
+        # step so per-step decay moves toward 1, enlarging the receptive field at
+        # inference. Guarded so factor 1.0 (default) leaves delta byte-identical.
+        if self.config.long_ctx_factor != 1.0:
+            delta = delta / self.config.long_ctx_factor
         a = -torch.exp(self.A_log)                   # (H,) scalar decay, fp32
         return delta, a, B, C
 

--- a/src/model/cuda_train_step.py
+++ b/src/model/cuda_train_step.py
@@ -146,9 +146,11 @@ def make_sft_train_step(model, optimizer, *, grad_clip: float = 1.0,
 
 
 def _masked_seq_logprob(model, inputs, targets, mask) -> torch.Tensor:
-    """Per-sequence summed log-prob of `targets` over masked (response) positions. (B,).
+    """Per-sequence SUMMED log-prob of `targets` over masked (response) positions. (B,).
 
-    Torch port of `mlx_train_step._masked_seq_logprob`."""
+    Torch port of `mlx_train_step._masked_seq_logprob` — see its note on the summed (not
+    length-normalized) convention and the length-bias it implies. Keep the two in parity:
+    if you switch one to a mean (`/ m.sum(-1).clamp_min(1.0)`), switch both."""
     logits = model.forward(inputs).float()                   # (B, L, V)
     device = logits.device
     logp = logits - torch.logsumexp(logits, dim=-1, keepdim=True)

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -546,9 +546,9 @@ class MoEBlock(nn.Module):
             # count; ranking breaks ties by index so exactly k survive.
             ranks = mx.argsort(mx.argsort(-probs, axis=-1), axis=-1)
             gate = mx.where(ranks < k, probs, mx.zeros_like(probs))
+            gate = gate / mx.sum(gate, axis=-1, keepdims=True)   # renormalize the kept gates
         else:
-            gate = probs
-        gate = gate / mx.sum(gate, axis=-1, keepdims=True)   # renormalize the kept gates
+            gate = probs                                          # softmax already sums to 1
         outs = mx.stack([e(xn, cd) for e in self.experts], axis=-2)   # (..., E, d_model)
         y = mx.sum(gate[..., None] * _f32(outs), axis=-2)    # combine in fp32
         return _cast(y, cd)
@@ -656,8 +656,11 @@ class MLXMambaModel(ModelInterface, nn.Module):
         (`mlx_teacher.MLXConversionTeacher.forward(return_hidden=True)`)."""
         h = _cast(self.embedding(mx.array(token_batch)), self._cd)
         hs = [h]
-        for layer in self.layers:
-            h = layer.forward_seq(h)
+        # Use the checkpointed layer closures (not raw forward_seq) so the hidden-align
+        # distill stage respects grad_checkpoint — otherwise every layer's activations
+        # are retained in backward at student depth and the run swaps.
+        for layer_fn in self._layer_fns:
+            h = layer_fn(h)
             hs.append(h)
         return tuple(hs)
 
@@ -667,10 +670,12 @@ class MLXMambaModel(ModelInterface, nn.Module):
         the teacher's attention they were matched against)."""
         h = _cast(self.embedding(mx.array(token_batch)), self._cd)
         out: List[Tuple[int, Array]] = []
-        for i, layer in enumerate(self.layers):
+        # Advance through the checkpointed closures (grad_checkpoint-aware); the mixing
+        # matrix itself is read off the layer input separately.
+        for i, (layer, layer_fn) in enumerate(zip(self.layers, self._layer_fns)):
             if not self.config.is_attention_layer(i):
                 out.append((i, layer.mixing_matrix(h).mean(axis=1)))    # head-average -> (B,L,L)
-            h = layer.forward_seq(h)
+            h = layer_fn(h)
         return out
 
     def init_state(self, batch_size: int) -> State:

--- a/src/model/mlx_train_step.py
+++ b/src/model/mlx_train_step.py
@@ -138,7 +138,15 @@ def make_sft_train_step(model, optimizer, *, grad_clip: float = 1.0,
 
 
 def _masked_seq_logprob(model, inputs, targets, mask) -> mx.array:
-    """Per-sequence summed log-prob of `targets` over masked (response) positions. (B,)."""
+    """Per-sequence SUMMED log-prob of `targets` over masked (response) positions. (B,).
+
+    NOTE: this is the raw sum, not the length-normalized mean. The DPO margin is then
+    proportional to response length, so chosen/rejected pairs of very different lengths
+    bias the objective toward the shorter response. This matches the original DPO paper
+    (sum); it is correct when chosen and rejected have comparable lengths. If you train on
+    length-imbalanced pairs, switch to `/ mx.maximum(m.sum(-1), 1.0)` here AND in
+    `cuda_train_step._masked_seq_logprob` to keep the two backends in parity.
+    """
     logits = model.forward(inputs).astype(mx.float32)        # (B, L, V)
     logp = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
     t = mx.array(targets).astype(mx.int32)

--- a/src/serve/sampling.py
+++ b/src/serve/sampling.py
@@ -71,6 +71,14 @@ def sample(
             if banned.size:
                 logits[banned] = -np.inf
 
+    if not np.any(np.isfinite(logits)):
+        # Every token was banned (e.g. no_repeat_ngram_size covering the whole vocab):
+        # there is no valid next token. Fall back to a uniform draw rather than the
+        # greedy path returning a banned argmax or `_softmax` producing NaN probs that
+        # crash `rng.choice` mid-generation.
+        rng = rng or np.random.default_rng()
+        return int(rng.integers(logits.size))
+
     if temperature == 0:
         return int(logits.argmax())
     if temperature < 0:

--- a/src/serve/sampling.py
+++ b/src/serve/sampling.py
@@ -86,7 +86,10 @@ def sample(
 
     logits = logits / temperature
 
-    # top-k: keep only the k highest logits.
+    # top-k: keep only the k highest logits. NOTE: on ties at the cutoff this keeps
+    # MORE than k tokens (every logit >= the k-th largest survives) — the same
+    # tie-inclusive behavior as HF Transformers' top_k. Exact-k would need an argsort
+    # tiebreak; the inclusive form is intentional here.
     if top_k is not None and 0 < top_k < logits.size:
         kth = np.partition(logits, -top_k)[-top_k]
         logits = np.where(logits < kth, -np.inf, logits)

--- a/src/serve/sessions.py
+++ b/src/serve/sessions.py
@@ -116,8 +116,14 @@ class SessionStore:
         return self.model.clone_state(self._states[session_id])
 
     def set_state(self, session_id: str, state: State) -> None:
-        """Restore a session to a previously captured snapshot (e.g. a rewind target)."""
-        self._states[session_id] = state
+        """Restore a session to a previously captured snapshot (e.g. a rewind target).
+
+        Clones on the way in — symmetric with `get_state` — so the store owns an
+        independent copy. Without this, installing a `RewindTree.rewind(...)` result
+        (which aliases the tree node) lets a subsequent in-place `step` mutation on a
+        numpy/CUDA state silently corrupt the retained snapshot.
+        """
+        self._states[session_id] = self.model.clone_state(state)
         self._states.move_to_end(session_id)
 
     # --- introspection ---

--- a/src/serve/spec_decode.py
+++ b/src/serve/spec_decode.py
@@ -2,10 +2,15 @@
 
 Draft-and-verify decoding accelerates autoregressive generation: a cheap drafter
 proposes the next few tokens, the real model verifies them in one batched pass, and
-verification keeps the output distribution exact. This module holds the two BACKEND-FREE
-pieces — the drafter and the accept rule — so they are testable without mlx. The stateful
-verifier pass and the timing live in `scripts/spec_decode.py` (it advances the model's
-`step` recurrence on the backend).
+verification keeps the output identical to plain decoding. This module holds the two
+BACKEND-FREE pieces — the drafter and the accept rule — so they are testable without mlx.
+The stateful verifier pass and the timing live in `scripts/spec_decode.py` (it advances
+the model's `step` recurrence on the backend).
+
+GREEDY ONLY: the accept rule (`first_mismatch`) compares draft tokens against the
+verifier's *argmax*, so the preserved output is the GREEDY decode. It is NOT
+distribution-preserving for temperature>0 / top-p sampling — that needs the Leviathan
+et al. rejection-sampling rule, which this does not implement. Drive it greedily.
 
 The drafter here is **prompt-lookup** (a.k.a. n-gram / self-speculative): it proposes
 continuations by finding where the current context's tail recurred earlier and copying

--- a/src/train/checkpoint.py
+++ b/src/train/checkpoint.py
@@ -58,6 +58,7 @@ def _atomic_write_bytes(path: str, data: bytes) -> None:
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp, path)
+        _fsync_dir(d)   # make the rename itself durable, not just the file data
     except BaseException:
         try:
             os.unlink(tmp)
@@ -85,6 +86,9 @@ def save_weights(state_dict: Dict[str, np.ndarray], path: str,
         save_file(tensors, tmp)
         _fsync_path(tmp)
         os.replace(tmp, path)
+        # Durable rename even when save_weights runs standalone (model.save outside
+        # CheckpointStore), not only when a later CheckpointStore dir-fsync covers it.
+        _fsync_dir(d)
     except BaseException:
         try:
             os.unlink(tmp)

--- a/src/train/checkpoint.py
+++ b/src/train/checkpoint.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
@@ -32,6 +33,15 @@ import numpy as np
 # only ever sees the complete old file or the complete new one, never a partial.
 def _fsync_path(path: str) -> None:
     fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _fsync_dir(path: str) -> None:
+    """fsync a directory so a rename/creation inside it is durable across power loss."""
+    fd = os.open(str(path), os.O_RDONLY)
     try:
         os.fsync(fd)
     finally:
@@ -103,61 +113,107 @@ def load_weights(model: Any, path: str) -> None:
     model._load_portable(weights)
 
 
-# --- within-backend resume bundle ------------------------------------------
-# The COMMIT marker is written LAST, after the optimizer + meta are durably on
-# disk. Its presence is the bundle's "this is complete and consistent" flag:
-# `load_resume` refuses any bundle without it, so a checkpoint interrupted
-# mid-write is detected loudly rather than silently resumed half-formed.
-_COMMIT = "COMMIT"
+# --- within-backend resume: double-buffered, crash-safe ---------------------
+class CheckpointStore:
+    """Crash-safe, double-buffered checkpoint area (one conversation's worth of resume).
 
+    A long run (the poc is ~26 days) WILL be interrupted mid-checkpoint by preemption /
+    OOM / a manual kill. Atomic per-file writes stop *truncation*, but a single-slot
+    layout still loses resumability when a crash lands between writing the new weights and
+    the new optimizer (newer weights, older optimizer; or no marker at all). This store
+    keeps TWO slots plus an atomically-flipped ``LATEST`` pointer:
 
-def save_resume(path: str, *, step: int, loss_scale_state: Any,
-                optimizer_serializer: Callable[[str], None]) -> None:
-    """Save a same-backend resume bundle: step, fp16 loss-scale state, optimizer state.
+      <root>/LATEST        text file naming the live slot ("slot-a" | "slot-b")
+      <root>/slot-a/       weights.safetensors (+ .config.json), optimizer.state*, resume_meta.json
+      <root>/slot-b/       (same)
 
-    Note `loss_scale_state` holds the dynamic fp16 loss scaler's state (or None for
-    fp32/bf16) — NOT an RNG state. The data order on resume is reconstructed
-    deterministically from (seed, step, grad_accum) by the training loop, and the
-    model has no train-time RNG (no dropout; the only random op is weight init,
-    overwritten by the loaded weights), so there is no RNG to persist.
+    Each checkpoint is written **in full** to the INACTIVE slot (so the live one is never
+    touched), every file is fsync'd, and only then is ``LATEST`` flipped in one atomic
+    rename — the single commit point. A crash before the flip leaves ``LATEST`` pointing
+    at the previous, fully-intact checkpoint; a crash during the flip leaves either the
+    old or the new name, both naming a complete slot. The previous checkpoint always
+    survives until the next one is durably committed.
 
-    `optimizer_serializer(opt_path)` is supplied by the backend (e.g. MLX/torch),
-    since optimizer state layout is backend-specific. Written via temp+rename so a
-    partial optimizer dump never overwrites the previous good one.
+    Each slot holds the FULL checkpoint: portable weights (the cross-backend bridge) AND
+    the within-backend resume bundle (optimizer + step + fp16 loss-scale state). Note the
+    loss-scale state is NOT an RNG state — the data order on resume is reconstructed
+    deterministically from (seed, step, grad_accum) and the model has no train-time RNG.
     """
-    path = str(path)
-    Path(path).mkdir(parents=True, exist_ok=True)
-    commit = Path(path, _COMMIT)
-    # Invalidate the bundle for the duration of the write. The backend optimizer
-    # serializer owns its real filename(s) (it appends an extension), so we cannot
-    # temp+rename it ourselves; instead we gate consistency on the COMMIT marker.
-    # If we crash anywhere below before COMMIT is rewritten, `load_resume` refuses
-    # this bundle rather than resuming a half-written optimizer + newer weights.
-    # (Single-slot: a crashed checkpoint is not resumable — double-buffered slots
-    # that preserve the previous checkpoint are a documented follow-up.)
-    if commit.exists():
-        commit.unlink()
-    optimizer_serializer(str(Path(path, "optimizer.state")))
-    meta = {"step": int(step), "loss_scale_state": _jsonable(loss_scale_state)}
-    _atomic_write_text(Path(path, "resume_meta.json"), json.dumps(meta))
-    _atomic_write_text(commit, json.dumps({"step": int(step)}))
 
+    _SLOTS = ("slot-a", "slot-b")
 
-def load_resume(path: str, optimizer_deserializer: Callable[[str], Any]) -> dict:
-    """Restore the resume bundle. Returns {step, loss_scale_state, optimizer}.
+    def __init__(self, root: str):
+        self.root = Path(root)
 
-    Refuses a bundle whose COMMIT marker is missing — that means the checkpoint
-    was interrupted mid-write and is not safe to resume from.
-    """
-    path = str(path)
-    if not Path(path, _COMMIT).exists():
-        raise RuntimeError(
-            f"resume bundle at {path!r} has no COMMIT marker — it was written "
-            "partially (interrupted mid-checkpoint) and is unsafe to resume from."
-        )
-    meta = json.loads(Path(path, "resume_meta.json").read_text())
-    meta["optimizer"] = optimizer_deserializer(str(Path(path, "optimizer.state")))
-    return meta
+    # -- pointer ----------------------------------------------------------------
+    def _latest_file(self) -> Path:
+        return self.root / "LATEST"
+
+    def latest_slot(self) -> Optional[str]:
+        f = self._latest_file()
+        if not f.exists():
+            return None
+        slot = f.read_text().strip()
+        return slot if slot in self._SLOTS else None
+
+    def has_checkpoint(self) -> bool:
+        return self.latest_slot() is not None
+
+    def _inactive_slot(self) -> str:
+        return self._SLOTS[1] if self.latest_slot() == self._SLOTS[0] else self._SLOTS[0]
+
+    # -- write/read -------------------------------------------------------------
+    def save(self, *, step: int, loss_scale_state: Any,
+             weights_serializer: Callable[[str], None],
+             optimizer_serializer: Callable[[str], None]) -> str:
+        """Write a full checkpoint to the inactive slot, then atomically make it live.
+
+        `weights_serializer(path)` writes portable weights (e.g. `model.save`) and
+        `optimizer_serializer(path)` the backend optimizer state — both supplied by the
+        caller so this stays backend-free. Returns the slot that was committed.
+        """
+        slot = self._inactive_slot()
+        slot_dir = self.root / slot
+        # Start the inactive slot fresh — safe because LATEST still names the other slot,
+        # so destroying a stale/partial inactive slot never touches the live checkpoint.
+        if slot_dir.exists():
+            shutil.rmtree(slot_dir)
+        slot_dir.mkdir(parents=True, exist_ok=True)
+
+        weights_serializer(str(slot_dir / "weights.safetensors"))   # + .config.json sidecar
+        optimizer_serializer(str(slot_dir / "optimizer.state"))     # backend owns the extension
+        meta = {"step": int(step), "loss_scale_state": _jsonable(loss_scale_state)}
+        _atomic_write_text(slot_dir / "resume_meta.json", json.dumps(meta))
+
+        # Durably flush every file's DATA (the backend optimizer dump may not fsync
+        # itself, and we don't know its exact name), then the slot directory.
+        for f in slot_dir.iterdir():
+            _fsync_path(str(f))
+        _fsync_dir(slot_dir)
+
+        # Commit: flip LATEST (atomic rename), then fsync root so the flip persists.
+        _atomic_write_text(self._latest_file(), slot)
+        _fsync_dir(self.root)
+        return slot
+
+    def load(self, *, weights_deserializer: Callable[[str], None],
+             optimizer_deserializer: Callable[[str], Any]) -> dict:
+        """Load the live checkpoint into the model + optimizer. Returns
+        {step, loss_scale_state, optimizer, slot}. Raises if no checkpoint is committed."""
+        slot = self.latest_slot()
+        if slot is None:
+            raise RuntimeError(f"no committed checkpoint under {str(self.root)!r}")
+        slot_dir = self.root / slot
+        weights_deserializer(str(slot_dir / "weights.safetensors"))
+        meta = json.loads((slot_dir / "resume_meta.json").read_text())
+        meta["optimizer"] = optimizer_deserializer(str(slot_dir / "optimizer.state"))
+        meta["slot"] = slot
+        return meta
+
+    def latest_weights_path(self) -> Optional[str]:
+        """Path to the live slot's portable weights (for downstream eval/serving), or None."""
+        slot = self.latest_slot()
+        return str(self.root / slot / "weights.safetensors") if slot else None
 
 
 def _jsonable(x: Any) -> Any:

--- a/src/train/checkpoint.py
+++ b/src/train/checkpoint.py
@@ -15,24 +15,75 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 import numpy as np
 
 
+# --- durable (crash-safe) writes -------------------------------------------
+# A long run (the poc is ~26 days) WILL be interrupted mid-checkpoint by
+# preemption / OOM / a manual kill. A naive `write_text` or `save_file` leaves a
+# truncated, half-written file that silently corrupts the only checkpoint. Every
+# artifact below is therefore written to a temp file in the same directory,
+# flushed + fsync'd, then `os.replace`d into place (atomic on POSIX): a reader
+# only ever sees the complete old file or the complete new one, never a partial.
+def _fsync_path(path: str) -> None:
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _atomic_write_bytes(path: str, data: bytes) -> None:
+    path = str(path)
+    d = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=d, prefix=".tmp-", suffix=".swap")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _atomic_write_text(path: str, text: str) -> None:
+    _atomic_write_bytes(path, text.encode("utf-8"))
+
+
 # --- portable weights -------------------------------------------------------
 def save_weights(state_dict: Dict[str, np.ndarray], path: str,
                  config: Optional[Any] = None) -> None:
-    """Save weights as safetensors + a `<path>.config.json` sidecar."""
+    """Save weights as safetensors + a `<path>.config.json` sidecar (atomically)."""
     from safetensors.numpy import save_file  # lazy
 
     path = str(path)
     tensors = {k: np.asarray(v) for k, v in state_dict.items()}
-    save_file(tensors, path)
+    d = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=d, prefix=".tmp-", suffix=".safetensors")
+    os.close(fd)  # safetensors writes by path, not fd
+    try:
+        save_file(tensors, tmp)
+        _fsync_path(tmp)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
     if config is not None:
         cfg = config.to_dict() if hasattr(config, "to_dict") else dict(config)
-        Path(path + ".config.json").write_text(json.dumps(cfg, indent=2))
+        _atomic_write_text(path + ".config.json", json.dumps(cfg, indent=2))
 
 
 def load_weights_dict(path: str) -> Dict[str, np.ndarray]:
@@ -53,23 +104,57 @@ def load_weights(model: Any, path: str) -> None:
 
 
 # --- within-backend resume bundle ------------------------------------------
-def save_resume(path: str, *, step: int, rng_state: Any,
+# The COMMIT marker is written LAST, after the optimizer + meta are durably on
+# disk. Its presence is the bundle's "this is complete and consistent" flag:
+# `load_resume` refuses any bundle without it, so a checkpoint interrupted
+# mid-write is detected loudly rather than silently resumed half-formed.
+_COMMIT = "COMMIT"
+
+
+def save_resume(path: str, *, step: int, loss_scale_state: Any,
                 optimizer_serializer: Callable[[str], None]) -> None:
-    """Save a same-backend resume bundle: training step, RNG state, optimizer state.
+    """Save a same-backend resume bundle: step, fp16 loss-scale state, optimizer state.
+
+    Note `loss_scale_state` holds the dynamic fp16 loss scaler's state (or None for
+    fp32/bf16) — NOT an RNG state. The data order on resume is reconstructed
+    deterministically from (seed, step, grad_accum) by the training loop, and the
+    model has no train-time RNG (no dropout; the only random op is weight init,
+    overwritten by the loaded weights), so there is no RNG to persist.
 
     `optimizer_serializer(opt_path)` is supplied by the backend (e.g. MLX/torch),
-    since optimizer state layout is backend-specific.
+    since optimizer state layout is backend-specific. Written via temp+rename so a
+    partial optimizer dump never overwrites the previous good one.
     """
     path = str(path)
     Path(path).mkdir(parents=True, exist_ok=True)
-    meta = {"step": int(step), "rng_state": _jsonable(rng_state)}
-    Path(path, "resume_meta.json").write_text(json.dumps(meta))
+    commit = Path(path, _COMMIT)
+    # Invalidate the bundle for the duration of the write. The backend optimizer
+    # serializer owns its real filename(s) (it appends an extension), so we cannot
+    # temp+rename it ourselves; instead we gate consistency on the COMMIT marker.
+    # If we crash anywhere below before COMMIT is rewritten, `load_resume` refuses
+    # this bundle rather than resuming a half-written optimizer + newer weights.
+    # (Single-slot: a crashed checkpoint is not resumable — double-buffered slots
+    # that preserve the previous checkpoint are a documented follow-up.)
+    if commit.exists():
+        commit.unlink()
     optimizer_serializer(str(Path(path, "optimizer.state")))
+    meta = {"step": int(step), "loss_scale_state": _jsonable(loss_scale_state)}
+    _atomic_write_text(Path(path, "resume_meta.json"), json.dumps(meta))
+    _atomic_write_text(commit, json.dumps({"step": int(step)}))
 
 
 def load_resume(path: str, optimizer_deserializer: Callable[[str], Any]) -> dict:
-    """Restore the resume bundle. Returns {step, rng_state, optimizer}."""
+    """Restore the resume bundle. Returns {step, loss_scale_state, optimizer}.
+
+    Refuses a bundle whose COMMIT marker is missing — that means the checkpoint
+    was interrupted mid-write and is not safe to resume from.
+    """
     path = str(path)
+    if not Path(path, _COMMIT).exists():
+        raise RuntimeError(
+            f"resume bundle at {path!r} has no COMMIT marker — it was written "
+            "partially (interrupted mid-checkpoint) and is unsafe to resume from."
+        )
     meta = json.loads(Path(path, "resume_meta.json").read_text())
     meta["optimizer"] = optimizer_deserializer(str(Path(path, "optimizer.state")))
     return meta

--- a/src/train/loop.py
+++ b/src/train/loop.py
@@ -45,12 +45,24 @@ class TrainConfig:
 TrainStepFn = Callable[[ModelInterface, list, float], dict]
 
 
-def _micro_batch_stream(train_loader: PackedLoader, seed: int):
-    """Infinite stream of (inputs, targets), reseeding the shuffle each epoch."""
-    epoch_idx = 0
+def _micro_batch_stream(train_loader: PackedLoader, seed: int, start_micro: int = 0):
+    """Infinite stream of (inputs, targets), reseeding the shuffle each epoch.
+
+    `start_micro` fast-forwards the stream to the position reached after that many
+    micro-batches — this is what makes resume continue the data sequence instead of
+    replaying the corpus from the top. The stream is fully deterministic given
+    (seed, epoch length), so the position is reconstructed from `start_micro` alone:
+    skip whole epochs for free (just advance the per-epoch reseed) and fast-forward
+    the remainder within the current epoch via `epoch(skip_batches=...)`.
+    """
+    per_epoch = len(train_loader)
+    if per_epoch <= 0:
+        raise ValueError("train_loader yields no batches per epoch")
+    epoch_idx, skip = divmod(start_micro, per_epoch)
     while True:
-        yield from train_loader.epoch(reseed=seed + epoch_idx)
+        yield from train_loader.epoch(reseed=seed + epoch_idx, skip_batches=skip)
         epoch_idx += 1
+        skip = 0
 
 
 def train(
@@ -78,7 +90,8 @@ def train(
     log = logger or (lambda payload: print(payload))
     tokens_per_step = train_loader.batch_size * train_loader.seq_len * cfg.grad_accum
 
-    stream = _micro_batch_stream(train_loader, cfg.seed)
+    stream = _micro_batch_stream(train_loader, cfg.seed,
+                                 start_micro=start_step * cfg.grad_accum)
     t0 = time.perf_counter()
     steps_since_log = 0
 

--- a/src/train/loss_scale.py
+++ b/src/train/loss_scale.py
@@ -25,12 +25,14 @@ class DynamicLossScaler:
         backoff: float = 0.5,
         growth_interval: int = 2000,
         min_scale: float = 1.0,
+        max_scale: float = 2.0 ** 24,
     ):
         self.scale = float(init_scale)
         self.growth_factor = float(growth_factor)
         self.backoff = float(backoff)
         self.growth_interval = int(growth_interval)
         self.min_scale = float(min_scale)
+        self.max_scale = float(max_scale)
         self._good_steps = 0
 
     def update(self, overflow: bool) -> None:
@@ -41,7 +43,10 @@ class DynamicLossScaler:
             return
         self._good_steps += 1
         if self._good_steps >= self.growth_interval:
-            self.scale *= self.growth_factor
+            # Cap growth: without a ceiling the scale doubles unboundedly until the
+            # scaled loss itself overflows fp16, wasting a step every cycle. 2**24
+            # matches PyTorch AMP / Apex defaults.
+            self.scale = min(self.max_scale, self.scale * self.growth_factor)
             self._good_steps = 0
 
     def state_dict(self) -> dict:

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -8,9 +8,10 @@ runs anywhere. Guards the resume bundle against a realistic NumPy RNG state
 import json
 
 import numpy as np
+import pytest
 
 from src.train.checkpoint import (
-    save_weights, load_weights_dict, save_resume, load_resume,
+    save_weights, load_weights_dict, save_resume, load_resume, _jsonable,
 )
 
 
@@ -39,26 +40,63 @@ def test_save_weights_writes_config_sidecar(tmp_path):
     assert sidecar == {"d_model": 64, "n_layers": 2}
 
 
-def test_resume_bundle_with_realistic_rng_state(tmp_path):
-    bundle = tmp_path / "resume"
-    rng_state = np.random.default_rng(0).bit_generator.state  # nested dict + np types
-
-    saved = {}
-
-    def opt_serializer(p):
-        saved["path"] = p
-        # stand in for a backend optimizer dump
+def _dummy_opt_io():
+    def serializer(p):
         np.save(p + ".npy", np.arange(3))
 
-    def opt_deserializer(p):
+    def deserializer(p):
         return np.load(p + ".npy")
 
-    # Must not raise on nested RNG state.
-    save_resume(str(bundle), step=42, rng_state=rng_state,
-                optimizer_serializer=opt_serializer)
+    return serializer, deserializer
 
-    meta = load_resume(str(bundle), optimizer_deserializer=opt_deserializer)
+
+def test_resume_bundle_roundtrips_nested_state(tmp_path):
+    """A nested NumPy structure (the worst case _jsonable handles) survives exactly."""
+    bundle = tmp_path / "resume"
+    nested = np.random.default_rng(0).bit_generator.state  # nested dict + np ndarray/scalars
+    ser, deser = _dummy_opt_io()
+
+    save_resume(str(bundle), step=42, loss_scale_state=nested,
+                optimizer_serializer=ser)
+    meta = load_resume(str(bundle), optimizer_deserializer=deser)
+
     assert meta["step"] == 42
     assert np.array_equal(meta["optimizer"], np.arange(3))
-    # rng_state survived JSON serialization as a plain structure.
-    assert json.dumps(meta["rng_state"])  # serializable
+    # The restored structure equals the jsonable projection of the original — a real
+    # content check, not just "is serializable".
+    assert meta["loss_scale_state"] == _jsonable(nested)
+
+
+def test_resume_bundle_roundtrips_loss_scale_state(tmp_path):
+    """The actual payload: a DynamicLossScaler.state_dict() restores its values."""
+    bundle = tmp_path / "resume"
+    state = {"scale": 4096.0, "good_steps": 137}
+    ser, deser = _dummy_opt_io()
+
+    save_resume(str(bundle), step=7, loss_scale_state=state, optimizer_serializer=ser)
+    meta = load_resume(str(bundle), optimizer_deserializer=deser)
+
+    assert meta["loss_scale_state"] == state
+
+
+def test_load_resume_refuses_bundle_without_commit_marker(tmp_path):
+    """An interrupted checkpoint (no COMMIT) is rejected, not silently resumed."""
+    bundle = tmp_path / "resume"
+    ser, deser = _dummy_opt_io()
+    save_resume(str(bundle), step=5, loss_scale_state=None, optimizer_serializer=ser)
+
+    (bundle / "COMMIT").unlink()  # simulate a mid-write interruption
+
+    with pytest.raises(RuntimeError, match="COMMIT"):
+        load_resume(str(bundle), optimizer_deserializer=deser)
+
+
+def test_save_resume_leaves_no_temp_files(tmp_path):
+    """Atomic writes clean up after themselves — no stray .tmp/.swap on success."""
+    bundle = tmp_path / "resume"
+    ser, _ = _dummy_opt_io()
+    save_resume(str(bundle), step=1, loss_scale_state=None, optimizer_serializer=ser)
+
+    leftovers = [p.name for p in bundle.iterdir()
+                 if p.name.endswith((".tmp", ".swap")) or p.name.startswith(".tmp-")]
+    assert leftovers == [], f"unexpected temp files left behind: {leftovers}"

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,8 +1,10 @@
 """Unit tests for portable weight save/load and the double-buffered CheckpointStore.
 
 Backend-free: uses numpy weight dicts and dummy weight/optimizer (de)serializers, so it
-runs anywhere. Guards the resume bundle against a realistic NumPy RNG state
-(nested dict + np.ndarray + np scalars), which a shallow JSON conversion breaks, and the
+runs anywhere. The resume metadata persists `step` + the fp16 `loss_scale_state` (NOT an
+RNG state — the data order on resume is reconstructed deterministically); these tests
+guard `_jsonable` against a realistic nested NumPy structure (nested dict + np.ndarray +
+np scalars — the worst case it handles), which a shallow JSON conversion breaks, plus the
 crash-safety contract (the previous checkpoint survives a write interrupted mid-flight).
 """
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,17 +1,19 @@
-"""Unit tests for portable weight save/load and the within-backend resume bundle.
+"""Unit tests for portable weight save/load and the double-buffered CheckpointStore.
 
-Backend-free: uses numpy weight dicts and dummy optimizer (de)serializers, so it
+Backend-free: uses numpy weight dicts and dummy weight/optimizer (de)serializers, so it
 runs anywhere. Guards the resume bundle against a realistic NumPy RNG state
-(nested dict + np.ndarray + np scalars), which a shallow JSON conversion breaks.
+(nested dict + np.ndarray + np scalars), which a shallow JSON conversion breaks, and the
+crash-safety contract (the previous checkpoint survives a write interrupted mid-flight).
 """
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 from src.train.checkpoint import (
-    save_weights, load_weights_dict, save_resume, load_resume, _jsonable,
+    save_weights, load_weights_dict, CheckpointStore, _jsonable,
 )
 
 
@@ -40,63 +42,99 @@ def test_save_weights_writes_config_sidecar(tmp_path):
     assert sidecar == {"d_model": 64, "n_layers": 2}
 
 
-def _dummy_opt_io():
-    def serializer(p):
-        np.save(p + ".npy", np.arange(3))
+def _dummy_io(weights_tag="w0", opt_value=3):
+    """Dummy weight + optimizer (de)serializers writing recognizable content. `seen`
+    captures what `load` deserialized so tests can assert an exact round-trip."""
+    seen = {}
 
-    def deserializer(p):
+    def w_ser(p):
+        Path(p).write_text(weights_tag)
+
+    def o_ser(p):
+        np.save(p + ".npy", np.arange(opt_value))
+
+    def w_deser(p):
+        seen["weights"] = Path(p).read_text()
+
+    def o_deser(p):
         return np.load(p + ".npy")
 
-    return serializer, deserializer
+    return seen, w_ser, o_ser, w_deser, o_deser
 
 
-def test_resume_bundle_roundtrips_nested_state(tmp_path):
-    """A nested NumPy structure (the worst case _jsonable handles) survives exactly."""
-    bundle = tmp_path / "resume"
+def test_store_roundtrips_step_weights_and_nested_state(tmp_path):
+    """A full checkpoint (weights + optimizer + nested loss-scale state) round-trips."""
+    store = CheckpointStore(str(tmp_path / "resume"))
     nested = np.random.default_rng(0).bit_generator.state  # nested dict + np ndarray/scalars
-    ser, deser = _dummy_opt_io()
+    seen, w_ser, o_ser, w_deser, o_deser = _dummy_io(weights_tag="hello")
 
-    save_resume(str(bundle), step=42, loss_scale_state=nested,
-                optimizer_serializer=ser)
-    meta = load_resume(str(bundle), optimizer_deserializer=deser)
+    slot = store.save(step=42, loss_scale_state=nested,
+                      weights_serializer=w_ser, optimizer_serializer=o_ser)
+    assert slot == "slot-a"
+    meta = store.load(weights_deserializer=w_deser, optimizer_deserializer=o_deser)
 
-    assert meta["step"] == 42
+    assert meta["step"] == 42 and meta["slot"] == "slot-a"
+    assert seen["weights"] == "hello"
     assert np.array_equal(meta["optimizer"], np.arange(3))
-    # The restored structure equals the jsonable projection of the original — a real
-    # content check, not just "is serializable".
+    # Restored structure equals the jsonable projection — a real content check.
     assert meta["loss_scale_state"] == _jsonable(nested)
 
 
-def test_resume_bundle_roundtrips_loss_scale_state(tmp_path):
-    """The actual payload: a DynamicLossScaler.state_dict() restores its values."""
-    bundle = tmp_path / "resume"
+def test_store_roundtrips_loss_scale_state(tmp_path):
+    store = CheckpointStore(str(tmp_path / "resume"))
     state = {"scale": 4096.0, "good_steps": 137}
-    ser, deser = _dummy_opt_io()
-
-    save_resume(str(bundle), step=7, loss_scale_state=state, optimizer_serializer=ser)
-    meta = load_resume(str(bundle), optimizer_deserializer=deser)
-
+    _, w_ser, o_ser, w_deser, o_deser = _dummy_io()
+    store.save(step=7, loss_scale_state=state, weights_serializer=w_ser,
+               optimizer_serializer=o_ser)
+    meta = store.load(weights_deserializer=w_deser, optimizer_deserializer=o_deser)
     assert meta["loss_scale_state"] == state
 
 
-def test_load_resume_refuses_bundle_without_commit_marker(tmp_path):
-    """An interrupted checkpoint (no COMMIT) is rejected, not silently resumed."""
-    bundle = tmp_path / "resume"
-    ser, deser = _dummy_opt_io()
-    save_resume(str(bundle), step=5, loss_scale_state=None, optimizer_serializer=ser)
-
-    (bundle / "COMMIT").unlink()  # simulate a mid-write interruption
-
-    with pytest.raises(RuntimeError, match="COMMIT"):
-        load_resume(str(bundle), optimizer_deserializer=deser)
+def test_store_alternates_slots(tmp_path):
+    """Successive checkpoints ping-pong between the two slots."""
+    store = CheckpointStore(str(tmp_path / "resume"))
+    _, w_ser, o_ser, _, _ = _dummy_io()
+    slots = [store.save(step=i, loss_scale_state=None, weights_serializer=w_ser,
+                        optimizer_serializer=o_ser) for i in range(3)]
+    assert slots == ["slot-a", "slot-b", "slot-a"]
 
 
-def test_save_resume_leaves_no_temp_files(tmp_path):
-    """Atomic writes clean up after themselves — no stray .tmp/.swap on success."""
-    bundle = tmp_path / "resume"
-    ser, _ = _dummy_opt_io()
-    save_resume(str(bundle), step=1, loss_scale_state=None, optimizer_serializer=ser)
+def test_store_load_without_checkpoint_raises(tmp_path):
+    store = CheckpointStore(str(tmp_path / "resume"))
+    assert not store.has_checkpoint()
+    _, _, _, w_deser, o_deser = _dummy_io()
+    with pytest.raises(RuntimeError, match="no committed checkpoint"):
+        store.load(weights_deserializer=w_deser, optimizer_deserializer=o_deser)
 
-    leftovers = [p.name for p in bundle.iterdir()
-                 if p.name.endswith((".tmp", ".swap")) or p.name.startswith(".tmp-")]
-    assert leftovers == [], f"unexpected temp files left behind: {leftovers}"
+
+def test_store_crash_mid_write_preserves_previous_checkpoint(tmp_path):
+    """The core double-buffering guarantee: a checkpoint interrupted mid-write leaves
+    the PREVIOUS committed checkpoint fully intact and loadable."""
+    store = CheckpointStore(str(tmp_path / "resume"))
+    seen, w_ser, o_ser, w_deser, o_deser = _dummy_io(weights_tag="good-step-10")
+    store.save(step=10, loss_scale_state=None, weights_serializer=w_ser,
+               optimizer_serializer=o_ser)
+
+    # Second checkpoint dies mid-write (serializer raises) — LATEST is never flipped.
+    def boom(p):
+        Path(p).write_text("half-written")
+        raise RuntimeError("killed mid-checkpoint")
+
+    with pytest.raises(RuntimeError, match="killed mid-checkpoint"):
+        store.save(step=20, loss_scale_state=None, weights_serializer=boom,
+                   optimizer_serializer=o_ser)
+
+    # The live checkpoint is still step 10, with its original weights.
+    meta = store.load(weights_deserializer=w_deser, optimizer_deserializer=o_deser)
+    assert meta["step"] == 10 and meta["slot"] == "slot-a"
+    assert seen["weights"] == "good-step-10"
+
+
+def test_store_save_leaves_no_temp_files(tmp_path):
+    store = CheckpointStore(str(tmp_path / "resume"))
+    _, w_ser, o_ser, _, _ = _dummy_io()
+    store.save(step=1, loss_scale_state=None, weights_serializer=w_ser,
+               optimizer_serializer=o_ser)
+    stray = [p.name for p in (tmp_path / "resume" / "slot-a").iterdir()
+             if p.name.endswith((".tmp", ".swap")) or p.name.startswith(".tmp-")]
+    assert stray == [], f"unexpected temp files: {stray}"

--- a/tests/test_cuda_train_step.py
+++ b/tests/test_cuda_train_step.py
@@ -18,7 +18,7 @@ from src.model.cuda_backend import CUDAMambaModel
 from src.model.cuda_train_step import make_train_step, save_optimizer, load_optimizer
 from src.train.loss_scale import DynamicLossScaler
 from src.train.loop import TrainConfig, train
-from src.train.checkpoint import save_resume, load_resume
+from src.train.checkpoint import CheckpointStore
 from src.data.pack import pack_ids
 from src.data.loader import PackedLoader
 
@@ -149,18 +149,17 @@ def test_save_kill_resume_exact(tmp_path):
     res = {}
     ma, oa, sfa = fresh()
     run(ma, sfa, 0, half, res)
-    weights = str(tmp_path / "weights.safetensors")
-    bundle = str(tmp_path / "resume")
-    ma.save(weights)
-    save_resume(bundle, step=half, loss_scale_state=None,
-                optimizer_serializer=lambda p: save_optimizer(oa, p))
+    store = CheckpointStore(str(tmp_path / "resume"))
+    store.save(step=half, loss_scale_state=None,
+               weights_serializer=lambda p: ma.save(p),
+               optimizer_serializer=lambda p: save_optimizer(oa, p))
     del ma, oa, sfa                                   # "kill"
 
     torch.manual_seed(999)
     mb = CUDAMambaModel(cfg)
-    mb.load(weights)
     ob = _adam(mb)
-    meta = load_resume(bundle, optimizer_deserializer=lambda p: load_optimizer(ob, p))
+    meta = store.load(weights_deserializer=lambda p: mb.load(p),
+                      optimizer_deserializer=lambda p: load_optimizer(ob, p))
     sfb = make_train_step(mb, ob, grad_clip=1.0, scaler=None)
     run(mb, sfb, meta["step"], N, res)
 

--- a/tests/test_cuda_train_step.py
+++ b/tests/test_cuda_train_step.py
@@ -152,7 +152,7 @@ def test_save_kill_resume_exact(tmp_path):
     weights = str(tmp_path / "weights.safetensors")
     bundle = str(tmp_path / "resume")
     ma.save(weights)
-    save_resume(bundle, step=half, rng_state=None,
+    save_resume(bundle, step=half, loss_scale_state=None,
                 optimizer_serializer=lambda p: save_optimizer(oa, p))
     del ma, oa, sfa                                   # "kill"
 

--- a/tests/test_grpo.py
+++ b/tests/test_grpo.py
@@ -20,11 +20,14 @@ def test_group_advantages_standardized_per_group():
 
 
 def test_grpo_loss_matches_formula():
+    # Hand-computed reference (NOT a recompute of the function's own expression, which
+    # would be tautological): adv*logp = [1*-1, -1*-2, 0*-0.5] = [-1, 2, 0];
+    # loss = -mean([-1, 2, 0]) = -(1/3); mean|adv| = mean([1, 1, 0]) = 2/3.
     logp = np.array([-1.0, -2.0, -0.5])
     adv = np.array([1.0, -1.0, 0.0])
     loss, mabs = grpo_loss_from_logprobs(logp, adv)
-    assert np.isclose(loss, float(-np.mean(adv * logp)))
-    assert np.isclose(mabs, float(np.mean(np.abs(adv))))
+    assert loss == pytest.approx(-1.0 / 3.0)
+    assert mabs == pytest.approx(2.0 / 3.0)
 
 
 def test_grpo_loss_zero_advantage_is_zero():

--- a/tests/test_mlx_parity.py
+++ b/tests/test_mlx_parity.py
@@ -131,6 +131,21 @@ def test_forward_step_parity_toy():
     assert result["ok"], result
 
 
+def test_forward_step_parity_multichunk():
+    """The toy/hybrid parity cases above use L=32/40 < chunk_size (64), so the SSD scan
+    runs as a single degenerate chunk — the across-chunk state handoff (the likeliest
+    source of a subtle train/infer divergence) is never exercised. Force >=3 chunks.
+    """
+    mx.random.seed(0)
+    cfg = load_config("config/toy.yaml")
+    model = MLXMambaModel(cfg)
+    Q = cfg.chunk_size or 64
+    B, L = 2, 2 * Q + 1                      # 3 chunks: full, full, remainder
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
+    assert result["ok"], result
+
+
 def test_forward_step_parity_hybrid():
     # The hybrid model interleaves attention blocks (RoPE + KV cache). forward (full
     # causal attention) and step (incremental cache) must still agree — the attention

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -76,9 +76,18 @@ def test_moe_validation():
 # --------------------------------------------------------------------------- #
 # MLX-guarded: dense path unchanged, parity, routing
 # --------------------------------------------------------------------------- #
-mx = pytest.importorskip("mlx.core")
+# Use a per-test skip marker, NOT a module-level `importorskip`: the latter runs at
+# import time and skips the WHOLE module on a non-Mac host, silently dropping the
+# portable config/validation tests above (which need no backend).
+try:
+    import mlx.core as mx
+    HAVE_MLX = True
+except ImportError:
+    HAVE_MLX = False
+requires_mlx = pytest.mark.skipif(not HAVE_MLX, reason="requires mlx (Apple Silicon)")
 
 
+@requires_mlx
 def test_dense_path_byte_identical_with_moe_off():
     """A model built with MoE off must be byte-for-byte the pre-#53 model: same layer
     types, same params, same logits."""
@@ -93,6 +102,7 @@ def test_dense_path_byte_identical_with_moe_off():
     assert np.array_equal(y, np.array(model.forward(tokens)))    # deterministic
 
 
+@requires_mlx
 def test_moe_model_builds_with_expected_block_types():
     from src.model.mlx_backend import MLXMambaModel, MambaBlock, MoEBlock
     cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
@@ -105,6 +115,7 @@ def test_moe_model_builds_with_expected_block_types():
     assert cfg.num_parameters() == actual
 
 
+@requires_mlx
 def test_moe_forward_step_parity():
     """MoE is pointwise, so the chunked forward and the one-step recurrence must agree
     (fp32 ~1e-4), like the Mamba/attention blocks."""
@@ -125,6 +136,7 @@ def test_moe_forward_step_parity():
     assert rel < 1e-4
 
 
+@requires_mlx
 def test_router_selects_top_k():
     """With top_k=1 the combined output must equal the single argmax-routed expert."""
     from src.model.mlx_backend import MLXMambaModel, MoEBlock
@@ -142,6 +154,7 @@ def test_router_selects_top_k():
         assert np.allclose(combined[i], expert_outs[i, e], atol=1e-5)
 
 
+@requires_mlx
 def test_router_keeps_exactly_k_on_ties():
     """A zeroed router makes all experts tie; exactly top_k must be kept (not all of
     them), so the combination is the mean of the first k experts — not all E."""

--- a/tests/test_repetition_penalty.py
+++ b/tests/test_repetition_penalty.py
@@ -79,6 +79,18 @@ def test_no_repeat_ngram_size_one_bans_all_seen():
     assert set(banned.tolist()) == {1, 3}
 
 
+def test_all_tokens_banned_falls_back_without_crash():
+    # n=1 bans every previously-seen token; with prev covering the whole vocab there is
+    # no legal next token. Must fall back to a valid draw (not crash on NaN probs under
+    # sampling, nor return a banned argmax under greedy).
+    logits = np.zeros(3)
+    rng = np.random.default_rng(0)
+    for temp in (0.0, 1.0):
+        tok = sample(logits, temperature=temp, previous_tokens=[0, 1, 2],
+                     no_repeat_ngram_size=1, rng=rng)
+        assert 0 <= tok < 3
+
+
 def test_no_repeat_ngram_no_match_is_noop():
     # Trailing 1-gram (2,) never occurred earlier in [0,1,2]; nothing is banned.
     banned = _banned_ngram_tokens(np.array([0, 1, 2]), n=2, vocab_size=8)

--- a/tests/test_retrieval_probe.py
+++ b/tests/test_retrieval_probe.py
@@ -66,9 +66,17 @@ def test_recall_accuracy_perfect_and_chance():
 
 
 # --- end-to-end probe: the hybrid measurably out-recalls pure Mamba (MLX, ~20s) ---
-mx = pytest.importorskip("mlx.core")
+# Per-test skip marker, NOT a module-level `importorskip` (which would skip the whole
+# module on a non-Mac host, dropping the portable MQAR data-contract tests above).
+try:
+    import mlx.core  # noqa: F401
+    HAVE_MLX = True
+except ImportError:
+    HAVE_MLX = False
+requires_mlx = pytest.mark.skipif(not HAVE_MLX, reason="requires mlx (Apple Silicon)")
 
 
+@requires_mlx
 def test_hybrid_outrecalls_pure_mamba():
     """At enough key-value pairs the SSM's fixed-width state saturates and pure Mamba
     stays near chance, while a hybrid with a couple of attention layers recalls almost

--- a/tests/test_spec_decode.py
+++ b/tests/test_spec_decode.py
@@ -85,10 +85,16 @@ def test_verify_block_matches_sequential_step():
     block_logits, block_states = model.verify_block(tokens, state)
     for a, b in zip(seq_logits, block_logits):
         assert np.allclose(a, np.array(b), atol=1e-5)
-    # final state from the block must equal the sequential final state
-    final_seq = np.array(h[0][1])           # layer 0 ssm state
-    final_blk = np.array(block_states[-1][0][1])
-    assert np.allclose(final_seq, final_blk, atol=1e-5)
+    # The block's final state must equal the sequential final state for EVERY layer and
+    # BOTH components (conv + ssm) — comparing only layer-0 ssm hid bugs in later layers
+    # or in conv-state accumulation.
+    final_seq, final_blk = h, block_states[-1]
+    assert len(final_seq) == len(final_blk)
+    for li, (seq_layer, blk_layer) in enumerate(zip(final_seq, final_blk)):
+        assert len(seq_layer) == len(blk_layer)
+        for ci, (s, b) in enumerate(zip(seq_layer, blk_layer)):
+            assert np.allclose(np.array(s), np.array(b), atol=1e-5), \
+                f"state mismatch at layer {li} component {ci}"
 
 
 def _greedy_plain(model, prompt, max_new):

--- a/tests/test_train_loop.py
+++ b/tests/test_train_loop.py
@@ -4,7 +4,11 @@ Uses fakes (no backend) so these run on any host. The loop's contract is exercis
 through an injected `train_step` that records its calls.
 """
 
-from src.train.loop import TrainConfig, train
+import numpy as np
+
+from src.data.loader import PackedLoader
+from src.data.pack import pack_ids
+from src.train.loop import TrainConfig, train, _micro_batch_stream
 
 
 class FakeLoader:
@@ -15,8 +19,11 @@ class FakeLoader:
         self.seq_len = seq_len
         self.n_batches = n_batches
 
-    def epoch(self, reseed=None):
-        for i in range(self.n_batches):
+    def __len__(self):
+        return self.n_batches
+
+    def epoch(self, reseed=None, skip_batches=0):
+        for i in range(skip_batches, self.n_batches):
             yield (("inp", i), ("tgt", i))
 
 
@@ -82,3 +89,48 @@ def test_start_step_resume_runs_only_remaining():
     train(None, loader, cfg, fake_step, start_step=7)
 
     assert len(calls) == 3               # steps 7, 8, 9 only
+
+
+def _hashable(batch):
+    inp, tgt = batch
+    return (inp.tobytes(), tgt.tobytes())
+
+
+def test_resume_stream_continues_data_not_restart(tmp_path):
+    """P0.1 regression: resuming at step K must yield the SAME data the uninterrupted
+    run would see at steps K.., not replay the corpus from the top. Pure numpy — runs
+    without a backend. Uses distinct token values so every batch is identifiable, and a
+    small enough loader that the resume point lands well past the first epoch boundary.
+    """
+    seq_len, batch_size, grad_accum, seed = 4, 2, 1, 123
+    n_chunks = 20                                  # per_epoch = 20 // 2 = 10 micro-batches
+    n_tokens = n_chunks * (seq_len + 1)
+    packed = tmp_path / "train.bin"
+    pack_ids(np.arange(n_tokens, dtype=np.uint16), packed, dtype=np.uint16)
+
+    def fresh_loader():
+        return PackedLoader(packed, seq_len, batch_size, shuffle=True, seed=seed)
+
+    total_micro = 25                               # spans >2 epochs (10 micro/epoch)
+    full = [_hashable(b) for b in
+            _itertools_take(_micro_batch_stream(fresh_loader(), seed, start_micro=0),
+                            total_micro)]
+
+    resume_k = 13                                  # mid second epoch
+    resumed = [_hashable(b) for b in
+               _itertools_take(_micro_batch_stream(fresh_loader(), seed,
+                                                   start_micro=resume_k),
+                               total_micro - resume_k)]
+
+    assert resumed == full[resume_k:], "resumed stream diverged from the uninterrupted one"
+    # And sanity: the stream is NOT just repeating epoch 0 (would make the test vacuous).
+    assert full[:10] != full[10:20]
+
+
+def _itertools_take(it, n):
+    out = []
+    for x in it:
+        out.append(x)
+        if len(out) == n:
+            break
+    return out

--- a/tests/test_val_loss.py
+++ b/tests/test_val_loss.py
@@ -1,8 +1,21 @@
 """Unit tests for the val-loss numeric core (runs anywhere, numpy only)."""
 
 import numpy as np
+import pytest
 
-from src.eval.val_loss import cross_entropy, perplexity
+from src.eval.val_loss import cross_entropy, perplexity, evaluate
+
+
+class _EmptyLoader:
+    def epoch(self):
+        return iter(())
+
+
+def test_evaluate_empty_loader_raises_not_false_perfect():
+    # An empty val loader must fail loudly, not report perplexity=1.0 (the best possible
+    # score), which would silently mask a misconfigured eval path.
+    with pytest.raises(ValueError, match="empty"):
+        evaluate(model=None, loader=_EmptyLoader())
 
 
 def test_cross_entropy_uniform_logits():


### PR DESCRIPTION
## Context

Pre-RunPod code-quality audit (6 agents across model / training / data / serve-eval / tests / scripts). The codebase was found **structurally sound** — correct SSD math, intact hardware seam, correct dtype/packing and SFT/DPO masking — so those are unchanged. The real issues clustered in **resume/checkpoint durability** and **test integrity on a non-Mac (RunPod/Linux) host**. This PR remediates them ahead of the multi-week poc run. Three commits: P0–P3, the remaining HIGH/Medium findings, then double-buffered checkpoints.

## P0 — resume/checkpoint durability (the blockers)

- **Resume replayed data from the top.** The loop always rebuilt the batch stream at epoch 0, so a resumed run re-trained the front of the corpus. Now the stream position is reconstructed deterministically from `seed + start_step*grad_accum` (skip whole epochs free; `loader.epoch(skip_batches=)` for the remainder). No RNG is persisted because the model has **no train-time RNG** (no dropout; init is overwritten by loaded weights). All three loaders gained `skip_batches`.
- **Checkpoints are now double-buffered & crash-safe** (`CheckpointStore`). Two slots + an atomically-flipped `LATEST` pointer: each checkpoint is written in full (portable weights + optimizer + step + fp16 loss-scale state) to the inactive slot, fsync'd, then `LATEST` flips in one atomic rename — the single commit point. A crash mid-write leaves the **previous checkpoint fully intact** (the key guarantee for a 26-day run). Replaces the earlier single-slot atomic+COMMIT approach.
- **Misleading `rng_state` bundle key** renamed to `loss_scale_state` (it only ever held fp16 loss-scale state).
- **Terminal double-checkpoint** guarded in `train`/`sft`/`dpo`.

## P1 — test integrity

- Added a **multi-chunk** forward/step parity case (`L = 2*chunk+1`); the existing cases ran a single degenerate chunk.
- Replaced module-level `importorskip` in `test_moe` / `test_retrieval_probe` with `HAVE_MLX` + `@requires_mlx`, so **~11 pure-numpy portable tests now run on Linux** instead of being silently skipped.
- De-tautologized `test_grpo`; conformance checks now **return** `ok` instead of raising, making the doc-boundary / forward-step assertions load-bearing. Strengthened the spec-decode state check to compare **all layers + both state components** (was layer-0 ssm only).
- New tests: resume-stream continuation (portable — runs on RunPod), `CheckpointStore` round-trip / slot-alternation / **crash-preserves-previous** / refuse-when-empty, sampling all-banned fallback, empty-val-loader raise.

## P2/P3 — correctness, robustness + hygiene

- **CUDA backend:** ported the `long_ctx_factor` discretization divide into `cuda_backend._project` (was MLX-only — #54 silently no-op'd on CUDA).
- **Distillation:** routed `hidden_states` / `mixing_matrices` through the checkpointed `_layer_fns` so the hidden-align / mixing-match stages respect `grad_checkpoint` (they run under `value_and_grad`).
- **rlvr.py:** added `--out` (dedicated dir, never clobbers `--init`) + `--ckpt-every` periodic checkpointing.
- **backend.py:** auto-select via `importlib.find_spec('mlx')` instead of swallowing `SystemExit`.
- Sampling: uniform-draw fallback when every token is banned (was a NaN crash); documented tie-inclusive top-k. Loss scale: `max_scale` cap (2²⁴). `SessionStore.set_state` clones (rewind aliasing). `val_loss` raises on zero tokens (was false perplexity 1.0). MoE: dropped the redundant `k==E` renorm. Documented the DPO summed-logprob convention and spec-decode's greedy-only restriction.
- Doc/comment fixes: CLAUDE.md bf16 18%→16%, `bench_precision` mlx import guard, `moe_experiment` #30→#53, `spec_decode` example, vocab-ceiling comments.

## Verification

- Full suite: **447 passed, 1 opt-in skip**.
- Smoke gate (M4): resume exact, `max|diff| = 2.4e-7`, now exercising `CheckpointStore`.
- Real `scripts/train.py` checkpoint→resume cycle: both slots populated, resume from the live slot, terminal double-write suppressed, canonical `weights.safetensors` materialized.

## Deferred (Low/Info or out-of-scope for the imminent run)

`sizing` activation-byte estimate (crude heuristic, no correctness impact), needle-probe query-position randomization (eval rigor), dedup 32-bit shingle (production-scale only), `pyproject` torch/mlx upper bounds (avoided to not fight the RunPod install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSMoaQw3LFaABpsomsigWE