### PR TITLE
feat(cuda): CUDA smoke gate + mamba-ssm fused scan fast path (#39, #40)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,11 @@ as a smoothly decreasing held-out validation-perplexity curve — not benchmark 
 
 ```bash
 # Install (Apple Silicon — the normal dev environment):
-pip install -e ".[dev,data,mlx]"   # mlx requires Apple Silicon; omit on Linux/CUDA hosts
+pip install -e ".[dev,data,mlx]"
+
+# Install (Linux/CUDA host — e.g. RunPod):
+pip install -e ".[dev,data,cuda]"          # base CUDA backend (pure-PyTorch)
+pip install -e ".[dev,data,cuda-fast]"     # + mamba-ssm Triton scan + causal-conv1d (#40)
 
 # Tests (uses the venv at .venv):
 .venv/bin/python -m pytest                                   # full suite (36 tests)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,13 @@ datatrove = ["datatrove>=0.6"]
 # Apple Silicon backend (NOT installable on Linux/CUDA hosts).
 mlx = ["mlx>=0.18"]
 # CUDA / PyTorch backend (Linux/CUDA host; also runs CPU-only for conformance on a Mac).
-# The optional mamba-ssm fused selective-scan kernel is a separate perf extra (#40).
 cuda = ["torch>=2.0"]
+# Optional fused CUDA kernels (#40): mamba-ssm provides the Triton SSD chunked scan
+# (mamba_chunk_scan_combined) and causal-conv1d the depthwise conv fast path.
+# Both are auto-detected at runtime and degrade gracefully when absent.
+# Note: mamba-ssm 2.x top-level package requires a compatible transformers version;
+# the ops submodule used here (mamba_ssm.ops.triton) works independently.
+cuda-fast = ["torch>=2.0", "mamba-ssm>=2.0", "causal-conv1d>=1.0"]
 # Experiment logging.
 logging = ["wandb>=0.16"]
 # Tier-2 OLMES/lm-eval benchmark harness. A heavy optional dependency (some

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -201,9 +201,14 @@ def _cuda_backend() -> Backend:
             "The distillation train step (M10/#100) is implemented on the MLX dev backend "
             "only; the CUDA distill step is deferred.")
 
+    _dev = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def _model_cls(cfg):
+        return CUDAMambaModel(cfg, device=_dev)
+
     return Backend(
         name="cuda",
-        model_cls=CUDAMambaModel,
+        model_cls=_model_cls,
         make_train_step=_make_train_step,
         save_optimizer=_save_optimizer,
         load_optimizer=_load_optimizer,

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -201,7 +201,7 @@ def _cuda_backend() -> Backend:
             "The distillation train step (M10/#100) is implemented on the MLX dev backend "
             "only; the CUDA distill step is deferred.")
 
-    _dev = "cuda" if torch.cuda.is_available() else "cpu"
+    _dev = "cuda:0" if torch.cuda.is_available() else "cpu"
 
     def _model_cls(cfg):
         return CUDAMambaModel(cfg, device=_dev)

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -33,6 +33,41 @@ from .interface import ModelInterface, State, Array
 _DTYPES = {"fp32": torch.float32, "fp16": torch.float16, "bf16": torch.bfloat16}
 
 
+# --------------------------------------------------------------------------- #
+# Optional fused fast paths (#40): mamba-ssm SSD kernel + causal-conv1d.
+# Both degrade gracefully to the plain-PyTorch path when the package is absent
+# or the tensor is on CPU (kernels require CUDA). mamba-ssm's top-level
+# __init__.py has a stale transformers import; stub the package so only the ops
+# submodule is loaded.
+# --------------------------------------------------------------------------- #
+_FUSED_SCAN_FN = None          # sentinel: None = not yet tried; False = unavailable
+
+
+def _fused_scan():
+    """Return mamba_chunk_scan_combined, or None if unavailable."""
+    global _FUSED_SCAN_FN
+    if _FUSED_SCAN_FN is None:
+        try:
+            import sys, types, importlib.metadata
+            if "mamba_ssm" not in sys.modules:
+                pkg_dir = str(importlib.metadata.distribution("mamba_ssm").locate_file("mamba_ssm"))
+                stub = types.ModuleType("mamba_ssm")
+                stub.__path__ = [pkg_dir]
+                stub.__package__ = "mamba_ssm"
+                sys.modules["mamba_ssm"] = stub
+            from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+            _FUSED_SCAN_FN = mamba_chunk_scan_combined
+        except Exception:
+            _FUSED_SCAN_FN = False
+    return _FUSED_SCAN_FN if _FUSED_SCAN_FN else None
+
+
+try:
+    from causal_conv1d import causal_conv1d_fn as _CAUSAL_CONV1D
+except Exception:
+    _CAUSAL_CONV1D = None
+
+
 def _silu(x: Array) -> Array:
     return F.silu(x)
 
@@ -173,6 +208,9 @@ class SelectiveSSM(nn.Module):
     def parallel(self, x: Array, seg_ids: Array = None) -> Array:
         """SSD chunked-matmul scan. x: (B, L, d_inner) -> (B, L, d_inner).
 
+        Dispatches to `mamba_chunk_scan_combined` (#40) when the tensor is on CUDA and
+        mamba-ssm is installed; otherwise falls back to the pure-PyTorch path.
+
         Pads L up to a multiple of the chunk length Q (padded steps carry zero input and
         are trimmed). All decays are exp of non-positive sums, so it is overflow-safe.
 
@@ -184,6 +222,25 @@ class SelectiveSSM(nn.Module):
         Q = self.config.chunk_size or 64
         cd = _DTYPES[self.config.precision]
         delta, a, Bm, Cm = self._project(x)          # delta (B,L,H); Bm,Cm (B,L,N) — fp32
+
+        # --- fused CUDA fast path (#40) -------------------------------------------
+        fn = _fused_scan()
+        if fn is not None and x.device.type == "cuda":
+            # mamba_chunk_scan_combined expects:
+            #   x    (B,L,H,P) fp32    — raw head-shaped input (kernel handles dt*x)
+            #   dt   (B,L,H)   fp32    — softplus(dt_proj(dt_pre)), already computed
+            #   A    (H,)      fp32    — negative scalar decay (-exp(A_log))
+            #   B    (B,L,G,N) fp32    — G=ngroups=1
+            #   C    (B,L,G,N) fp32
+            #   D    (H,)             — per-head skip (added inside kernel)
+            #   seq_idx (B,L) int32   — maps each position to its document id (#68)
+            X = _f32(x).reshape(B_, L, H, P)
+            si = (seg_ids.to(torch.int32) if seg_ids is not None else None)
+            Y = fn(X, delta, a, Bm[:, :, None, :], Cm[:, :, None, :], Q,
+                   D=self.D, seq_idx=si, dt_softplus=False)    # (B,L,H,P) fp32
+            return _cast(Y.reshape(B_, L, d_inner), cd)
+
+        # --- pure-PyTorch fallback ------------------------------------------------
         X = _f32(x).reshape(B_, L, H, P)             # whole scan runs in fp32
 
         pad = (-L) % Q
@@ -257,9 +314,16 @@ class MambaBlock(nn.Module):
         self.out_proj = nn.Linear(d_inner, config.d_model, bias=False)
 
     def _conv_seq(self, x_main: Array, cd) -> Array:
-        """Causal depthwise conv in `cd`. torch Conv1d is channels-first, so transpose
-        (B,L,di) <-> (B,di,L) around it; the caller slices to the first L outputs."""
+        """Causal depthwise conv in `cd`. Uses causal_conv1d_fn (#40) on CUDA when
+        available; falls back to F.conv1d. The caller slices to the first L outputs."""
         c = self.conv
+        if _CAUSAL_CONV1D is not None and x_main.device.type == "cuda":
+            # causal_conv1d_fn: (B, C, L) x (C, K) -> (B, C, L), no extra padding needed.
+            # Our weight is (d_inner, 1, K) in torch Conv1d format; squeeze the group dim.
+            w = c.weight.to(cd).squeeze(1)             # (d_inner, K)
+            y = _CAUSAL_CONV1D(x_main.transpose(1, 2).to(cd), w,
+                               c.bias.to(cd), activation=None)
+            return y.transpose(1, 2)
         y = F.conv1d(x_main.transpose(1, 2).to(cd), c.weight.to(cd), c.bias.to(cd),
                      c.stride, c.padding, c.dilation, c.groups)
         return y.transpose(1, 2)

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -50,7 +50,17 @@ def _fused_scan():
         try:
             import sys, types, importlib.metadata
             if "mamba_ssm" not in sys.modules:
-                pkg_dir = str(importlib.metadata.distribution("mamba_ssm").locate_file("mamba_ssm"))
+                # Use the canonical PyPI name (hyphen); fall back to underscore for
+                # environments where the dist was installed under the import name.
+                for _distname in ("mamba-ssm", "mamba_ssm"):
+                    try:
+                        pkg_dir = str(importlib.metadata.distribution(_distname).locate_file("mamba_ssm"))
+                        break
+                    except importlib.metadata.PackageNotFoundError:
+                        continue
+                else:
+                    _FUSED_SCAN_FN = False
+                    return None
                 stub = types.ModuleType("mamba_ssm")
                 stub.__path__ = [pkg_dir]
                 stub.__package__ = "mamba_ssm"

--- a/tests/test_cuda_parity.py
+++ b/tests/test_cuda_parity.py
@@ -145,6 +145,36 @@ def test_forward_step_parity_hybrid():
     assert result["ok"], result
 
 
+def test_fused_scan_matches_vanilla():
+    """Fused mamba_chunk_scan_combined (#40) agrees with pure-PyTorch scan on CUDA.
+
+    Skipped when CUDA is unavailable or mamba-ssm is not installed. Compares in fp32
+    at the same ~1e-4 rel tolerance used for cross-backend parity."""
+    from src.model.cuda_backend import _fused_scan
+    if not torch.cuda.is_available():
+        pytest.skip("no CUDA device")
+    if _fused_scan() is None:
+        pytest.skip("mamba-ssm fused kernel not available")
+
+    torch.manual_seed(42)
+    cfg = load_config("config/toy.yaml")
+    dev = torch.device("cuda")
+    ssm = SelectiveSSM(cfg).to(dev)
+    B, L, di = 2, cfg.seq_len, cfg.d_inner
+    x_cpu = torch.randn(B, L, di) * 0.1
+
+    with torch.no_grad():
+        # GPU path — dispatches to fused kernel
+        y_fused = ssm.parallel(x_cpu.to(dev)).cpu().numpy()
+        # CPU path — pure-PyTorch fallback
+        y_vanilla = ssm.to("cpu").parallel(x_cpu).numpy()
+        ssm.to(dev)   # restore
+
+    max_abs = float(np.abs(y_fused.astype(np.float64) - y_vanilla.astype(np.float64)).max())
+    assert np.allclose(y_fused, y_vanilla, rtol=1e-4, atol=1e-5), (
+        f"fused scan differs from vanilla: max|diff|={max_abs:.3e}")
+
+
 def test_portable_roundtrip(tmp_path):
     """save -> reload into a fresh instance -> identical logits (the portable bridge)."""
     torch.manual_seed(0)


### PR DESCRIPTION
## Summary

Closes #39 and #40 (final open M8 sub-issues). Verified on RunPod A40.

- **#39 — CUDA smoke gate:** fix `_cuda_backend()` to auto-select `cuda:0`, then run and pass the smoke gate on real CUDA hardware
- **#40 — mamba-ssm fused kernel:** wire `mamba_chunk_scan_combined` (Triton SSD scan) and `causal_conv1d_fn` as opt-in fast paths; parity-tested vs pure-PyTorch

## Changes

### `src/model/backend.py`
`_cuda_backend()` now wraps `model_cls` in a closure that picks `cuda:0` when `torch.cuda.is_available()`. Previously the model always landed on CPU even on a CUDA host, so `train.py` and `smoke_test.py` never exercised real GPU kernels. Tests that construct `CUDAMambaModel()` directly are unaffected (default stays `device="cpu"`).

### `src/model/cuda_backend.py`
- `_fused_scan()` — lazy loader that stubs `mamba_ssm` top-level (its `__init__.py` has a stale `transformers.generation` import) and imports `mamba_chunk_scan_combined` from `mamba_ssm.ops.triton.ssd_combined`. Returns `None` on any failure (CPU path, absent package).
- `SelectiveSSM.parallel()` — dispatches to the Triton kernel on CUDA: passes `x(B,L,H,P)`, `delta(B,L,H)`, `A(H,)=-exp(A_log)`, `B/C(B,L,1,N)` (ngroups=1), `D(H,)` skip, and `seg_ids` as `seq_idx=int32` for packing-aware doc-boundary masking (#68). Falls back to the pure-PyTorch chunked-matmul scan on CPU.
- `MambaBlock._conv_seq()` — uses `causal_conv1d_fn` on CUDA when `causal-conv1d` is installed. `_conv_seq_seg` (boundary-aware path) keeps the manual loop.
- `_CAUSAL_CONV1D` — module-level try/except import, no hard dep.

### `tests/test_cuda_parity.py`
`test_fused_scan_matches_vanilla` — creates a toy SSM on CUDA, runs the fused path, compares to the CPU pure-PyTorch path at fp32 ~1e-4 rel tolerance. Skips when CUDA unavailable or mamba-ssm absent.

### `pyproject.toml`
Documents `[cuda-fast]` optional extra (`mamba-ssm>=2.0`, `causal-conv1d>=1.0`).

## Test plan

- [x] `python -m pytest tests/ -q` → 360 passed, 32 skipped (MLX auto-skips on CUDA host), 0 failures
- [x] `test_fused_scan_matches_vanilla` passes on A40 (fused vs vanilla `max|diff| < 1e-5`)
- [x] `python scripts/smoke_test.py --data data/split --backend cuda` → `SMOKE TEST PASSED ✅` (resume `max|diff|=7.6e-6`)
- [x] `python scripts/train.py --config config/toy.yaml --data data/split --backend cuda --total-steps 20 --batch-size 4 --out runs/cuda-gate` → loss decreasing, checkpoint/resume working

🤖 Generated with [Claude Code](https://claude.ai/claude-code)