### PR TITLE
docs(CLAUDE.md): update M10 status — machinery merged, remaining work is pod-gated runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,9 +149,10 @@ The smoke gate stresses exactly this round-trip.
   run is still pending (user-driven).
 - The **active program is M10 — distillation** (**GitHub issue #65**, the live tracker): distil a
   compact Mamba-2 hybrid student from a frozen teacher, sweep layouts, post-train the winner. The
-  building blocks exist (teacher loader, student init, staged loss, manifest, sweep table); the
-  corpus-scale teacher-logit precompute (#94), R2 + RunPod plumbing (#80), and the end-to-end
-  cloud distill run (#81) are pending. There is **no `scripts/distill.py` yet**.
+  core machinery is implemented — teacher loader (#93), student init (#99), staged distill loss
+  (#100), sweep harness (#98), and the distillation driver `scripts/distill.py` (#81). The
+  **remaining work is pod-gated runs**, not builds: the 8k corpus build, the teacher top-k
+  precompute (#94), the two-layout sweep (#81), and post-training/eval — per the #65 ordered chain.
 - `docs/design/` documents the design choices and rationale (start at
   `docs/design/README.md`); `docs/infrastructure.md` is the R2 + RunPod runbook. After completing
   a milestone, tick its box in the relevant tracker (#2 / #65).


### PR DESCRIPTION
## Summary

- Removes the stale sentence "There is **no `scripts/distill.py` yet**." — `scripts/distill.py` exists and is merged.
- Rewrites the M10 pending-work clause to accurately reflect current state: teacher loader (#93), student init (#99), staged distill loss (#100), sweep harness (#98), and `scripts/distill.py` (#81) are all implemented; the remaining work is pod-gated runs (8k corpus build, teacher top-k precompute #94, two-layout sweep, post-training/eval) per the #65 ordered chain.
- No other files changed — this is a CLAUDE.md-only patch to avoid merge conflicts with active src/ work.

## Test plan

- [x] `grep -n "no .scripts/distill.py. yet" CLAUDE.md` returns nothing
- [x] `grep -n "distill\.py" CLAUDE.md` shows the driver correctly referenced in the implemented-machinery list
- [x] `git diff --stat` shows only `CLAUDE.md` changed (1 file, 4 ins / 3 del)
- [x] Surrounding sentences and links (issue #65, #93–#100, #81, #94) preserved intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)