### PR TITLE
fix(eval): bound large-vocab val CE memory + cuda bench device arg

### DIFF
--- a/scripts/bench_cuda_train_step.py
+++ b/scripts/bench_cuda_train_step.py
@@ -93,14 +93,29 @@ def main() -> None:
             "MoE-Mamba (#53) is MLX-only; the CUDA backend can't build it. Bench a dense "
             "config (e.g. config/poc.yaml / config/toy.yaml).")
 
-    device = ("cuda" if torch.cuda.is_available() else "cpu") if args.device == "auto" \
-        else args.device
-    if device == "cuda" and not torch.cuda.is_available():
+    # Fail fast on the one request the backend cannot satisfy.
+    if args.device == "cuda" and not torch.cuda.is_available():
         raise SystemExit("--device cuda requested but torch.cuda.is_available() is False.")
-    on_cuda = device == "cuda"
 
     seq = args.seq if args.seq is not None else cfg.seq_len
     tokens_per_step = args.batch * seq * args.grad_accum
+
+    # The exact wiring of scripts/train.py --backend cuda — measures the production path.
+    backend = get_backend("cuda")
+    backend.seed(args.seed)
+    model = backend.model_cls(cfg)  # backend picks cuda:0 / cpu internally (mirrors train.py)
+    opt = backend.make_optimizer(model, args.lr)
+
+    # Derive device/on_cuda from where the model ACTUALLY lives, not from --device: the cuda
+    # backend's model_cls auto-selects (cuda:0 if available, else cpu) exactly as train.py
+    # does and ignores an arbitrary --device, so trusting the CLI here would let the
+    # sync/peak-mem reporting diverge from reality (e.g. --device cpu on a CUDA host would
+    # still build a cuda model but skip synchronize/peak-mem and print misleading numbers).
+    on_cuda = next(model.parameters()).is_cuda
+    device = "cuda" if on_cuda else "cpu"
+    if args.device != "auto" and args.device != device:
+        print(f"[bench/cuda] note: --device {args.device} requested, but the cuda backend "
+              f"built the model on {device} (it auto-selects like train.py); reporting {device}.")
 
     print(f"[bench/cuda] torch {torch.__version__}  device={device}  {platform.platform()}")
     if on_cuda:
@@ -111,11 +126,6 @@ def main() -> None:
     print(f"[bench/cuda] batch={args.batch} x seq={seq} x grad_accum={args.grad_accum} "
           f"= {tokens_per_step} tokens/step  iters={args.iters} (+{args.warmup} warmup)\n")
 
-    # The exact wiring of scripts/train.py --backend cuda — measures the production path.
-    backend = get_backend("cuda")
-    backend.seed(args.seed)
-    model = backend.model_cls(cfg)  # backend picks cuda:0 / cpu internally (mirrors train.py)
-    opt = backend.make_optimizer(model, args.lr)
     scaler = scaler_for_precision(cfg.precision)
     train_step = backend.make_train_step(model, opt, grad_clip=1.0, scaler=scaler)
 

--- a/scripts/bench_cuda_train_step.py
+++ b/scripts/bench_cuda_train_step.py
@@ -114,7 +114,7 @@ def main() -> None:
     # The exact wiring of scripts/train.py --backend cuda — measures the production path.
     backend = get_backend("cuda")
     backend.seed(args.seed)
-    model = backend.model_cls(cfg, device=device)
+    model = backend.model_cls(cfg)  # backend picks cuda:0 / cpu internally (mirrors train.py)
     opt = backend.make_optimizer(model, args.lr)
     scaler = scaler_for_precision(cfg.precision)
     train_step = backend.make_train_step(model, opt, grad_clip=1.0, scaler=scaler)

--- a/src/eval/val_loss.py
+++ b/src/eval/val_loss.py
@@ -15,6 +15,13 @@ import numpy as np
 from ..model.interface import ModelInterface
 from ..data.loader import PackedLoader
 
