### PR TITLE
feat(mlx): local dev-velocity — compile/fp16 teacher, API teacher, small configs, validate recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,14 @@ python -m src.data.split --packed data/packed.bin --out data/split --val-tokens 
 
 For a **real corpus** and the full train → serve → eval flow, see
 [`docs/usage.md`](docs/usage.md); for the **cloud** (R2 + RunPod) pipeline, see
-[`docs/infrastructure.md`](docs/infrastructure.md).
+[`docs/infrastructure.md`](docs/infrastructure.md). To **validate every stage locally** in one
+offline command — and for the small local-training configs (`config/small.yaml`,
+`config/poc-small.yaml`) and the local Qwen3 teacher — see
+[`docs/local-development.md`](docs/local-development.md):
+
+```bash
+scripts/local_validate.sh      # data → smoke gate → small.yaml train → distill smoke → teacher precompute
+```
 
 Run the smoke gate (the M4 gate) to confirm the backend, training loop, and exact-resume all
 pass before scaling:

--- a/config/poc-small.yaml
+++ b/config/poc-small.yaml
@@ -1,0 +1,48 @@
+# poc-small.yaml — ~97M, REAL-BUT-SLOW local POC (the "<=100M trained locally" target).
+#
+# Purpose: the largest model you can plausibly TRAIN on Apple Silicon and still call a model —
+# a real-tokenizer (~97M) run for local POC experiments, distinct from small.yaml (fast code-path
+# iteration) and poc.yaml (~127M, the cloud/reserve scale run). It is poc.yaml's layout dialed
+# down to land just under 100M total: same head width and SSM, fewer/narrower layers.
+#
+# COST EXPECTATION (set before you start): MEASURED on an M-series part via
+# `scripts/bench_train_step.py --config config/poc-small.yaml --batch 16 --grad-accum 2` ->
+# ~18.8 s/step at 32,768 tok/step, peak ~12.9 GB (first step ~21 s incl. init). That is ~75 s/step
+# if scaled to poc.yaml's 131,072-tok protocol — comparable per-token to poc's ~99 s/step baseline
+# (issue #31) but well under half the memory. So a Chinchilla-ish ~2B-token run is on the order of
+# DAYS of local compute: this config is for SHORT local POC runs, not a from-scratch pretrain. For
+# real scale, train on CUDA cloud (poc.yaml / the distillation path).
+d_model: 768           # d_inner = expand*d_model = 1536
+n_layers: 16           # poc.yaml is 24; 16 lands ~97M total (see below)
+d_state: 16            # SSM state width N (per head, shared B/C group)
+expand: 2
+d_conv: 4
+head_dim: 64           # Mamba-2/SSD: 1536/64 = 24 heads (scalar A per head)
+dt_rank: auto
+
+vocab_size: 50280      # allenai/OLMo-7B-hf (<65536 -> uint16). OLMo (not Qwen3) keeps the tied
+                       # embedding (50280*768 ~= 38.6M) from dominating, so layers ~= 58.7M and the
+                       # total is a clean ~97.4M. (Qwen3's 151k vocab would make embedding ~116M and
+                       # blow the <=100M budget — the documented poc-qwen embedding-heavy tradeoff.)
+seq_len: 1024
+tie_embeddings: true   # MANDATORY: the embedding is a large share of the budget at this vocab.
+
+# fp16 + dynamic loss scaling — the Metal-friendly precision path (#3; ~16% over bf16).
+precision: fp16
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: true  # 16 layers is lighter than poc's 24, but keep recompute on by default so
+                       # the fp16 backward stays within unified memory. Safe to set false if you
+                       # have headroom and want a faster step (measure peak with bench_train_step).
+
+# dt-projection bias init (load-bearing — identical across the config family)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001
+
+# --- Local POC run (decision record; run params are CLI flags, not model config) -----
+#   # Build a real OLMo-tokenized corpus (or reuse one); then a short local run:
+#   .venv/bin/python scripts/train.py --config config/poc-small.yaml --data data/split \
+#       --out runs/poc-small --total-tokens 200000000 --batch-size 16 --grad-accum 2 \
+#       --eval-every 200 --ckpt-every 500
+# Success = a smoothly decreasing val_perplexity in runs/poc-small/metrics.jsonl with a stable
+# grad_norm (the POC bar, not benchmark scores — issue #13).

