### PR TITLE
feat: [#81] distill.py driver + CUDA distill backend + smoke gate

### DIFF
--- a/config/toy-distill.yaml
+++ b/config/toy-distill.yaml
@@ -1,0 +1,24 @@
+# Toy distillation manifest — drives the offline smoke gate (scripts/distill_smoke.py) and the
+# driver tests. Tiny dims, all three distillation stages, the MOHAWK init (freezes nothing, so the
+# whole student trains). `conversion_teacher: synthetic` tells the precompute/distill drivers to
+# build a random TeacherConfig.tiny() instead of loading HF weights (no network).
+#
+# manifest_to_config() forces the qwen25 vocab (151646) + bf16; the offline gate overrides those
+# with `--vocab 256 --precision fp32` (byte-fallback corpus, bit-faithful fp32) — this manifest is
+# NOT a real run config. Layout mirrors tests/test_distill_train_step.py's toy student so the
+# shapes are known-good (head_dim 16 | d_inner=96 -> 6 heads; attn every 2nd layer).
+student: toy-distill
+conversion_teacher: synthetic
+tokenizer: qwen25
+seq_len: 16
+init: mohawk
+stages: [mixing-match, hidden-align, logit-distill]
+layout:
+  d_model: 48
+  n_layers: 4
+  attention_every: 2
+  state_size: 16
+  head_dim: 16
+  n_attn_heads: 4
+corpus: ""
+teacher_outputs: ""

--- a/scripts/distill.py
+++ b/scripts/distill.py
@@ -98,7 +98,7 @@ def main() -> None:
     from src.model.backend import get_backend
     from src.model.teacher import TeacherConfig
     from src.data.loader import PackedLoader
-    from src.data.teacher_outputs import DistillLoader
+    from src.data.teacher_outputs import DistillLoader, read_teacher_meta
     from src.train.distill_manifest import (DistillStage, distill_stages, load_manifest,
                                             manifest_to_config)
     from src.train.loss_scale import scaler_for_precision
@@ -177,9 +177,21 @@ def main() -> None:
             grad_clip=args.grad_clip, scaler=scaler)
 
         if stage == DistillStage.LOGIT_DISTILL:
+            # Fail fast on a vocab mismatch: if the teacher-outputs were cached over a wider vocab
+            # than the student's (e.g. an unknown conversion_teacher so the precompute used the
+            # padded model vocab), the cached top-k indices can exceed cfg.vocab_size and the KL
+            # gather would later fail with a cryptic index error. Passing vocab_size also makes the
+            # loader's token guard catch out-of-range ids.
+            tmeta = read_teacher_meta(args.teacher_outputs, "train")
+            if tmeta["vocab_size"] > cfg.vocab_size:
+                raise SystemExit(
+                    f"teacher-outputs vocab_size {tmeta['vocab_size']} > student vocab "
+                    f"{cfg.vocab_size}: cached top-k indices can exceed the student vocab. Re-run "
+                    f"precompute_teacher with a teacher whose effective_vocab_size matches the "
+                    f"student tokenizer (the #94 precompute guard enforces this for real runs).")
             loader = DistillLoader(args.corpus / "train.bin", args.teacher_outputs, "train",
                                    cfg.seq_len, args.batch_size, k=args.k, shuffle=True,
-                                   seed=args.seed)
+                                   seed=args.seed, vocab_size=cfg.vocab_size)
         else:
             loader = _InputsLoader(PackedLoader(args.corpus / "train.bin", cfg.seq_len,
                                                 args.batch_size, shuffle=True, seed=args.seed))

