### PR TITLE
docs(runbook): CUDA-pod verification checklist (M10 steps 3–7)

### DIFF
--- a/docs/runbooks/m10-pod-chain.md
+++ b/docs/runbooks/m10-pod-chain.md
@@ -87,3 +87,60 @@ python -m src.data.r2_sync up "$T" s3://monica-training/_smoke/staging-check
 python -m src.data.r2_sync down s3://monica-training/_smoke/staging-check "$T-down" && diff -r "$T" "$T-down" && echo OK
 python -c "from src.data.r2_sync import _fs_for; fs,_=_fs_for('s3://monica-training/'); [fs.rm_file(f) for f in fs.find('monica-training/_smoke')]"
 ```
+
+## Verification checklist (confirm on the CUDA pod)
+
+Everything above was built and unit-tested on a Mac; these are the **real-hardware risks that a
+Mac cannot exercise**. Ordered cheapest-first, so a failure surfaces *before* the dominant GPU
+spend (step 3). The corpus + SFT corpora already passed their Mac-side manifest assertions and
+are staged on R2 (see #65) — the items below re-verify them in the CUDA environment.
+
+### A. Environment — before any GPU spend
+- [ ] `pip install -e ".[dev,data,cuda-fast]"` succeeds (`mamba-ssm>=2.0` + `causal-conv1d>=1.0`).
+- [ ] **The fused Triton SSD scan actually engages** — not the silent pure-PyTorch fallback. Import
+  `mamba_ssm` / `causal_conv1d` and confirm a forward uses them (else throughput tanks; this is the
+  whole point of `cuda-fast`, #40).
+- [ ] `s3fs==2026.2.0` pin holds (a bare `pip install s3fs` upgrades fsspec and breaks `datasets`).
+- [ ] `r2_sync down` works from the pod in-region (zero-egress); `.env` creds resolve.
+- [ ] bf16 path ⇒ **Ampere+** card (A100/H100 80 GB). Confirm `nvidia-smi`.
+
+### B. Corpus integrity (cheap — before precompute)
+- [ ] `r2_sync down s3://monica-training/poc-distill/corpus/tokenized/qwen3-8k /vol/corpus8k`, then
+  `split --shards /vol/corpus8k --out /vol/split8k --val-tokens 10000000`.
+- [ ] Assert: dtype **uint32**, train/val provably disjoint, doc-boundary `.bounds` present, and
+  **max token id < `len(tokenizer)`** — the Qwen3 special-token bound (`<|im_start|>`/`<|im_end|>`
+  exceed `vocab_size`) fixed in #153/#154. Confirm the on-pod data clears it.
+
+### C. Pre-flight CUDA smoke (before the dominant-cost run)
+- [ ] `python scripts/distill_smoke.py --backend cuda` — student init (MOHAWK / Mamba-in-the-Llama)
+  + all three stages (mixing-match → hidden-align → logit-distill) run end-to-end at toy scale.
+- [ ] `python scripts/precompute_teacher.py --synthetic --backend cuda` then a tiny **real** slice —
+  confirms **Qwen3-4B-Thinking loads on CUDA** (per-head QK RMSNorm, no QKV bias, `rope_theta` 5e6),
+  top-k cache writes + `--push` round-trip.
+- [ ] **Fill in `src/conformance/backend_parity.py`** (currently a skeleton — runs only where CUDA
+  is present) and run `tests/test_cuda_parity.py`: MLX↔CUDA agreement in **fp32 at ~1e-4 rel**. This
+  is the conformance check explicitly deferred to the CUDA scale-up.
+
+### D. Step 3 — teacher precompute (dominant cost)
+- [ ] Bench tok/s + $/Mtoken on a small slice and **extrapolate to ~1.9B before committing**.
+- [ ] Positional alignment: the split's `seq_len` (8192) **equals** the manifest's — the precompute
+  is positionally aligned to the split.
+
+### E. Step 4 — student sweep (top failure risk)
+- [ ] **MOHAWK stage-1 O(L²) OOM at seq 8192** — `mixing-match` materializes a per-layer
+  `(B,H,L,L)` matrix for student **and** teacher. The seq-1024 Path-A rehearsal already OOM'd an
+  80 GB card at batch 8; at 8192 it is ~64× tighter. Verify **micro-batch 1–2 + high grad-accum +
+  `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`** actually fits. (Most likely failure.)
+- [ ] `torch.compile` of the student forward (#145/#147) and SDPA (#144/#146) engage on CUDA with
+  no graph-break errors.
+- [ ] **Checkpoint-to-R2 + `--resume` survives a kill** (pods are ephemeral) — resumes the
+  furthest-progressed stage of that manifest.
+- [ ] All three stage losses drop for **both** layouts (the Path-A success signal) → Phase-2 winner.
+
+### F. Step 5 — post-train the winner
+- [ ] `scripts/sft.py` (instruct → reasoning) and `scripts/rlvr.py` (GRPO) run on CUDA.
+- [ ] CUDA seg_ids doc-boundary reset (#111) holds under packing.
+
+### G. Step 6 — headline (back on Mac / MLX)
+- [ ] The CUDA-trained **portable safetensors load in the MLX backend** (the seam round-trip is the
+  whole point) — then context length + tok/s vs a same-size transformer = the POC success gate (#104).


### PR DESCRIPTION
Adds a **"Verification checklist (confirm on the CUDA pod)"** section to `docs/runbooks/m10-pod-chain.md` — the real-hardware risks a Mac can't exercise, ordered cheapest-first so failures surface before the dominant GPU spend (teacher precompute).

Covers: cuda-fast fused Triton scan actually engaging (no silent fallback); on-pod corpus integrity + the Qwen3 token-id bound (#153/#154); a cheap CUDA smoke (`distill_smoke.py --backend cuda`, `precompute_teacher.py --synthetic`) + filling in the deferred `backend_parity` MLX↔CUDA conformance; teacher-precompute cost bench; the **MOHAWK stage-1 O(L²) OOM at seq 8192** (top risk); checkpoint-to-R2 `--resume`; and the final CUDA→MLX safetensors round-trip for the #104 tok/s headline.

Companion to the #65 status update (Mac-buildable half done; remaining work is pod-gated). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)