### PR TITLE
feat: Distill efficiency: torch.compile the student forward (#145)

### DIFF
--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -77,6 +77,13 @@ class MambaConfig:
     # 32GB and swaps). Off for toy/smoke (tiny; keep exact-resume cheap).
     grad_checkpoint: bool = False
 
+    # CUDA-only (#145): compile the student forward with torch.compile (inductor) to fuse
+    # the SSD scan + hybrid forward's many small ops (~1.3-2x on GPU). Opt-in and default
+    # OFF so every parity/conformance/smoke path runs the eager code unchanged. A no-op on
+    # MLX (the MLX backend never reads it) and on the eager torch path. The optional
+    # mamba-ssm/causal-conv1d kernels (#40) graph-break inductor around them (safe).
+    torch_compile: bool = False
+
     # --- hybrid attention (#67) ---
     # Make the model a Mamba-2 HYBRID: every Nth block is a causal multi-head
     # attention block INSTEAD OF a Mamba block (n_layers unchanged). Pure SSMs lag on

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -587,6 +587,12 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         self._state = None
         self.to(self._device)
         _report_fast_path_once(self._device)
+        # torch.compile (#145): fuse the pure-tensor forward (layer loop + head) via inductor.
+        # Opt-in (default off) so the eager path — and every parity/conformance run — is
+        # untouched. We compile the inner `_forward_compute` rather than `forward`, which
+        # opens with a numpy->tensor boundary that isn't cleanly traceable. A no-op when off.
+        if config.torch_compile:
+            self._forward_compute = torch.compile(self._forward_compute)
 
     def _head(self, h: Array) -> Array:
         # Logits + cross-entropy run in fp32 (wide-vocab softmax stability); h is upcast
@@ -607,6 +613,13 @@ class CUDAMambaModel(ModelInterface, nn.Module):
             return _checkpoint(layer.forward_seq, h, seg_ids, use_reentrant=False)
         return layer.forward_seq(h, seg_ids)
 
+    def _forward_compute(self, h: Array, seg: Array = None) -> Array:
+        """Pure-tensor forward (layer loop + final norm + head) — the region torch.compile
+        wraps (#145). Split out of `forward` so the numpy->tensor boundary stays eager."""
+        for layer in self.layers:
+            h = self._layer_forward(layer, h, seg)
+        return self._head(self.norm_f(h))
+
     # --- ModelInterface ---
     def forward(self, token_batch: Array, seg_ids: Array = None) -> Array:
         ids = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
@@ -614,9 +627,7 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         seg = None
         if seg_ids is not None:                      # (B, L) document ids -> boundary-aware (#68)
             seg = torch.as_tensor(np.asarray(seg_ids), dtype=torch.long, device=self._device)
-        for layer in self.layers:
-            h = self._layer_forward(layer, h, seg)
-        return self._head(self.norm_f(h))
+        return self._forward_compute(h, seg)
 
     def step(self, token: Array, state: State) -> Tuple[Array, State]:
         ids = torch.as_tensor(np.asarray(token), dtype=torch.long, device=self._device)

--- a/tests/test_cuda_compile.py
+++ b/tests/test_cuda_compile.py
@@ -1,0 +1,81 @@
+"""torch.compile of the CUDA student forward (#145). Torch CPU; skipped where torch
+(or a working inductor/C-compiler) is absent.
+
+The flag `MambaConfig.torch_compile` wraps `CUDAMambaModel._forward_compute` with
+torch.compile. These guard two things:
+  * compile changes NO numerics — compiled vs eager logits agree at fp32 ~1e-4, built
+    from one shared state_dict (the same standard as tests/test_cuda_parity.py);
+  * the compiled region traces through the grad-checkpoint wrapper (the riskiest
+    interaction the #145 plan flagged) — a forward+backward yields finite grads.
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import load_config
+from src.model.cuda_backend import CUDAMambaModel
+
+
+def _np(a):
+    return a.detach().cpu().numpy()
+
+
+@pytest.fixture(scope="module")
+def _compile_works():
+    """Skip the whole module if torch.compile can't run here (e.g. CI without a C
+    compiler) — feature-detect on a trivial fn rather than assume."""
+    try:
+        f = torch.compile(lambda t: t * 2 + 1)
+        f(torch.zeros(2))
+    except Exception as e:  # pragma: no cover - environment-dependent
+        pytest.skip(f"torch.compile unusable here: {type(e).__name__}: {e}")
+
+
+def test_compiled_forward_matches_eager(_compile_works):
+    """Compiled forward == eager forward at fp32 ~1e-4 (hybrid: Mamba + attention)."""
+    torch.manual_seed(0)
+    cfg = load_config("config/toy-hybrid.yaml")          # fp32, exercises both block types
+    eager = CUDAMambaModel(cfg)
+    eager.eval()
+
+    cfg_c = load_config("config/toy-hybrid.yaml")
+    cfg_c.torch_compile = True
+    compiled = CUDAMambaModel(cfg_c)
+    compiled.load_state_dict(eager.state_dict())         # share weights exactly
+    compiled.eval()
+
+    B, L = 2, cfg.seq_len
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    with torch.no_grad():
+        y_eager = _np(eager.forward(tokens))
+        y_comp = _np(compiled.forward(tokens))
+    max_abs = float(np.max(np.abs(y_eager - y_comp)))
+    assert np.allclose(y_eager, y_comp, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
+
+
+def test_compiled_grad_checkpoint_backward_runs(_compile_works):
+    """Compile + grad_checkpoint (use_reentrant=False) traces and backprops to finite
+    grads — the interaction the #145 plan called out as the likely break point."""
+    torch.manual_seed(0)
+    cfg = load_config("config/toy-hybrid.yaml")
+    cfg.torch_compile = True
+    cfg.grad_checkpoint = True
+    model = CUDAMambaModel(cfg)
+    model.train()
+
+    B, L = 2, cfg.seq_len
+    rng = np.random.default_rng(1)
+    tokens = rng.integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    targets = torch.as_tensor(rng.integers(0, cfg.vocab_size, size=(B, L)), dtype=torch.long)
+
+    logits = model.forward(tokens)                        # (B, L, V), fp32 head
+    loss = torch.nn.functional.cross_entropy(
+        logits.reshape(-1, logits.shape[-1]), targets.reshape(-1))
+    loss.backward()
+
+    assert torch.isfinite(loss), f"non-finite loss {loss}"
+    grads = [p.grad for p in model.parameters() if p.grad is not None]
+    assert grads, "no gradients populated"
+    assert all(torch.isfinite(g).all() for g in grads), "non-finite gradient"


