### PR TITLE
fix: select Qwen2.5 tokenizer in eval_olmes.py + generate.py (#13)

### DIFF
--- a/scripts/eval_olmes.py
+++ b/scripts/eval_olmes.py
@@ -6,10 +6,12 @@ end": with random-init or 100M-scale weights the accuracies will sit near
 chance — that is expected and fine for the POC.
 
 Needs the eval extra (pip install -e ".[eval]") and network for the HF
-datasets + OLMo tokenizer. If `datasets` refuses
-piqa's script-based loader, set HF_DATASETS_TRUST_REMOTE_CODE=1 or drop piqa.
+datasets + the model tokenizer. Pick the tokenizer that matches the config with
+`--tokenizer` (default `qwen25`, the active distillation program; use `olmo` for
+the original OLMo-vocab `config/poc.yaml`). If `datasets` refuses piqa's
+script-based loader, set HF_DATASETS_TRUST_REMOTE_CODE=1 or drop piqa.
 
-    .venv/bin/python scripts/eval_olmes.py --config config/poc.yaml --tasks piqa --limit 10
+    .venv/bin/python scripts/eval_olmes.py --config config/poc-qwen.yaml --tasks piqa --limit 10
 """
 
 from __future__ import annotations
@@ -30,8 +32,11 @@ def main() -> None:
     ap.add_argument("--limit", type=int, default=None,
                     help="examples per task (small values for smoke runs)")
     ap.add_argument("--output", type=Path, default=None, help="write results JSON here")
+    ap.add_argument("--tokenizer", choices=("qwen25", "olmo"), default="qwen25",
+                    help="tokenizer matching the config's vocab (default: qwen25; "
+                         "use olmo for the OLMo-vocab config/poc.yaml)")
     ap.add_argument("--byte-fallback", action="store_true",
-                    help="offline ByteTokenizer (toy config only; not OLMo-compatible)")
+                    help="offline ByteTokenizer (toy config only; not OLMo/Qwen-compatible)")
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args()
 
@@ -56,7 +61,11 @@ def main() -> None:
             "lm-eval not found — install the eval extra:\n"
             "    .venv/bin/pip install -e \".[eval]\""
         ) from e
-    from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
+    from src.data.tokenize import (
+        ByteTokenizer,
+        load_olmo_tokenizer,
+        load_qwen25_tokenizer,
+    )
     from src.eval.olmes_adapter import make_lm_eval_adapter
     from src.model.blocks import load_config
     from src.model.mlx_backend import MLXMambaModel
@@ -72,7 +81,12 @@ def main() -> None:
         print("RANDOM INIT — no --weights given; scores will be chance level.")
         print("=" * 70)
 
-    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer()
+    if args.byte_fallback:
+        tok = ByteTokenizer()
+    elif args.tokenizer == "qwen25":
+        tok = load_qwen25_tokenizer()
+    else:
+        tok = load_olmo_tokenizer()
     # A tokenizer that can emit ids >= the model vocab would crash deep in the
     # embedding lookup; fail here with a clear message instead.
     if tok.vocab_size > cfg.vocab_size:

--- a/scripts/eval_olmes.py
+++ b/scripts/eval_olmes.py
@@ -25,7 +25,7 @@ import numpy as np
 
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
+    ap.add_argument("--config", type=Path, default=Path("config/poc-qwen.yaml"))
     ap.add_argument("--weights", type=Path, default=None,
                     help="portable .safetensors checkpoint; RANDOM INIT if omitted")
     ap.add_argument("--tasks", default="hellaswag,arc_easy,arc_challenge,piqa")

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -51,8 +51,11 @@ def main() -> None:
     ap.add_argument("--no-repeat-ngram-size", type=int, default=None,
                     help="hard-ban repeating any n-gram of this size (e.g. 3)")
     ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--tokenizer", choices=("qwen25", "olmo"), default="qwen25",
+                    help="tokenizer matching the config's vocab (default: qwen25; "
+                         "use olmo for the OLMo-vocab config/poc.yaml)")
     ap.add_argument("--byte-fallback", action="store_true",
-                    help="offline ByteTokenizer (toy config only; not OLMo-compatible)")
+                    help="offline ByteTokenizer (toy config only; not OLMo/Qwen-compatible)")
     args = ap.parse_args()
     if not args.chat and args.prompt is None:
         ap.error("provide --prompt for completion mode, or --chat for the REPL")
@@ -65,7 +68,11 @@ def main() -> None:
         raise SystemExit(
             "mlx not found — run with the project venv on Apple Silicon:\n"
             "    .venv/bin/python scripts/generate.py ...")
-    from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
+    from src.data.tokenize import (
+        ByteTokenizer,
+        load_olmo_tokenizer,
+        load_qwen25_tokenizer,
+    )
     from src.model.blocks import load_config
     from src.model.mlx_backend import MLXMambaModel
 
@@ -78,7 +85,12 @@ def main() -> None:
     else:
         print("RANDOM INIT — no --weights; output will be gibberish.", file=sys.stderr)
 
-    tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer()
+    if args.byte_fallback:
+        tok = ByteTokenizer()
+    elif args.tokenizer == "qwen25":
+        tok = load_qwen25_tokenizer()
+    else:
+        tok = load_olmo_tokenizer()
     if tok.vocab_size > cfg.vocab_size:
         raise SystemExit(
             f"tokenizer vocab {tok.vocab_size} exceeds model vocab {cfg.vocab_size} "

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -36,7 +36,7 @@ from src.serve.sessions import SessionStore
 def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
+    ap.add_argument("--config", type=Path, default=Path("config/poc-qwen.yaml"))
     ap.add_argument("--weights", type=Path, default=None,
                     help="portable .safetensors checkpoint; RANDOM INIT if omitted")
     ap.add_argument("--prompt", default=None, help="completion-mode prompt")


### PR DESCRIPTION
## What

`scripts/eval_olmes.py` hard-loaded the **OLMo** tokenizer, but the active `poc-qwen` model (and the M10 distillation students) use the **Qwen2.5** tokenizer. Running OLMES on the trained ~205M `poc-qwen` checkpoint therefore used the wrong tokenizer.

## Change

- Add `--tokenizer {qwen25,olmo}` (default `qwen25`, the active program), wired to the existing `load_qwen25_tokenizer` in `src/data/tokenize.py`.
- `olmo` keeps the original OLMo-vocab `config/poc.yaml` path working; `--byte-fallback` still takes precedence for toy configs.
- Docstring + example updated to `config/poc-qwen.yaml`.

## Validation

Ran end-to-end on the trained ~205M `poc-qwen` weights (`--tokenizer qwen25 --limit 200`):

| Task | acc | acc_norm |
|---|---|---|
| arc_challenge | 0.230 | 0.190 |
| arc_easy | 0.300 | 0.365 |
| hellaswag | 0.320 | 0.315 |
| piqa | 0.530 | 0.525 |

Runs clean; near-chance scores as expected at 205M (the POC criterion is the val-ppl curve, not benchmark scores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjE2MKaukTLNNqRi7n1Gc2