### PR TITLE
feat: Distill efficiency: SDPA/FlashAttention for the hybrid attention layers

### DIFF
--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -526,17 +526,24 @@ class AttentionBlock(nn.Module):
         q, k, v = self._qkv(xn, cd)                          # (B,H,L,Dh) fp32
         cos, sin = _rope_cos_sin(torch.arange(L, device=x.device), self.Dh)
         q, k = _apply_rope(q, cos, sin), _apply_rope(k, cos, sin)
-        scores = (q @ k.transpose(-1, -2)) / math.sqrt(self.Dh)      # (B,H,L,L)
-        causal = torch.tril(torch.ones((L, L), dtype=torch.bool, device=x.device))
+        # SDPA (#144): fuses QKᵀ/softmax/AV and never materializes the (B,H,L,L) score
+        # tensor — the O(L²) memory hot spot at seq 8192. GEMMs run in the compute dtype
+        # (cd); softmax stays fp32-stable inside SDPA. In an fp32 config cd==fp32, so this
+        # matches the old eager path within reduction order (parity holds at ~1e-4); a
+        # bf16 run becomes FlashAttention-eligible.
+        q, k, v = q.to(cd), k.to(cd), v.to(cd)
+        scale = 1.0 / math.sqrt(self.Dh)
         if seg_ids is None:
-            scores = scores.masked_fill(~causal, float("-inf"))
+            out = F.scaled_dot_product_attention(q, k, v, is_causal=True, scale=scale)
         else:
             # Block-diagonal: a token only attends within its own document (#68). Exact for
             # arbitrary boundaries (attention needs no chunk-alignment, unlike the SSM scan).
+            # The causal diagonal keeps each row's self-key, so no row is fully masked (no NaN).
+            causal = torch.tril(torch.ones((L, L), dtype=torch.bool, device=x.device))
             same = seg_ids[:, :, None] == seg_ids[:, None, :]        # (B,L,L)
             allow = causal[None] & same                             # (B,L,L)
-            scores = scores.masked_fill(~allow[:, None], float("-inf"))
-        out = _softmax_lastdim(scores) @ v                   # (B,H,L,Dh)
+            out = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=allow[:, None], scale=scale)      # (B,H,L,Dh)
         out = out.permute(0, 2, 1, 3).reshape(x.shape[0], L, self.H * self.Dh)
         return x + _linear(self.o_proj, _cast(out, cd), cd)
 

--- a/src/model/cuda_teacher.py
+++ b/src/model/cuda_teacher.py
@@ -151,10 +151,9 @@ class CUDATeacher(ConversionTeacher):
         h = self._w["embed"][tokens]                          # (B, L, D)
         L = h.shape[1]
         cos, sin = _rope_cos_sin(torch.arange(L, device=self._device), c.head_dim, c.rope_theta)
-        mask = self._causal_mask(L)
         hidden: List[torch.Tensor] = [h] if return_hidden else []
         for i in range(c.n_layers):
-            h = h + self._attn(h, i, cos, sin, mask)
+            h = h + self._attn(h, i, cos, sin)
             h = h + self._mlp(h, i)
             if return_hidden:
                 hidden.append(h)
@@ -178,11 +177,11 @@ class CUDATeacher(ConversionTeacher):
         h = self._w["embed"][tokens]
         L = h.shape[1]
         cos, sin = _rope_cos_sin(torch.arange(L, device=self._device), c.head_dim, c.rope_theta)
-        mask = self._causal_mask(L)
+        mask = self._causal_mask(L)                           # still needed by _attn_probs
         mats = []
         for i in range(c.n_layers):
             mats.append(self._attn_probs(h, i, cos, sin, mask).detach())
-            h = h + self._attn(h, i, cos, sin, mask)
+            h = h + self._attn(h, i, cos, sin)
             h = h + self._mlp(h, i)
         return tuple(mats)
 
@@ -231,8 +230,8 @@ class CUDATeacher(ConversionTeacher):
         scores = scores.masked_fill(~mask, float("-inf"))
         return _softmax_lastdim(scores).mean(dim=1)              # head-average -> (B,L,L)
 
