### PR TITLE
fix(data): Qwen3 vocab-bound check + MoT config for SFT corpus builders

### DIFF
--- a/src/data/instruct_sft.py
+++ b/src/data/instruct_sft.py
@@ -36,6 +36,15 @@ from . import chat_template, storage
 from .sft_data import _messages_of
 
 
+def _effective_vocab_size(tokenizer) -> Optional[int]:
+    """The largest valid token id + 1, using len() when available (covers added special tokens
+    like Qwen3's <|im_start|>/<|im_end|> whose ids exceed tokenizer.vocab_size)."""
+    try:
+        return len(tokenizer)
+    except TypeError:
+        return getattr(tokenizer, "vocab_size", None)
+
+
 def build_chat_sft_records(rows: Iterable[dict], tokenizer, *, max_seq_len: Optional[int] = 8192,
                            stats: Optional[dict] = None) -> Iterator[dict]:
     """Yield `{input_ids, target_ids, loss_mask}` records from chat rows, masked to the assistant
@@ -43,7 +52,7 @@ def build_chat_sft_records(rows: Iterable[dict], tokenizer, *, max_seq_len: Opti
     appends **no** extra EOS — `<|im_end|>` is already the last token of each assistant span and is
     trained as the stop token. Rows whose tokenized length exceeds `max_seq_len` are dropped
     (truncating a response would teach the model to stop mid-answer)."""
-    vocab = getattr(tokenizer, "vocab_size", None)
+    vocab = _effective_vocab_size(tokenizer)
     for rec in rows:
         messages = _messages_of(rec)
         out = _record_from_messages(messages, tokenizer, max_seq_len, vocab)
@@ -153,7 +162,7 @@ def build_instruct_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwen
 def _records_with_source(cleaned_rows: List[dict], tok, max_seq_len: int, stats: dict):
     """Yield `(cleaned_row, masked_record)` for rows that survive masking — pairs the kept record
     with its source row so per-source counts stay accurate."""
-    vocab = getattr(tok, "vocab_size", None)
+    vocab = _effective_vocab_size(tok)
     for row in cleaned_rows:
         out = _record_from_messages(row["messages"], tok, max_seq_len, vocab)
         if out is None:

--- a/src/data/reasoning_sft.py
+++ b/src/data/reasoning_sft.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 from . import chat_template, storage
+from .instruct_sft import _effective_vocab_size
 
 
 def _valid_rows(rows: Iterable[dict]) -> List[dict]:
@@ -93,7 +94,7 @@ def build_reasoning_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwe
 
     tok = _load_tokenizer(tokenizer, model_id, byte_fallback)
     dtype = packing_dtype_for(tok.vocab_size)          # uint16 (byte) / uint32 (Qwen3)
-    vocab = getattr(tok, "vocab_size", None)
+    vocab = _effective_vocab_size(tok)
 
     # Masked JSONL records + the per-trace token streams for atomic packing (kept in lockstep, so
     # the packed documents are exactly the traces that survived masking + the length cap).

--- a/src/data/reasoning_traces.py
+++ b/src/data/reasoning_traces.py
@@ -79,8 +79,11 @@ def mot_row_to_messages(row: dict, source: str = "mot") -> Optional[dict]:
 
 
 def load_mixture_of_thoughts(split: str = "train", max_examples: Optional[int] = None,
-                             config: Optional[str] = None) -> Iterator[dict]:
-    """Stream open-r1/Mixture-of-Thoughts and map rows to tagged trace rows (lazy `datasets`)."""
+                             config: Optional[str] = "all") -> Iterator[dict]:
+    """Stream open-r1/Mixture-of-Thoughts and map rows to tagged trace rows (lazy `datasets`).
+
+    `config` selects the dataset sub-split ("all", "math", "code", "science"). The upstream
+    dataset now requires an explicit config (previously None was valid; changed on HF Hub)."""
     from datasets import load_dataset  # pragma: no cover - network/optional extra
 
     ds = load_dataset("open-r1/Mixture-of-Thoughts", config, split=split, streaming=True)


### PR DESCRIPTION
## Summary

- `instruct_sft` + `reasoning_sft`: vocab sanity guard used `tokenizer.vocab_size` (151643 for Qwen3) which is the base vocab — excludes special tokens like `<|im_end|>` (id 151645). Introduce `_effective_vocab_size()` that uses `len(tok)` when available (HF tokenizers support it; `ByteTokenizer` does not, falls back to `vocab_size`).
- `reasoning_traces.load_mixture_of_thoughts`: HF Hub now requires an explicit config name for `open-r1/Mixture-of-Thoughts` (previously `None` was valid). Default config to `"all"` so the existing CLI and lambda loader continue to work unchanged.

Both bugs were hit during the M10 Path B corpus run and fixed in-flight. Instruct SFT confirmed complete (223,995 records, sources: oasst1 + flan + handauthored). Reasoning SFT unblocked and running.

## Test plan
- [x] All 497 tests pass (`pytest -q -rs`: 497 passed, 3 skipped)
- [x] Instruct SFT real run completed: `n_records=223995`, `tokenizer=qwen3`, `template=qwen-chatml`, sources include oasst1 and flan
- [x] Reasoning SFT unblocked after MoT config fix, running against 200K traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)