### PR TITLE
chore(distill): add 1k validation manifest (#65)

### DIFF
--- a/config/manifests/student-1b-attn-hi-1k.yaml
+++ b/config/manifests/student-1b-attn-hi-1k.yaml
@@ -7,10 +7,11 @@
 # layout are unchanged. corpus/teacher_outputs are supplied via the distill.py / precompute_teacher.py
 # CLI args, so they are left empty here.
 #
-# Validated 2026-06-21 on an A100 80GB (batch 2, expandable_segments): all three stages' losses
-# decreased and a portable student weights.safetensors was written. NOTE: MOHAWK stage 1
-# (mixing-match) materializes a per-layer (B, H, L, L) mixing matrix for both student and teacher —
-# O(L^2) memory — so keep the micro-batch small at seq 1024 (batch 8 OOMs an 80GB card; batch 2 fits).
+# Validated 2026-06-21 on an A100 80GB (batch 2, env PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True):
+# all three stages' losses decreased and a portable student weights.safetensors was written. NOTE:
+# MOHAWK stage 1 (mixing-match) materializes a per-layer (B, H, L, L) mixing matrix for both student
+# and teacher — O(L^2) memory — so keep the micro-batch small at seq 1024 (batch 8 OOMs an 80GB card;
+# batch 2 fits) and set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True to limit fragmentation.
 student: 1b-attn-hi-1k
 conversion_teacher: open-r1/OpenR1-Distill-7B
 tokenizer: qwen25                # Qwen2.5 vocab 151646 (#90) — teacher shares it

--- a/config/manifests/student-1b-attn-hi-1k.yaml
+++ b/config/manifests/student-1b-attn-hi-1k.yaml
@@ -1,0 +1,26 @@
+# Path A validation variant of student-1b-attn-hi.yaml (#65 / M10).
+#
+# Purpose: prove the real distillation pipeline (#94 teacher top-k precompute + #81 distill driver)
+# works end-to-end on cloud — with the REAL 7B teacher and the REAL ~1B student — cheaply, before
+# building the full 8k corpus. Only seq_len (8192 -> 1024, reusing the existing 1k Qwen corpus) and
+# the stage list (distillation stages only) differ from student-1b-attn-hi.yaml; the teacher and
+# layout are unchanged. corpus/teacher_outputs are supplied via the distill.py / precompute_teacher.py
+# CLI args, so they are left empty here.
+#
+# Validated 2026-06-21 on an A100 80GB (batch 2, expandable_segments): all three stages' losses
+# decreased and a portable student weights.safetensors was written. NOTE: MOHAWK stage 1
+# (mixing-match) materializes a per-layer (B, H, L, L) mixing matrix for both student and teacher —
+# O(L^2) memory — so keep the micro-batch small at seq 1024 (batch 8 OOMs an 80GB card; batch 2 fits).
+student: 1b-attn-hi-1k
+conversion_teacher: open-r1/OpenR1-Distill-7B
+tokenizer: qwen25                # Qwen2.5 vocab 151646 (#90) — teacher shares it
+seq_len: 1024
+layout:
+  d_model: 2048
+  n_layers: 28                   # ~1.03B params; matches the teacher's 28 layers (Mamba-in-the-Llama init)
+  attention_every: 8             # 3 of 28 layers attention (~10.7%) — mirrors student-1b-attn-hi
+  state_size: 128                # -> MambaConfig.d_state
+init: mamba-in-the-llama
+stages: [mixing-match, hidden-align, logit-distill]
+corpus: ""                       # supplied via distill.py --corpus
+teacher_outputs: ""              # supplied via precompute_teacher.py --out / distill.py --teacher-outputs


### PR DESCRIPTION
## What

Adds `config/manifests/student-1b-attn-hi-1k.yaml` — a **Path A validation** variant of `student-1b-attn-hi.yaml`: `seq_len 1024` (reuses the existing 1k Qwen corpus) with the distillation stages only. The real 7B teacher (`open-r1/OpenR1-Distill-7B`) and ~1B student layout are unchanged.

## Why

It lets us prove the real distillation pipeline (**#94** teacher top-k precompute + **#81** distill driver) works end-to-end **on cloud, with the real models, cheaply** — before investing in the full 8k corpus build (Path B). Corpus/teacher-outputs are passed via CLI, so the manifest only encodes the architecture + stages.

## Validation (A100 80GB, 2026-06-21)

Precompute over a 4M/1M-token real-Qwen slice, then `distill.py` through all three stages:

| Stage | loss start → min |
|---|---|
| mixing-match | 0.001135 → 0.000249 |
| hidden-align | 186.9 → 49.6 |
| logit-distill | 5.708 → 4.22 |

All stages decreased; portable `weights.safetensors` (~1B, 4.12 GB) written. Init correctly froze the 3 attention layers `[7, 15, 23]` (~979.8M trainable).

**Gotcha captured in the file's header:** MOHAWK stage 1 materializes a per-layer `(B, H, L, L)` mixing matrix for student + teacher (O(L²)), so at seq 1024 a micro-batch of 8 OOMs an 80 GB card — use batch 2 + `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjE2MKaukTLNNqRi7n1Gc2