--- a/scripts/distill.py
+++ b/scripts/distill.py
@@ -1,0 +1,226 @@
+"""Distillation driver (#81) — train a Mamba-2 hybrid student from a frozen teacher.
+
+The end-to-end M10 distill run for ONE manifest (a sweep iterates this over sibling manifests):
+load the manifest, build the frozen conversion teacher (#93) and the student (its layout resolved
+by `manifest_to_config`), initialize the student from the teacher (#99), then loop the manifest's
+distillation stages (`mixing-match -> hidden-align -> logit-distill`, #100), swapping the
+objective per stage on the shared backend-free training loop. Each stage gets a fresh optimizer
+and its own crash-safe checkpoint area + metrics under `<out>/<stage>/`; the student weights
+persist across stages (it is one model). Resume restarts the furthest-progressed stage exactly.
+
+The `logit-distill` stage streams the cached teacher top-k (#94, `--teacher-outputs`) with zero
+teacher inference; `hidden-align`/`mixing-match` recompute the teacher on the fly. Backend imports
+stay behind `src.model.backend.get_backend`, so `--help` works on any host.
+
+    # cloud distill run (CUDA), single manifest:
+    .venv/bin/python scripts/distill.py --manifest config/manifests/student-1b-attn-hi.yaml \\
+        --corpus data/poc-distill/split --teacher-outputs data/poc-distill/teacher-outputs/topk-logits \\
+        --out runs/distill-hi --backend cuda --steps-per-stage 2000 --batch-size 8 --grad-accum 4
+
+    # offline toy gate (byte vocab, synthetic teacher, fp32): see scripts/distill_smoke.py
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--manifest", type=Path, required=True, help="student trial manifest")
+    ap.add_argument("--corpus", type=Path, required=True, help="dir with train.bin/val.bin")
+    ap.add_argument("--teacher-outputs", type=Path, default=None,
+                    help="cached teacher top-k dir (required for the logit-distill stage)")
+    ap.add_argument("--out", type=Path, default=Path("runs/distill"))
+    ap.add_argument("--backend", choices=("auto", "mlx", "cuda"), default="auto")
+    ap.add_argument("--steps-per-stage", type=int, default=1000,
+                    help="optimizer steps per distill stage (per-stage flags override)")
+    ap.add_argument("--mixing-steps", type=int, default=None)
+    ap.add_argument("--hidden-steps", type=int, default=None)
+    ap.add_argument("--logit-steps", type=int, default=None)
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--grad-accum", type=int, default=1)
+    ap.add_argument("--base-lr", type=float, default=3e-4)
+    ap.add_argument("--warmup-steps", type=int, default=None, help="default: steps//100 (min 1)")
+    ap.add_argument("--grad-clip", type=float, default=1.0)
+    ap.add_argument("--k", type=int, default=None, help="logit-distill: top-k to use (<= cached k)")
+    ap.add_argument("--temperature", type=float, default=2.0)
+    ap.add_argument("--ce-weight", type=float, default=0.1)
+    ap.add_argument("--kl-weight", type=float, default=0.9)
+    ap.add_argument("--log-every", type=int, default=10)
+    ap.add_argument("--eval-every", type=int, default=200)
+    ap.add_argument("--ckpt-every", type=int, default=500)
+    ap.add_argument("--eval-batches", type=int, default=50)
+    ap.add_argument("--init-loss-scale", type=float, default=2.0 ** 13)
+    ap.add_argument("--resume", action="store_true", help="resume the furthest-progressed stage")
+    ap.add_argument("--seed", type=int, default=0)
+    # Toy/offline overrides (the smoke gate): manifest_to_config forces qwen25 vocab + bf16.
+    ap.add_argument("--synthetic", action="store_true",
+                    help="build a synthetic toy teacher (TeacherConfig.tiny) — offline tests only")
+    ap.add_argument("--vocab", type=int, default=None, help="override student/teacher vocab (toy)")
+    ap.add_argument("--precision", default=None, help="override precision, e.g. fp32 (toy)")
+    return ap.parse_args()
+
+
+def _teacher_config_for(model_id: str):
+    """Known teacher repo id -> TeacherConfig (so logits slice to the tokenizer vocab)."""
+    from src.model.teacher import TeacherConfig
+    known = {"open-r1/OpenR1-Distill-7B": TeacherConfig.openr1_distill_7b,
+             "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": TeacherConfig.qwen_1_5b}
+    return known[model_id]() if model_id in known else None
+
+
+class _InputsLoader:
+    """Wrap a `PackedLoader` to yield 1-tuples `(inputs,)` for stages whose teacher is recomputed
+    on the fly (hidden-align / mixing-match). Mirrors the loader duck-type the loop needs
+    (`batch_size`, `seq_len`, `__len__`, `epoch(reseed, skip_batches)`)."""
+
+    def __init__(self, packed):
+        self._p = packed
+        self.batch_size = packed.batch_size
+        self.seq_len = packed.seq_len
+
+    def __len__(self):
+        return len(self._p)
+
+    def epoch(self, reseed=None, skip_batches=0):
+        for inputs, _targets in self._p.epoch(reseed=reseed, skip_batches=skip_batches):
+            yield (inputs,)
+
+
+def main() -> None:
+    args = _parse_args()
+
+    import numpy as np
+
+    from src.model.backend import get_backend
+    from src.model.teacher import TeacherConfig
+    from src.data.loader import PackedLoader
+    from src.data.teacher_outputs import DistillLoader
+    from src.train.distill_manifest import (DistillStage, distill_stages, load_manifest,
+                                            manifest_to_config)
+    from src.train.loss_scale import scaler_for_precision
+    from src.train.loop import TrainConfig, train
+    from src.train.logging import JsonlLogger
+    from src.train.checkpoint import CheckpointStore
+    from src.eval.val_loss import evaluate
+
+    backend = get_backend(args.backend)
+    manifest = load_manifest(args.manifest)
+    cfg = manifest_to_config(manifest)
+    if args.vocab is not None:
+        cfg.vocab_size = args.vocab
+    if args.precision is not None:
+        cfg.precision = args.precision
+    cfg.validate()
+
+    stages = distill_stages(manifest)
+    if not stages:
+        raise SystemExit(f"manifest {args.manifest} has no distillation stages")
+    if DistillStage.LOGIT_DISTILL in stages and args.teacher_outputs is None:
+        raise SystemExit("--teacher-outputs is required for the logit-distill stage")
+
+    # --- teacher + student + init ---------------------------------------------
+    backend.seed(args.seed)
+    if args.synthetic or manifest.conversion_teacher == "synthetic":
+        tcfg = TeacherConfig.tiny()
+        if args.vocab is not None:
+            tcfg.vocab_size = args.vocab
+        teacher = backend.make_teacher(config=tcfg)
+    else:
+        mid = manifest.conversion_teacher
+        teacher = backend.make_teacher(config=_teacher_config_for(mid), pretrained=mid)
+
+    student = backend.model_cls(cfg)
+    report = backend.init_student(student, teacher, manifest.init)
+    print(f"[init] {report.method}: mapped {report.n_layers_mapped} layers, "
+          f"frozen={report.frozen_layers}, trainable~{report.n_trainable_params/1e6:.1f}M, "
+          f"frozen~{report.n_frozen_params/1e6:.1f}M")
+
+    out = args.out
+    out.mkdir(parents=True, exist_ok=True)
+    np_to = backend.to_numpy
+    max_b = args.eval_batches or None
+    val_loader = PackedLoader(args.corpus / "val.bin", cfg.seq_len, args.batch_size,
+                              shuffle=False, drop_last=False)
+    val_eval = lambda m: evaluate(m, val_loader, max_batches=max_b, to_numpy=np_to)
+
+    _stage_steps = {DistillStage.MIXING_MATCH: args.mixing_steps,
+                    DistillStage.HIDDEN_ALIGN: args.hidden_steps,
+                    DistillStage.LOGIT_DISTILL: args.logit_steps}
+
+    # --- resume detection: restart the furthest-progressed stage --------------
+    resume_idx = 0
+    if args.resume:
+        for idx in range(len(stages) - 1, -1, -1):
+            if CheckpointStore(str(out / stages[idx].value / "resume")).has_checkpoint():
+                resume_idx = idx
+                break
+
+    for idx, stage in enumerate(stages):
+        if idx < resume_idx:
+            continue   # baked into the checkpoint we load for `resume_idx`
+
+        steps = _stage_steps[stage] if _stage_steps[stage] is not None else args.steps_per_stage
+        warmup = args.warmup_steps if args.warmup_steps is not None else max(1, steps // 100)
+        stage_out = out / stage.value
+        stage_out.mkdir(parents=True, exist_ok=True)
+
+        opt = backend.make_optimizer(student, args.base_lr)      # fresh optimizer per stage
+        scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
+        teacher_arg = None if stage == DistillStage.LOGIT_DISTILL else teacher
+        train_step = backend.make_distill_train_step(
+            student, opt, stage=stage, teacher=teacher_arg, ce_weight=args.ce_weight,
+            kl_weight=args.kl_weight, temperature=args.temperature,
+            grad_clip=args.grad_clip, scaler=scaler)
+
+        if stage == DistillStage.LOGIT_DISTILL:
+            loader = DistillLoader(args.corpus / "train.bin", args.teacher_outputs, "train",
+                                   cfg.seq_len, args.batch_size, k=args.k, shuffle=True,
+                                   seed=args.seed)
+        else:
+            loader = _InputsLoader(PackedLoader(args.corpus / "train.bin", cfg.seq_len,
+                                                args.batch_size, shuffle=True, seed=args.seed))
+
+        store = CheckpointStore(str(stage_out / "resume"))
+        start_step = 0
+        resuming = (idx == resume_idx and args.resume and store.has_checkpoint())
+        if resuming:
+            meta = store.load(weights_deserializer=lambda p: student.load(p),
+                              optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
+            start_step = int(meta["step"])
+            if scaler is not None:
+                scaler.load_state_dict(meta.get("loss_scale_state") or {})
+            print(f"[resume] stage={stage.value} from step {start_step} slot={meta['slot']}")
+
+        logger = JsonlLogger(str(stage_out / "metrics.jsonl"), append=resuming)
+
+        def on_checkpoint(step: int, _store=store, _opt=opt, _scaler=scaler) -> None:
+            _store.save(step=step,
+                        loss_scale_state=(_scaler.state_dict() if _scaler else None),
+                        weights_serializer=lambda p: student.save(p),
+                        optimizer_serializer=lambda p: backend.save_optimizer(_opt, p))
+
+        tcfg = TrainConfig(total_steps=steps, base_lr=args.base_lr, warmup_steps=warmup,
+                           grad_accum=args.grad_accum, grad_clip=args.grad_clip,
+                           log_every=args.log_every, eval_every=args.eval_every,
+                           ckpt_every=args.ckpt_every, out_dir=str(stage_out), seed=args.seed)
+        print(f"[stage] {stage.value}: {steps} steps (warmup {warmup})")
+        train(student, loader, tcfg, train_step, val_eval=val_eval, logger=logger,
+              on_checkpoint=on_checkpoint, start_step=start_step)
+        if steps % tcfg.ckpt_every != 0:
+            on_checkpoint(steps)
+        logger.close()
+
+    # --- final portable weights + eval ----------------------------------------
+    weights_path = str(out / "weights.safetensors")
+    student.save(weights_path)
+    final = evaluate(student, val_loader, max_batches=max_b, to_numpy=np_to)
+    print(f"[done] stages={[s.value for s in stages]}  val_loss={final['val_loss']:.4f}  "
+          f"val_perplexity={final['val_perplexity']:.4f}  weights={weights_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/distill_smoke.py
+++ b/scripts/distill_smoke.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import subprocess
 import sys
@@ -96,7 +97,7 @@ def main() -> None:
     for stage in STAGES:
         metrics_path = run_out / stage / "metrics.jsonl"
         losses = [json.loads(line)["loss"] for line in metrics_path.read_text().splitlines() if line]
-        assert losses and all(l == l for l in losses), f"{stage}: non-finite loss {losses}"
+        assert losses and all(math.isfinite(l) for l in losses), f"{stage}: non-finite loss {losses}"
         assert min(losses) < losses[0], f"{stage}: loss never dropped below start {losses}"
         assert (run_out / stage / "resume").exists(), f"{stage}: no resume bundle"
         print(f"[{stage}] loss {losses[0]:.4f} -> min {min(losses):.4f}  ✓")

--- a/scripts/distill_smoke.py
+++ b/scripts/distill_smoke.py
@@ -58,12 +58,15 @@ def main() -> None:
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--out", type=Path, default=Path("runs/distill-smoke"))
     ap.add_argument("--steps-per-stage", type=int, default=12)
+    ap.add_argument("--backend", choices=("mlx", "cuda"), default="mlx",
+                    help="backend to gate on (mlx: Apple-Silicon dev; cuda: torch GPU/CPU)")
     args = ap.parse_args()
 
+    probe = "mlx.core" if args.backend == "mlx" else "torch"
     try:
-        import mlx.core  # noqa: F401
+        __import__(probe)
     except ImportError:
-        raise SystemExit("distill_smoke requires the MLX backend (Apple Silicon dev host)")
+        raise SystemExit(f"distill_smoke --backend {args.backend} requires {probe!r}")
 
     out = args.out
     out.mkdir(parents=True, exist_ok=True)
@@ -73,12 +76,13 @@ def main() -> None:
 
     # 1) cache the synthetic teacher's top-k, aligned to the split corpus.
     _run(["scripts/precompute_teacher.py", "--manifest", str(MANIFEST), "--data", str(split_dir),
-          "--out", str(teacher_out), "--backend", "mlx", "--k", "8", "--batch-size", "2",
+          "--out", str(teacher_out), "--backend", args.backend, "--k", "8", "--batch-size", "2",
           "--synthetic"], "precompute")
 
-    # 2) run the full distill flow (all three stages) on MLX.
+    # 2) run the full distill flow (all three stages).
     distill_argv = ["scripts/distill.py", "--manifest", str(MANIFEST), "--corpus", str(split_dir),
-                    "--teacher-outputs", str(teacher_out), "--out", str(run_out), "--backend", "mlx",
+                    "--teacher-outputs", str(teacher_out), "--out", str(run_out),
+                    "--backend", args.backend,
                     "--synthetic", "--vocab", str(VOCAB), "--precision", "fp32",
                     "--base-lr", "1e-2", "--steps-per-stage", str(args.steps_per_stage),
                     "--batch-size", "2", "--grad-accum", "1", "--log-every", "1",

--- a/scripts/distill_smoke.py
+++ b/scripts/distill_smoke.py
@@ -1,0 +1,109 @@
+"""Distillation smoke gate (#81) — the end-to-end distill flow on MLX, offline.
+
+The distill analogue of `scripts/smoke_test.py`: builds a tiny byte-vocab corpus and a synthetic
+teacher, caches the teacher top-k (#94), then runs `scripts/distill.py` through all three
+distillation stages (mixing-match -> hidden-align -> logit-distill) for a handful of steps each.
+It asserts every stage's loss is finite and decreases, the portable student weights + per-stage
+resume bundles are written, and that a `--resume` invocation reloads a checkpoint cleanly. The
+loop + checkpoint machinery's bit-exact resume is covered by the M4 gate (`smoke_test.py`); the
+distill stages reuse it unchanged.
+
+    .venv/bin/python scripts/distill_smoke.py --out runs/distill-smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+MANIFEST = REPO / "config" / "toy-distill.yaml"
+SEQ_LEN = 16
+VOCAB = 256
+STAGES = ("mixing-match", "hidden-align", "logit-distill")
+
+
+def _build_corpus(root: Path) -> Path:
+    """Byte-vocab tokenized corpus -> train.bin/val.bin split (the PackedLoader format)."""
+    from src.data import storage
+    from src.data.corpus import ingest_dummy
+    from src.data.distill_corpus import build_distill_corpus
+    from src.data.split import split_shards
+
+    out_root = root / "pd"
+    build_distill_corpus(ingest_dummy(400, source="smoke"), out_root, tokenizer="qwen25",
+                         seq_len=SEQ_LEN, byte_fallback=True)
+    tok_dir = storage.corpus_tokenized_dir(out_root, "qwen25", SEQ_LEN)
+    split_dir = root / "split"
+    split_shards(tok_dir, split_dir, val_tokens=SEQ_LEN * 4)
+    return split_dir
+
+
+def _run(argv: list, label: str) -> subprocess.CompletedProcess:
+    env = {"PYTHONPATH": str(REPO), "PATH": os.environ.get("PATH", "")}
+    res = subprocess.run([sys.executable, *argv], cwd=REPO, capture_output=True, text=True, env=env)
+    if res.returncode != 0:
+        print(res.stdout)
+        print(res.stderr, file=sys.stderr)
+        raise SystemExit(f"{label} failed (exit {res.returncode})")
+    return res
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, default=Path("runs/distill-smoke"))
+    ap.add_argument("--steps-per-stage", type=int, default=12)
+    args = ap.parse_args()
+
+    try:
+        import mlx.core  # noqa: F401
+    except ImportError:
+        raise SystemExit("distill_smoke requires the MLX backend (Apple Silicon dev host)")
+
+    out = args.out
+    out.mkdir(parents=True, exist_ok=True)
+    split_dir = _build_corpus(out)
+    teacher_out = out / "teacher-outputs"
+    run_out = out / "run"
+
+    # 1) cache the synthetic teacher's top-k, aligned to the split corpus.
+    _run(["scripts/precompute_teacher.py", "--manifest", str(MANIFEST), "--data", str(split_dir),
+          "--out", str(teacher_out), "--backend", "mlx", "--k", "8", "--batch-size", "2",
+          "--synthetic"], "precompute")
+
+    # 2) run the full distill flow (all three stages) on MLX.
+    distill_argv = ["scripts/distill.py", "--manifest", str(MANIFEST), "--corpus", str(split_dir),
+                    "--teacher-outputs", str(teacher_out), "--out", str(run_out), "--backend", "mlx",
+                    "--synthetic", "--vocab", str(VOCAB), "--precision", "fp32",
+                    "--base-lr", "1e-2", "--steps-per-stage", str(args.steps_per_stage),
+                    "--batch-size", "2", "--grad-accum", "1", "--log-every", "1",
+                    "--eval-every", "4", "--ckpt-every", "4"]
+    _run(distill_argv, "distill")
+
+    # 3) assert per-stage loss is finite and training reduces it below the start, and artifacts
+    # exist. We check `min(losses) < losses[0]` rather than `last < first`: at the smoke lr the
+    # hidden-align MSE oscillates (and MLX GPU ops aren't bit-deterministic run to run), so the
+    # honest, stable signal of "the machinery trains" is that the loss dips below its start.
+    for stage in STAGES:
+        metrics_path = run_out / stage / "metrics.jsonl"
+        losses = [json.loads(line)["loss"] for line in metrics_path.read_text().splitlines() if line]
+        assert losses and all(l == l for l in losses), f"{stage}: non-finite loss {losses}"
+        assert min(losses) < losses[0], f"{stage}: loss never dropped below start {losses}"
+        assert (run_out / stage / "resume").exists(), f"{stage}: no resume bundle"
+        print(f"[{stage}] loss {losses[0]:.4f} -> min {min(losses):.4f}  ✓")
+    assert (run_out / "weights.safetensors").exists(), "no portable student weights"
+
+    # 4) a --resume invocation reloads the furthest stage's checkpoint cleanly.
+    _run(distill_argv + ["--resume"], "distill --resume")
+
+    print("\nDISTILL SMOKE PASSED ✅  all stages decrease, checkpoints + weights written, "
+          "resume reloads cleanly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/precompute_teacher.py
+++ b/scripts/precompute_teacher.py
@@ -16,7 +16,7 @@ backend import stays behind `src.model.backend.get_backend`, so `--help` works o
         --push s3://monica-training/poc-distill/teacher-outputs/topk-logits
 
     # offline smoke (byte vocab, synthetic teacher — no network/weights):
-    .venv/bin/python scripts/precompute_teacher.py --manifest config/manifests/toy-distill.yaml \\
+    .venv/bin/python scripts/precompute_teacher.py --manifest config/toy-distill.yaml \\
         --data /tmp/toy-split --out /tmp/teacher-outputs --backend mlx --k 8 --synthetic
 """
 

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -198,15 +198,14 @@ def _cuda_backend() -> Backend:
                              "(pass `config=...`), or `pretrained=<dir/repo>` for real weights")
         return CUDATeacher.from_config(config, seed=seed)
 
-    def _student_init_unsupported(*args, **kwargs):
-        raise NotImplementedError(
-            "Student init (M10/#99) is implemented on the MLX dev backend only; "
-            "the CUDA initializer is deferred.")
+    def _init_student(student, teacher, method):
+        """Initialize a student from a teacher (#99), torch port; `method` is an `InitMethod`."""
+        from .cuda_student_init import init_student
+        return init_student(student, teacher, method)
 
-    def _distill_unsupported(*args, **kwargs):
-        raise NotImplementedError(
-            "The distillation train step (M10/#100) is implemented on the MLX dev backend "
-            "only; the CUDA distill step is deferred.")
+    def _make_distill_train_step(*args, **kwargs):
+        from .cuda_distill import make_distill_train_step
+        return make_distill_train_step(*args, **kwargs)
 
     _dev = "cuda:0" if torch.cuda.is_available() else "cpu"
 
@@ -227,6 +226,6 @@ def _cuda_backend() -> Backend:
         make_dpo_train_step=_make_dpo_train_step,
         make_grpo_train_step=_make_grpo_train_step,
         make_teacher=_make_teacher,
-        init_student=_student_init_unsupported,
-        make_distill_train_step=_distill_unsupported,
+        init_student=_init_student,
+        make_distill_train_step=_make_distill_train_step,
     )

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -294,6 +294,23 @@ class SelectiveSSM(nn.Module):
         Y = Y + X[:, :L] * self.D[None, None, :, None]       # skip
         return _cast(Y.reshape(B_, L, d_inner), cd)          # back to compute dtype
 
+    def mixing_matrix(self, x: Array) -> Array:
+        """Materialize the dense (B, H, L, L) 1-semiseparable mixing matrix M such that
+        `einsum('bhij,bjhp->bihp', M, X) == parallel(x)` (X = head-split input) in the
+        single-segment case — torch port of `mlx_backend.SelectiveSSM.mixing_matrix`. This is
+        the matrix the SSD scan applies; the distillation `mixing-match` stage (#100) matches it
+        against the teacher's attention. Folds in the per-step `delta` scaling and per-head `D`
+        skip; does NOT model the `seg_ids` path. Dense O(L^2) — a training-time auxiliary."""
+        B_, L, _ = x.shape
+        delta, a, Bm, Cm = self._project(x)          # delta (B,L,H); Bm,Cm (B,L,N) — fp32
+        gh = (delta * a).permute(0, 2, 1)            # (B,H,L) log-decay (<= 0)
+        decay = torch.exp(_segsum(gh))               # (B,H,L,L): exp(cumA_i-cumA_j), causal
+        CB = torch.einsum("bin,bjn->bij", Cm, Bm)    # (B,L,L) shared B/C group
+        delta_col = delta.permute(0, 2, 1)[:, :, None, :]            # (B,H,1,L) delta_j
+        M = decay * CB[:, None] * delta_col                          # (B,H,L,L)
+        eye = torch.eye(L, dtype=M.dtype, device=M.device)
+        return M + self.D[None, :, None, None] * eye[None, None]     # + D skip on the diagonal
+
     def recurrence(self, x: Array, state: State) -> Tuple[Array, State]:
         """One timestep. x: (B, d_inner), state h: (B, H, P, N) -> y: (B, d_inner)."""
         B_ = x.shape[0]
@@ -382,6 +399,18 @@ class MambaBlock(nn.Module):
         y = self.ssm.parallel(xc, seg_ids)
         y = y * _silu(z)
         return x + _linear(self.out_proj, y, cd)
+
+    def mixing_matrix(self, x: Array) -> Array:
+        """This block's head-split SSM mixing matrix (B, H, L, L), for distillation
+        `mixing-match` (#100). Runs the block front-end (norm -> in_proj main -> causal conv
+        -> SiLU) then materializes the SSM matrix on that input. Torch port of
+        `mlx_backend.MambaBlock.mixing_matrix`."""
+        L = x.shape[1]
+        cd = _DTYPES[self.config.precision]
+        xn = self.norm(x)
+        x_main, _ = torch.chunk(_linear(self.in_proj, xn, cd), 2, dim=-1)
+        xc = _silu(self._conv_seq(x_main, cd)[:, :L])
+        return self.ssm.mixing_matrix(xc)
 
     def step(self, x: Array, state: State) -> Tuple[Array, State]:
         conv_state, ssm_state = state                        # (B,k-1,di), (B,H,P,N)
@@ -565,6 +594,33 @@ class CUDAMambaModel(ModelInterface, nn.Module):
             h, st2 = layer.step(h, st)
             new_state.append(st2)
         return self._head(self.norm_f(h)), new_state
+
+    # --- distillation matching accessors (#100) ------------------------------
+    def hidden_states(self, token_batch: Array) -> Tuple[Array, ...]:
+        """Per-layer hidden states for the `hidden-align` stage: the embedding output followed
+        by each layer's output (length n_layers + 1) — the HF/teacher convention. Uses
+        `_layer_forward` so grad_checkpoint is respected (torch port of
+        `mlx_backend.MLXMambaModel.hidden_states`)."""
+        ids = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
+        h = _cast(self.embedding(ids), self._cd)
+        hs = [h]
+        for layer in self.layers:
+            h = self._layer_forward(layer, h)
+            hs.append(h)
+        return tuple(hs)
+
+    def mixing_matrices(self, token_batch: Array) -> List[Tuple[int, Array]]:
+        """For the `mixing-match` stage: each Mamba layer's head-averaged mixing matrix
+        `(B, L, L)` paired with its layer index. Attention layers are skipped. Torch port of
+        `mlx_backend.MLXMambaModel.mixing_matrices`."""
+        ids = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
+        h = _cast(self.embedding(ids), self._cd)
+        out: List[Tuple[int, Array]] = []
+        for i, layer in enumerate(self.layers):
+            if not self.config.is_attention_layer(i):
+                out.append((i, layer.mixing_matrix(h).mean(dim=1)))     # head-average -> (B,L,L)
+            h = self._layer_forward(layer, h)
+        return out
 
     def init_state(self, batch_size: int) -> State:
         c = self.config

--- a/src/model/cuda_distill.py
+++ b/src/model/cuda_distill.py
@@ -1,0 +1,144 @@
+"""CUDA / PyTorch distillation train step (#100) — torch port of `mlx_distill.py`.
+
+The staged distillation matching: a student is trained against the frozen teacher through the
+manifest's `stages` (`mixing-match -> hidden-align -> logit-distill`). Each stage is a different
+`TrainStepFn` built by `make_distill_train_step(..., stage=...)`; the driver loops the stages
+swapping the step. The objective-specific loss is computed in torch; accumulation / fp16 scaling /
+clipping / the optimizer step are shared via `cuda_train_step._accumulate_and_step` (so the four
+training objectives and distillation all funnel through one tail).
+
+Stage micro-batch tuples (same as the MLX backend):
+  * logit-distill : (inputs, targets, topk_vals, topk_idx)  — cached teacher top-k (#94).
+  * hidden-align  : (inputs, teacher_hidden) cached, OR (inputs,) on-the-fly (teacher recompute).
+  * mixing-match  : (inputs,) on-the-fly (teacher attention matrices recomputed).
+
+This file imports `torch`; it lives below the seam and nothing portable imports it.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from .cuda_train_step import _accumulate_and_step
+from ..train.distill_manifest import DistillStage
+
+
+def _align(i: int, n_src: int, n_dst: int) -> int:
+    """Map index `i` in a depth-`n_src` stack onto a depth-`n_dst` one, endpoint-to-endpoint."""
+    if n_src <= 1:
+        return 0
+    return min(n_dst - 1, max(0, int(round(i * (n_dst - 1) / (n_src - 1)))))
+
+
+def _kl_topk(student_logits: torch.Tensor, topk_vals: torch.Tensor, topk_idx: torch.Tensor,
+             temperature: float) -> torch.Tensor:
+    """T^2-scaled KL(teacher || student) over the teacher's top-k support (Hinton scaling).
+
+    `student_logits` (B,L,V) fp32; `topk_vals`/`topk_idx` (B,L,k). Teacher and student are each
+    softmaxed over the SAME k indices at temperature T. Torch port of `mlx_distill._kl_topk`."""
+    T = temperature
+    p = F.softmax(topk_vals.float() / T, dim=-1)                # teacher over support
+    sg = torch.gather(student_logits, -1, topk_idx.long()) / T  # student logits at the k indices
+    logq = sg - torch.logsumexp(sg, dim=-1, keepdim=True)       # student log-softmax / k
+    kl = (p * (torch.log(p + 1e-9) - logq)).sum(dim=-1)         # (B,L)
+    return (T * T) * kl.mean()
+
+
+def _ce(logits: torch.Tensor, targets) -> torch.Tensor:
+    V = logits.shape[-1]
+    t = torch.as_tensor(np.asarray(targets), dtype=torch.long, device=logits.device).reshape(-1)
+    return F.cross_entropy(logits.reshape(-1, V), t, reduction="mean")
+
+
+def _hidden_mse(student_hs, teacher_hs, layers: List[int], n_s: int, n_t: int) -> torch.Tensor:
+    """Mean MSE between aligned student/teacher hidden states over the overlapping channels
+    (widths differ; compare the shared `min(d)`). Torch port of `mlx_distill._hidden_mse`."""
+    terms = []
+    for s in layers:
+        th_idx = 0 if s == 0 else 1 + _align(s - 1, n_s, n_t)
+        th = teacher_hs[th_idx]
+        sh = student_hs[s]
+        m = min(sh.shape[-1], th.shape[-1])
+        diff = sh[..., :m].float() - th[..., :m].float().to(sh.device)
+        terms.append((diff * diff).mean())
+    return torch.stack(terms).mean()
+
+
+def _mixing_mse(student_mats, teacher_mats, n_s: int, n_t: int) -> torch.Tensor:
+    """Mean MSE between each student Mamba layer's head-averaged mixing matrix and the
+    depth-aligned teacher attention matrix (both (B,L,L)). Torch port."""
+    terms = []
+    for (i, sm) in student_mats:
+        tm = teacher_mats[_align(i, n_s, n_t)]
+        diff = sm.float() - tm.float().to(sm.device)
+        terms.append((diff * diff).mean())
+    return torch.stack(terms).mean()
+
+
+def make_distill_train_step(model, optimizer, *, stage, teacher=None,
+                            ce_weight: float = 0.1, kl_weight: float = 0.9,
+                            temperature: float = 2.0, hidden_layers: Optional[List[int]] = None,
+                            grad_clip: float = 1.0, scaler=None) -> Callable:
+    """Build a distillation `train_step(model, micro_batches, lr) -> dict` for one `stage`.
+
+    `stage` is a `DistillStage` (or its string). `teacher` (a frozen `ConversionTeacher`) is
+    required for on-the-fly `hidden-align`/`mixing-match`; `logit-distill` and cached
+    `hidden-align` need no teacher. Torch mirror of `mlx_distill.make_distill_train_step`.
+    """
+    if not isinstance(stage, DistillStage):
+        stage = DistillStage.from_str(str(stage))
+    n_s = model.config.n_layers
+    params = list(model.parameters())
+    dev = model._device
+
+    if stage == DistillStage.LOGIT_DISTILL:
+        def _loss(mb) -> torch.Tensor:
+            inputs, targets, tv, ti = mb
+            logits = model.forward(inputs).float()                      # (B,L,V)
+            tv_t = torch.as_tensor(np.asarray(tv), dtype=torch.float32, device=logits.device)
+            ti_t = torch.as_tensor(np.asarray(ti), dtype=torch.long, device=logits.device)
+            return ce_weight * _ce(logits, targets) + kl_weight * _kl_topk(
+                logits, tv_t, ti_t, temperature)
+
+    elif stage == DistillStage.HIDDEN_ALIGN:
+        n_t = teacher.n_layers if teacher is not None else None
+        layers = hidden_layers if hidden_layers is not None else list(range(1, n_s + 1))
+        if teacher is not None:                                          # on-the-fly recompute
+            def _loss(mb) -> torch.Tensor:
+                inputs = mb[0]
+                with torch.no_grad():
+                    t_hs = [h.detach().to(dev)
+                            for h in teacher.forward(inputs, return_hidden=True).hidden_states]
+                return _hidden_mse(model.hidden_states(inputs), t_hs, layers, n_s, n_t)
+        else:                                                           # cached teacher hidden
+            def _loss(mb) -> torch.Tensor:
+                inputs, teacher_hidden = mb
+                t_hs = [torch.as_tensor(np.asarray(h), device=dev) for h in teacher_hidden]
+                nt = len(t_hs) - 1
+                return _hidden_mse(model.hidden_states(inputs), t_hs, layers, n_s, nt)
+
+    elif stage == DistillStage.MIXING_MATCH:
+        if teacher is None:
+            raise ValueError("mixing-match requires a teacher (on-the-fly attention matrices)")
+        if all(model.config.is_attention_layer(i) for i in range(n_s)):
+            raise ValueError("mixing-match has no Mamba layers to match in a pure-attention "
+                             "layout (attn_every covers every layer); skip this stage")
+        n_t = teacher.n_layers
+
+        def _loss(mb) -> torch.Tensor:
+            inputs = mb[0]
+            with torch.no_grad():
+                t_mats = [m.detach().to(dev) for m in teacher.attention_matrices(inputs)]
+            return _mixing_mse(model.mixing_matrices(inputs), t_mats, n_s, n_t)
+    else:                                                               # unreachable
+        raise ValueError(f"unknown distill stage {stage!r}")
+
+    def train_step(model, micro_batches, lr: float) -> dict:
+        return _accumulate_and_step(optimizer, params, _loss, micro_batches, lr,
+                                    grad_clip, scaler)
+
+    return train_step

--- a/src/model/cuda_student_init.py
+++ b/src/model/cuda_student_init.py
@@ -97,12 +97,15 @@ def _init_mamba_layer(layer, proj, dt_rank: int, d_state: int) -> None:
     d_inner = layer.out_proj.weight.shape[1]
     # x_proj: rows are [dt(dt_rank) | B(d_state) | C(d_state)] -> set B from K, C from Q.
     xw = layer.ssm.x_proj.weight
-    B_new = _fit(_to_t(proj.k), (d_state, d_inner))
-    C_new = _fit(_to_t(proj.q), (d_state, d_inner))
+    # `.to(xw.device)`: the teacher tensors and the student param can be on different devices
+    # (e.g. teacher cuda, student cuda:0 — or any cross-device mix on GPU). `torch.cat` requires
+    # one device, so place the teacher-derived blocks on the param's device before concatenating.
+    B_new = _fit(_to_t(proj.k), (d_state, d_inner)).to(xw.device)
+    C_new = _fit(_to_t(proj.q), (d_state, d_inner)).to(xw.device)
     _copy(layer.ssm.x_proj.weight, torch.cat([xw[:dt_rank], B_new, C_new], dim=0))
     # in_proj: rows are [main(d_inner) | gate(d_inner)] -> set main from V, keep gate.
     iw = layer.in_proj.weight
-    main_new = _fit(_to_t(proj.v), (d_inner, iw.shape[1]))
+    main_new = _fit(_to_t(proj.v), (d_inner, iw.shape[1])).to(iw.device)
     _copy(layer.in_proj.weight, torch.cat([main_new, iw[d_inner:]], dim=0))
     # out_proj <- O.
     _copy(layer.out_proj.weight, _fit(_to_t(proj.o), tuple(layer.out_proj.weight.shape)))

--- a/src/model/cuda_student_init.py
+++ b/src/model/cuda_student_init.py
@@ -1,0 +1,148 @@
+"""CUDA / PyTorch student initialization from a frozen teacher (#99) — torch port of
+`mlx_student_init.py`.
+
+Turns the transformer teacher (#93) into the Mamba-2 hybrid student by one of two methods
+(`docs/design/10-distillation.md`):
+
+  * **Mamba-in-the-Llama** (`InitMethod.MAMBA_IN_THE_LLAMA`): init the Mamba layers from the
+    teacher's attention projections (Q->C, K->B, V->input, O->output), copy the kept attention
+    layers, and FREEZE them. Reference: arXiv:2408.15237.
+  * **MOHAWK** (`InitMethod.MOHAWK`): copy attention layers where present, leave Mamba at default
+    init, freeze nothing; the work is the progressive matching the distill loss runs (#100).
+
+The mapping is adaptive (`_fit`): exact copy where dims align, else copy the overlapping block
+and zero-pad/truncate. nn.Linear weight layout is `(out, in)` in BOTH torch and MLX, so the
+per-projection shapes match the MLX port verbatim. Freezing uses `requires_grad_(False)`: the
+optimizer holds `model.parameters()` but frozen params get no grad, so `cuda_train_step`'s grad
+norm / AdamW step skip them (the torch analogue of MLX's `freeze` + `value_and_grad`).
+
+This file imports `torch`; it lives below the seam and nothing portable imports it.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from ..train.distill_manifest import InitMethod, InitReport
+
+
+def _to_t(arr) -> torch.Tensor:
+    """Teacher projections are torch tensors (CUDATeacher); accept numpy too for safety."""
+    return arr if isinstance(arr, torch.Tensor) else torch.as_tensor(arr)
+
+
+def _fit(src: torch.Tensor, shape: Tuple[int, ...]) -> torch.Tensor:
+    """Adaptive copy of `src` into an array of `shape`: keep the overlapping region per axis,
+    zero-pad/truncate the rest. Exact (returns `src`'s values) when shapes already match."""
+    crop = src[tuple(slice(0, min(s, d)) for s, d in zip(src.shape, shape))]
+    # F.pad consumes pad amounts from the LAST axis backward: [l_last, r_last, l_prev, r_prev, ...]
+    pad: List[int] = []
+    for d, c in zip(reversed(shape), reversed(crop.shape)):
+        pad.extend([0, d - c])
+    return F.pad(crop, pad)
+
+
+def _expand_kv(w: torch.Tensor, n_heads: int, n_kv_heads: int, head_dim: int) -> torch.Tensor:
+    """Expand a GQA key/value projection (n_kv_heads*head_dim, d) to full MHA width
+    (n_heads*head_dim, d) by repeating each kv head's block (matches inference-time repeat)."""
+    if n_kv_heads == n_heads:
+        return w
+    rep = n_heads // n_kv_heads
+    d = w.shape[-1]
+    return w.reshape(n_kv_heads, head_dim, d).repeat_interleave(rep, dim=0).reshape(
+        n_heads * head_dim, d)
+
+
+def _copy(param: torch.nn.Parameter, value: torch.Tensor) -> None:
+    """Copy `value` into `param` in place (shape must already match — `_fit` ensures it)."""
+    with torch.no_grad():
+        param.copy_(value.to(param.dtype))
+
+
+def _teacher_layer_for(i: int, n_student: int, n_teacher: int) -> int:
+    """Align student depth onto teacher depth, endpoint-to-endpoint (evenly spaced)."""
+    if n_student <= 1:
+        return 0
+    return min(n_teacher - 1, int(round(i * (n_teacher - 1) / (n_student - 1))))
+
+
+def _init_embeddings(student, teacher) -> None:
+    """Copy the teacher's token embedding (and, untied, the lm_head) onto the student, cropping
+    with `_fit` — making the student residual stream the teacher's first-`d_model` subspace."""
+    cfg = student.config
+    shape = (cfg.vocab_size, cfg.d_model)
+    _copy(student.embedding.weight, _fit(_to_t(teacher.embedding_matrix()), shape))
+    if not cfg.tie_embeddings:    # student.lm_head exists only when untied (cuda_backend)
+        _copy(student.lm_head.weight, _fit(_to_t(teacher.lm_head_matrix()), shape))
+
+
+def _init_attention_layer(layer, proj, tcfg) -> None:
+    """Copy a teacher attention layer's Q/K/V/O onto a student attention block (`qkv_proj`,
+    `o_proj`), expanding GQA to full heads and adaptively fitting to the student's width."""
+    q = _to_t(proj.q)
+    k = _expand_kv(_to_t(proj.k), tcfg.n_heads, tcfg.n_kv_heads, tcfg.head_dim)
+    v = _expand_kv(_to_t(proj.v), tcfg.n_heads, tcfg.n_kv_heads, tcfg.head_dim)
+    d_attn, d_model = layer.qkv_proj.weight.shape[0] // 3, layer.qkv_proj.weight.shape[1]
+    blocks = [_fit(w, (d_attn, d_model)) for w in (q, k, v)]
+    _copy(layer.qkv_proj.weight, torch.cat(blocks, dim=0))           # (3*d_attn, d_model)
+    _copy(layer.o_proj.weight, _fit(_to_t(proj.o), tuple(layer.o_proj.weight.shape)))
+
+
+def _init_mamba_layer(layer, proj, dt_rank: int, d_state: int) -> None:
+    """Mamba-in-the-Llama mapping onto one Mamba block: Q->C, K->B (the d_state slices of
+    `x_proj`), V->input (`in_proj` main half), O->`out_proj`. Untouched rows keep their init."""
+    d_inner = layer.out_proj.weight.shape[1]
+    # x_proj: rows are [dt(dt_rank) | B(d_state) | C(d_state)] -> set B from K, C from Q.
+    xw = layer.ssm.x_proj.weight
+    B_new = _fit(_to_t(proj.k), (d_state, d_inner))
+    C_new = _fit(_to_t(proj.q), (d_state, d_inner))
+    _copy(layer.ssm.x_proj.weight, torch.cat([xw[:dt_rank], B_new, C_new], dim=0))
+    # in_proj: rows are [main(d_inner) | gate(d_inner)] -> set main from V, keep gate.
+    iw = layer.in_proj.weight
+    main_new = _fit(_to_t(proj.v), (d_inner, iw.shape[1]))
+    _copy(layer.in_proj.weight, torch.cat([main_new, iw[d_inner:]], dim=0))
+    # out_proj <- O.
+    _copy(layer.out_proj.weight, _fit(_to_t(proj.o), tuple(layer.out_proj.weight.shape)))
+
+
+def init_student(student, teacher, method: InitMethod) -> InitReport:
+    """Initialize `student` (a `CUDAMambaModel`) from `teacher` (a `ConversionTeacher`).
+
+    Returns an `InitReport`. For Mamba-in-the-Llama the kept attention layers are frozen
+    (`requires_grad_(False)`); for MOHAWK nothing is frozen.
+    """
+    if not isinstance(method, InitMethod):
+        method = InitMethod.from_str(str(method))
+    cfg = student.config
+    tcfg = teacher.config
+    S, T = cfg.n_layers, teacher.n_layers
+    dt_rank, d_state = cfg.dt_rank_resolved, cfg.d_state
+
+    _init_embeddings(student, teacher)
+
+    frozen_layers: List[int] = []
+    n_mapped = 0
+    for i in range(S):
+        proj = teacher.attention_projection(_teacher_layer_for(i, S, T))
+        is_attn = cfg.is_attention_layer(i)
+        if is_attn:
+            _init_attention_layer(student.layers[i], proj, tcfg)
+            n_mapped += 1
+            if method == InitMethod.MAMBA_IN_THE_LLAMA:
+                student.layers[i].requires_grad_(False)
+                frozen_layers.append(i)
+        elif method == InitMethod.MAMBA_IN_THE_LLAMA:
+            _init_mamba_layer(student.layers[i], proj, dt_rank, d_state)
+            n_mapped += 1
+        # MOHAWK leaves Mamba layers at their default init (refined by progressive matching #100).
+
+    total = sum(p.numel() for p in student.parameters())
+    trainable = sum(p.numel() for p in student.parameters() if p.requires_grad)
+    return InitReport(
+        method=method.value, n_layers_mapped=n_mapped,
+        n_frozen_params=total - trainable, n_trainable_params=trainable,
+        frozen_layers=frozen_layers,
+    )

--- a/tests/test_cuda_distill.py
+++ b/tests/test_cuda_distill.py
@@ -1,0 +1,191 @@
+"""CUDA/torch distillation loss + train step (#100). Torch CPU; parity vs MLX where available.
+
+Covers the materialized mixing matrix (vs the scan), KL on top-k, the three stage steps (loss
+decreases), the stage guards, and cross-backend loss parity at fp32 — the same standard as
+src/conformance/backend_parity.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.backend import get_backend
+from src.model.blocks import MambaConfig
+from src.model.teacher import TeacherConfig
+from src.model.cuda_backend import CUDAMambaModel, SelectiveSSM
+from src.model.cuda_teacher import CUDATeacher
+from src.model.cuda_distill import make_distill_train_step, _kl_topk
+from src.train.distill_manifest import DistillStage, InitMethod
+
+VOCAB = 256
+
+
+def _have_mlx():
+    try:
+        import mlx.core  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _tcfg():
+    return TeacherConfig(vocab_size=VOCAB, d_model=64, n_layers=3, n_heads=4, n_kv_heads=2,
+                         head_dim=16, intermediate_size=128)
+
+
+def _scfg(precision="fp32"):
+    return MambaConfig(d_model=48, n_layers=4, d_state=16, expand=2, d_conv=4, head_dim=16,
+                       vocab_size=VOCAB, seq_len=16, attn_every=2, n_attn_heads=4, precision=precision)
+
+
+def _numpy_teacher_weights(cfg, seed=0):
+    rng = np.random.default_rng(seed)
+    scale = 1.0 / math.sqrt(cfg.d_model)
+    f = lambda *s: (rng.standard_normal(s) * scale).astype(np.float32)
+    w = {"embed": f(cfg.vocab_size, cfg.d_model)}
+    for i in range(cfg.n_layers):
+        p = f"layer.{i}."
+        w[p + "input_ln"] = np.ones(cfg.d_model, np.float32)
+        w[p + "q_w"] = f(cfg.q_dim, cfg.d_model); w[p + "q_b"] = f(cfg.q_dim)
+        w[p + "k_w"] = f(cfg.kv_dim, cfg.d_model); w[p + "k_b"] = f(cfg.kv_dim)
+        w[p + "v_w"] = f(cfg.kv_dim, cfg.d_model); w[p + "v_b"] = f(cfg.kv_dim)
+        w[p + "o_w"] = f(cfg.d_model, cfg.q_dim)
+        w[p + "post_ln"] = np.ones(cfg.d_model, np.float32)
+        w[p + "gate_w"] = f(cfg.intermediate_size, cfg.d_model)
+        w[p + "up_w"] = f(cfg.intermediate_size, cfg.d_model)
+        w[p + "down_w"] = f(cfg.d_model, cfg.intermediate_size)
+    w["final_ln"] = np.ones(cfg.d_model, np.float32)
+    return w
+
+
+def _teacher():
+    return CUDATeacher.from_config(_tcfg(), seed=0)
+
+
+def _student(precision="fp32"):
+    get_backend("cuda").seed(0)
+    return CUDAMambaModel(_scfg(precision))
+
+
+def _tokens(B=2, L=8):
+    return np.random.default_rng(0).integers(0, VOCAB, size=(B, L)).astype(np.int64)
+
+
+def _opt(model, lr=1e-2):
+    return get_backend("cuda").make_optimizer(model, lr)
+
+
+# --- mixing matrix + KL ------------------------------------------------------
+def test_mixing_matrix_reproduces_parallel_scan():
+    cfg = MambaConfig(d_model=32, n_layers=1, d_state=16, head_dim=16, vocab_size=64,
+                      seq_len=12, precision="fp32")
+    ssm = SelectiveSSM(cfg)
+    torch.manual_seed(0)
+    with torch.no_grad():
+        x = torch.randn(2, 12, cfg.d_inner)
+        Y = ssm.parallel(x)
+        M = ssm.mixing_matrix(x)
+        Xh = x.reshape(2, 12, cfg.n_heads, cfg.head_dim)
+        Ym = torch.einsum("bhij,bjhp->bihp", M, Xh).reshape(2, 12, cfg.d_inner)
+        assert float((Y - Ym).abs().max()) < 1e-4
+
+
+def test_kl_topk_nonneg_and_zero_at_match():
+    rng = np.random.default_rng(1)
+    logits = torch.tensor(rng.normal(size=(2, 4, VOCAB)).astype(np.float32))
+    k = 8
+    idx = torch.argsort(-logits, dim=-1)[..., :k]
+    vals = torch.gather(logits, -1, idx)
+    assert abs(float(_kl_topk(logits, vals, idx, 2.0))) < 1e-4               # student==teacher
+    bumped = vals + torch.arange(k, dtype=torch.float32)
+    assert float(_kl_topk(logits, bumped, idx, 2.0)) > 0
+
+
+# --- stage steps -------------------------------------------------------------
+def _logit_batch(teacher, tokens, k=16):
+    vals, idx = teacher.topk_logits(tokens, k)
+    targets = np.roll(tokens, -1, axis=1)
+    return (tokens, targets, teacher.to_numpy(vals), teacher.to_numpy(idx))
+
+
+def test_logit_distill_step_decreases():
+    teacher, student = _teacher(), _student()
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.LOGIT_DISTILL)
+    mb = _logit_batch(teacher, _tokens())
+    losses = [step(student, [mb], 1e-2)["loss"] for _ in range(4)]
+    assert all(np.isfinite(losses)) and losses[-1] < losses[0]
+
+
+def test_hidden_align_step_decreases():
+    teacher = _teacher()
+    student = _student()
+    get_backend("cuda").init_student(student, teacher, InitMethod.MOHAWK)
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.HIDDEN_ALIGN,
+                                   teacher=teacher)
+    losses = [step(student, [(_tokens(),)], 1e-2)["loss"] for _ in range(4)]
+    assert all(np.isfinite(losses)) and losses[-1] < losses[0]
+
+
+def test_mixing_match_step_decreases():
+    teacher = _teacher()
+    student = _student()
+    get_backend("cuda").init_student(student, teacher, InitMethod.MOHAWK)
+    step = make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH,
+                                   teacher=teacher)
+    losses = [step(student, [(_tokens(),)], 1e-2)["loss"] for _ in range(4)]
+    assert all(np.isfinite(losses)) and losses[-1] < losses[0]
+
+
+def test_mixing_match_requires_teacher():
+    with pytest.raises(ValueError, match="requires a teacher"):
+        make_distill_train_step(_student(), _opt(_student()), stage=DistillStage.MIXING_MATCH)
+
+
+def test_mixing_match_rejects_pure_attention():
+    cfg = MambaConfig(d_model=48, n_layers=2, d_state=16, head_dim=16, vocab_size=VOCAB,
+                      seq_len=16, attn_every=1, n_attn_heads=4, precision="fp32")
+    student = CUDAMambaModel(cfg)
+    with pytest.raises(ValueError, match="no Mamba layers"):
+        make_distill_train_step(student, _opt(student), stage=DistillStage.MIXING_MATCH,
+                                teacher=_teacher())
+
+
+# --- cross-backend loss parity ----------------------------------------------
+@pytest.mark.skipif(not _have_mlx(), reason="mlx unavailable")
+@pytest.mark.parametrize("stage", [DistillStage.LOGIT_DISTILL, DistillStage.HIDDEN_ALIGN,
+                                   DistillStage.MIXING_MATCH])
+def test_loss_parity_vs_mlx(stage):
+    import mlx.core as mx
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_teacher import MLXConversionTeacher
+    from src.model.mlx_distill import make_distill_train_step as mlx_step
+
+    tcfg, scfg = _tcfg(), _scfg()
+    npw = _numpy_teacher_weights(tcfg, seed=7)
+    ct = CUDATeacher(tcfg, {k: torch.tensor(v) for k, v in npw.items()})
+    mt = MLXConversionTeacher(tcfg, {k: mx.array(v) for k, v in npw.items()})
+
+    ms = MLXMambaModel(scfg)
+    cs = CUDAMambaModel(scfg)
+    cs._load_portable(ms._portable_state_dict())          # identical student weights
+
+    tokens = _tokens()
+    teacher_arg = None if stage == DistillStage.LOGIT_DISTILL else (ct, mt)
+    if stage == DistillStage.LOGIT_DISTILL:
+        # one cached top-k batch (from the shared teacher) feeds both backends.
+        vals, idx = ct.topk_logits(tokens, 16)
+        mb = (tokens, np.roll(tokens, -1, axis=1), ct.to_numpy(vals), ct.to_numpy(idx))
+        c_step = make_distill_train_step(cs, _opt(cs), stage=stage)
+        m_step = mlx_step(ms, get_backend("mlx").make_optimizer(ms, 1e-2), stage=stage)
+    else:
+        mb = (tokens,)
+        c_step = make_distill_train_step(cs, _opt(cs), stage=stage, teacher=ct)
+        m_step = mlx_step(ms, get_backend("mlx").make_optimizer(ms, 1e-2), stage=stage, teacher=mt)
+
+    # lr=0 -> weights unchanged; compare the loss the two backends compute on identical inputs.
+    c_loss = c_step(cs, [mb], 0.0)["loss"]
+    m_loss = m_step(ms, [mb], 0.0)["loss"]
+    assert abs(c_loss - m_loss) < 1e-3, f"{stage}: cuda {c_loss} vs mlx {m_loss}"

--- a/tests/test_cuda_distill.py
+++ b/tests/test_cuda_distill.py
@@ -140,8 +140,9 @@ def test_mixing_match_step_decreases():
 
 
 def test_mixing_match_requires_teacher():
+    s = _student()
     with pytest.raises(ValueError, match="requires a teacher"):
-        make_distill_train_step(_student(), _opt(_student()), stage=DistillStage.MIXING_MATCH)
+        make_distill_train_step(s, _opt(s), stage=DistillStage.MIXING_MATCH)
 
 
 def test_mixing_match_rejects_pure_attention():

--- a/tests/test_cuda_student_init.py
+++ b/tests/test_cuda_student_init.py
@@ -1,0 +1,143 @@
+"""CUDA/torch student init from a teacher (#99). Torch CPU; parity vs MLX where available.
+
+Covers the adaptive `_fit`/`_expand_kv` helpers, embedding transfer, the Mamba-in-the-Llama
+freeze (attention layers -> requires_grad False) vs MOHAWK (nothing frozen), the InitReport
+counts, and full cross-backend parity (identical teacher + student start -> identical init).
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import MambaConfig
+from src.model.teacher import TeacherConfig
+from src.model.cuda_backend import CUDAMambaModel
+from src.model.cuda_teacher import CUDATeacher
+from src.model.cuda_student_init import init_student, _fit, _expand_kv
+from src.train.distill_manifest import InitMethod
+
+VOCAB = 256
+
+
+def _have_mlx():
+    try:
+        import mlx.core  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _tcfg():
+    return TeacherConfig(vocab_size=VOCAB, d_model=64, n_layers=3, n_heads=4, n_kv_heads=2,
+                         head_dim=16, intermediate_size=128)
+
+
+def _student_cfg():
+    return MambaConfig(d_model=48, n_layers=4, d_state=16, expand=2, d_conv=4, head_dim=16,
+                       vocab_size=VOCAB, seq_len=16, attn_every=2, n_attn_heads=4, precision="fp32")
+
+
+def _numpy_teacher_weights(cfg, seed=0):
+    rng = np.random.default_rng(seed)
+    scale = 1.0 / math.sqrt(cfg.d_model)
+    f = lambda *s: (rng.standard_normal(s) * scale).astype(np.float32)
+    w = {"embed": f(cfg.vocab_size, cfg.d_model)}
+    for i in range(cfg.n_layers):
+        p = f"layer.{i}."
+        w[p + "input_ln"] = np.ones(cfg.d_model, np.float32)
+        w[p + "q_w"] = f(cfg.q_dim, cfg.d_model); w[p + "q_b"] = f(cfg.q_dim)
+        w[p + "k_w"] = f(cfg.kv_dim, cfg.d_model); w[p + "k_b"] = f(cfg.kv_dim)
+        w[p + "v_w"] = f(cfg.kv_dim, cfg.d_model); w[p + "v_b"] = f(cfg.kv_dim)
+        w[p + "o_w"] = f(cfg.d_model, cfg.q_dim)
+        w[p + "post_ln"] = np.ones(cfg.d_model, np.float32)
+        w[p + "gate_w"] = f(cfg.intermediate_size, cfg.d_model)
+        w[p + "up_w"] = f(cfg.intermediate_size, cfg.d_model)
+        w[p + "down_w"] = f(cfg.d_model, cfg.intermediate_size)
+    w["final_ln"] = np.ones(cfg.d_model, np.float32)
+    return w
+
+
+# --- helpers -----------------------------------------------------------------
+def test_fit_crop_and_pad():
+    src = torch.arange(12).reshape(3, 4).float()
+    out = _fit(src, (2, 6))                       # crop rows 3->2, pad cols 4->6
+    assert out.shape == (2, 6)
+    assert torch.equal(out[:, :4], src[:2])
+    assert torch.all(out[:, 4:] == 0)
+    assert torch.equal(_fit(src, (3, 4)), src)    # exact when shapes match
+
+
+def test_expand_kv():
+    w = torch.arange(2 * 16 * 5).reshape(2 * 16, 5).float()   # 2 kv heads, head_dim 16
+    out = _expand_kv(w, n_heads=4, n_kv_heads=2, head_dim=16)
+    assert out.shape == (4 * 16, 5)
+    # each kv head's 16-row block is repeated `rep=2` times
+    assert torch.equal(out[:16], w[:16]) and torch.equal(out[16:32], w[:16])
+
+
+# --- init behavior -----------------------------------------------------------
+def test_embedding_transfer():
+    teacher = CUDATeacher.from_config(_tcfg(), seed=0)
+    student = CUDAMambaModel(_student_cfg())
+    init_student(student, teacher, InitMethod.MOHAWK)
+    te = teacher.to_numpy(teacher.embedding_matrix())
+    se = student.embedding.weight.detach().numpy()
+    m = min(te.shape[1], se.shape[1])
+    assert np.allclose(se[:, :m], te[:VOCAB, :m], atol=1e-5)
+
+
+def test_mamba_in_the_llama_freezes_attention():
+    cfg = _student_cfg()
+    teacher = CUDATeacher.from_config(_tcfg(), seed=0)
+    student = CUDAMambaModel(cfg)
+    report = init_student(student, teacher, InitMethod.MAMBA_IN_THE_LLAMA)
+    attn_layers = [i for i in range(cfg.n_layers) if cfg.is_attention_layer(i)]
+    assert report.frozen_layers == attn_layers
+    for i in attn_layers:
+        assert all(not p.requires_grad for p in student.layers[i].parameters())
+    for i in range(cfg.n_layers):
+        if i not in attn_layers:
+            assert all(p.requires_grad for p in student.layers[i].parameters())
+    assert report.n_frozen_params + report.n_trainable_params == sum(
+        p.numel() for p in student.parameters())
+    assert report.n_frozen_params > 0
+
+
+def test_mohawk_freezes_nothing():
+    student = CUDAMambaModel(_student_cfg())
+    report = init_student(student, CUDATeacher.from_config(_tcfg(), seed=0), InitMethod.MOHAWK)
+    assert report.frozen_layers == []
+    assert report.n_frozen_params == 0
+    assert all(p.requires_grad for p in student.parameters())
+
+
+@pytest.mark.skipif(not _have_mlx(), reason="mlx unavailable")
+@pytest.mark.parametrize("method", [InitMethod.MAMBA_IN_THE_LLAMA, InitMethod.MOHAWK])
+def test_parity_vs_mlx(method):
+    import mlx.core as mx
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_teacher import MLXConversionTeacher
+    from src.model.mlx_student_init import init_student as mlx_init
+
+    tcfg, scfg = _tcfg(), _student_cfg()
+    npw = _numpy_teacher_weights(tcfg, seed=5)
+
+    # Identical teachers from the shared numpy weights.
+    ct = CUDATeacher(tcfg, {k: torch.tensor(v) for k, v in npw.items()})
+    mt = MLXConversionTeacher(tcfg, {k: mx.array(v) for k, v in npw.items()})
+
+    # Identical students: build both, then load the MLX student's portable weights into the torch one.
+    ms = MLXMambaModel(scfg)
+    cs = CUDAMambaModel(scfg)
+    cs._load_portable(ms._portable_state_dict())
+
+    mlx_init(ms, mt, method)
+    init_student(cs, ct, method)
+
+    pm, pc = ms._portable_state_dict(), cs._portable_state_dict()
+    assert set(pm) == set(pc)
+    for k in pm:
+        assert np.max(np.abs(np.asarray(pm[k]) - np.asarray(pc[k]))) < 1e-4, f"mismatch at {k}"

--- a/tests/test_distill_driver.py
+++ b/tests/test_distill_driver.py
@@ -1,0 +1,32 @@
+"""End-to-end distill driver gate (#81). Runs scripts/distill_smoke.py — build toy corpus +
+synthetic teacher top-k, then scripts/distill.py through all three stages on MLX, asserting each
+stage's loss decreases, the portable weights + per-stage resume bundles are written, and a
+--resume invocation reloads cleanly. MLX-only (the smoke runs on the dev backend).
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def test_distill_smoke_end_to_end(tmp_path):
+    out = tmp_path / "distill-smoke"
+    res = subprocess.run(
+        [sys.executable, "scripts/distill_smoke.py", "--out", str(out), "--steps-per-stage", "12"],
+        cwd=REPO, capture_output=True, text=True,
+        env={"PYTHONPATH": str(REPO), "PATH": os.environ.get("PATH", "")},
+    )
+    assert res.returncode == 0, f"distill_smoke failed:\n{res.stdout}\n{res.stderr}"
+    assert "DISTILL SMOKE PASSED" in res.stdout
+    run = out / "run"
+    assert (run / "weights.safetensors").exists()
+    for stage in ("mixing-match", "hidden-align", "logit-distill"):
+        assert (run / stage / "metrics.jsonl").exists()
+        assert (run / stage / "resume").exists()

--- a/tests/test_distill_driver.py
+++ b/tests/test_distill_driver.py
@@ -1,7 +1,8 @@
 """End-to-end distill driver gate (#81). Runs scripts/distill_smoke.py — build toy corpus +
-synthetic teacher top-k, then scripts/distill.py through all three stages on MLX, asserting each
-stage's loss decreases, the portable weights + per-stage resume bundles are written, and a
---resume invocation reloads cleanly. MLX-only (the smoke runs on the dev backend).
+synthetic teacher top-k, then scripts/distill.py through all three stages, asserting each stage's
+loss drops below its start, the portable weights + per-stage resume bundles are written, and a
+--resume invocation reloads cleanly. Parametrized over the available backends (mlx on Apple
+Silicon, cuda where torch is installed — incl. torch-CPU), so a CUDA-only box still gets the gate.
 """
 
 import os
@@ -11,19 +12,38 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("mlx.core")
-
 REPO = Path(__file__).resolve().parents[1]
 
 
-def test_distill_smoke_end_to_end(tmp_path):
-    out = tmp_path / "distill-smoke"
+def _available_backends():
+    backends = []
+    try:
+        import mlx.core  # noqa: F401
+        backends.append("mlx")
+    except ImportError:
+        pass
+    try:
+        import torch  # noqa: F401
+        backends.append("cuda")
+    except ImportError:
+        pass
+    return backends
+
+
+_BACKENDS = _available_backends()
+
+
+@pytest.mark.skipif(not _BACKENDS, reason="no backend (mlx/torch) available")
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_distill_smoke_end_to_end(tmp_path, backend):
+    out = tmp_path / f"distill-smoke-{backend}"
     res = subprocess.run(
-        [sys.executable, "scripts/distill_smoke.py", "--out", str(out), "--steps-per-stage", "12"],
+        [sys.executable, "scripts/distill_smoke.py", "--backend", backend, "--out", str(out),
+         "--steps-per-stage", "12"],
         cwd=REPO, capture_output=True, text=True,
         env={"PYTHONPATH": str(REPO), "PATH": os.environ.get("PATH", "")},
     )
-    assert res.returncode == 0, f"distill_smoke failed:\n{res.stdout}\n{res.stderr}"
+    assert res.returncode == 0, f"distill_smoke ({backend}) failed:\n{res.stdout}\n{res.stderr}"
     assert "DISTILL SMOKE PASSED" in res.stdout
     run = out / "run"
     assert (run / "weights.safetensors").exists()


### PR DESCRIPTION
Supersedes #136 (auto-closed by GitHub when its stacked base branch `feat/teacher-precompute` was deleted on #135's merge; GitHub won't reopen a PR whose base branch was removed). Same branch, rebased onto `main`, retargeted here.

## What & why
The `scripts/distill.py` driver for an end-to-end M10 distillation (#81) plus the full CUDA (PyTorch) distill backend (student-init + staged distill step + model accessors), so the cloud run is possible. Builds on #94 (merged).

## Changes
- **`scripts/distill.py`** — single-manifest driver: build teacher + student, init student from teacher (#99), loop the distill stages (mixing-match → hidden-align → logit-distill, #100) on the backend-free loop; per-stage fresh optimizer + crash-safe checkpoint subdir; `--resume` restarts the furthest-progressed stage.
- **CUDA distill backend** (was `NotImplementedError`): `cuda_student_init.py`, `cuda_distill.py`, and `hidden_states`/`mixing_matrices`/`mixing_matrix` on `cuda_backend.py`; wired into `backend.py`.
- **`config/toy-distill.yaml` + `scripts/distill_smoke.py`** — offline gate, `--backend {mlx,cuda}`.

## Review fixes carried over from #136
- `cuda_student_init._init_mamba_layer`: place teacher tensors on the student param's device before `torch.cat` (cross-device cat raised on GPU; CPU/MLX-harmless).
- `distill.py`: fail-fast guard when teacher-outputs `vocab_size > cfg.vocab_size`; pass `vocab_size` into `DistillLoader`.
- `distill_smoke.py`: `math.isfinite` (the old check only caught NaN, not inf).
- `test_cuda_distill.py`: build the student once so the optimizer matches the model.

## Verification
- Local (Mac): full suite **487 passed, 3 skipped**; `distill_smoke` mlx + cuda pass.
- **Real A40 GPU** (provisioned + torn down): CUDA suite **21 passed, 5 skipped** (MLX-only); `distill_smoke --backend cuda` all 3 stages drop; `smoke_test --backend cuda` resume bit-exact; MiL init on CUDA student+teacher (the device-mix path) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)