### PR TITLE
feat: [#94] teacher top-k logit precompute + CUDA teacher

### DIFF
--- a/scripts/precompute_teacher.py
+++ b/scripts/precompute_teacher.py
@@ -37,7 +37,9 @@ def _parse_args() -> argparse.Namespace:
                     help="teacher-outputs dir (default: <data>/teacher-outputs/topk-logits)")
     ap.add_argument("--backend", choices=("auto", "mlx", "cuda"), default="auto",
                     help="hardware backend (the 7B precompute uses cuda on the cloud GPU)")
-    ap.add_argument("--k", type=int, default=50, help="logits cached per token (footprint ~6k B/token)")
+    ap.add_argument("--k", type=int, default=50,
+                    help="logits cached per token; footprint 6*k B/token (fp16 vals + uint32 idx), "
+                         "e.g. k=50 -> ~300 B/token")
     ap.add_argument("--batch-size", type=int, default=8, help="chunks per teacher forward")
     ap.add_argument("--pretrained", default=None,
                     help="HF checkpoint dir / repo id (default: manifest.conversion_teacher)")
@@ -94,12 +96,27 @@ def main() -> None:
         teacher = backend.make_teacher(config=_teacher_config_for(model_id), pretrained=model_id)
         teacher_info = {"model_id": model_id, "synthetic": False,
                         "vocab_size": teacher.config.vocab_size}
+        # Guard the foot-gun: if the teacher emits logits over a wider vocab than the student's
+        # tokenizer vocab (e.g. `from_pretrained(config=None)` builds a TeacherConfig from HF
+        # config.json, which omits `tokenizer_vocab_size`, so effective_vocab includes padded
+        # rows), the cached top-k indices can point at rows the student cannot represent. Fail
+        # loudly instead of silently writing unusable artifacts.
+        if teacher.config.effective_vocab_size != manifest.vocab_size:
+            raise SystemExit(
+                f"teacher effective_vocab_size {teacher.config.effective_vocab_size} != manifest "
+                f"tokenizer vocab {manifest.vocab_size} ({manifest.tokenizer}); the student cannot "
+                f"consume these top-k indices. Use a --pretrained id known to _teacher_config_for "
+                f"(it sets tokenizer_vocab_size), or extend it — see TeacherConfig.openr1_distill_7b.")
 
     eff_vocab = teacher.config.effective_vocab_size
     out_dir = args.out or storage.teacher_outputs_dir(args.data)
     out_dir = Path(out_dir)
     splits = [s for s in args.splits.split(",") if s]
 
+    # The teacher clamps k to min(k, effective_vocab) in topk_logits, so the actual cached k can
+    # be smaller than args.k; record THAT (from the per-split meta) in the manifest so it agrees
+    # with the per-split meta files downstream consumers read.
+    actual_k = args.k
     for split in splits:
         data = open_packed(args.data / f"{split}.bin")
         n_tokens = int(data.shape[0])
@@ -113,10 +130,11 @@ def main() -> None:
                                   seq_len=seq_len, vocab_size=eff_vocab,
                                   src_packed=str(args.data / f"{split}.bin"),
                                   src_n_tokens=n_tokens)
+        actual_k = meta["k"]
         print(f"teacher top-k [{split}]: {meta['n_rows']} rows x k={meta['k']} "
               f"({n_chunks} chunks x {seq_len}) -> {out_dir}")
 
