### PR TITLE
Add training-time estimator (param size × hardware → wall-clock)

### DIFF
--- a/docs/design/09-hybrid-architectures.md
+++ b/docs/design/09-hybrid-architectures.md
@@ -98,12 +98,26 @@ Example (`python scripts/train_time.py`, Chinchilla-optimal 20 tokens/param budg
 | — | 7B | 140.00B | 185.2 y | 171.9 d | 25.3 d |
 
 The spread is the headline: a from-scratch 1B run is years on the laptop but days on
-a single H100, and the laptop is only viable at the `poc` rung (or for the short
-distillation runs, which need ≪ Chinchilla tokens — see [distillation](10-distillation.md)).
-Pass `--tokens 3B` for a fixed budget across sizes, or `--config <yaml>` to estimate
-an exact config. These are first-principles estimates (generic `6·N·D`, not the
-SSM/attention split); the real per-step cost is what `scripts/bench_train_step.py`
-(MLX) and `scripts/bench_cuda_train_step.py` (CUDA) measure.
+a single H100, and the laptop is only viable at the `poc` rung. Pass `--tokens 3B`
+for a fixed budget across sizes, or `--config <yaml>` to estimate an exact config.
+
+**Chinchilla is an upper bound, not a POC run.** `20×params` is the *compute-optimal*
+budget; exploratory POC runs use **far fewer** tokens (just enough to watch the loss
+curve drop), so the table above over-states what we actually do on the laptop. The
+honest laptop question is the inverse — "how many tokens fit in a day?" — which
+`--hours N` answers and which matches measured experience (a ~200M model trains
+**~72M tokens in 24h on M1 Pro**, a normal short POC, *not* the 4B Chinchilla budget):
+
+| model | params | M1 Pro / 24h | 1× H100 / 24h | 8× H100 / 24h |
+|---|---|---|---|---|
+| poc | ~127M | 114M | 45.0B | 306B |
+| — | 200M | 72M | 28.5B | 194B |
+| 1b | ~1.03B | 14M | 5.5B | 37.5B |
+
+These are first-principles estimates (generic `6·N·D`, not the SSM/attention split);
+the real per-step cost is what `scripts/bench_train_step.py` (MLX) and
+`scripts/bench_cuda_train_step.py` (CUDA) measure. The short distillation runs in
+particular need ≪ Chinchilla tokens — see [distillation](10-distillation.md).
 
 ### Precision differs from the POC
 

--- a/docs/design/09-hybrid-architectures.md
+++ b/docs/design/09-hybrid-architectures.md
@@ -75,6 +75,36 @@ against the built model's portable state-dict param sum. Training memory ≈ 8 B
 (weights+grad+AdamW), or **~10 B/param with 8-bit Adam** — the VRAM-tight lever used in
 Phase 5 (#75).
 
+### Estimating training time
+
+Sizing answers "does it fit?"; the companion estimator answers "how long?".
+`src/model/train_time.py` + `scripts/train_time.py` turn a param count and a token
+budget into estimated wall-clock via the standard `6·N·D` training-FLOPs model
+divided by each machine's achieved throughput. The **M1 Pro** figure is *calibrated*
+from the one measured point we have — ~99 s/step at 131,072 tokens/step for `poc`
+(~1.0 TFLOP/s effective), which reproduces the "3B tokens ≈ 26 days" rule of thumb.
+The **H100** figures are bf16 dense peak (~990 TFLOPS) × an assumed 40% MFU (single)
+and ×85% scaling (8-GPU); there is no in-repo H100 bench yet, so treat them as
+planning estimates and retune with `--mfu` / `--scaling`.
+
+Example (`python scripts/train_time.py`, Chinchilla-optimal 20 tokens/param budget):
+
+| model | params | tokens (20×) | M1 Pro | 1× H100 | 8× H100 |
+|---|---|---|---|---|---|
+| poc | ~127M | 2.53B | 22.2 d | 1.4 h | 11.9 m |
+| — | 270M | 5.40B | 100.6 d | 6.1 h | 54.1 m |
+| 1b | ~1.03B | 20.67B | 4.0 y | 3.7 d | 13.2 h |
+| — | 3B | 60.00B | 34.0 y | 31.6 d | 4.6 d |
+| — | 7B | 140.00B | 185.2 y | 171.9 d | 25.3 d |
+
+The spread is the headline: a from-scratch 1B run is years on the laptop but days on
+a single H100, and the laptop is only viable at the `poc` rung (or for the short
+distillation runs, which need ≪ Chinchilla tokens — see [distillation](10-distillation.md)).
+Pass `--tokens 3B` for a fixed budget across sizes, or `--config <yaml>` to estimate
+an exact config. These are first-principles estimates (generic `6·N·D`, not the
+SSM/attention split); the real per-step cost is what `scripts/bench_train_step.py`
+(MLX) and `scripts/bench_cuda_train_step.py` (CUDA) measure.
+
 ### Precision differs from the POC
 
 `poc.yaml` uses **fp16 + loss scaling** because fp16 is ~18% faster than bf16 *on MLX/Metal*

--- a/scripts/train_time.py
+++ b/scripts/train_time.py
@@ -62,6 +62,8 @@ def main() -> None:
         sizes = [(args.config.stem, cfg.num_parameters())]
     elif args.params is not None:
         sizes = [(label.strip(), parse_count(label)) for label in args.params.split(",") if label.strip()]
+        if not sizes:
+            ap.error("--params resolved to no sizes (check for stray commas/whitespace)")
         # Re-label with the canonical compact form so 0.27B and 270M read the same.
         sizes = [(format_count(p), p) for _, p in sizes]
     else:
@@ -71,6 +73,8 @@ def main() -> None:
     registry = default_registry(mfu=args.mfu, scaling=args.scaling)
     if args.hardware is not None:
         names = [n.strip() for n in args.hardware.split(",") if n.strip()]
+        if not names:
+            ap.error("--hardware resolved to no entries (check for stray commas/whitespace)")
         unknown = [n for n in names if n not in registry]
         if unknown:
             ap.error(f"unknown hardware {unknown}; choose from {list(registry)}")

--- a/scripts/train_time.py
+++ b/scripts/train_time.py
@@ -7,6 +7,7 @@ numbers are planning estimates; see `src/model/train_time.py` for the assumption
 
   python scripts/train_time.py                            # default ladder, all 3 machines
   python scripts/train_time.py --tokens 3B                # fixed budget (m1pro col ≈ 26 d)
+  python scripts/train_time.py --hours 24 --params 200M   # tokens trainable in 24h (M1 ≈ 72M)
   python scripts/train_time.py --params 1B,7B --hardware h100,8xh100
   python scripts/train_time.py --config config/student-1b.yaml
   python scripts/train_time.py --mfu 0.5 --scaling 0.9    # H100 sensitivity
@@ -29,6 +30,7 @@ from src.model.train_time import (  # noqa: E402
     default_sizes,
     format_count,
     format_report,
+    format_trainable_report,
     parse_count,
 )
 
@@ -44,6 +46,8 @@ def main() -> None:
                     help="comma-separated param ladder with K/M/B suffixes, e.g. 270M,3B,7B")
     ap.add_argument("--tokens", type=str, default=None,
                     help="fixed token budget for every size (e.g. 3B); default is Chinchilla 20×params")
+    ap.add_argument("--hours", type=float, default=None,
+                    help="inverse mode: show TOKENS trainable in this many hours instead of time-to-train")
     ap.add_argument("--hardware", type=str, default=None,
                     help="comma-separated subset/order of hardware (default: m1pro,h100,8xh100)")
     ap.add_argument("--mfu", type=float, default=DEFAULT_MFU,
@@ -74,9 +78,11 @@ def main() -> None:
     else:
         hardware = list(registry.values())
 
-    fixed_tokens = parse_count(args.tokens) if args.tokens is not None else None
-
-    print(format_report(sizes, hardware, fixed_tokens=fixed_tokens))
+    if args.hours is not None:
+        print(format_trainable_report(sizes, hardware, args.hours * 3600.0))
+    else:
+        fixed_tokens = parse_count(args.tokens) if args.tokens is not None else None
+        print(format_report(sizes, hardware, fixed_tokens=fixed_tokens))
 
 
 if __name__ == "__main__":

--- a/scripts/train_time.py
+++ b/scripts/train_time.py
@@ -1,0 +1,83 @@
+"""Estimate training wall-clock for various param sizes on reference hardware.
+
+Answers "how long would training a model of size X take on hardware Y?" using the
+6·N·D FLOPs model and a small hardware registry (M1 Pro — calibrated from the
+measured poc 99 s/step anchor; single H100 and 8×H100 — peak × assumed MFU). All
+numbers are planning estimates; see `src/model/train_time.py` for the assumptions.
+
+  python scripts/train_time.py                            # default ladder, all 3 machines
+  python scripts/train_time.py --tokens 3B                # fixed budget (m1pro col ≈ 26 d)
+  python scripts/train_time.py --params 1B,7B --hardware h100,8xh100
+  python scripts/train_time.py --config config/student-1b.yaml
+  python scripts/train_time.py --mfu 0.5 --scaling 0.9    # H100 sensitivity
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+# Allow `python scripts/train_time.py` from the repo root without installation.
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.model.blocks import load_config  # noqa: E402
+from src.model.train_time import (  # noqa: E402
+    DEFAULT_MFU,
+    DEFAULT_SCALING,
+    default_registry,
+    default_sizes,
+    format_count,
+    format_report,
+    parse_count,
+)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=None,
+                    help="estimate a single config YAML (exact param count) instead of the ladder")
+    ap.add_argument("--config-dir", type=Path, default=Path("config"),
+                    help="directory holding the family YAMLs (default: config/)")
+    ap.add_argument("--params", type=str, default=None,
+                    help="comma-separated param ladder with K/M/B suffixes, e.g. 270M,3B,7B")
+    ap.add_argument("--tokens", type=str, default=None,
+                    help="fixed token budget for every size (e.g. 3B); default is Chinchilla 20×params")
+    ap.add_argument("--hardware", type=str, default=None,
+                    help="comma-separated subset/order of hardware (default: m1pro,h100,8xh100)")
+    ap.add_argument("--mfu", type=float, default=DEFAULT_MFU,
+                    help=f"assumed H100 model-FLOPs utilization (default: {DEFAULT_MFU})")
+    ap.add_argument("--scaling", type=float, default=DEFAULT_SCALING,
+                    help=f"assumed 8×H100 scaling efficiency (default: {DEFAULT_SCALING})")
+    args = ap.parse_args()
+
+    # Which model sizes.
+    if args.config is not None:
+        cfg = load_config(args.config)
+        sizes = [(args.config.stem, cfg.num_parameters())]
+    elif args.params is not None:
+        sizes = [(label.strip(), parse_count(label)) for label in args.params.split(",") if label.strip()]
+        # Re-label with the canonical compact form so 0.27B and 270M read the same.
+        sizes = [(format_count(p), p) for _, p in sizes]
+    else:
+        sizes = default_sizes(args.config_dir)
+
+    # Which hardware.
+    registry = default_registry(mfu=args.mfu, scaling=args.scaling)
+    if args.hardware is not None:
+        names = [n.strip() for n in args.hardware.split(",") if n.strip()]
+        unknown = [n for n in names if n not in registry]
+        if unknown:
+            ap.error(f"unknown hardware {unknown}; choose from {list(registry)}")
+        hardware = [registry[n] for n in names]
+    else:
+        hardware = list(registry.values())
+
+    fixed_tokens = parse_count(args.tokens) if args.tokens is not None else None
+
+    print(format_report(sizes, hardware, fixed_tokens=fixed_tokens))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/model/train_time.py
+++ b/src/model/train_time.py
@@ -1,0 +1,208 @@
+"""Portable training-time estimator: param size × hardware -> wall-clock.
+
+Turns a parameter count and a token budget into an estimated training wall-clock
+time on a few reference machines (M1 Pro, single H100, 8×H100). It complements
+`src/model/sizing.py` (which answers "does it fit?") by answering "how long?".
+
+ABOVE THE SEAM — imports no backend (`mlx`/`torch`). Everything here is closed-form
+arithmetic over two well-worn approximations; treat the outputs as PLANNING
+ESTIMATES, not measurements (the only measured throughput is the M1 Pro anchor
+below — see `scripts/bench_train_step.py` for the real per-step cost).
+
+Two approximations:
+
+  * Training compute  ~  6 · N_params · N_tokens   (the standard Kaplan/Chinchilla
+    forward+backward FLOPs estimate: ~2·N per token forward, ~4·N backward).
+  * Achieved throughput  =  peak_flops · MFU · n_devices · scaling_efficiency
+    where MFU (model-FLOPs utilization) and the multi-GPU scaling efficiency are
+    the tunable assumptions.
+
+The **M1 Pro** entry is not assumed — it is CALIBRATED from the one measured point
+in the repo: ~99 s/step at 131,072 tokens/step for the ~127M `poc` config
+(CLAUDE.md, issue #30). That fixes M1 Pro's achieved throughput at ~1.0 TFLOP/s
+and makes the M1 Pro column reproduce the documented "3B-token run ≈ 26 days".
+The H100 entries use H100 bf16 dense peak × an assumed MFU; there is no in-repo
+H100 benchmark yet, so they are clearly labelled estimates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Union
+
+from .sizing import load_family
+
+TFLOP = 1e12
+
+# --- 6·N·D training-FLOPs constant -------------------------------------------
+FLOPS_PER_PARAM_PER_TOKEN = 6  # ~2N fwd + ~4N bwd per token
+
+# --- Measured calibration anchor (CLAUDE.md / issue #30) ----------------------
+# config/poc.yaml at the standard protocol: batch 32 × grad_accum 4 × seq 1024.
+ANCHOR_PARAMS = 126_731_712       # == load_config("config/poc.yaml").num_parameters()
+ANCHOR_TOKENS_PER_STEP = 131_072  # 32 × 4 × 1024
+ANCHOR_SECONDS_PER_STEP = 99.0
+
+# --- Chinchilla compute-optimal token budget ---------------------------------
+CHINCHILLA_TOKENS_PER_PARAM = 20
+
+# --- H100 reference peak (bf16, dense, no sparsity) ---------------------------
+H100_PEAK_TFLOPS = 990.0
+DEFAULT_MFU = 0.40            # plausible bf16 MFU for a tuned SSM/attention hybrid
+DEFAULT_SCALING = 0.85        # 8-GPU near-linear scaling efficiency assumption
+
+
+def training_flops(params: int, tokens: float) -> float:
+    """Estimated total training FLOPs for `tokens` tokens (6·N·D)."""
+    return FLOPS_PER_PARAM_PER_TOKEN * params * tokens
+
+
+def chinchilla_tokens(params: int) -> int:
+    """Compute-optimal token budget: 20 tokens per parameter."""
+    return CHINCHILLA_TOKENS_PER_PARAM * params
+
+
+@dataclass(frozen=True)
+class Hardware:
+    """A reference machine and its achieved (effective) training throughput.
+
+    `effective_flops` is FLOP/s actually delivered to training — for GPUs it is
+    `peak_tflops·TFLOP · mfu · n_devices · scaling`; for the calibrated M1 Pro it
+    is derived from the measured bench point.
+    """
+
+    name: str
+    effective_flops: float
+    note: str
+    peak_tflops: Optional[float] = None
+    mfu: Optional[float] = None
+    n_devices: int = 1
+    scaling: float = 1.0
+    calibrated: bool = False
+
+
+def _m1pro_effective_flops() -> float:
+    """Achieved FLOP/s on M1 Pro, calibrated from the measured 99 s/step anchor."""
+    tokens_per_sec = ANCHOR_TOKENS_PER_STEP / ANCHOR_SECONDS_PER_STEP
+    return training_flops(ANCHOR_PARAMS, tokens_per_sec)
+
+
+def gpu_hardware(name: str, peak_tflops: float, mfu: float, n_devices: int,
+                 scaling: float, note: str) -> Hardware:
+    """Build a GPU Hardware from peak × MFU × devices × scaling."""
+    eff = peak_tflops * TFLOP * mfu * n_devices * scaling
+    return Hardware(name, eff, note, peak_tflops=peak_tflops, mfu=mfu,
+                    n_devices=n_devices, scaling=scaling, calibrated=False)
+
+
+def default_registry(mfu: float = DEFAULT_MFU,
+                     scaling: float = DEFAULT_SCALING) -> dict:
+    """The three reference machines, keyed by name (insertion order preserved)."""
+    m1pro = Hardware(
+        "m1pro", _m1pro_effective_flops(),
+        "poc 99 s/step @ 131K tok/step (CLAUDE.md)",
+        peak_tflops=10.4, mfu=None, n_devices=1, scaling=1.0, calibrated=True,
+    )
+    h100 = gpu_hardware(
+        "h100", H100_PEAK_TFLOPS, mfu, 1, 1.0,
+        f"H100 bf16 peak × {mfu:.0%} MFU (no in-repo bench)",
+    )
+    cluster = gpu_hardware(
+        "8xh100", H100_PEAK_TFLOPS, mfu, 8, scaling,
+        f"8×H100 bf16 peak × {mfu:.0%} MFU × {scaling:.0%} scaling",
+    )
+    return {hw.name: hw for hw in (m1pro, h100, cluster)}
+
+
+def train_seconds(params: int, tokens: float, hw: Hardware) -> float:
+    """Estimated wall-clock seconds to train `params` over `tokens` on `hw`."""
+    return training_flops(params, tokens) / hw.effective_flops
+
+
+def parse_count(text: str) -> int:
+    """Parse a human count with a K/M/B/G/T suffix: '270M' -> 270_000_000."""
+    s = text.strip().upper()
+    mult = 1.0
+    suffixes = {"K": 1e3, "M": 1e6, "B": 1e9, "G": 1e9, "T": 1e12}
+    if s and s[-1] in suffixes:
+        mult = suffixes[s[-1]]
+        s = s[:-1]
+    return int(float(s) * mult)
+
+
+def format_count(params: int) -> str:
+    """Render a param count compactly: 126731712 -> '127M'."""
+    if params >= 1e9:
+        return f"{params / 1e9:.2f}B"
+    if params >= 1e6:
+        return f"{params / 1e6:.0f}M"
+    return str(params)
+
+
+def format_time(seconds: float) -> str:
+    """Render seconds in the largest sensible unit: s / m / h / d / y."""
+    minute, hour, day, year = 60.0, 3600.0, 86400.0, 86400.0 * 365.0
+    if seconds < minute:
+        return f"{seconds:.0f} s"
+    if seconds < hour:
+        return f"{seconds / minute:.1f} m"
+    if seconds < day:
+        return f"{seconds / hour:.1f} h"
+    if seconds < year:
+        return f"{seconds / day:.1f} d"
+    return f"{seconds / year:.1f} y"
+
+
+def default_sizes(config_dir: Union[str, Path] = "config") -> list:
+    """(label, params) ladder: real configs (poc, 1b) + a generic round ladder."""
+    sizes = [(name, cfg.num_parameters()) for name, cfg in load_family(config_dir)]
+    for label in ("270M", "3B", "7B"):
+        sizes.append((label, parse_count(label)))
+    return sorted(sizes, key=lambda lp: lp[1])
+
+
+def format_report(sizes: Iterable[tuple], hardware: Iterable[Hardware],
+                  fixed_tokens: Optional[int] = None) -> str:
+    """Render the full estimate: an assumptions block + a size × hardware table.
+
+    `sizes` is an iterable of (label, params). Token budget per row is
+    `fixed_tokens` if given, else Chinchilla 20×params.
+    """
+    sizes = list(sizes)
+    hardware = list(hardware)
+
+    budget_desc = (f"{format_count(fixed_tokens)} tokens (fixed, --tokens)"
+                   if fixed_tokens is not None
+                   else f"{CHINCHILLA_TOKENS_PER_PARAM}× params (Chinchilla compute-optimal)")
+
+    lines = [
+        "Training-time estimate  (PLANNING ESTIMATE — not a benchmark)",
+        f"  compute model : {FLOPS_PER_PARAM_PER_TOKEN}·N·D FLOPs  (fwd+bwd)",
+        f"  token budget  : {budget_desc}",
+        "  throughput    :",
+    ]
+    for hw in hardware:
+        tag = "measured-calibrated" if hw.calibrated else "estimate"
+        lines.append(f"    {hw.name:<8} {hw.effective_flops / TFLOP:>8.1f} TFLOP/s  "
+                     f"({tag}: {hw.note})")
+    lines.append("")
+
+    # Table: size | params | tokens | one time column per hardware.
+    name_w = max(5, max(len(label) for label, _ in sizes))
+    col_w = max(8, max(len(hw.name) for hw in hardware))
+    header = (f"{'size':<{name_w}} {'params':>8} {'tokens':>9}  "
+              + "  ".join(f"{hw.name:>{col_w}}" for hw in hardware))
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for label, params in sizes:
+        tokens = fixed_tokens if fixed_tokens is not None else chinchilla_tokens(params)
+        cells = []
+        for hw in hardware:
+            cells.append(f"{format_time(train_seconds(params, tokens, hw)):>{col_w}}")
+        lines.append(
+            f"{label:<{name_w}} {format_count(params):>8} {format_count(tokens):>9}  "
+            + "  ".join(cells)
+        )
+    return "\n".join(lines)

--- a/src/model/train_time.py
+++ b/src/model/train_time.py
@@ -120,6 +120,15 @@ def train_seconds(params: int, tokens: float, hw: Hardware) -> float:
     return training_flops(params, tokens) / hw.effective_flops
 
 
+def tokens_trainable(params: int, seconds: float, hw: Hardware) -> float:
+    """Inverse of `train_seconds`: tokens trainable in `seconds` on `hw`.
+
+    The natural laptop question — "what can I train in a day?" — and the right
+    lens for exploratory POC runs, which run far fewer than Chinchilla tokens.
+    """
+    return hw.effective_flops * seconds / (FLOPS_PER_PARAM_PER_TOKEN * params)
+
+
 def parse_count(text: str) -> int:
     """Parse a human count with a K/M/B/G/T suffix: '270M' -> 270_000_000."""
     s = text.strip().upper()
@@ -205,4 +214,45 @@ def format_report(sizes: Iterable[tuple], hardware: Iterable[Hardware],
             f"{label:<{name_w}} {format_count(params):>8} {format_count(tokens):>9}  "
             + "  ".join(cells)
         )
+    if fixed_tokens is None:
+        lines.append("")
+        lines.append("note: 20×params is compute-optimal — an UPPER BOUND, not a POC run.")
+        lines.append("      Exploratory runs use far fewer tokens; use --hours N for what a")
+        lines.append("      fixed wall-clock buys (e.g. a 200M model trains ~72M tokens in 24h on M1).")
+    return "\n".join(lines)
+
+
+def format_trainable_report(sizes: Iterable[tuple], hardware: Iterable[Hardware],
+                            seconds: float) -> str:
+    """Inverse report: tokens trainable in a fixed wall-clock window per machine.
+
+    The lens that matches how POC runs are actually planned ("what fits in a
+    day?"). `sizes` is an iterable of (label, params); `seconds` is the budget.
+    """
+    sizes = list(sizes)
+    hardware = list(hardware)
+
+    lines = [
+        "Tokens trainable in a fixed wall-clock  (PLANNING ESTIMATE — not a benchmark)",
+        f"  compute model : {FLOPS_PER_PARAM_PER_TOKEN}·N·D FLOPs  (fwd+bwd)",
+        f"  wall-clock    : {format_time(seconds)}",
+        "  throughput    :",
+    ]
+    for hw in hardware:
+        tag = "measured-calibrated" if hw.calibrated else "estimate"
+        lines.append(f"    {hw.name:<8} {hw.effective_flops / TFLOP:>8.1f} TFLOP/s  "
+                     f"({tag}: {hw.note})")
+    lines.append("")
+
+    name_w = max(5, max(len(label) for label, _ in sizes))
+    col_w = max(9, max(len(hw.name) for hw in hardware))
+    header = (f"{'size':<{name_w}} {'params':>8}  "
+              + "  ".join(f"{hw.name:>{col_w}}" for hw in hardware))
+    lines.append(header)
+    lines.append("-" * len(header))
+
+    for label, params in sizes:
+        cells = [f"{format_count(int(tokens_trainable(params, seconds, hw))):>{col_w}}"
+                 for hw in hardware]
+        lines.append(f"{label:<{name_w}} {format_count(params):>8}  " + "  ".join(cells))
     return "\n".join(lines)

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -36,6 +36,7 @@ PORTABLE_MODULES = [
     "src.model.teacher",
     "src.model.api_teacher",
     "src.model.sizing",
+    "src.model.train_time",
     "src.data.loader",
     "src.data.corpus",
     "src.data.storage",

--- a/tests/test_train_time.py
+++ b/tests/test_train_time.py
@@ -1,0 +1,79 @@
+"""Tests for the portable training-time estimator (src/model/train_time.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.model.train_time import (
+    ANCHOR_PARAMS,
+    ANCHOR_SECONDS_PER_STEP,
+    ANCHOR_TOKENS_PER_STEP,
+    chinchilla_tokens,
+    default_registry,
+    format_count,
+    format_time,
+    parse_count,
+    train_seconds,
+    training_flops,
+)
+
+SECONDS_PER_DAY = 86400.0
+
+
+def test_m1pro_reproduces_measured_anchor():
+    """The calibrated M1 Pro must reproduce its own bench point exactly."""
+    hw = default_registry()["m1pro"]
+    secs = train_seconds(ANCHOR_PARAMS, ANCHOR_TOKENS_PER_STEP, hw)
+    assert secs == pytest.approx(ANCHOR_SECONDS_PER_STEP, rel=1e-9)
+
+
+def test_m1pro_3b_run_is_about_26_days():
+    """Sanity: poc-scale @ 3B tokens on M1 Pro ≈ 26 days (CLAUDE.md claim)."""
+    hw = default_registry()["m1pro"]
+    days = train_seconds(ANCHOR_PARAMS, 3e9, hw) / SECONDS_PER_DAY
+    assert days == pytest.approx(26.0, abs=1.0)
+
+
+def test_cluster_scales_over_single_h100():
+    """8×H100 effective throughput = 8 × single × scaling efficiency."""
+    reg = default_registry(mfu=0.40, scaling=0.85)
+    ratio = reg["8xh100"].effective_flops / reg["h100"].effective_flops
+    assert ratio == pytest.approx(8 * 0.85, rel=1e-9)
+
+
+def test_overrides_change_h100_only():
+    """--mfu/--scaling retune the GPU entries but never the calibrated M1 Pro."""
+    base = default_registry()
+    tuned = default_registry(mfu=0.50, scaling=0.90)
+    assert tuned["m1pro"].effective_flops == base["m1pro"].effective_flops
+    assert tuned["h100"].effective_flops > base["h100"].effective_flops
+
+
+def test_chinchilla_and_flops():
+    assert chinchilla_tokens(1_000) == 20_000
+    assert training_flops(100, 10) == 6 * 100 * 10
+
+
+def test_format_time_units():
+    assert format_time(30) == "30 s"
+    assert format_time(90).endswith(" m")
+    assert format_time(2 * 3600).endswith(" h")
+    assert format_time(3 * 86400).endswith(" d")
+    assert format_time(2 * 365 * 86400).endswith(" y")
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("270M", 270_000_000),
+    ("3B", 3_000_000_000),
+    ("7b", 7_000_000_000),
+    ("1.5B", 1_500_000_000),
+    ("500K", 500_000),
+    ("1000", 1000),
+])
+def test_parse_count(text, expected):
+    assert parse_count(text) == expected
+
+
+def test_format_count_roundtrip_label():
+    assert format_count(126_731_712) == "127M"
+    assert format_count(1_033_650_944) == "1.03B"

--- a/tests/test_train_time.py
+++ b/tests/test_train_time.py
@@ -13,6 +13,7 @@ from src.model.train_time import (
     format_count,
     format_time,
     parse_count,
+    tokens_trainable,
     train_seconds,
     training_flops,
 )
@@ -32,6 +33,20 @@ def test_m1pro_3b_run_is_about_26_days():
     hw = default_registry()["m1pro"]
     days = train_seconds(ANCHOR_PARAMS, 3e9, hw) / SECONDS_PER_DAY
     assert days == pytest.approx(26.0, abs=1.0)
+
+
+def test_tokens_trainable_is_inverse_of_train_seconds():
+    """tokens_trainable and train_seconds must round-trip exactly."""
+    hw = default_registry()["m1pro"]
+    secs = train_seconds(500_000_000, 1.2e9, hw)
+    assert tokens_trainable(500_000_000, secs, hw) == pytest.approx(1.2e9, rel=1e-9)
+
+
+def test_200m_in_24h_on_m1_matches_real_run():
+    """Ground-truth reconciliation: a 200M model trains ~72M tokens in 24h on M1."""
+    hw = default_registry()["m1pro"]
+    tokens = tokens_trainable(200_000_000, SECONDS_PER_DAY, hw)
+    assert tokens / 1e6 == pytest.approx(72.0, abs=3.0)
 
 
 def test_cluster_scales_over_single_h100():


### PR DESCRIPTION
Portable estimator that turns a parameter count and token budget into an
estimated training wall-clock on reference hardware (M1 Pro, single H100,
8×H100). Uses the 6·N·D training-FLOPs model; M1 Pro throughput is calibrated
from the measured poc 99 s/step anchor (reproduces the ~26-day / 3B-token
figure in CLAUDE.md), H100 entries are peak × assumed MFU.

- src/model/train_time.py: portable logic (no backend), reuses sizing.load_family
- scripts/train_time.py: thin CLI mirroring scripts/model_size.py
- tests/test_train_time.py: calibration, scaling, formatting, parsing
- tests/test_import_guard.py: register the new portable module

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ULjtooL2j5uPgS738wcC8e