### PR DESCRIPTION
Closes #145

## Summary
Adds an opt-in `torch.compile` path for the CUDA student forward, defaulting **off** so every existing parity/conformance/smoke path runs the eager code unchanged.

- **`MambaConfig.torch_compile: bool = False`** (`src/model/blocks.py`) — a portable bool (no torch import above the seam; import guard stays green). No-op on MLX and on the eager torch path.
- **`CUDAMambaModel`** (`src/model/cuda_backend.py`) — splits the pure-tensor region (layer loop + final norm + head) into `_forward_compute`, leaving the numpy→tensor boundary in `forward` eager (not cleanly traceable). When the flag is set, `__init__` wraps `_forward_compute` with `torch.compile`.
- Left eager by design: `step`/decode and the distill accessors (short sequences / shape churn). The optional `mamba-ssm`/`causal-conv1d` kernels (#40) graph-break inductor around them (safe partitions); grad-checkpoint stays inside the compiled region.

> Scope: **student only** (per plan). Teacher-forward compile (`CUDATeacher.forward`, the dominant #94 cost) is a clean fast-follow once this lever is proven on the pod.

## Testing
- [x] Tests added — `tests/test_cuda_compile.py`: compiled-vs-eager forward parity at fp32 ~1e-4 (shared `state_dict`), and a compile×grad_checkpoint backward to finite grads (the flagged risk).
- [x] All tests passing — full suite **488 passed, 3 expected skips**; import guard green; `test_cuda_parity` green.
- [x] Manual testing — M4 smoke gate resume-exact (max|Δloss| 1.19e-07); bench wiring-sanity through the full train step shows **identical loss/grad_norm** compile-off vs on, with a ~19.7s one-time CPU compile warmup.
- [ ] **Authoritative seq-8192 GPU before/after bench — pod-deferred** (and whether the win nets out over a sweep trial's step count given compile warmup); to be recorded on #145 before closing.

## Note
Independent of #144 (PR #146, SDPA) — both touch `src/model/cuda_backend.py`, so a rebase/merge-order check is wanted when both land. This branch is off `main` (pre-SDPA); compile simply wraps whatever attention path is present once they merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)