-    write_manifest(out_dir, k=args.k, seq_len=seq_len, effective_vocab_size=eff_vocab,
+    write_manifest(out_dir, k=actual_k, seq_len=seq_len, effective_vocab_size=eff_vocab,
                    corpus_manifest=str(args.data), teacher=teacher_info, splits=splits)
 
     if args.push:

--- a/scripts/precompute_teacher.py
+++ b/scripts/precompute_teacher.py
@@ -1,0 +1,129 @@
+"""Teacher top-k logit precompute driver (#94) — the dominant, precompute-once cost of M10.
+
+Runs the FROZEN conversion teacher over the flat packed distill corpus (`<data>/train.bin`,
+`<data>/val.bin` — `src/data/split.py`'s output) and caches, per token, the top-`k` logits +
+vocab indices, aligned positionally to the corpus tokens. Every student trial then reads these
+back with ZERO teacher inference (`src.data.teacher_outputs.DistillLoader`), so the expensive
+7B forward is paid once and reused across the layout sweep (docs/design/10-distillation.md).
+
+The teacher forward is the program's heaviest GPU job, so this runs on the cloud GPU via
+`--backend cuda` (the torch `CUDATeacher`); `--backend mlx` is the Apple-Silicon path. The
+backend import stays behind `src.model.backend.get_backend`, so `--help` works on any host.
+
+    # real run (cloud GPU): cache top-50 for the OpenR1-Distill-7B teacher, push to R2
+    .venv/bin/python scripts/precompute_teacher.py --manifest config/manifests/student-1b-attn-hi.yaml \\
+        --data data/poc-distill/split --backend cuda --k 50 \\
+        --push s3://monica-training/poc-distill/teacher-outputs/topk-logits
+
+    # offline smoke (byte vocab, synthetic teacher — no network/weights):
+    .venv/bin/python scripts/precompute_teacher.py --manifest config/manifests/toy-distill.yaml \\
+        --data /tmp/toy-split --out /tmp/teacher-outputs --backend mlx --k 8 --synthetic
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--manifest", type=Path, required=True,
+                    help="student manifest (supplies conversion_teacher, seq_len)")
+    ap.add_argument("--data", type=Path, required=True, help="dir with train.bin/val.bin")
+    ap.add_argument("--splits", default="train,val", help="comma-separated splits (default train,val)")
+    ap.add_argument("--out", type=Path, default=None,
+                    help="teacher-outputs dir (default: <data>/teacher-outputs/topk-logits)")
+    ap.add_argument("--backend", choices=("auto", "mlx", "cuda"), default="auto",
+                    help="hardware backend (the 7B precompute uses cuda on the cloud GPU)")
+    ap.add_argument("--k", type=int, default=50, help="logits cached per token (footprint ~6k B/token)")
+    ap.add_argument("--batch-size", type=int, default=8, help="chunks per teacher forward")
+    ap.add_argument("--pretrained", default=None,
+                    help="HF checkpoint dir / repo id (default: manifest.conversion_teacher)")
+    ap.add_argument("--synthetic", action="store_true",
+                    help="build a synthetic toy teacher (TeacherConfig.tiny) — offline tests only")
+    ap.add_argument("--push", default=None,
+                    help="after writing, mirror --out to this fsspec URI / R2 prefix (#80)")
+    return ap.parse_args()
+
+
+def _teacher_config_for(model_id: str):
+    """Map a known teacher repo id to its `TeacherConfig` (so logits slice to the tokenizer
+    vocab — see `TeacherConfig.openr1_distill_7b`'s note). None lets `from_pretrained` read
+    the checkpoint's `config.json`."""
+    from src.model.teacher import TeacherConfig
+    known = {"open-r1/OpenR1-Distill-7B": TeacherConfig.openr1_distill_7b,
+             "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": TeacherConfig.qwen_1_5b}
+    return known[model_id]() if model_id in known else None
+
+
+def _topk_blocks(teacher, backend, data, n_chunks, stride, seq_len, batch_size, k):
+    """Yield `(vals, idx)` numpy blocks over the packed file in on-disk chunk order (no shuffle
+    — alignment is positional). Each block is `(b, seq_len, k_eff)`."""
+    import numpy as np
+    for c0 in range(0, n_chunks, batch_size):
+        c1 = min(c0 + batch_size, n_chunks)
+        rows = [np.asarray(data[c * stride: c * stride + seq_len], dtype=np.int64)
+                for c in range(c0, c1)]
+        inputs = np.stack(rows)                         # (b, seq_len)
+        vals, idx = teacher.topk_logits(inputs, k)
+        yield backend.to_numpy(vals), backend.to_numpy(idx)
+
+
+def main() -> None:
+    args = _parse_args()
+
+    from src.model.backend import get_backend
+    from src.model.teacher import TeacherConfig
+    from src.train.distill_manifest import load_manifest
+    from src.data import storage
+    from src.data.pack import open_packed
+    from src.data.teacher_outputs import write_teacher_topk, write_manifest
+
+    manifest = load_manifest(args.manifest)
+    seq_len = manifest.seq_len
+    backend = get_backend(args.backend)
+
+    if args.synthetic:
+        teacher = backend.make_teacher(config=TeacherConfig.tiny())
+        teacher_info = {"model_id": None, "synthetic": True,
+                        "vocab_size": teacher.config.vocab_size}
+    else:
+        model_id = args.pretrained or manifest.conversion_teacher
+        teacher = backend.make_teacher(config=_teacher_config_for(model_id), pretrained=model_id)
+        teacher_info = {"model_id": model_id, "synthetic": False,
+                        "vocab_size": teacher.config.vocab_size}
+
+    eff_vocab = teacher.config.effective_vocab_size
+    out_dir = args.out or storage.teacher_outputs_dir(args.data)
+    out_dir = Path(out_dir)
+    splits = [s for s in args.splits.split(",") if s]
+
+    for split in splits:
+        data = open_packed(args.data / f"{split}.bin")
+        n_tokens = int(data.shape[0])
+        stride = seq_len + 1
+        n_chunks = n_tokens // stride
+        if n_chunks == 0:
+            raise ValueError(f"{split}.bin too small for one chunk (seq_len={seq_len})")
+        blocks = _topk_blocks(teacher, backend, data, n_chunks, stride, seq_len,
+                              args.batch_size, args.k)
+        meta = write_teacher_topk(out_dir, split, blocks=blocks, n_chunks=n_chunks,
+                                  seq_len=seq_len, vocab_size=eff_vocab,
+                                  src_packed=str(args.data / f"{split}.bin"),
+                                  src_n_tokens=n_tokens)
+        print(f"teacher top-k [{split}]: {meta['n_rows']} rows x k={meta['k']} "
+              f"({n_chunks} chunks x {seq_len}) -> {out_dir}")
+
+    write_manifest(out_dir, k=args.k, seq_len=seq_len, effective_vocab_size=eff_vocab,
+                   corpus_manifest=str(args.data), teacher=teacher_info, splits=splits)
+
+    if args.push:
+        from src.data.r2_sync import upload_dir
+        written = upload_dir(out_dir, args.push)
+        print(f"pushed {len(written)} file(s): {out_dir} -> {args.push}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/teacher_outputs.py
+++ b/src/data/teacher_outputs.py
@@ -194,7 +194,10 @@ class DistillLoader:
         vals = np.stack([b[2] for b in batch])        # (B, seq_len, k)
         idx = np.stack([b[3] for b in batch])
         if self.vocab_size is not None:
-            top = int(inputs.max())
+            # Check inputs AND targets (targets are inputs shifted by one, so a bad/overflow id
+            # in the last position appears only in targets) — mirrors PackedLoader, which checks
+            # the max over the full seq_len+1 chunk before the input/target split.
+            top = int(max(int(inputs.max()), int(targets.max())))
             if top >= self.vocab_size:
                 raise ValueError(
                     f"token id {top} >= vocab_size {self.vocab_size} in {self.path}. "

--- a/src/data/teacher_outputs.py
+++ b/src/data/teacher_outputs.py
@@ -1,0 +1,203 @@
+"""Cached teacher top-k outputs (#94): the frozen teacher's per-token top-k logits, the
+dominant precompute of the distillation program.
+
+The teacher forward over the corpus depends only on (teacher, corpus), never on the
+student — so it is computed ONCE (`scripts/precompute_teacher.py`) and every student trial
+reads it back with zero teacher inference (`DistillLoader`). This module owns the on-disk
+format and the loader; it is **portable** (numpy only, no `mlx`/`torch`) like `loader.py`.
+
+Alignment is positional against the flat packed `train.bin`/`val.bin` the distill loader
+reads (`split.py`'s output, NOT the multi-shard corpus). `PackedLoader` cuts non-overlapping
+`seq_len+1` chunks; the teacher top-k is taken at the `seq_len` INPUT positions of each chunk
+(unshifted), so teacher row `t` is the teacher's prediction of `targets[t]` — exactly what
+the distill `_kl_topk` (#100) matches the student against. Per packed file we store
+`n_chunks * seq_len` rows in on-disk chunk order, so chunk `c` -> rows
+`[c*seq_len : c*seq_len+seq_len]`. Sharing `seq_len`/`n_chunks`/seed with `PackedLoader`
+makes `DistillLoader`'s shuffle + `skip_batches` byte-identical, so training resume stays exact.
+
+On-disk layout under a teacher-outputs dir (one set per split):
+
+    teacher-<split>.topk_vals   float16 (n_rows, k)   raw C-order .tofile dump (mmap-friendly)
+    teacher-<split>.topk_idx    uint32  (n_rows, k)
+    teacher-<split>.meta.json   {split, k, n_rows, n_chunks, seq_len, vals_dtype, idx_dtype,
+                                 vocab_size, src_packed, src_n_tokens}
+    manifest.json               run-level summary (k, dtypes, splits, teacher, corpus ref)
+
+Footprint is `k*(2+4)` bytes/token (fp16 vals + uint32 idx): k=50 ~= 600 GB at 2B tokens.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Iterator, Optional, Tuple
+
+import numpy as np
+
+from .pack import open_packed
+
+#: On-disk dtypes. idx is uint32 (Qwen2.5 effective vocab 151646 overflows uint16); vals are
+#: fp16 — the KL is a softmax over the k-support after `/T`, so fp16 logit precision is ample.
+VALS_DTYPE = np.dtype(np.float16)
+IDX_DTYPE = np.dtype(np.uint32)
+
+
+def topk_outputs_paths(out_dir, split: str) -> dict:
+    """The three file paths for one split's cached top-k (`teacher-<split>.*`)."""
+    base = Path(out_dir) / f"teacher-{split}"
+    return {"vals": base.with_suffix(".topk_vals"),
+            "idx": base.with_suffix(".topk_idx"),
+            "meta": base.with_suffix(".meta.json")}
+
+
+def write_teacher_topk(out_dir, split: str, *, blocks: Iterable[Tuple[np.ndarray, np.ndarray]],
+                       n_chunks: int, seq_len: int, vocab_size: int,
+                       src_packed: str, src_n_tokens: Optional[int] = None) -> dict:
+    """Stream per-batch top-k blocks to disk and write the split's `.meta.json`.
+
+    `blocks` yields `(vals_block, idx_block)` in on-disk chunk order; each block is shaped
+    `(..., k)` (e.g. `(batch, seq_len, k)`) and is flattened to `(rows, k)`, cast to fp16 /
+    uint32, and appended. `k` is taken from the first block (the teacher may have clamped it
+    to the vocab). Returns the meta dict. Streaming keeps memory bounded over a large corpus.
+    """
+    paths = topk_outputs_paths(out_dir, split)
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    n_rows, k = 0, None
+    with open(paths["vals"], "wb") as vf, open(paths["idx"], "wb") as xf:
+        for vb, ib in blocks:
+            vb = np.ascontiguousarray(np.asarray(vb).reshape(-1, np.asarray(vb).shape[-1]),
+                                      dtype=VALS_DTYPE)
+            ib = np.ascontiguousarray(np.asarray(ib).reshape(-1, np.asarray(ib).shape[-1]),
+                                      dtype=IDX_DTYPE)
+            if k is None:
+                k = vb.shape[1]
+            if vb.shape[1] != k or ib.shape[1] != k:
+                raise ValueError(f"inconsistent k across blocks: {vb.shape[1]}/{ib.shape[1]} != {k}")
+            if vb.shape[0] != ib.shape[0]:
+                raise ValueError("vals/idx block row counts differ")
+            vb.tofile(vf)
+            ib.tofile(xf)
+            n_rows += vb.shape[0]
+    expected = n_chunks * seq_len
+    if n_rows != expected:
+        raise ValueError(f"wrote {n_rows} teacher rows, expected n_chunks*seq_len = {expected}")
+    meta = {"split": split, "k": int(k or 0), "n_rows": int(n_rows), "n_chunks": int(n_chunks),
+            "seq_len": int(seq_len), "vals_dtype": VALS_DTYPE.name, "idx_dtype": IDX_DTYPE.name,
+            "vocab_size": int(vocab_size), "src_packed": str(src_packed),
+            "src_n_tokens": (int(src_n_tokens) if src_n_tokens is not None else None)}
+    paths["meta"].write_text(json.dumps(meta, indent=2))
+    return meta
+
+
+def read_teacher_meta(out_dir, split: str) -> dict:
+    """Load one split's `.meta.json` (k, n_rows, n_chunks, seq_len, dtypes, ...)."""
+    return json.loads(topk_outputs_paths(out_dir, split)["meta"].read_text())
+
+
+def write_manifest(out_dir, *, k: int, seq_len: int, effective_vocab_size: int,
+                   corpus_manifest: Optional[str], teacher: Optional[dict],
+                   splits: Iterable[str]) -> dict:
+    """Write the run-level `manifest.json` tying the per-split files to the teacher + corpus."""
+    splits = list(splits)
+    n_rows_total = sum(read_teacher_meta(out_dir, s)["n_rows"] for s in splits)
+    manifest = {"k": int(k), "seq_len": int(seq_len),
+                "vals_dtype": VALS_DTYPE.name, "idx_dtype": IDX_DTYPE.name,
+                "effective_vocab_size": int(effective_vocab_size),
+                "corpus_manifest": corpus_manifest, "teacher": teacher,
+                "splits": splits, "n_rows_total": int(n_rows_total)}
+    (Path(out_dir) / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return manifest
+
+
+class DistillLoader:
+    """Stream `(inputs, targets, topk_vals, topk_idx)` for the logit-distill stage (#100).
+
+    Mirrors `PackedLoader` exactly — same `stride`/`n_chunks`/shuffle/`skip_batches` math, so
+    `epoch(reseed=s)` visits chunks in the SAME order as `PackedLoader(..., seed=s)` and resume
+    fast-forwards identically. The extra outputs are the cached teacher top-k for each chunk's
+    input positions: `topk_vals` `(B, seq_len, k)` fp32, `topk_idx` `(B, seq_len, k)` int64.
+    """
+
+    def __init__(self, packed_path: Path, topk_dir, split: str, seq_len: int, batch_size: int,
+                 k: Optional[int] = None, shuffle: bool = True, seed: int = 0,
+                 drop_last: bool = True, vocab_size: Optional[int] = None):
+        self.path = packed_path
+        self.data = open_packed(packed_path)
+        self.seq_len = seq_len
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.drop_last = drop_last
+        self.vocab_size = vocab_size
+        self.rng = np.random.default_rng(seed)
+
+        # Non-overlapping chunks of length seq_len+1 (extra token = shift target) — same as
+        # PackedLoader, so the chunk index space (and thus the shuffle) is identical.
+        self.stride = seq_len + 1
+        self.n_chunks = (self.data.shape[0]) // self.stride
+        if self.n_chunks == 0:
+            raise ValueError("packed file too small for one chunk")
+
+        meta = read_teacher_meta(topk_dir, split)
+        if meta["seq_len"] != seq_len:
+            raise ValueError(f"teacher-{split} seq_len {meta['seq_len']} != loader seq_len {seq_len}")
+        if meta["n_chunks"] != self.n_chunks:
+            raise ValueError(
+                f"teacher-{split} n_chunks {meta['n_chunks']} != packed n_chunks {self.n_chunks} "
+                f"({self.path}) — teacher outputs are not aligned to this packed file")
+        self.k_stored = int(meta["k"])
+        self.k = int(k) if k is not None else self.k_stored
+        if self.k > self.k_stored:
+            raise ValueError(f"requested k={self.k} exceeds stored k={self.k_stored}")
+        n_rows = int(meta["n_rows"])
+        paths = topk_outputs_paths(topk_dir, split)
+        self.vals = np.memmap(paths["vals"], dtype=np.dtype(meta["vals_dtype"]), mode="r",
+                              shape=(n_rows, self.k_stored))
+        self.idx = np.memmap(paths["idx"], dtype=np.dtype(meta["idx_dtype"]), mode="r",
+                             shape=(n_rows, self.k_stored))
+
+    def _chunk(self, idx: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        start = idx * self.stride
+        chunk = np.asarray(self.data[start: start + self.stride], dtype=np.int64)
+        r0 = idx * self.seq_len
+        vals = np.asarray(self.vals[r0: r0 + self.seq_len, : self.k], dtype=np.float32)
+        tidx = np.asarray(self.idx[r0: r0 + self.seq_len, : self.k], dtype=np.int64)
+        return chunk[:-1], chunk[1:], vals, tidx
+
+    def __len__(self) -> int:
+        full = self.n_chunks // self.batch_size
+        return full if self.drop_last else (self.n_chunks + self.batch_size - 1) // self.batch_size
+
+    def epoch(self, reseed: Optional[int] = None,
+              skip_batches: int = 0) -> Iterator[tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]]:
+        """Yield `(inputs, targets, topk_vals, topk_idx)` for one pass. Shuffle + `skip_batches`
+        semantics are byte-identical to `PackedLoader.epoch` (so resume order matches)."""
+        if reseed is not None:
+            self.rng = np.random.default_rng(reseed)
+        order = np.arange(self.n_chunks)
+        if self.shuffle:
+            self.rng.shuffle(order)
+        if skip_batches:
+            order = order[skip_batches * self.batch_size:]
+
+        batch = []
+        for idx in order:
+            batch.append(self._chunk(int(idx)))
+            if len(batch) == self.batch_size:
+                yield self._collate(batch)
+                batch = []
+        if batch and not self.drop_last:
+            yield self._collate(batch)
+
+    def _collate(self, batch: list) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        inputs = np.stack([b[0] for b in batch])      # (B, seq_len)
+        targets = np.stack([b[1] for b in batch])
+        vals = np.stack([b[2] for b in batch])        # (B, seq_len, k)
+        idx = np.stack([b[3] for b in batch])
+        if self.vocab_size is not None:
+            top = int(inputs.max())
+            if top >= self.vocab_size:
+                raise ValueError(
+                    f"token id {top} >= vocab_size {self.vocab_size} in {self.path}. "
+                    "The packed data does not match the model config — likely a stale or "
+                    "clobbered data file.")
+        return inputs, targets, vals, idx

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -186,10 +186,17 @@ def _cuda_backend() -> Backend:
         from .cuda_train_step import make_grpo_train_step
         return make_grpo_train_step(*args, **kwargs)
 
-    def _teacher_unsupported(*args, **kwargs):
-        raise NotImplementedError(
-            "The conversion teacher (M10/#93) is implemented on the MLX dev backend only; "
-            "the CUDA teacher loader is deferred.")
+    def _make_teacher(config=None, *, pretrained=None, seed=0):
+        """Frozen conversion teacher (#93/#94), torch port. `pretrained` (an HF checkpoint dir /
+        repo id) loads real weights — this is how the dominant teacher precompute runs on the
+        cloud GPU; otherwise a synthetic teacher is built from `config`."""
+        from .cuda_teacher import CUDATeacher
+        if pretrained is not None:
+            return CUDATeacher.from_pretrained(pretrained, config)
+        if config is None:
+            raise ValueError("make_teacher needs a TeacherConfig for the synthetic path "
+                             "(pass `config=...`), or `pretrained=<dir/repo>` for real weights")
+        return CUDATeacher.from_config(config, seed=seed)
 
     def _student_init_unsupported(*args, **kwargs):
         raise NotImplementedError(
@@ -219,7 +226,7 @@ def _cuda_backend() -> Backend:
         make_sft_train_step=_make_sft_train_step,
         make_dpo_train_step=_make_dpo_train_step,
         make_grpo_train_step=_make_grpo_train_step,
-        make_teacher=_teacher_unsupported,
+        make_teacher=_make_teacher,
         init_student=_student_init_unsupported,
         make_distill_train_step=_distill_unsupported,
     )

--- a/src/model/cuda_teacher.py
+++ b/src/model/cuda_teacher.py
@@ -1,0 +1,296 @@
+"""CUDA / PyTorch conversion teacher (below the seam — may import torch).
+
+A faithful torch port of `mlx_teacher.MLXConversionTeacher`: a frozen, forward-only Qwen2
+decoder (open-r1/OpenR1-Distill-7B by default) implementing the portable `ConversionTeacher`
+protocol (`src/model/teacher.py`). It exists so the dominant teacher precompute (#94) can run
+on the cloud GPU via `--backend cuda`; the MLX teacher remains the Apple-Silicon dev path.
+
+Like the MLX teacher, weights are a plain `dict[str, torch.Tensor]` (NOT an `nn.Module`), so
+the teacher exposes no parameter tree — it can never be handed to an optimizer, and
+`trainable_parameters()` is empty. Forward outputs are `.detach()`-ed (the torch analogue of
+`mx.stop_gradient`): even composed into a student loss, no gradient reaches the teacher. All
+compute is fp32 (teacher logits feed a KL term; stability beats speed and the forward is a
+one-time precompute). Runs on CUDA when available, else CPU (so parity is testable on a Mac/Linux
+box). RoPE/attention idioms mirror `cuda_backend.py` but with a theta-configurable RoPE (Qwen2
+`rope_theta`, up to 300k for Open-R1's 32k context).
+
+This file imports `torch`, so it lives BELOW the seam — nothing portable imports it.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from .teacher import (AttnProjections, ConversionTeacher, TeacherConfig,
+                      TeacherForward)
+
+
+def _device() -> torch.device:
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """RMSNorm in fp32 (matches `cuda_backend.RMSNorm` / `mlx_teacher._rms_norm`)."""
+    xf = x.to(torch.float32)
+    norm = torch.rsqrt(torch.mean(xf * xf, dim=-1, keepdim=True) + eps)
+    return weight * (xf * norm)
+
+
+def _rope_cos_sin(positions: torch.Tensor, head_dim: int, theta: float
+                  ) -> Tuple[torch.Tensor, torch.Tensor]:
+    """RoPE cos/sin for absolute `positions` (fp32), theta-configurable (Qwen2 rope_theta).
+    Generalizes `cuda_backend._rope_cos_sin` (which hardcodes theta=10000). (T, head_dim)."""
+    half = head_dim // 2
+    device = positions.device
+    inv_freq = torch.exp(-math.log(theta)
+                         * torch.arange(0, half, dtype=torch.float32, device=device) / half)
+    ang = positions.to(torch.float32)[:, None] * inv_freq[None, :]    # (T, half)
+    cos = torch.cat([torch.cos(ang), torch.cos(ang)], dim=-1)         # (T, head_dim)
+    sin = torch.cat([torch.sin(ang), torch.sin(ang)], dim=-1)
+    return cos, sin
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    half = x.shape[-1] // 2
+    return torch.cat([-x[..., half:], x[..., :half]], dim=-1)
+
+
+def _apply_rope(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    # x: (B, H, T, Dh); cos/sin: (T, Dh) broadcast over (B, H).
+    return x * cos[None, None] + _rotate_half(x) * sin[None, None]
+
+
+def _softmax_lastdim(scores: torch.Tensor) -> torch.Tensor:
+    scores = scores - torch.amax(scores, dim=-1, keepdim=True)
+    w = torch.exp(scores)
+    return w / torch.sum(w, dim=-1, keepdim=True)
+
+
+def _silu(x: torch.Tensor) -> torch.Tensor:
+    return F.silu(x)
+
+
+class CUDATeacher(ConversionTeacher):
+    """Frozen Qwen2 conversion teacher on PyTorch. See module docstring."""
+
+    def __init__(self, config: TeacherConfig, weights: Dict[str, torch.Tensor]):
+        config.validate()
+        self.config = config
+        self._device = _device()
+        # All compute in fp32 (KL stability; one-time precompute). Held off the autograd graph.
+        self._w = {k: v.detach().to(self._device, torch.float32) for k, v in weights.items()}
+
+    # --- constructors --------------------------------------------------------
+    @classmethod
+    def from_config(cls, config: TeacherConfig, *, seed: int = 0) -> "CUDATeacher":
+        """Random-init synthetic teacher (offline tests / small local checks). The weight
+        layout matches `mlx_teacher.from_config` so a parity test can build both from the
+        same numpy arrays."""
+        config.validate()
+        g = torch.Generator().manual_seed(seed)
+        c = config
+        scale = 1.0 / math.sqrt(c.d_model)
+
+        def rand(*shape):
+            return torch.randn(*shape, generator=g) * scale
+
+        w: Dict[str, torch.Tensor] = {"embed": rand(c.vocab_size, c.d_model)}
+        for i in range(c.n_layers):
+            p = f"layer.{i}."
+            w[p + "input_ln"] = torch.ones(c.d_model)
+            w[p + "q_w"] = rand(c.q_dim, c.d_model)
+            w[p + "q_b"] = torch.zeros(c.q_dim)
+            w[p + "k_w"] = rand(c.kv_dim, c.d_model)
+            w[p + "k_b"] = torch.zeros(c.kv_dim)
+            w[p + "v_w"] = rand(c.kv_dim, c.d_model)
+            w[p + "v_b"] = torch.zeros(c.kv_dim)
+            w[p + "o_w"] = rand(c.d_model, c.q_dim)
+            w[p + "post_ln"] = torch.ones(c.d_model)
+            w[p + "gate_w"] = rand(c.intermediate_size, c.d_model)
+            w[p + "up_w"] = rand(c.intermediate_size, c.d_model)
+            w[p + "down_w"] = rand(c.d_model, c.intermediate_size)
+        w["final_ln"] = torch.ones(c.d_model)
+        if not c.tie_embeddings:
+            w["lm_head"] = rand(c.vocab_size, c.d_model)
+        return cls(config, w)
+
+    @classmethod
+    def from_pretrained(cls, path, config: Optional[TeacherConfig] = None) -> "CUDATeacher":
+        """Load a local HuggingFace Qwen2 checkpoint (config.json + safetensors), or an HF repo id.
+
+        Mirrors `mlx_teacher.from_pretrained`: a bare 'owner/name' is fetched lazily via
+        `huggingface_hub.snapshot_download`; `config.json` resolves to a `TeacherConfig` when
+        none is passed (but pass `openr1_distill_7b()` so logits are sliced to the tokenizer
+        vocab — see that config's note)."""
+        p = Path(path)
+        if not p.exists():
+            repo_id = str(path) if "/" in str(path) else (config.model_id if config else None)
+            if not repo_id:
+                raise FileNotFoundError(
+                    f"teacher path {p} not found and no repo id (pass an HF 'owner/name' path "
+                    "or a config with model_id)")
+            from huggingface_hub import snapshot_download   # lazy: optional dep, not in tests
+            p = Path(snapshot_download(repo_id))
+        if config is None:
+            with open(p / "config.json") as f:
+                config = TeacherConfig.from_hf_dict(json.load(f))
+        hf = _load_safetensors_dir(p)
+        return cls(config, _hf_to_internal(hf, config))
+
+    # --- ConversionTeacher ---------------------------------------------------
+    def forward(self, token_batch, *, return_hidden: bool = False) -> TeacherForward:
+        tokens = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
+        c = self.config
+        h = self._w["embed"][tokens]                          # (B, L, D)
+        L = h.shape[1]
+        cos, sin = _rope_cos_sin(torch.arange(L, device=self._device), c.head_dim, c.rope_theta)
+        mask = self._causal_mask(L)
+        hidden: List[torch.Tensor] = [h] if return_hidden else []
+        for i in range(c.n_layers):
+            h = h + self._attn(h, i, cos, sin, mask)
+            h = h + self._mlp(h, i)
+            if return_hidden:
+                hidden.append(h)
+        # Emit logits over the tokenizer vocab (padded embedding rows are never teacher targets).
+        logits = (_rms_norm(h, self._w["final_ln"], c.rms_norm_eps)
+                  @ self._lm_head().t())[..., :c.effective_vocab_size]
+        hs = tuple(t.detach() for t in hidden) if return_hidden else None
+        return TeacherForward(logits=logits.detach(), hidden_states=hs)
+
+    def topk_logits(self, token_batch, k: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        logits = self.forward(token_batch).logits             # (B, L, Ve)
+        k = min(k, logits.shape[-1])
+        vals, idx = torch.topk(logits, k, dim=-1)             # sorted descending
+        return vals.detach(), idx
+
+    def attention_matrices(self, token_batch) -> Tuple[torch.Tensor, ...]:
+        """Per-layer head-averaged causal attention `softmax(QK^T/sqrt(Dh))`, each `(B, L, L)`,
+        for the distillation `mixing-match` stage (#100). Detached (frozen teacher)."""
+        c = self.config
+        tokens = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
+        h = self._w["embed"][tokens]
+        L = h.shape[1]
+        cos, sin = _rope_cos_sin(torch.arange(L, device=self._device), c.head_dim, c.rope_theta)
+        mask = self._causal_mask(L)
+        mats = []
+        for i in range(c.n_layers):
+            mats.append(self._attn_probs(h, i, cos, sin, mask).detach())
+            h = h + self._attn(h, i, cos, sin, mask)
+            h = h + self._mlp(h, i)
+        return tuple(mats)
+
+    def attention_projection(self, layer: int) -> AttnProjections:
+        p = f"layer.{layer}."
+        g = lambda s: self._w[p + s].detach()
+        return AttnProjections(q=g("q_w"), k=g("k_w"), v=g("v_w"), o=g("o_w"),
+                               q_bias=g("q_b"), k_bias=g("k_b"), v_bias=g("v_b"))
+
+    def embedding_matrix(self) -> torch.Tensor:
+        return self._w["embed"].detach()
+
+    def lm_head_matrix(self) -> torch.Tensor:
+        return self._lm_head().detach()
+
+    def to_numpy(self, array) -> np.ndarray:
+        return array.detach().to("cpu").numpy()
+
+    # --- internals -----------------------------------------------------------
+    def _lm_head(self) -> torch.Tensor:
+        return self._w["embed"] if self.config.tie_embeddings else self._w["lm_head"]
+
+    def _causal_mask(self, L: int) -> torch.Tensor:
+        return torch.tril(torch.ones((L, L), dtype=torch.bool, device=self._device))
+
+    def _attn_probs(self, x: torch.Tensor, i: int, cos: torch.Tensor, sin: torch.Tensor,
+                    mask: torch.Tensor) -> torch.Tensor:
+        """Head-averaged causal attention probabilities for layer `i` -> (B, L, L)."""
+        c = self.config
+        p = f"layer.{i}."
+        B, L, _ = x.shape
+        Hq, Hkv, Dh = c.n_heads, c.n_kv_heads, c.head_dim
+        xn = _rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps)
+        q = xn @ self._w[p + "q_w"].t() + self._w[p + "q_b"]
+        k = xn @ self._w[p + "k_w"].t() + self._w[p + "k_b"]
+
+        def heads(t, H):
+            return t.reshape(B, L, H, Dh).permute(0, 2, 1, 3)
+        q, k = heads(q, Hq), heads(k, Hkv)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        if Hkv != Hq:
+            k = k.repeat_interleave(Hq // Hkv, dim=1)
+        scores = (q @ k.transpose(-1, -2)) / math.sqrt(Dh)       # (B,Hq,L,L)
+        scores = scores.masked_fill(~mask, float("-inf"))
+        return _softmax_lastdim(scores).mean(dim=1)              # head-average -> (B,L,L)
+
+    def _attn(self, x: torch.Tensor, i: int, cos: torch.Tensor, sin: torch.Tensor,
+              mask: torch.Tensor) -> torch.Tensor:
+        c = self.config
+        p = f"layer.{i}."
+        B, L, _ = x.shape
+        Hq, Hkv, Dh = c.n_heads, c.n_kv_heads, c.head_dim
+        xn = _rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps)
+        q = xn @ self._w[p + "q_w"].t() + self._w[p + "q_b"]    # (B,L,q_dim)
+        k = xn @ self._w[p + "k_w"].t() + self._w[p + "k_b"]    # (B,L,kv_dim)
+        v = xn @ self._w[p + "v_w"].t() + self._w[p + "v_b"]
+
+        def heads(t, H):
+            return t.reshape(B, L, H, Dh).permute(0, 2, 1, 3)   # (B,H,L,Dh)
+        q, k, v = heads(q, Hq), heads(k, Hkv), heads(v, Hkv)
+        q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
+        if Hkv != Hq:                                          # GQA: repeat kv across groups
+            rep = Hq // Hkv
+            k, v = k.repeat_interleave(rep, dim=1), v.repeat_interleave(rep, dim=1)
+        scores = (q @ k.transpose(-1, -2)) / math.sqrt(Dh)      # (B,Hq,L,L)
+        scores = scores.masked_fill(~mask, float("-inf"))
+        out = _softmax_lastdim(scores) @ v                     # (B,Hq,L,Dh)
+        out = out.permute(0, 2, 1, 3).reshape(B, L, Hq * Dh)
+        return out @ self._w[p + "o_w"].t()                    # (B,L,D), o has no bias
+
+    def _mlp(self, x: torch.Tensor, i: int) -> torch.Tensor:
+        c = self.config
+        p = f"layer.{i}."
+        xn = _rms_norm(x, self._w[p + "post_ln"], c.rms_norm_eps)
+        gate = _silu(xn @ self._w[p + "gate_w"].t())
+        up = xn @ self._w[p + "up_w"].t()
+        return (gate * up) @ self._w[p + "down_w"].t()
+
+
+# --- HuggingFace checkpoint loading ------------------------------------------
+def _load_safetensors_dir(p: Path) -> Dict[str, torch.Tensor]:
+    """Load + merge every `*.safetensors` shard in a directory into one dict."""
+    from safetensors.torch import load_file
+    files = sorted(p.glob("*.safetensors"))
+    if not files:
+        raise FileNotFoundError(f"no .safetensors found in {p}")
+    out: Dict[str, torch.Tensor] = {}
+    for f in files:
+        out.update(load_file(str(f)))
+    return out
+
+
+def _hf_to_internal(hf: Dict[str, torch.Tensor], cfg: TeacherConfig) -> Dict[str, torch.Tensor]:
+    """Map HuggingFace Qwen2 parameter names onto the internal weight-dict layout (mirrors
+    `mlx_teacher._hf_to_internal`)."""
+    w: Dict[str, torch.Tensor] = {"embed": hf["model.embed_tokens.weight"]}
+    for i in range(cfg.n_layers):
+        hp, p = f"model.layers.{i}.", f"layer.{i}."
+        w[p + "input_ln"] = hf[hp + "input_layernorm.weight"]
+        w[p + "post_ln"] = hf[hp + "post_attention_layernorm.weight"]
+        for proj, dst in (("q_proj", "q"), ("k_proj", "k"), ("v_proj", "v")):
+            w[p + dst + "_w"] = hf[hp + f"self_attn.{proj}.weight"]
+            w[p + dst + "_b"] = hf[hp + f"self_attn.{proj}.bias"]
+        w[p + "o_w"] = hf[hp + "self_attn.o_proj.weight"]
+        w[p + "gate_w"] = hf[hp + "mlp.gate_proj.weight"]
+        w[p + "up_w"] = hf[hp + "mlp.up_proj.weight"]
+        w[p + "down_w"] = hf[hp + "mlp.down_proj.weight"]
+    w["final_ln"] = hf["model.norm.weight"]
+    if not cfg.tie_embeddings:
+        w["lm_head"] = hf["lm_head.weight"]
+    return w

--- a/tests/test_cuda_teacher.py
+++ b/tests/test_cuda_teacher.py
@@ -1,0 +1,104 @@
+"""CUDA/torch conversion teacher (#94). Torch CPU; parity vs MLX where mlx is available.
+
+The teacher runs on CPU (no CUDA needed), so forward shapes / top-k / the frozen contract are
+testable anywhere torch is installed. The cross-backend parity test (built from one shared numpy
+weight dict) guards that the torch port agrees with the MLX teacher at fp32 — the same standard
+as src/conformance/backend_parity.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.teacher import TeacherConfig
+from src.model.cuda_teacher import CUDATeacher
+
+
+def _cfg():
+    return TeacherConfig(vocab_size=256, d_model=64, n_layers=2, n_heads=4, n_kv_heads=2,
+                         head_dim=16, intermediate_size=128, tokenizer_vocab_size=200)
+
+
+def _numpy_weights(cfg, seed=0):
+    """Synthetic weights in the shared `mlx_teacher`/`cuda_teacher` dict layout, so both
+    backends can be built from the SAME arrays for parity."""
+    rng = np.random.default_rng(seed)
+    scale = 1.0 / math.sqrt(cfg.d_model)
+    f = lambda *s: (rng.standard_normal(s) * scale).astype(np.float32)
+    w = {"embed": f(cfg.vocab_size, cfg.d_model)}
+    for i in range(cfg.n_layers):
+        p = f"layer.{i}."
+        w[p + "input_ln"] = np.ones(cfg.d_model, np.float32)
+        w[p + "q_w"] = f(cfg.q_dim, cfg.d_model); w[p + "q_b"] = f(cfg.q_dim)
+        w[p + "k_w"] = f(cfg.kv_dim, cfg.d_model); w[p + "k_b"] = f(cfg.kv_dim)
+        w[p + "v_w"] = f(cfg.kv_dim, cfg.d_model); w[p + "v_b"] = f(cfg.kv_dim)
+        w[p + "o_w"] = f(cfg.d_model, cfg.q_dim)
+        w[p + "post_ln"] = np.ones(cfg.d_model, np.float32)
+        w[p + "gate_w"] = f(cfg.intermediate_size, cfg.d_model)
+        w[p + "up_w"] = f(cfg.intermediate_size, cfg.d_model)
+        w[p + "down_w"] = f(cfg.d_model, cfg.intermediate_size)
+    w["final_ln"] = np.ones(cfg.d_model, np.float32)
+    return w
+
+
+def _tokens(B=2, L=8, vocab=200):
+    return np.random.default_rng(1).integers(0, vocab, size=(B, L)).astype(np.int64)
+
+
+def test_forward_shapes_and_effective_vocab():
+    cfg = _cfg()
+    teacher = CUDATeacher.from_config(cfg, seed=0)
+    out = teacher.forward(_tokens(), return_hidden=True)
+    assert out.logits.shape == (2, 8, cfg.effective_vocab_size)   # sliced to tokenizer vocab
+    assert len(out.hidden_states) == cfg.n_layers + 1
+    assert out.logits.requires_grad is False                      # frozen contract
+
+
+def test_topk_descending_and_in_range():
+    cfg = _cfg()
+    teacher = CUDATeacher.from_config(cfg, seed=0)
+    vals, idx = teacher.topk_logits(_tokens(), k=5)
+    assert vals.shape == (2, 8, 5) and idx.shape == (2, 8, 5)
+    v = teacher.to_numpy(vals)
+    assert np.all(np.diff(v, axis=-1) <= 1e-5)                    # descending
+    i = teacher.to_numpy(idx)
+    assert i.min() >= 0 and i.max() < cfg.effective_vocab_size
+
+
+def test_no_trainable_parameters():
+    teacher = CUDATeacher.from_config(_cfg(), seed=0)
+    assert teacher.trainable_parameters() == {}
+
+
+def _have_mlx():
+    try:
+        import mlx.core  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _have_mlx(), reason="mlx unavailable")
+def test_parity_vs_mlx_fp32():
+    import mlx.core as mx
+    from src.model.mlx_teacher import MLXConversionTeacher
+
+    cfg = _cfg()
+    npw = _numpy_weights(cfg, seed=3)
+    cuda = CUDATeacher(cfg, {k: torch.tensor(v) for k, v in npw.items()})
+    mlx_t = MLXConversionTeacher(cfg, {k: mx.array(v) for k, v in npw.items()})
+
+    tokens = _tokens()
+    lc = cuda.to_numpy(cuda.forward(tokens).logits)
+    lm = np.array(mlx_t.forward(tokens).logits)
+    assert lc.shape == lm.shape
+    assert np.max(np.abs(lc - lm)) < 1e-3                          # fp32 cross-backend parity
+
+    # top-k: same logits -> same indices and (close) values.
+    vc, ic = cuda.topk_logits(tokens, 6)
+    vm, im = mlx_t.topk_logits(tokens, 6)
+    assert np.array_equal(cuda.to_numpy(ic), np.array(im))
+    assert np.max(np.abs(cuda.to_numpy(vc) - np.array(vm))) < 1e-3

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -39,6 +39,7 @@ PORTABLE_MODULES = [
     "src.data.corpus",
     "src.data.storage",
     "src.data.distill_corpus",
+    "src.data.teacher_outputs",
     "src.data.r2_sync",
     "src.data.datatrove_pipeline",
     "src.data.filters",

--- a/tests/test_precompute_teacher.py
+++ b/tests/test_precompute_teacher.py
@@ -1,0 +1,87 @@
+"""Offline end-to-end test of the teacher top-k precompute driver (#94).
+
+Builds a tiny byte-vocab packed split, runs `scripts/precompute_teacher.py --synthetic` as a
+subprocess (the real CLI), then asserts the cached files line up with the corpus and that a
+student trial reads them back with ZERO teacher inference (AC#3).
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from src.data.pack import pack_ids
+from src.data.teacher_outputs import DistillLoader, read_teacher_meta
+
+REPO = Path(__file__).resolve().parents[1]
+VOCAB = 256
+SEQ_LEN = 4
+
+
+def _backend():
+    """Pick an available backend for the synthetic teacher (mlx preferred, else torch/cuda-CPU)."""
+    try:
+        import mlx.core  # noqa: F401
+        return "mlx"
+    except ImportError:
+        pass
+    try:
+        import torch  # noqa: F401
+        return "cuda"
+    except ImportError:
+        pytest.skip("no backend (mlx/torch) available for the synthetic teacher")
+
+
+def _write_manifest(path: Path):
+    path.write_text(
+        "student: toy\n"
+        "conversion_teacher: synthetic\n"
+        "tokenizer: qwen25\n"
+        f"seq_len: {SEQ_LEN}\n"
+        "init: mohawk\n"
+        "stages: [logit-distill]\n"
+        "layout: {d_model: 16, n_layers: 2}\n")
+
+
+def _build_split(data_dir: Path, n_chunks: int):
+    data_dir.mkdir(parents=True, exist_ok=True)
+    stride = SEQ_LEN + 1
+    for split, n in (("train", n_chunks), ("val", 2)):
+        ids = (np.arange(n * stride + 1) % VOCAB).astype(np.uint16)
+        pack_ids(ids, data_dir / f"{split}.bin", dtype=np.uint16)
+
+
+def test_precompute_cli_offline(tmp_path):
+    backend = _backend()
+    data = tmp_path / "split"
+    out = tmp_path / "teacher-outputs"
+    n_chunks = 5
+    _build_split(data, n_chunks)
+    manifest = tmp_path / "toy.yaml"
+    _write_manifest(manifest)
+
+    res = subprocess.run(
+        [sys.executable, "scripts/precompute_teacher.py",
+         "--manifest", str(manifest), "--data", str(data), "--out", str(out),
+         "--backend", backend, "--k", "8", "--batch-size", "2", "--synthetic"],
+        cwd=REPO, capture_output=True, text=True,
+        env={"PYTHONPATH": str(REPO), "PATH": __import__("os").environ.get("PATH", "")},
+    )
+    assert res.returncode == 0, f"precompute failed:\n{res.stdout}\n{res.stderr}"
+
+    # per-split meta aligned to the packed corpus
+    meta = read_teacher_meta(out, "train")
+    assert meta["n_chunks"] == n_chunks and meta["seq_len"] == SEQ_LEN
+    assert meta["n_rows"] == n_chunks * SEQ_LEN and meta["k"] == 8
+    manifest_json = json.loads((out / "manifest.json").read_text())
+    assert manifest_json["splits"] == ["train", "val"]
+    assert manifest_json["teacher"]["synthetic"] is True
+
+    # AC#3: a student trial reads the cached signal with NO teacher (zero teacher inference).
+    loader = DistillLoader(data / "train.bin", out, "train", SEQ_LEN, batch_size=2, shuffle=False)
+    inputs, targets, vals, idx = next(iter(loader.epoch()))
+    assert inputs.shape == (2, SEQ_LEN) and vals.shape == (2, SEQ_LEN, 8)
+    assert idx.min() >= 0 and idx.max() < VOCAB

--- a/tests/test_teacher_outputs.py
+++ b/tests/test_teacher_outputs.py
@@ -1,0 +1,153 @@
+"""Cached teacher top-k format + DistillLoader (#94). Portable — no backend import.
+
+Covers the write/read round-trip, positional alignment to the packed corpus tokens, exact
+shuffle/skip parity with PackedLoader (so training resume stays bit-exact), the k-subslice,
+and the vocab guard.
+"""
+
+import numpy as np
+import pytest
+
+from src.data.loader import PackedLoader
+from src.data.pack import pack_ids
+from src.data.teacher_outputs import (DistillLoader, read_teacher_meta, topk_outputs_paths,
+                                      write_manifest, write_teacher_topk)
+
+VOCAB = 256
+
+
+def _build_packed(tmp_path, n_chunks, seq_len, split="train"):
+    """Write a flat packed token file whose token at position i is `i % VOCAB`, so the
+    loader's chunking is verifiable by value."""
+    stride = seq_len + 1
+    n_tokens = n_chunks * stride + 2          # +2 leftover tokens the loader ignores
+    ids = (np.arange(n_tokens) % VOCAB).astype(np.uint16)
+    path = tmp_path / f"{split}.bin"
+    pack_ids(ids, path, dtype=np.uint16)
+    return path
+
+
+def _write_aligned_topk(tmp_path, out_dir, n_chunks, seq_len, k, split="train"):
+    """Cache top-k where row r has idx[r,0] == vals[r,0] == r (the global teacher-row index),
+    so alignment (chunk c, position p) -> row c*seq_len+p can be asserted exactly."""
+    n_rows = n_chunks * seq_len
+    rows = np.arange(n_rows)
+    vals = np.zeros((n_rows, k), dtype=np.float32)
+    idx = np.zeros((n_rows, k), dtype=np.int64)
+    vals[:, 0] = rows
+    idx[:, 0] = rows % VOCAB
+    # remaining columns: arbitrary but distinct, in range
+    for c in range(1, k):
+        vals[:, c] = -rows - c
+        idx[:, c] = (rows + c) % VOCAB
+    meta = write_teacher_topk(out_dir, split, blocks=[(vals, idx)], n_chunks=n_chunks,
+                              seq_len=seq_len, vocab_size=VOCAB,
+                              src_packed=str(tmp_path / f"{split}.bin"), src_n_tokens=n_rows)
+    return meta
+
+
+def test_write_read_roundtrip(tmp_path):
+    n_chunks, seq_len, k = 6, 4, 3
+    out = tmp_path / "teacher-outputs"
+    meta = _write_aligned_topk(tmp_path, out, n_chunks, seq_len, k)
+    assert meta["k"] == k
+    assert meta["n_rows"] == n_chunks * seq_len
+    assert meta["vals_dtype"] == "float16" and meta["idx_dtype"] == "uint32"
+
+    read = read_teacher_meta(out, "train")
+    assert read == meta
+    paths = topk_outputs_paths(out, "train")
+    assert paths["vals"].exists() and paths["idx"].exists() and paths["meta"].exists()
+    # raw fp16 dump: file size == n_rows * k * 2 bytes
+    assert paths["vals"].stat().st_size == n_chunks * seq_len * k * 2
+
+
+def test_write_rejects_wrong_row_count(tmp_path):
+    out = tmp_path / "teacher-outputs"
+    bad = (np.zeros((5, 3), np.float32), np.zeros((5, 3), np.int64))
+    with pytest.raises(ValueError, match="expected n_chunks"):
+        write_teacher_topk(out, "train", blocks=[bad], n_chunks=6, seq_len=4,
+                           vocab_size=VOCAB, src_packed="x")
+
+
+def test_distill_loader_shapes_and_alignment(tmp_path):
+    n_chunks, seq_len, k, B = 6, 4, 3, 2
+    _build_packed(tmp_path, n_chunks, seq_len)
+    out = tmp_path / "teacher-outputs"
+    _write_aligned_topk(tmp_path, out, n_chunks, seq_len, k)
+
+    loader = DistillLoader(tmp_path / "train.bin", out, "train", seq_len, B,
+                           shuffle=False, drop_last=True)
+    # Walk a no-shuffle epoch: chunk indices come out 0,1,2,... so we can predict every value.
+    seen = 0
+    for inputs, targets, vals, idx in loader.epoch():
+        assert inputs.shape == (B, seq_len) and targets.shape == (B, seq_len)
+        assert vals.shape == (B, seq_len, k) and idx.shape == (B, seq_len, k)
+        for b in range(B):
+            c = seen + b
+            # token i == i % VOCAB; chunk c starts at c*(seq_len+1)
+            base = c * (seq_len + 1)
+            assert np.array_equal(inputs[b], (base + np.arange(seq_len)) % VOCAB)
+            assert np.array_equal(targets[b], (base + 1 + np.arange(seq_len)) % VOCAB)
+            # teacher row for (chunk c, position p) is c*seq_len + p (encoded in column 0)
+            expected_rows = c * seq_len + np.arange(seq_len)
+            assert np.array_equal(vals[b, :, 0], expected_rows.astype(np.float32))
+        seen += B
+
+
+def test_shuffle_and_skip_match_packed_loader(tmp_path):
+    """DistillLoader must visit chunks in the SAME order as PackedLoader for the same seed,
+    and skip_batches must drop the same prefix — this is what keeps training resume exact."""
+    n_chunks, seq_len, k, B, seed = 12, 4, 3, 2, 7
+    _build_packed(tmp_path, n_chunks, seq_len)
+    out = tmp_path / "teacher-outputs"
+    _write_aligned_topk(tmp_path, out, n_chunks, seq_len, k)
+
+    pk = PackedLoader(tmp_path / "train.bin", seq_len, B, shuffle=True, seed=seed)
+    dl = DistillLoader(tmp_path / "train.bin", out, "train", seq_len, B, shuffle=True, seed=seed)
+    for (pi, pt), (di, dt, _, _) in zip(pk.epoch(), dl.epoch()):
+        assert np.array_equal(pi, di) and np.array_equal(pt, dt)
+
+    # skip_batches=2 drops the same two leading batches as a fresh reseeded epoch's tail.
+    pk_full = list(PackedLoader(tmp_path / "train.bin", seq_len, B, shuffle=True, seed=seed)
+                   .epoch(reseed=seed))
+    dl_skip = list(DistillLoader(tmp_path / "train.bin", out, "train", seq_len, B,
+                                 shuffle=True, seed=seed).epoch(reseed=seed, skip_batches=2))
+    assert len(dl_skip) == len(pk_full) - 2
+    for (pi, _), (di, _, _, _) in zip(pk_full[2:], dl_skip):
+        assert np.array_equal(pi, di)
+
+
+def test_k_subslice(tmp_path):
+    n_chunks, seq_len, k, B = 4, 4, 5, 2
+    _build_packed(tmp_path, n_chunks, seq_len)
+    out = tmp_path / "teacher-outputs"
+    _write_aligned_topk(tmp_path, out, n_chunks, seq_len, k)
+
+    dl = DistillLoader(tmp_path / "train.bin", out, "train", seq_len, B, k=2, shuffle=False)
+    _, _, vals, idx = next(iter(dl.epoch()))
+    assert vals.shape[-1] == 2 and idx.shape[-1] == 2
+    with pytest.raises(ValueError, match="exceeds stored k"):
+        DistillLoader(tmp_path / "train.bin", out, "train", seq_len, B, k=99)
+
+
+def test_alignment_mismatch_rejected(tmp_path):
+    """A teacher-outputs file built for a different n_chunks must be rejected."""
+    n_chunks, seq_len, k, B = 6, 4, 3, 2
+    _build_packed(tmp_path, n_chunks, seq_len)
+    out = tmp_path / "teacher-outputs"
+    # write meta claiming a different n_chunks
+    _write_aligned_topk(tmp_path, out, n_chunks - 1, seq_len, k)
+    with pytest.raises(ValueError, match="not aligned"):
+        DistillLoader(tmp_path / "train.bin", out, "train", seq_len, B)
+
+
+def test_manifest_written(tmp_path):
+    n_chunks, seq_len, k = 4, 4, 3
+    out = tmp_path / "teacher-outputs"
+    _write_aligned_topk(tmp_path, out, n_chunks, seq_len, k)
+    m = write_manifest(out, k=k, seq_len=seq_len, effective_vocab_size=VOCAB,
+                       corpus_manifest="data/poc-distill", teacher={"model_id": "x"},
+                       splits=["train"])
+    assert m["n_rows_total"] == n_chunks * seq_len
+    assert (out / "manifest.json").exists()


### PR DESCRIPTION
## What & why

Closes the first pending distillation piece (#94): the frozen teacher's forward over the corpus is the dominant cost of M10 and depends only on (teacher, corpus), so it must be precomputed **once** and reused by every student trial. This PR adds the on-disk format, the writer/driver, the reader, and the CUDA teacher needed to run the precompute on the cloud GPU.

Part of the M10 distillation program (#65). Built in a worktree off `main`; PR2 (`scripts/distill.py` + CUDA distill step + smoke gate, #81) builds on this branch.

## Changes

- **`src/data/teacher_outputs.py`** (portable) — on-disk format (`teacher-<split>.topk_vals` fp16, `.topk_idx` uint32, `.meta.json`, run `manifest.json`) **positionally aligned** to the flat packed `train.bin`/`val.bin`, plus `DistillLoader` that mirrors `PackedLoader`'s chunking/shuffle/`skip_batches` so training resume stays bit-exact. Yields `(inputs, targets, topk_vals, topk_idx)` — the logit-distill micro-batch (#100).
- **`scripts/precompute_teacher.py`** — backend-agnostic driver. Runs the 7B teacher on the cloud GPU via `--backend cuda`; `--synthetic` offline path; optional `--push` to R2.
- **`src/model/cuda_teacher.py`** — torch port of `MLXConversionTeacher` (frozen Qwen2 forward, theta-aware RoPE, GQA, top-k), wired into the CUDA backend's `make_teacher` (previously `NotImplementedError`).
- **Tests** — format round-trip + alignment + `PackedLoader` resume parity; CUDA teacher shapes/top-k + **fp32 parity vs MLX**; offline precompute CLI end-to-end (AC#3: reuse needs zero teacher inference). `src.data.teacher_outputs` added to the seam guard.

## Design decisions

- **Alignment is positional** against the post-split flat files (not the multi-shard corpus) — the only design that lets `DistillLoader` reuse `PackedLoader`'s shuffle/skip and keep resume exact.
- **Teacher top-k taken at input positions (unshifted)**; targets stay the one-token shift — matches `_kl_topk` and the existing distill-test convention.
- **k=50, fp16 vals, uint32 idx** → ~600 GB at 2B tokens (k is a CLI knob).

## Acceptance criteria (#94)

- [x] Top-k logits + indices written, aligned to corpus tokens; footprint controlled by k
- [x] A distill train step can stream `(input_ids, teacher_topk_logits, teacher_topk_idx)` (`DistillLoader`)
- [x] Re-running a student trial reuses the outputs with zero teacher inference

## Verification

```
.venv/bin/python -m pytest tests/test_teacher_outputs.py tests/test_cuda_teacher.py \
  tests/test_precompute_teacher.py tests/test_import_guard.py -q   # 31 passed
.venv/bin/python -m pytest -q                                       # 468 passed, 3 skipped
.venv/bin/python scripts/smoke_test.py --data <fresh-toy-split>     # resume exact, eval runs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)