-    def _attn(self, x: torch.Tensor, i: int, cos: torch.Tensor, sin: torch.Tensor,
-              mask: torch.Tensor) -> torch.Tensor:
+    def _attn(self, x: torch.Tensor, i: int, cos: torch.Tensor,
+              sin: torch.Tensor) -> torch.Tensor:
         c = self.config
         p = f"layer.{i}."
         B, L, _ = x.shape
@@ -251,9 +250,14 @@ class CUDATeacher(ConversionTeacher):
         if Hkv != Hq:                                          # GQA: repeat kv across groups
             rep = Hq // Hkv
             k, v = k.repeat_interleave(rep, dim=1), v.repeat_interleave(rep, dim=1)
-        scores = (q @ k.transpose(-1, -2)) / math.sqrt(Dh)      # (B,Hq,L,L)
-        scores = scores.masked_fill(~mask, float("-inf"))
-        out = _softmax_lastdim(scores) @ v                     # (B,Hq,L,Dh)
+        # SDPA (#144): attention here is pure-causal (the teacher has no seg_ids path), so
+        # `is_causal=True` reproduces `mask` without materializing the (B,Hq,L,L) score
+        # tensor — the dominant #94 precompute hot spot at seq 8192. SDPA inherits q/k/v
+        # dtype (fp32 — weights load fp32) and keeps the softmax fp32-stable internally. The
+        # mixing-matrix path (`_attn_probs`) stays eager: it needs the softmax weights, which
+        # SDPA does not expose.
+        out = F.scaled_dot_product_attention(q, k, v, is_causal=True,
+                                             scale=1.0 / math.sqrt(Dh))   # (B,Hq,L,Dh)
         out = out.permute(0, 2, 1, 3).reshape(B, L, Hq * Dh)
         return out @ self._w[p + "o_w"].t()                    # (B,L,D), o has no bias
 


### PR DESCRIPTION
Closes #144

## Summary
Replaces the hand-rolled eager attention (`QKᵀ/√Dh` → manual softmax → `@V`) with `torch.nn.functional.scaled_dot_product_attention` (SDPA) in the two places the idiom appears in the CUDA backend:

- **`AttentionBlock.forward_seq`** (hybrid student): casts q/k/v to the compute dtype before SDPA, so **fp32 configs are numerically unchanged** (parity holds at ~1e-4) while **bf16 runs become FlashAttention-eligible**. `is_causal=True` for the single-doc path; a block-diagonal boolean `attn_mask` (`causal & same-doc`) preserves the #68 `seg_ids` packing-aware doc-boundary reset. The causal diagonal guarantees no fully-masked row (no NaN).
- **`CUDATeacher._attn`** (the dominant #94 teacher-precompute path): pure-causal, so `is_causal=True` reproduces the prior mask **without materializing the `(B,Hq,L,L)` score tensor** — the O(L²) memory hot spot at seq 8192. Drops the now-unused `mask` arg/build from `_attn` and its callers.

Left eager by design: the teacher **mixing-matrix** path (`_attn_probs`) needs the softmax *weights*, which SDPA doesn't expose; the decode **`step`** paths are single-query and `forward_step_parity`-sensitive.

> Note (follow-up, out of scope): the teacher loads weights as fp32 (`cuda_teacher.py:89`), so its SDPA win here is **memory** (avoids the score-tensor materialization). The flash *speed* kernel additionally needs a bf16 teacher.

## Testing
- [x] Tests added/updated — existing parity tests cover the changed paths
- [x] All tests passing — `cuda_parity` + `backend_parity` (MLX↔CUDA hybrid incl. seg_ids) + `cuda_teacher` parity at fp32 ~1e-4; full suite **486 passed, 3 expected skips**; import guard green
- [x] Manual testing completed — M4 smoke gate (resume exact, max|Δloss| 2.4e-07); CPU functional bench through the full hybrid train step (finite loss/grad)
- [ ] **Authoritative seq-8192 GPU before/after bench — deferred to the pod** (inherently a GPU task; to be recorded on #144 before closing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)