### PR TITLE
fix(data): tool_sft vocab-bound check uses effective vocab (Qwen3 specials)

### DIFF
--- a/src/data/tool_sft.py
+++ b/src/data/tool_sft.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 from . import chat_template, storage
+from .instruct_sft import _effective_vocab_size
 from .tool_sources import TOOL_CALL_OPEN, TOOLS_OPEN, TOOLS_CLOSE
 
 
@@ -141,7 +142,7 @@ def build_tool_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwen3",
             f.write(json.dumps(row) + "\n")
 
     tok = _load_tokenizer(tokenizer, model_id, byte_fallback)
-    vocab = getattr(tok, "vocab_size", None)
+    vocab = _effective_vocab_size(tok)
     tok_dir.mkdir(parents=True, exist_ok=True)
 
     n_records = n_tokens = n_skipped = n_abstention = n_with_distractors = 0

--- a/tests/test_tool_sft.py
+++ b/tests/test_tool_sft.py
@@ -8,6 +8,7 @@ import random
 import pytest
 
 from src.data.chat_template import IM_END, _ROLES, render, response_spans
+from src.data.instruct_sft import _effective_vocab_size
 from src.data.sft_loader import SFTLoader
 from src.data.tokenize import ByteTokenizer
 from src.data.tool_sft import _valid_rows, build_tool_sft
@@ -274,3 +275,44 @@ def test_valid_rows_filters_correctly():
     result = _valid_rows([good, bad_role, bad_empty])
     assert len(result) == 1
     assert result[0]["source"] == "handauthored"
+
+
+# --------------------------------------------------------------------------- #
+# Regression: effective vocab size uses len(tok), not tok.vocab_size (#153)
+# --------------------------------------------------------------------------- #
+
+def test_effective_vocab_size_uses_len_not_vocab_size():
+    """_effective_vocab_size must return len(tok) when available, not vocab_size.
+
+    Qwen3 adds <|im_start|>/<|im_end|> as special tokens whose ids sit ABOVE
+    tokenizer.vocab_size. The old `getattr(tok, "vocab_size", None)` check would
+    raise a spurious ValueError for any row whose tokens include those specials.
+    """
+
+    class FakeQwen3Tokenizer:
+        """Stub with len(tok)=20 but vocab_size=10 — simulates Qwen3 added specials."""
+        vocab_size = 10
+
+        def __len__(self):
+            return 20
+
+    tok = FakeQwen3Tokenizer()
+    assert _effective_vocab_size(tok) == 20, (
+        "_effective_vocab_size should return len(tok)=20, not vocab_size=10"
+    )
+
+
+def test_tool_sft_does_not_raise_with_extended_vocab(tmp_path):
+    """build_tool_sft must not raise when the tokenizer's len() > vocab_size.
+
+    This was the latent bug: the old vocab-bound check used `vocab_size` directly,
+    so any real Qwen3 token id in [vocab_size, len(tok)) would trigger a false
+    ValueError. Byte-fallback tests masked it because ByteTokenizer.vocab_size==256
+    and len(ByteTokenizer)==256 (no gap). Here we use ByteTokenizer (always safe for
+    offline tests) and verify the build succeeds end-to-end with n_records >= 1.
+    """
+    manifest = build_tool_sft(
+        handauthored_tool_records(), tmp_path,
+        tokenizer="qwen25", byte_fallback=True, seq_len=8192,
+    )
+    assert manifest["n_records"] >= 1, "expected at least one tokenized record"


### PR DESCRIPTION
## Summary

- **Latent bug**: `tool_sft.py` used `getattr(tok, "vocab_size", None)` to bound-check token ids. Qwen3 adds `<|im_start|>` and `<|im_end|>` as special tokens whose ids sit **above** `tokenizer.vocab_size` but below `len(tokenizer)`. On a real Qwen3 run, any row whose tokens include those specials would trigger a false `ValueError` — despite the tokenizer being correct.
- **Why tests missed it**: All existing tests use `ByteTokenizer`, which has `vocab_size == len()` (no gap). Byte-fallback never exercises the Qwen3 special-token range.
- **Fix**: Import and use `_effective_vocab_size` from `instruct_sft` (merged in #153), matching the pattern already used in `reasoning_sft.py`. `_effective_vocab_size` returns `len(tokenizer)`, falling back to `vocab_size` only if `__len__` raises.

## Regression tests added (`tests/test_tool_sft.py`)

- `test_effective_vocab_size_uses_len_not_vocab_size`: unit test with a stub where `len=20` but `vocab_size=10` — asserts the helper returns 20.
- `test_tool_sft_does_not_raise_with_extended_vocab`: end-to-end `build_tool_sft` sanity check confirming `n_records >= 1` (belt-and-suspenders; byte-fallback always safe for offline tests).

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_tool_sft.py tests/test_import_guard.py -q` → 15 passed

Fixes latent vocab-bound bug introduced in #102; mirrors fix from #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)