+# Bound a single stable-softmax temporary — `blk` and the `exp(blk - m)` it spawns are
+# each (chunk, V) in float64 — to this many bytes, so eval memory scales with vocab, not
+# batch size. The cap keeps small/test vocabs (where the budget far exceeds the row count)
+# in a single block, so their result stays bit-identical to the full-array float64 reduction.
+_CE_CHUNK_BYTES = 256 * 1024 * 1024  # ~256 MiB per float64 (chunk, V) temporary
+_CE_CHUNK_CAP = 4096                 # upper bound on rows/chunk
+
 
 def _ce_sum_chunked(flat: np.ndarray, targets: np.ndarray,
                     weights: Optional[np.ndarray] = None) -> tuple[float, float]:
@@ -22,12 +29,16 @@ def _ce_sum_chunked(flat: np.ndarray, targets: np.ndarray,
     (rows = tokens, cols = vocab), plus the total weight. Computed in float64 over
     row-chunks so the stable-softmax temporaries are bounded to (chunk, V) instead of
     the full (B*T, V): at the Qwen2.5 vocab (151,646) a single eval batch's logits are
-    ~40 GB in float64, which made eval thrash/OOM on the host. Chunked, the result is
-    bit-identical to the full-array float64 computation for chunk >= n (the test sizes),
-    so the numeric contract with `masked_cross_entropy` is preserved.
+    ~40 GB in float64, which made eval thrash/OOM on the host. `chunk` shrinks with V so
+    each (chunk, V) float64 temporary stays under `_CE_CHUNK_BYTES` regardless of vocab
+    (~221 rows at the Qwen2.5 vocab), capped at `_CE_CHUNK_CAP`. For chunk >= n (small /
+    test vocabs, where the byte budget exceeds the row count) the whole array is one block,
+    so the result is bit-identical to the full-array float64 computation and the numeric
+    contract with `masked_cross_entropy` is preserved.
     """
     n = flat.shape[0]
-    chunk = 4096
+    vocab = flat.shape[1]
+    chunk = min(_CE_CHUNK_CAP, max(1, _CE_CHUNK_BYTES // (vocab * 8)))
     total, wsum = 0.0, 0.0
     for s in range(0, n, chunk):
         blk = np.asarray(flat[s:s + chunk], dtype=np.float64)

--- a/src/eval/val_loss.py
+++ b/src/eval/val_loss.py
@@ -16,16 +16,43 @@ from ..model.interface import ModelInterface
 from ..data.loader import PackedLoader
 
 
+def _ce_sum_chunked(flat: np.ndarray, targets: np.ndarray,
+                    weights: Optional[np.ndarray] = None) -> tuple[float, float]:
+    """Sum of per-token cross-entropy (optionally `weights`-weighted) over `flat`
+    (rows = tokens, cols = vocab), plus the total weight. Computed in float64 over
+    row-chunks so the stable-softmax temporaries are bounded to (chunk, V) instead of
+    the full (B*T, V): at the Qwen2.5 vocab (151,646) a single eval batch's logits are
+    ~40 GB in float64, which made eval thrash/OOM on the host. Chunked, the result is
+    bit-identical to the full-array float64 computation for chunk >= n (the test sizes),
+    so the numeric contract with `masked_cross_entropy` is preserved.
+    """
+    n = flat.shape[0]
+    chunk = 4096
+    total, wsum = 0.0, 0.0
+    for s in range(0, n, chunk):
+        blk = np.asarray(flat[s:s + chunk], dtype=np.float64)
+        tgt = targets[s:s + chunk]
+        # log-softmax in a numerically stable way
+        m = blk.max(axis=-1, keepdims=True)
+        logZ = m[:, 0] + np.log(np.exp(blk - m).sum(axis=-1))
+        tok_ce = logZ - blk[np.arange(blk.shape[0]), tgt]
+        if weights is None:
+            total += float(tok_ce.sum())
+            wsum += tok_ce.shape[0]
+        else:
+            w = weights[s:s + chunk]
+            total += float((tok_ce * w).sum())
+            wsum += float(w.sum())
+    return total, wsum
+
+
 def cross_entropy(logits: np.ndarray, targets: np.ndarray) -> float:
     """Mean token-level cross-entropy (nats). logits (..., V), targets (...,)."""
-    logits = np.asarray(logits, dtype=np.float64)
+    flat = np.asarray(logits)
+    flat = flat.reshape(-1, flat.shape[-1])
     targets = np.asarray(targets).reshape(-1)
-    flat = logits.reshape(-1, logits.shape[-1])
-    # log-softmax in a numerically stable way
-    m = flat.max(axis=-1, keepdims=True)
-    logZ = m[:, 0] + np.log(np.exp(flat - m).sum(axis=-1))
-    chosen = flat[np.arange(flat.shape[0]), targets]
-    return float(np.mean(logZ - chosen))
+    total, n = _ce_sum_chunked(flat, targets)
+    return total / n
 
 
 def masked_cross_entropy(logits: np.ndarray, targets: np.ndarray,
@@ -37,18 +64,14 @@ def masked_cross_entropy(logits: np.ndarray, targets: np.ndarray,
     read for the loss value (they still index the logits, so pass in-range pad ids).
     Returns 0.0 for an all-zero mask (an all-padding batch contributes nothing).
     """
-    logits = np.asarray(logits, dtype=np.float64)
+    flat = np.asarray(logits)
+    flat = flat.reshape(-1, flat.shape[-1])
     targets = np.asarray(targets).reshape(-1)
     mask = np.asarray(mask, dtype=np.float64).reshape(-1)
-    flat = logits.reshape(-1, logits.shape[-1])
-    m = flat.max(axis=-1, keepdims=True)
-    logZ = m[:, 0] + np.log(np.exp(flat - m).sum(axis=-1))
-    chosen = flat[np.arange(flat.shape[0]), targets]
-    tok_ce = logZ - chosen
-    denom = mask.sum()
+    total, denom = _ce_sum_chunked(flat, targets, weights=mask)
     if denom == 0:
         return 0.0
-    return float((tok_ce * mask).sum() / denom)
+    return total / denom
 
 
 def perplexity(mean_ce_nats: float) -> float:


### PR DESCRIPTION
## What & why

Two fixes surfaced while executing the **poc-qwen** (~205M, Qwen2.5 vocab 151,646) training run on a CUDA H100.

### 1. Large-vocab validation eval stalls (`src/eval/val_loss.py`)
`cross_entropy` / `masked_cross_entropy` built the numerically-stable log-softmax over the **full `(B*T, V)` logits at once**. At the Qwen2.5 vocab that's a `(32768, 151646)` array ≈ **40 GB per eval batch** (plus an `exp()` temp of the same size) — which thrashes/OOMs the host and stalls validation. In the live run, eval **hung ~30 min at step 0** (the toy smoke test never caught it: vocab there is 256 → 67 MB).

Fix: factor a `float64` **row-chunked** helper `_ce_sum_chunked` that bounds the softmax temporary to `(chunk, V)`. It is **bit-identical to the old full-array float64 computation for `chunk >= n`**, so the `masked_cross_entropy`-vs-`cross_entropy` numeric contract and all eval tests are unchanged (kept float64 deliberately — float32 would break the `tests/test_masked_ce.py` 1e-9 cross-consistency check).

Note: this bounds **memory**; for very large vocab also pass a modest `--eval-batches` (the poc/distill runbooks do). A follow-up could move eval CE onto the backend/GPU for raw speed — out of scope here.

### 2. CUDA bench crashes before running (`scripts/bench_cuda_train_step.py`)
`backend.model_cls(cfg, device=device)` raised `TypeError` — the CUDA backend's `model_cls` takes only `(cfg)` and selects `cuda:0` internally (mirroring `scripts/train.py`). Dropped the stray `device=` kwarg.

## Test
- `tests/test_val_loss.py`, `tests/test_masked_ce.py` — pass (contract preserved).
- Full portable suite: **487 passed, 3 skipped** (env-gated: datatrove/CUDA/code-verifier).
- Both paths exercised on the H100: the bench runs (2.88 s/step) and the run's eval now completes in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)