--- a/config/small.yaml
+++ b/config/small.yaml
@@ -1,0 +1,44 @@
+# small.yaml — FAST LOCAL ITERATION config (~2.6M params, byte vocab).
+#
+# Purpose: exercise the REAL training/distill code paths end-to-end on Apple Silicon in
+# seconds, not validate a usable model. It sits in the gap between toy.yaml (~64K, 2 layers —
+# pure correctness/exact-resume) and poc*.yaml (~100-205M, 24 layers, ~99 s/step — too slow to
+# iterate on locally). Use it to sanity-check a change to the loop, the SSD scan, mixed
+# precision / loss scaling, checkpoint round-trip, or the distill stages before paying for a
+# cloud run. `scripts/local_validate.sh` trains this on the offline byte corpus.
+#
+# Real Mamba-2/SSD architecture (multi-head scalar-A SSM), just narrow + shallow.
+d_model: 256
+n_layers: 6
+d_state: 16            # SSM state width N (per head, shared B/C group)
+expand: 2              # d_inner = 512
+d_conv: 4
+head_dim: 64           # Mamba-2/SSD: 512/64 = 8 heads (scalar A per head)
+dt_rank: auto
+
+vocab_size: 256        # byte-fallback tokenizer -> runs fully offline (no HF download); matches
+                       # `tokenize --byte-fallback`. Bump to your tokenizer vocab to train on text.
+seq_len: 256
+tie_embeddings: true
+
+# fp16 + dynamic loss scaling on purpose: this is the precision path the real scale run uses
+# (#3), so the fast loop exercises the loss-scaler / overflow-skip stage too. Switch to fp32 if
+# you need bit-exact resume here (toy.yaml is the dedicated exact-resume gate).
+precision: fp16
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false # tiny + shallow -> activations fit easily; keep the step cheap
+
+# dt-projection bias init (load-bearing — identical across the config family)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001
+
+# --- Quick local smoke (a handful of steps on the offline byte corpus) ---------------
+#   python -m src.data.download --dummy --out data/raw --max-docs 2000
+#   python -m src.data.tokenize --in data/raw/dummy.txt --out data/ids.npy --byte-fallback
+#   python -m src.data.pack  --in data/ids.npy --out data/packed.bin
+#   python -m src.data.split --packed data/packed.bin --out data/small-split --val-tokens 2000
+#   .venv/bin/python scripts/train.py --config config/small.yaml --data data/small-split \
+#       --out runs/small --total-tokens 2000000 --batch-size 8 --grad-accum 1 --eval-every 50
+# MEASURED (M-series, `bench_train_step.py --config config/small.yaml --batch 8 --grad-accum 1`):
+# ~0.08 s/step at 2,048 tok/step, peak ~0.8 GB — sub-second iteration for code-path validation.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,8 +7,10 @@ implemented and verified; the M1–M8 milestones were tracked in
 [issue #2](https://github.com/travisgalloway/monica/issues/2). The **active program is M10 —
 distillation** ([issue #65](https://github.com/travisgalloway/monica/issues/65)). For the
 project overview, see the root [`README.md`](../../README.md); for end-to-end commands
-(install → data → train → serve/chat → eval) see [`../usage.md`](../usage.md), and for the
-cloud (R2 + RunPod) runbook see [`../infrastructure.md`](../infrastructure.md).
+(install → data → train → serve/chat → eval) see [`../usage.md`](../usage.md), for the
+cloud (R2 + RunPod) runbook see [`../infrastructure.md`](../infrastructure.md), and for the
+local Apple-Silicon dev loop (one-command validation, small training configs, local Qwen3
+teacher) see [`../local-development.md`](../local-development.md).
 
 Every claim here is sourced from a docstring or config comment in the code, with a
 `src/...` or `config/...` path so you can jump to the source of truth.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,138 @@
+# Local development on Apple Silicon (MLX)
+
+MLX is the **dev/validation backend**: it exists so you can prove a change correct, generate
+small amounts of teacher signal, and train test-scale models *locally* before paying for a CUDA
+cloud run. Scale training itself runs on CUDA/RunPod (see
+[`docs/infrastructure.md`](infrastructure.md)) — so this page is about **developer velocity**, not
+throughput. (The MLX *train-step throughput* optimizations were deliberately retired; see issue
+#30's decision record before reopening that.)
+
+Three things live here:
+
+1. [Validate every stage locally in one command](#1-validate-every-stage-locally)
+2. [Train test models locally (`small.yaml`, `poc-small.yaml`)](#2-train-test-models-locally)
+3. [Generate teacher signal locally (Qwen3 via MLX, or LM Studio)](#3-generate-teacher-signal-locally)
+
+All commands assume the Apple-Silicon install (`pip install -e ".[dev,data,mlx]"`) and the venv
+at `.venv`.
+
+---
+
+## 1. Validate every stage locally
+
+```bash
+scripts/local_validate.sh
+```
+
+One offline command (no network / HF / weights) that fails fast through every pipeline stage:
+
+| Stage | What it runs | What it proves |
+|---|---|---|
+| 1 data | `download --dummy` → `tokenize --byte-fallback` → `pack` → `split` | the data pipeline end-to-end |
+| 2 smoke | `scripts/smoke_test.py` on a **fresh** byte split | resume is bit-exact + val eval runs (fp32) |
+| 3 train | `scripts/train.py --config config/small.yaml` | the real fp16 + loss-scaling training path |
+| 4 distill | `scripts/distill_smoke.py` | the 3 staged losses (mixing-match → hidden-align → logit-distill) |
+| 5 teacher | `scripts/precompute_teacher.py --backend mlx --synthetic --compile` | the #94 precompute + the `mx.compile` lever |
+
+Knobs (env vars): `PYTHON` (default `.venv/bin/python`), `WORK` (default `runs/local-validate`),
+`STEPS` (default 20), `KEEP=1` to keep the work dir. Use this as the pre-push gate for any change
+to the loop, the SSD scan, mixed precision, checkpointing, or the distill stages.
+
+> The smoke gate must run on a **freshly built byte split**, not the real `data/split` (which is
+> the OLMo-vocab corpus) — `local_validate.sh` builds one for you.
+
+---
+
+## 2. Train test models locally
+
+There are now four rungs, so you can pick the one that matches your iteration speed:
+
+| Config | Params | Use | Cost (measured, M-series) |
+|---|---|---|---|
+| `config/toy.yaml` | ~64K | correctness / exact-resume gate | instant |
+| `config/small.yaml` | ~2.6M | **fast code-path iteration** (byte vocab, fp16) | **~0.08 s/step** @ 2,048 tok, ~0.8 GB |
+| `config/poc-small.yaml` | ~97M | **largest "real" model trainable locally** (OLMo vocab) | **~18.8 s/step** @ 32,768 tok, ~12.9 GB |
+| `config/poc.yaml` | ~127M | cloud / reserve scale run | ~99 s/step @ 131,072 tok |
+
+`small.yaml` is for *validating that training/distill code works*, in seconds. `poc-small.yaml` is
+the ≤100M "trainable locally" target — real Mamba-2/SSD architecture and a real tokenizer, but a
+Chinchilla-ish run is still **days** of local compute (it's for short POC runs; use CUDA cloud for
+scale). Both carry their measured step-time in the YAML header.
+
+```bash
+# fast loop (byte corpus from stage 1 above):
+.venv/bin/python scripts/train.py --config config/small.yaml --data <byte-split> \
+    --out runs/small --total-steps 200 --batch-size 8 --grad-accum 1
+
+# ~97M local POC (needs a real OLMo-tokenized corpus):
+.venv/bin/python scripts/train.py --config config/poc-small.yaml --data data/split \
+    --out runs/poc-small --total-tokens 200000000 --batch-size 16 --grad-accum 2
+
+# measure step-time / peak memory for any config:
+.venv/bin/python scripts/bench_train_step.py --config config/poc-small.yaml --batch 16 --grad-accum 2
+```
+
+---
+
+## 3. Generate teacher signal locally
+
+The distillation student trains against **cached teacher top-k logits** (the #94 precompute), then
+the `logit-distill` stage matches them with KL. You can produce that signal locally two ways.
+
+### 3a. Real Qwen3 teacher via MLX — *the recommended path*
+
+`MLXConversionTeacher.from_pretrained` runs the actual Qwen3 weights on Apple Silicon (white-box:
+full forward, hidden states, and Q/K/V/O projections — so it supports init #99 and **all** matching
+stages #100, not just logit-distill):
+
+```bash
+.venv/bin/python scripts/precompute_teacher.py \
+    --manifest config/manifests/student-1b-attn-hi.yaml \
+    --data data/poc-distill/split --backend mlx \
+    --pretrained Qwen/Qwen3-4B-Thinking-2507 \
+    --teacher-dtype fp16 --compile --k 50 --out runs/teacher-local
+```
+
+Two **local levers** (both opt-in; default is the bit-identical eager fp32 path, so conformance and
+the smoke gate are untouched):
+
+- `--teacher-dtype fp16` — hold/compute the teacher in fp16. Halves teacher memory (a 4B teacher
+  ~16 GB → ~8 GB), so it fits comfortably on a 32 GB Mac. RMSNorm/softmax stay fp32 internally.
+- `--compile` — `mx.compile` the teacher's logits-only forward (fixed-shape, forward-only — *not*
+  the student forward/eval path #30 rejected). Fuses the per-layer op stream; the cached top-k
+  **indices are identical** to eager (values within fp tolerance).
+
+> The `--pretrained` id must be one `precompute_teacher.py` knows (`_teacher_config_for`), so the
+> teacher's `effective_vocab_size` matches the manifest tokenizer vocab — otherwise it fails loudly
+> rather than caching unusable indices. At real corpus scale the footprint is large (k=50 ≈ 300
+> B/token); keep local runs to a small split.
+
+### 3b. LM Studio / OpenAI-compatible endpoint — *partial, convenience only*
+
+If a Qwen3 model is already loaded in [LM Studio](https://lmstudio.ai) (or llama.cpp `--server`,
+vLLM, …), point the precompute at its endpoint:
+
+```bash
+.venv/bin/python scripts/precompute_teacher.py \
+    --manifest config/toy-distill.yaml --data <split> --backend mlx \
+    --teacher-endpoint http://localhost:1234/v1 --endpoint-model qwen3-4b --k 10 \
+    --out runs/teacher-lmstudio
+```
+
+**This path is partial and approximate** (`src/model/api_teacher.py` documents it in full):
+
+- It implements **only** `topk_logits`, so it feeds the **logit-distill** stage only. An HTTP
+  endpoint exposes no weights/hidden states, so init (#99), `hidden-align`, and `mixing-match`
+  (#100) are **not** available — use 3a for those.
+- Values are **log-probs, not logits** (the KL temperature scaling is exact only at T=1), the
+  top-k count is **server-capped** (often ≤10–20), and top tokens are mapped string→id **best
+  effort** with the Qwen3 tokenizer (re-tokenization can drift the per-position alignment; the
+  teacher warns once).
+
+Prefer 3a for any real local validation; reach for 3b only as a quick convenience when the model
+is already serving.
+
+---
+
+See also: [`docs/usage.md`](usage.md) (full flow), [`docs/design/10-distillation.md`](design/10-distillation.md)
+(distillation design), [`docs/infrastructure.md`](infrastructure.md) (cloud R2 + RunPod).

--- a/scripts/local_validate.sh
+++ b/scripts/local_validate.sh
@@ -23,6 +23,12 @@ DATA="$WORK/data"
 
 cd "$(dirname "$0")/.."   # repo root
 echo "== local_validate :: python=$PY  work=$WORK  steps=$STEPS =="
+# Safety: WORK is rm -rf'd, so refuse empty / root / home / any absolute path — a mis-set
+# WORK (e.g. WORK=/) must never nuke the system. Keep it a relative path under the repo.
+case "$WORK" in
+  ""|"/"|"."|"./"|"~"*) echo "local_validate: refusing to rm unsafe WORK='$WORK'" >&2; exit 1 ;;
+  /*) echo "local_validate: refusing to rm absolute WORK='$WORK' (use a repo-relative path)" >&2; exit 1 ;;
+esac
 rm -rf "$WORK"; mkdir -p "$WORK"
 
 echo "== [1/5] data pipeline (offline byte fallback) =="

--- a/scripts/local_validate.sh
+++ b/scripts/local_validate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# local_validate.sh — one offline command that exercises every local pipeline stage on Apple
+# Silicon (or any host where the MLX backend imports). It is the "validate a change locally with
+# speed and ease" entry point: each stage fails fast, so a regression anywhere stops the run.
+#
+# Stages (all offline — byte-fallback tokenizer, synthetic teacher, no network/HF/weights):
+#   1. data     download(--dummy) -> tokenize(--byte-fallback) -> pack -> split
+#   2. smoke     scripts/smoke_test.py on a FRESH byte split (resume-exactness + val eval, fp32)
+#   3. train     scripts/train.py --config config/small.yaml  (a few real fp16 steps)
+#   4. distill   scripts/distill_smoke.py  (mixing-match -> hidden-align -> logit-distill, MLX)
+#   5. teacher   scripts/precompute_teacher.py --backend mlx --synthetic --compile
+#                (exercises the opt-in mx.compile teacher-forward lever)
+#
+# Usage:   scripts/local_validate.sh
+# Env:     PYTHON (default .venv/bin/python)   WORK (default runs/local-validate)
+#          STEPS (default 20)                  KEEP=1 to keep the work dir
+set -euo pipefail
+
+PY="${PYTHON:-.venv/bin/python}"
+WORK="${WORK:-runs/local-validate}"
+STEPS="${STEPS:-20}"
+DATA="$WORK/data"
+
+cd "$(dirname "$0")/.."   # repo root
+echo "== local_validate :: python=$PY  work=$WORK  steps=$STEPS =="
+rm -rf "$WORK"; mkdir -p "$WORK"
+
+echo "== [1/5] data pipeline (offline byte fallback) =="
+"$PY" -m src.data.download --dummy --out "$WORK/raw" --max-docs 8000
+"$PY" -m src.data.tokenize --in "$WORK/raw/dummy.txt" --out "$WORK/ids.npy" --byte-fallback
+"$PY" -m src.data.pack  --in "$WORK/ids.npy" --out "$WORK/packed.bin"
+"$PY" -m src.data.split --packed "$WORK/packed.bin" --out "$DATA" --val-tokens 4000
+
+echo "== [2/5] smoke gate (resume-exactness + val eval, fresh byte split) =="
+"$PY" scripts/smoke_test.py --config config/toy.yaml --data "$DATA" \
+    --steps "$STEPS" --batch-size 8 --out "$WORK/smoke"
+
+echo "== [3/5] small.yaml training (real fp16 path, $STEPS steps) =="
+"$PY" scripts/train.py --config config/small.yaml --data "$DATA" --out "$WORK/small" \
+    --total-steps "$STEPS" --batch-size 8 --grad-accum 1 --eval-every "$STEPS" --ckpt-every 100000
+
+echo "== [4/5] distillation smoke (3 staged losses, synthetic teacher) =="
+"$PY" scripts/distill_smoke.py --out "$WORK/distill" --backend mlx --steps-per-stage 8
+
+echo "== [5/5] teacher top-k precompute (MLX, synthetic, mx.compile lever) =="
+"$PY" scripts/precompute_teacher.py --manifest config/toy-distill.yaml --data "$DATA" \
+    --out "$WORK/teacher" --backend mlx --k 8 --synthetic --compile
+
+echo "== local_validate: ALL STAGES PASSED =="
+[ "${KEEP:-0}" = "1" ] || rm -rf "$WORK"

--- a/scripts/precompute_teacher.py
+++ b/scripts/precompute_teacher.py
@@ -45,6 +45,18 @@ def _parse_args() -> argparse.Namespace:
                     help="HF checkpoint dir / repo id (default: manifest.conversion_teacher)")
     ap.add_argument("--synthetic", action="store_true",
                     help="build a synthetic toy teacher (TeacherConfig.tiny) — offline tests only")
+    ap.add_argument("--teacher-endpoint", default=None,
+                    help="OpenAI-compatible base URL (e.g. LM Studio http://localhost:1234/v1) to use "
+                         "as a top-k-logit-only teacher. PARTIAL: feeds logit-distill only — no "
+                         "hidden-align/mixing-match/init. Prefer --pretrained for full fidelity.")
+    ap.add_argument("--endpoint-model", default=None,
+                    help="model name to request from --teacher-endpoint (default: server's loaded model)")
+    ap.add_argument("--teacher-dtype", choices=("fp32", "fp16"), default="fp32",
+                    help="MLX teacher compute dtype; fp16 halves teacher memory for the local "
+                         "Apple-Silicon precompute (default fp32 — the bit-identical path)")
+    ap.add_argument("--compile", action="store_true",
+                    help="mx.compile the MLX teacher's logits-only forward (fuses the per-layer "
+                         "op stream; opt-in, eager fp32 stays the default for conformance)")
     ap.add_argument("--push", default=None,
                     help="after writing, mirror --out to this fsspec URI / R2 prefix (#80)")
     return ap.parse_args()
@@ -86,13 +98,26 @@ def main() -> None:
     seq_len = manifest.seq_len
     backend = get_backend(args.backend)
 
-    if args.synthetic:
-        teacher = backend.make_teacher(config=TeacherConfig.tiny())
+    # MLX-local precompute levers (no-ops on the cuda backend, which has its own #145 path).
+    mlx_opts = {"compute_dtype": args.teacher_dtype, "compile": args.compile}
+
+    if args.teacher_endpoint:
+        # Backend-free, top-k-logit-only teacher over an OpenAI-compatible server (LM Studio etc.).
+        # PARTIAL: supports the logit-distill stage only; bypasses backend.make_teacher.
+        from src.model.api_teacher import ApiTopkTeacher
+        teacher = ApiTopkTeacher(base_url=args.teacher_endpoint, vocab_size=manifest.vocab_size,
+                                 tokenizer=manifest.tokenizer, model=args.endpoint_model)
+        teacher_info = {"model_id": args.endpoint_model, "endpoint": args.teacher_endpoint,
+                        "synthetic": False, "partial": "logit-distill only",
+                        "vocab_size": teacher.config.vocab_size}
+    elif args.synthetic:
+        teacher = backend.make_teacher(config=TeacherConfig.tiny(), **mlx_opts)
         teacher_info = {"model_id": None, "synthetic": True,
                         "vocab_size": teacher.config.vocab_size}
     else:
         model_id = args.pretrained or manifest.conversion_teacher
-        teacher = backend.make_teacher(config=_teacher_config_for(model_id), pretrained=model_id)
+        teacher = backend.make_teacher(config=_teacher_config_for(model_id), pretrained=model_id,
+                                       **mlx_opts)
         teacher_info = {"model_id": model_id, "synthetic": False,
                         "vocab_size": teacher.config.vocab_size}
         # Guard the foot-gun: if the teacher emits logits over a wider vocab than the student's

--- a/src/model/api_teacher.py
+++ b/src/model/api_teacher.py
@@ -1,0 +1,177 @@
+"""Top-k-logit-only conversion teacher over an OpenAI-compatible endpoint (LM Studio, llama.cpp
+`--server`, vLLM, ...). PORTABLE — pure stdlib + numpy + the HF tokenizer, no `mlx`/`torch` — so
+it stays above the seam and in `tests/test_import_guard.py`'s portable set.
+
+WHY THIS IS PARTIAL (read before using). A distillation conversion teacher is a frozen, white-box
+model: the student init (#99) reads its Q/K/V/O projections and embeddings, and the matching
+stages (#100) read per-layer hidden states (`hidden-align`) and attention matrices
+(`mixing-match`). A chat/completions HTTP endpoint exposes NONE of that — only per-token output
+logprobs. So this teacher implements ONLY `topk_logits`, which is enough to drive the **teacher
+top-k precompute (#94) -> the `logit-distill` stage (#100)** and nothing else. For real local
+validation prefer the full-fidelity MLX teacher (`precompute_teacher.py --backend mlx --pretrained
+Qwen/Qwen3-4B-Thinking-2507`, which runs the actual weights on Apple Silicon). Use this endpoint
+path only as a convenience when a model is already loaded in LM Studio.
+
+KNOWN APPROXIMATIONS (all documented, none silent):
+  * **logprobs, not logits.** Servers return log-probabilities (log-softmax over the full vocab).
+    The distill `_kl_topk` re-softmaxes the cached top-k at temperature T; at T==1 a constant
+    offset cancels so top-k logprobs == top-k logits, but at T!=1 the scaling is only approximate.
+  * **capped k.** The OpenAI `logprobs`/`top_logprobs` count is server-capped (often <=10-20), so
+    the effective cached k can be smaller than requested.
+  * **string->id remap.** Endpoints return top tokens as TEXT; we map them back to vocab ids with
+    the Qwen3 tokenizer best-effort (`convert_tokens_to_ids`, then a single-token `encode`
+    fallback). Unmappable entries are dropped (logged once).
+  * **re-tokenization alignment.** We must send the prompt as TEXT (ids are detokenized first),
+    and the server re-tokenizes; if its segmentation differs from the packed ids the per-position
+    alignment drifts. We align by position up to `seq_len`, padding/truncating, and warn once.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Tuple
+
+import numpy as np
+
+from .teacher import AttnProjections, ConversionTeacher
+
+_NEG_INF = float(np.finfo(np.float32).min)
+
+
+@dataclass
+class _ApiTeacherConfig:
+    """Minimal config the precompute driver reads (`vocab_size`, `effective_vocab_size`). The
+    endpoint teacher emits ids already clipped to the student tokenizer vocab, so the two match."""
+    vocab_size: int
+    n_layers: int = 0
+
+    @property
+    def effective_vocab_size(self) -> int:
+        return self.vocab_size
+
+
+def _http_post_json(url: str, payload: dict, timeout: float) -> dict:
+    """POST `payload` as JSON to `url`, return the parsed JSON response (stdlib only)."""
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:   # noqa: S310 (local trusted URL)
+        return json.loads(resp.read().decode("utf-8"))
+
+
+class ApiTopkTeacher(ConversionTeacher):
+    """Frozen top-k-logit-only teacher backed by an OpenAI-compatible completions endpoint.
+
+    Only `topk_logits` is supported; the white-box methods (`forward`, `attention_projection`,
+    `embedding_matrix`, `lm_head_matrix`) raise `NotImplementedError` pointing at `--pretrained`.
+    `_post`/`_tokenizer` are injectable seams so the unit tests run offline (no server, no HF).
+    """
+
+    def __init__(self, *, base_url: str, vocab_size: int, tokenizer: str = "qwen3",
+                 model: Optional[str] = None, timeout: float = 120.0,
+                 _post: Optional[Callable[[str, dict, float], dict]] = None,
+                 _tokenizer: Any = None):
+        if tokenizer != "qwen3" and _tokenizer is None:
+            raise ValueError(f"ApiTopkTeacher supports the qwen3 tokenizer (got {tokenizer!r}); the "
+                             "endpoint must serve a Qwen3-tokenizer model for id alignment")
+        self.config = _ApiTeacherConfig(vocab_size=int(vocab_size))
+        self._url = base_url.rstrip("/") + "/completions"
+        self._model = model
+        self._timeout = timeout
+        self._post = _post or _http_post_json
+        if _tokenizer is not None:
+            self._tok = _tokenizer
+        else:
+            from src.data.tokenize import load_qwen3_tokenizer   # lazy: HF, not in offline tests
+            self._tok = load_qwen3_tokenizer()
+        self._warned_align = False
+
+    # --- ConversionTeacher: the one supported method -------------------------
+    def topk_logits(self, token_batch, k: int) -> Tuple[np.ndarray, np.ndarray]:
+        """Per-token top-`k` (values, indices), each `(B, L, k)`, from the endpoint's logprobs.
+
+        Values are descending log-probs (see module note); padding for missing/unmappable entries
+        is `-inf` value / `0` index. Rows are processed one prompt at a time (echo + logprobs)."""
+        rows = np.asarray(token_batch)
+        if rows.ndim == 1:
+            rows = rows[None, :]
+        B, L = rows.shape
+        vals = np.full((B, L, k), _NEG_INF, dtype=np.float32)
+        idx = np.zeros((B, L, k), dtype=np.int64)
+        for b in range(B):
+            v_row, i_row = self._row_topk(rows[b].tolist(), L, k)
+            vals[b], idx[b] = v_row, i_row
+        return vals, idx
+
+    def _row_topk(self, ids: List[int], L: int, k: int) -> Tuple[np.ndarray, np.ndarray]:
+        prompt = self._tok.decode(ids)
+        payload = {"prompt": prompt, "max_tokens": 0, "echo": True, "logprobs": k,
+                   "temperature": 0.0}
+        if self._model is not None:
+            payload["model"] = self._model
+        resp = self._post(self._url, payload, self._timeout)
+        top_list = self._extract_top_logprobs(resp)
+        if len(top_list) != L and not self._warned_align:
+            print(f"ApiTopkTeacher: server re-tokenized prompt to {len(top_list)} positions != "
+                  f"seq_len {L}; aligning by position (truncate/pad). Top-k alignment is "
+                  f"APPROXIMATE — prefer --pretrained for exactness.", file=sys.stderr)
+            self._warned_align = True
+        vals = np.full((L, k), _NEG_INF, dtype=np.float32)
+        idx = np.zeros((L, k), dtype=np.int64)
+        for pos in range(min(L, len(top_list))):
+            pairs = self._map_tokens(top_list[pos])          # [(id, logprob), ...] descending
+            for j, (tid, lp) in enumerate(pairs[:k]):
+                vals[pos, j], idx[pos, j] = lp, tid
+        return vals, idx
+
+    @staticmethod
+    def _extract_top_logprobs(resp: dict) -> List[dict]:
+        """Pull the per-position `{token_str: logprob}` dicts from an OpenAI completions response."""
+        choices = resp.get("choices") or [{}]
+        lp = choices[0].get("logprobs") or {}
+        top = lp.get("top_logprobs")
+        return list(top) if top else []
+
+    def _map_tokens(self, top: dict) -> List[Tuple[int, float]]:
+        """Map a `{token_str: logprob}` dict to `[(vocab_id, logprob)]`, descending, dropping
+        unmappable tokens and ids outside the student tokenizer vocab."""
+        out: List[Tuple[int, float]] = []
+        for tok_str, lp in top.items():
+            tid = self._token_to_id(tok_str)
+            if tid is not None and 0 <= tid < self.config.vocab_size:
+                out.append((tid, float(lp)))
+        out.sort(key=lambda t: t[1], reverse=True)
+        return out
+
+    def _token_to_id(self, tok_str: str) -> Optional[int]:
+        tid = self._tok.convert_tokens_to_ids(tok_str)
+        unk = getattr(self._tok, "unk_token_id", None)
+        if isinstance(tid, int) and tid >= 0 and tid != unk:
+            return tid
+        enc = self._tok.encode(tok_str, add_special_tokens=False)
+        return enc[0] if len(enc) == 1 else None
+
+    def to_numpy(self, array) -> np.ndarray:
+        return np.asarray(array)
+
+    # --- ConversionTeacher: the white-box methods this path cannot provide ---
+    def forward(self, token_batch, *, return_hidden: bool = False):
+        raise NotImplementedError(self._unsupported("forward / hidden states"))
+
+    def attention_projection(self, layer: int) -> AttnProjections:
+        raise NotImplementedError(self._unsupported("attention projections (#99 init)"))
+
+    def embedding_matrix(self):
+        raise NotImplementedError(self._unsupported("embedding matrix (#99 init)"))
+
+    def lm_head_matrix(self):
+        raise NotImplementedError(self._unsupported("lm-head matrix (#99 init)"))
+
+    @staticmethod
+    def _unsupported(what: str) -> str:
+        return (f"ApiTopkTeacher exposes top-k logits only — {what} needs the model's weights, "
+                "which an OpenAI-compatible endpoint does not expose. Use a white-box teacher: "
+                "precompute_teacher.py --backend mlx --pretrained <Qwen3 id>.")

--- a/src/model/api_teacher.py
+++ b/src/model/api_teacher.py
@@ -24,6 +24,10 @@ KNOWN APPROXIMATIONS (all documented, none silent):
   * **re-tokenization alignment.** We must send the prompt as TEXT (ids are detokenized first),
     and the server re-tokenizes; if its segmentation differs from the packed ids the per-position
     alignment drifts. We align by position up to `seq_len`, padding/truncating, and warn once.
+  * **fully-padded positions.** When the server returns fewer positions than `seq_len` (or maps
+    no tokens at a position), that row is left entirely `_NEG_INF`. Such rows carry no teacher
+    signal; the distill loss (`_kl_topk` in mlx/cuda_distill) detects them (max over k below a
+    threshold) and EXCLUDES them from the KL average, so they inject no spurious gradient.
 """
 
 from __future__ import annotations

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -102,16 +102,22 @@ def _mlx_backend() -> Backend:
         from .mlx_train_step import make_grpo_train_step
         return make_grpo_train_step(*args, **kwargs)
 
-    def _make_teacher(config=None, *, pretrained=None, seed=0):
+    def _make_teacher(config=None, *, pretrained=None, seed=0,
+                      compute_dtype="fp32", compile=False):
         """Frozen conversion teacher (#93): `pretrained` (an HF checkpoint dir / repo id)
-        loads real weights; otherwise a synthetic teacher is built from `config`."""
+        loads real weights; otherwise a synthetic teacher is built from `config`.
+
+        `compute_dtype` ("fp32" default; "fp16" a local Apple-Silicon opt-in that halves teacher
+        memory) and `compile` (opt-in `mx.compile` of the logits-only forward) are MLX-local
+        precompute levers — both default to the bit-identical eager fp32 path."""
         from .mlx_teacher import MLXConversionTeacher
+        opts = dict(compute_dtype=compute_dtype, compile=compile)
         if pretrained is not None:
-            return MLXConversionTeacher.from_pretrained(pretrained, config)
+            return MLXConversionTeacher.from_pretrained(pretrained, config, **opts)
         if config is None:
             raise ValueError("make_teacher needs a TeacherConfig for the synthetic path "
                              "(pass `config=...`), or `pretrained=<dir/repo>` for real weights")
-        return MLXConversionTeacher.from_config(config, seed=seed)
+        return MLXConversionTeacher.from_config(config, seed=seed, **opts)
 
     def _init_student(student, teacher, method):
         """Initialize a student from a teacher (#99); `method` is an `InitMethod`."""
@@ -186,10 +192,14 @@ def _cuda_backend() -> Backend:
         from .cuda_train_step import make_grpo_train_step
         return make_grpo_train_step(*args, **kwargs)
 
-    def _make_teacher(config=None, *, pretrained=None, seed=0):
+    def _make_teacher(config=None, *, pretrained=None, seed=0,
+                      compute_dtype="fp32", compile=False):
         """Frozen conversion teacher (#93/#94), torch port. `pretrained` (an HF checkpoint dir /
         repo id) loads real weights — this is how the dominant teacher precompute runs on the
-        cloud GPU; otherwise a synthetic teacher is built from `config`."""
+        cloud GPU; otherwise a synthetic teacher is built from `config`.
+
+        `compute_dtype`/`compile` are accepted for a uniform `make_teacher` signature but are
+        MLX-local levers; the CUDA teacher's own dtype/torch.compile path is separate (#145)."""
         from .cuda_teacher import CUDATeacher
         if pretrained is not None:
             return CUDATeacher.from_pretrained(pretrained, config)

--- a/src/model/cuda_distill.py
+++ b/src/model/cuda_distill.py
@@ -41,11 +41,19 @@ def _kl_topk(student_logits: torch.Tensor, topk_vals: torch.Tensor, topk_idx: to
     `student_logits` (B,L,V) fp32; `topk_vals`/`topk_idx` (B,L,k). Teacher and student are each
     softmaxed over the SAME k indices at temperature T. Torch port of `mlx_distill._kl_topk`."""
     T = temperature
-    p = F.softmax(topk_vals.float() / T, dim=-1)                # teacher over support
+    tv = topk_vals.float()
+    p = F.softmax(tv / T, dim=-1)                               # teacher over support
     sg = torch.gather(student_logits, -1, topk_idx.long()) / T  # student logits at the k indices
     logq = sg - torch.logsumexp(sg, dim=-1, keepdim=True)       # student log-softmax / k
     kl = (p * (torch.log(p + 1e-9) - logq)).sum(dim=-1)         # (B,L)
-    return (T * T) * kl.mean()
+    # Mask fully-padded teacher positions (all _NEG_INF, or -inf after an fp16 cache round-trip
+    # — see ApiTopkTeacher): no teacher signal there, so don't let a uniform/NaN softmax inject
+    # a spurious target. No-op for white-box teachers (every row above threshold) -> parity-exact
+    # with the prior .mean(). Mirrors mlx_distill._kl_topk.
+    valid = tv.amax(dim=-1) > -1e30                             # (B,L)
+    kl = torch.where(valid, kl, torch.zeros_like(kl))
+    denom = valid.sum().clamp(min=1)
+    return (T * T) * (kl.sum() / denom)
 
 
 def _ce(logits: torch.Tensor, targets) -> torch.Tensor:

--- a/src/model/mlx_distill.py
+++ b/src/model/mlx_distill.py
@@ -45,11 +45,20 @@ def _kl_topk(student_logits: mx.array, topk_vals: mx.array, topk_idx: mx.array,
     softmaxed over the SAME k indices at temperature T, so the KL is computed on the shared
     support the cached signal (#94) provides."""
     T = temperature
-    p = mx.softmax(topk_vals.astype(mx.float32) / T, axis=-1)            # teacher over support
+    tv = topk_vals.astype(mx.float32)
+    p = mx.softmax(tv / T, axis=-1)                                      # teacher over support
     sg = mx.take_along_axis(student_logits, topk_idx.astype(mx.int32), axis=-1) / T
     logq = sg - mx.logsumexp(sg, axis=-1, keepdims=True)                 # student log-softmax/k
     kl = (p * (mx.log(p + 1e-9) - logq)).sum(axis=-1)                    # (B,L)
-    return (T * T) * kl.mean()
+    # Mask fully-padded teacher positions: a row whose entire top-k is padding (all _NEG_INF,
+    # or -inf after an fp16 cache round-trip — see ApiTopkTeacher) carries NO teacher signal.
+    # Its softmax is uniform (fp32) or NaN (fp16), which would inject a spurious target, so
+    # average KL over valid rows only. No-op for white-box teachers (every row has real values
+    # above the threshold) -> identical to the prior .mean() and parity-exact.
+    valid = mx.max(tv, axis=-1) > -1e30                                  # (B,L)
+    kl = mx.where(valid, kl, 0.0)
+    denom = mx.maximum(valid.astype(mx.float32).sum(), 1.0)
+    return (T * T) * (kl.sum() / denom)
 
 
 def _ce(logits: mx.array, targets) -> mx.array:

--- a/src/model/mlx_teacher.py
+++ b/src/model/mlx_teacher.py
@@ -33,7 +33,7 @@ import numpy as np
 
 from .teacher import (AttnProjections, ConversionTeacher, TeacherConfig,
                       TeacherForward)
-from .mlx_backend import _rotate_half, _silu, _softmax_lastdim
+from .mlx_backend import _DTYPES, _rotate_half, _silu, _softmax_lastdim
 
 
 def _rms_norm(x: mx.array, weight: mx.array, eps: float) -> mx.array:
@@ -62,16 +62,36 @@ def _apply_rope(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
 class MLXConversionTeacher(ConversionTeacher):
     """Frozen Qwen3 conversion teacher on MLX. See module docstring."""
 
-    def __init__(self, config: TeacherConfig, weights: Dict[str, mx.array]):
+    def __init__(self, config: TeacherConfig, weights: Dict[str, mx.array], *,
+                 compute_dtype: str = "fp32", compile: bool = False):
         config.validate()
         self.config = config
-        # All compute in fp32: teacher logits feed a KL term, so stability beats speed at
-        # POC scale and the teacher forward is a one-time precompute (#94) anyway.
-        self._w = {k: v.astype(mx.float32) for k, v in weights.items()}
+        if compute_dtype not in _DTYPES:
+            raise ValueError(f"compute_dtype must be one of {sorted(_DTYPES)}, got {compute_dtype!r}")
+        # Default fp32: teacher logits feed a KL term, so stability beats speed at POC scale and
+        # the forward is a one-time precompute (#94). `compute_dtype="fp16"` is a LOCAL opt-in
+        # (Apple-Silicon dev loop): it ~halves teacher memory (a 4B teacher ~16 GB -> ~8 GB) and
+        # speeds the precompute, at some numeric cost. RMSNorm/softmax stay fp32 (cast at the
+        # matmul site, mirroring mlx_backend's mixed-precision policy), and every cast is guarded
+        # so the fp32 path stays bit-identical to before (conformance/smoke untouched).
+        self._cd = _DTYPES[compute_dtype]
+        self._w = {k: v.astype(self._cd) for k, v in weights.items()}
+        # Opt-in mx.compile of the (logits-only) forward — fuses the per-layer op stream into one
+        # Metal graph. OFF by default so the eager path the conformance/parity tests exercise is
+        # untouched. NB this is the TEACHER PRECOMPUTE forward (fixed-shape, forward-only, not in
+        # the parity test path) — a different surface from the student forward/eval compile that
+        # issue #30 rejected (retrace on eval's trailing batch + lands in the parity path).
+        self._compiled_logits = mx.compile(self._logits) if compile else None
+
+    def _cast(self, t: mx.array) -> mx.array:
+        """Cast to the compute dtype; no-op (no identity node) when already there."""
+        return t if t.dtype == self._cd else t.astype(self._cd)
 
     # --- constructors --------------------------------------------------------
     @classmethod
-    def from_config(cls, config: TeacherConfig, *, seed: int = 0) -> "MLXConversionTeacher":
+    def from_config(cls, config: TeacherConfig, *, seed: int = 0,
+                    compute_dtype: str = "fp32", compile: bool = False
+                    ) -> "MLXConversionTeacher":
         """Random-init synthetic teacher (offline tests / small local checks)."""
         config.validate()
         key = mx.random.key(seed)
@@ -101,10 +121,11 @@ class MLXConversionTeacher(ConversionTeacher):
         if not c.tie_embeddings:
             w["lm_head"] = rand((c.vocab_size, c.d_model), next(ki))
         mx.eval(list(w.values()))
-        return cls(config, w)
+        return cls(config, w, compute_dtype=compute_dtype, compile=compile)
 
     @classmethod
-    def from_pretrained(cls, path, config: Optional[TeacherConfig] = None
+    def from_pretrained(cls, path, config: Optional[TeacherConfig] = None, *,
+                        compute_dtype: str = "fp32", compile: bool = False
                         ) -> "MLXConversionTeacher":
         """Load a local HuggingFace Qwen3 checkpoint directory (config.json + safetensors).
 
@@ -127,26 +148,44 @@ class MLXConversionTeacher(ConversionTeacher):
             with open(p / "config.json") as f:
                 config = TeacherConfig.from_hf_dict(json.load(f))
         hf = _load_safetensors_dir(p)
-        return cls(config, _hf_to_internal(hf, config))
+        return cls(config, _hf_to_internal(hf, config),
+                   compute_dtype=compute_dtype, compile=compile)
 
     # --- ConversionTeacher ---------------------------------------------------
-    def forward(self, token_batch, *, return_hidden: bool = False) -> TeacherForward:
-        tokens = mx.array(token_batch)
+    def _logits(self, tokens: mx.array) -> mx.array:
+        """Logits-only forward (the #94 precompute path) — a pure fn of `tokens` over the frozen
+        weight dict, so it is the `mx.compile` target. The hidden-states path stays in `forward`."""
         c = self.config
         h = self._w["embed"][tokens]                          # (B, L, D)
         L = h.shape[1]
         cos, sin = _rope_cos_sin(mx.arange(L), c.head_dim, c.rope_theta)
-        mask = mx.tril(mx.ones((L, L), dtype=mx.bool_))       # causal mask, built once
-        hidden: List[mx.array] = [h] if return_hidden else []
+        mask = self._causal_mask(L)
         for i in range(c.n_layers):
             h = h + self._attn(h, i, cos, sin, mask)
             h = h + self._mlp(h, i)
-            if return_hidden:
-                hidden.append(h)
         # Emit logits over the tokenizer vocab (padded embedding rows are never teacher targets).
-        logits = (_rms_norm(h, self._w["final_ln"], c.rms_norm_eps)
+        return (self._cast(_rms_norm(h, self._w["final_ln"], c.rms_norm_eps))
+                @ self._lm_head().T)[..., :c.effective_vocab_size]
+
+    def forward(self, token_batch, *, return_hidden: bool = False) -> TeacherForward:
+        tokens = mx.array(token_batch)
+        if not return_hidden:
+            fn = self._compiled_logits or self._logits   # compiled when enabled, else eager
+            return TeacherForward(logits=mx.stop_gradient(fn(tokens)), hidden_states=None)
+        # Hidden-states path (MOHAWK hidden-align #100) stays eager — not the precompute hot path.
+        c = self.config
+        h = self._w["embed"][tokens]                          # (B, L, D)
+        L = h.shape[1]
+        cos, sin = _rope_cos_sin(mx.arange(L), c.head_dim, c.rope_theta)
+        mask = self._causal_mask(L)
+        hidden: List[mx.array] = [h]
+        for i in range(c.n_layers):
+            h = h + self._attn(h, i, cos, sin, mask)
+            h = h + self._mlp(h, i)
+            hidden.append(h)
+        logits = (self._cast(_rms_norm(h, self._w["final_ln"], c.rms_norm_eps))
                   @ self._lm_head().T)[..., :c.effective_vocab_size]
-        hs = tuple(mx.stop_gradient(t) for t in hidden) if return_hidden else None
+        hs = tuple(mx.stop_gradient(t) for t in hidden)
         return TeacherForward(logits=mx.stop_gradient(logits), hidden_states=hs)
 
     def topk_logits(self, token_batch, k: int) -> Tuple[mx.array, mx.array]:
@@ -184,9 +223,9 @@ class MLXConversionTeacher(ConversionTeacher):
         p = f"layer.{i}."
         B, L, _ = x.shape
         Hq, Hkv, Dh = c.n_heads, c.n_kv_heads, c.head_dim
-        xn = _rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps)
-        q = xn @ self._w[p + "q_w"].T                                # (B,L,q_dim), Qwen3: no bias
-        k = xn @ self._w[p + "k_w"].T                                # (B,L,kv_dim)
+        xc = self._cast(_rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps))
+        q = xc @ self._w[p + "q_w"].T                                # (B,L,q_dim), Qwen3: no bias
+        k = xc @ self._w[p + "k_w"].T                                # (B,L,kv_dim)
 
         def heads(t, H):
             return t.reshape(B, L, H, Dh).transpose(0, 2, 1, 3)
@@ -229,10 +268,10 @@ class MLXConversionTeacher(ConversionTeacher):
         p = f"layer.{i}."
         B, L, _ = x.shape
         Hq, Hkv, Dh = c.n_heads, c.n_kv_heads, c.head_dim
-        xn = _rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps)
-        q = xn @ self._w[p + "q_w"].T                         # (B,L,q_dim), Qwen3: no bias
-        k = xn @ self._w[p + "k_w"].T                         # (B,L,kv_dim)
-        v = xn @ self._w[p + "v_w"].T
+        xc = self._cast(_rms_norm(x, self._w[p + "input_ln"], c.rms_norm_eps))
+        q = xc @ self._w[p + "q_w"].T                         # (B,L,q_dim), Qwen3: no bias
+        k = xc @ self._w[p + "k_w"].T                         # (B,L,kv_dim)
+        v = xc @ self._w[p + "v_w"].T
 
         def heads(t, H):
             return t.reshape(B, L, H, Dh).transpose(0, 2, 1, 3)   # (B,H,L,Dh)
@@ -245,16 +284,16 @@ class MLXConversionTeacher(ConversionTeacher):
             k, v = mx.repeat(k, rep, axis=1), mx.repeat(v, rep, axis=1)
         scores = (q @ k.transpose(0, 1, 3, 2)) / math.sqrt(Dh)   # (B,Hq,L,L)
         scores = mx.where(mask, scores, mx.array(float("-inf"), dtype=scores.dtype))
-        out = _softmax_lastdim(scores) @ v                   # (B,Hq,L,Dh)
+        out = self._cast(_softmax_lastdim(scores)) @ v       # (B,Hq,L,Dh)
         out = out.transpose(0, 2, 1, 3).reshape(B, L, Hq * Dh)
         return out @ self._w[p + "o_w"].T                    # (B,L,D), o has no bias
 
     def _mlp(self, x: mx.array, i: int) -> mx.array:
         c = self.config
         p = f"layer.{i}."
-        xn = _rms_norm(x, self._w[p + "post_ln"], c.rms_norm_eps)
-        gate = _silu(xn @ self._w[p + "gate_w"].T)
-        up = xn @ self._w[p + "up_w"].T
+        xc = self._cast(_rms_norm(x, self._w[p + "post_ln"], c.rms_norm_eps))
+        gate = _silu(xc @ self._w[p + "gate_w"].T)
+        up = xc @ self._w[p + "up_w"].T
         return (gate * up) @ self._w[p + "down_w"].T
 
 

--- a/tests/test_api_teacher.py
+++ b/tests/test_api_teacher.py
@@ -1,0 +1,89 @@
+"""Offline tests for the top-k-logit-only endpoint teacher (`src.model.api_teacher`).
+
+Portable (no mlx/torch). The HTTP call and the tokenizer are injected as fakes, so these run on
+any host with no server and no HF download.
+"""
+
+import numpy as np
+import pytest
+
+from src.model.api_teacher import ApiTopkTeacher
+
+
+class _FakeTokenizer:
+    """Tiny char-keyed tokenizer: token strings 'a'..'z' map to ids 0..25; decode is a no-op."""
+    unk_token_id = -1
+
+    def decode(self, ids):
+        return " ".join(str(i) for i in ids)
+
+    def convert_tokens_to_ids(self, tok):
+        return ord(tok) - ord("a") if len(tok) == 1 and "a" <= tok <= "z" else -1
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(c) - ord("a") for c in text if "a" <= c <= "z"]
+
+
+def _fake_server(top_per_pos):
+    """Build a `_post` returning an OpenAI completions response with the given top_logprobs."""
+    def _post(url, payload, timeout):
+        return {"choices": [{"logprobs": {"top_logprobs": top_per_pos}}]}
+    return _post
+
+
+def _teacher(top_per_pos, vocab_size=26):
+    return ApiTopkTeacher(base_url="http://localhost:9/v1", vocab_size=vocab_size,
+                          _post=_fake_server(top_per_pos), _tokenizer=_FakeTokenizer())
+
+
+def test_topk_shapes_and_descending_values():
+    top = [{"b": -0.1, "a": -2.0, "c": -3.0}, {"a": -0.5, "d": -1.5, "z": -4.0}]
+    t = _teacher(top)
+    vals, idx = t.topk_logits(np.array([[10, 11]]), k=3)
+    assert vals.shape == (1, 2, 3) and idx.shape == (1, 2, 3)
+    # position 0: b(1) > a(0) > c(2)
+    assert list(idx[0, 0]) == [1, 0, 2]
+    assert np.all(np.diff(vals[0, 0]) <= 0)        # descending
+    # position 1: a(0) > d(3) > z(25)
+    assert list(idx[0, 1]) == [0, 3, 25]
+
+
+def test_capped_k_pads_with_neg_inf():
+    top = [{"a": -0.1, "b": -1.0}]                  # only 2 entries, request k=4
+    vals, idx = _teacher(top).topk_logits(np.array([[5]]), k=4)
+    assert vals.shape == (1, 1, 4)
+    assert vals[0, 0, 0] > vals[0, 0, 2]
+    assert vals[0, 0, 2] == pytest.approx(np.finfo(np.float32).min)   # padding
+    assert vals[0, 0, 3] == pytest.approx(np.finfo(np.float32).min)
+
+
+def test_ids_outside_vocab_dropped():
+    # vocab_size=2 -> only ids 0,1 are representable; 'c'(2) must be dropped.
+    top = [{"a": -0.1, "c": -0.2, "b": -0.3}]
+    vals, idx = _teacher(top, vocab_size=2).topk_logits(np.array([[0]]), k=3)
+    assert list(idx[0, 0])[:2] == [0, 1]           # a, b kept; c dropped
+    assert vals[0, 0, 2] == pytest.approx(np.finfo(np.float32).min)
+
+
+def test_position_misalignment_pads_to_seq_len():
+    top = [{"a": -0.1}]                              # server returns 1 position, seq_len 3
+    vals, idx = _teacher(top).topk_logits(np.array([[1, 2, 3]]), k=2)
+    assert vals.shape == (1, 3, 2)
+    assert vals[0, 0, 0] > np.finfo(np.float32).min     # position 0 filled
+    assert vals[0, 1, 0] == pytest.approx(np.finfo(np.float32).min)   # 1,2 padded
+    assert vals[0, 2, 0] == pytest.approx(np.finfo(np.float32).min)
+
+
+def test_white_box_methods_raise():
+    t = _teacher([{"a": -0.1}])
+    for call in (lambda: t.forward(np.array([[1]])),
+                 lambda: t.attention_projection(0),
+                 lambda: t.embedding_matrix(),
+                 lambda: t.lm_head_matrix()):
+        with pytest.raises(NotImplementedError):
+            call()
+
+
+def test_rejects_non_qwen3_tokenizer_name():
+    with pytest.raises(ValueError):
+        ApiTopkTeacher(base_url="http://x/v1", vocab_size=4, tokenizer="olmo")

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -34,6 +34,7 @@ PORTABLE_MODULES = [
     "src.model.blocks",
     "src.model.backend",
     "src.model.teacher",
+    "src.model.api_teacher",
     "src.model.sizing",
     "src.data.loader",
     "src.data.corpus",

--- a/tests/test_teacher.py
+++ b/tests/test_teacher.py
@@ -49,6 +49,37 @@ def test_logits_sliced_to_tokenizer_vocab():
     assert mx.all(idx < 50).item()
 
 
+# --- local precompute levers: mx.compile + fp16 (default-off) -----------------
+def test_compiled_forward_matches_eager():
+    """The opt-in `compile=True` (mx.compile of the logits-only forward) must agree with the
+    eager path: top-k INDICES identical (the cached signal's alignment) and values within fp
+    tolerance (compile may reorder fused ops by ~1e-6 — well inside the 1e-4 conformance bar)."""
+    cfg = TeacherConfig.tiny()
+    toks = _tokens(2, 8, cfg.vocab_size)
+    eager = MLXConversionTeacher.from_config(cfg, seed=0)
+    comp = MLXConversionTeacher.from_config(cfg, seed=0, compile=True)
+    ve, ie = (np.array(a) for a in eager.topk_logits(toks, 5))
+    vc, ic = (np.array(a) for a in comp.topk_logits(toks, 5))
+    assert np.array_equal(ie, ic)
+    assert np.max(np.abs(ve - vc)) < 1e-4
+
+
+def test_fp16_teacher_runs_and_is_close():
+    """`compute_dtype="fp16"` (local memory lever) produces finite logits close to fp32."""
+    cfg = TeacherConfig.tiny()
+    toks = _tokens(2, 8, cfg.vocab_size)
+    lf = np.array(MLXConversionTeacher.from_config(cfg, seed=0).forward(toks).logits)
+    l16 = np.array(MLXConversionTeacher.from_config(cfg, seed=0, compute_dtype="fp16")
+                   .forward(toks).logits)
+    assert np.all(np.isfinite(l16)) and l16.shape == lf.shape
+    assert np.max(np.abs(lf - l16)) < 0.1
+
+
+def test_invalid_compute_dtype_rejected():
+    with pytest.raises(ValueError):
+        MLXConversionTeacher.from_config(TeacherConfig.tiny(), seed=0, compute_dtype="int8")
+
+
 # --- forward / shapes --------------------------------------------------------
 def test_forward_logits_shape():
     t = _tiny()


### PR DESCRIPTION
## Why

The backlog tracks CUDA optimizations (#40 fused kernels, #145 `torch.compile`). This asks the same of MLX — but with a key constraint from the repo's own decision record: **issue #30 retired MLX *train-step throughput* work** (MLX is the dev/validation backend; scale runs on CUDA cloud). So this PR does **not** chase MLX student-forward speed. It targets the productive axis instead — **local developer velocity**: validate stages fast, generate teacher signal locally, train test models ≤100M locally.

## What

**A. Teacher precompute levers** (sibling to the CUDA #145, on a surface #30 did *not* reject — the fixed-shape, forward-only *teacher* precompute, not the student/parity path)
- Opt-in `mx.compile` of `MLXConversionTeacher`'s logits-only forward (fuses the per-layer op stream).
- Opt-in `compute_dtype="fp16"` (a 4B teacher ~16 GB → ~8 GB; RMSNorm/softmax stay fp32 at the matmul site).
- Both default to the **bit-identical eager-fp32 path**; exposed as `--compile` / `--teacher-dtype`.
- Verified: compiled top-k **indices identical** to eager, values within ~1e-6.

**B. Local Qwen3 teacher**
- B1 already worked (`precompute_teacher.py --backend mlx --pretrained <Qwen3>`) — now documented as the primary, full-fidelity local path.
- B2: new **portable** `src/model/api_teacher.py` (`ApiTopkTeacher`) over an LM Studio / OpenAI-compatible endpoint via `--teacher-endpoint`. Implements `topk_logits` only (feeds logit-distill); raises clearly for the white-box methods an HTTP endpoint can't provide. **Partial/approximate** (logprobs≠logits, capped k, string→id remap) — documented loudly.

**C. Two configs** filling the toy↔poc gap (measured step-times in the YAML headers)
- `config/small.yaml` — ~2.6M, byte vocab, **~0.08 s/step** — fast code-path iteration.
- `config/poc-small.yaml` — ~97M (≤100M target), OLMo vocab, **~18.8 s/step @ 32k tok, ~12.9 GB** — largest "real" model trainable locally.

**D. One-command local validation**
- `scripts/local_validate.sh`: offline chain — data → smoke gate → `small.yaml` train → distill smoke → teacher precompute (with `--compile`).
- `docs/local-development.md` runbook; linked from README + design index.

## Verification

- Full suite **495 passed, 3 skipped**.
- Smoke gate exact-resume green (0.0 diff); `local_validate.sh` all 5 stages green.
- Compile parity + fp16 + API-teacher covered by new offline tests (`tests/test_teacher.py`, `tests/test_api_teacher.py`); `api_teacher` added to the import-guard portable set.

## Notes / non-goals

- Intentionally **not** reopening #30's retired MLX train-step throughput work or the rejected student-forward/SSD-kernel compile.
- B2 (LM Studio) is a convenience for logit-distill smoke only; prefer the MLX `--pretrained` teacher for real local validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)