### PR TITLE
fix(runpod): preflight A1 + bootstrap --no-build-isolation for torch 2.12

### DIFF
--- a/scripts/runpod/m10/bootstrap.sh
+++ b/scripts/runpod/m10/bootstrap.sh
@@ -24,9 +24,14 @@ fi
 cd "$WORKSPACE"
 echo "[bootstrap] repo at $(git rev-parse --short HEAD)"
 
-# --- 2. Install: cuda-fast for fused Mamba Triton scan + causal-conv1d (#40) ---
-echo "[bootstrap] pip install cuda-fast"
-pip install -e ".[dev,data,cuda-fast]"
+# --- 2. Install: base first, then mamba-ssm/causal-conv1d with --no-build-isolation.
+#    mamba-ssm's setup.py imports torch at build time; pip's isolated build env lacks it,
+#    so the plain `pip install -e ".[cuda-fast]"` form fails. Installing the base first
+#    (which resolves torch from the image) then building the Triton kernels against it works.
+echo "[bootstrap] pip install base (cuda)"
+pip install -e ".[dev,data,cuda]" -q
+echo "[bootstrap] pip install mamba-ssm + causal-conv1d (no-build-isolation)"
+pip install "mamba-ssm>=2.0" "causal-conv1d>=1.0" --no-build-isolation
 
 # --- 3. s3fs pin — a bare install upgrades fsspec and breaks datasets (#memory: s3fs-fsspec-pin) ---
 echo "[bootstrap] pin s3fs==2026.2.0"

--- a/scripts/runpod/m10/preflight.sh
+++ b/scripts/runpod/m10/preflight.sh
@@ -15,18 +15,21 @@ echo "=== M10 preflight: $(date) ==="
 echo ""
 echo "── A. Environment $(date) ──"
 
-echo "[A1] mamba_ssm + causal_conv1d importable (cuda-fast succeeded)"
+echo "[A1] fused Triton SSD scan engages via mamba_ssm.ops.triton (the critical path)"
 python -c "
-import mamba_ssm, causal_conv1d
-print('  mamba_ssm', mamba_ssm.__version__, 'causal_conv1d', causal_conv1d.__version__)
-"
-
-echo "[A2] fused Triton SSD scan engages (not the silent pure-PyTorch fallback)"
-python -c "
+# Test the actual code path, not the top-level mamba_ssm import.
+# mamba_ssm.__init__ imports selective_scan_cuda which has a known ABI mismatch on
+# torch 2.12+cu130 (symbol 'ib' vs 'jb' for unsigned int). The _fused_scan() stub
+# bypasses __init__ and imports ops.triton.ssd_combined directly — that path works.
+# causal_conv1d has the same ABI issue; the code falls back to PyTorch conv (minor hit).
 from src.model.cuda_backend import _fused_scan
 s = _fused_scan()
-assert s is not None, 'fused scan kernel not loaded — cuda-fast install failed or GPU not visible'
-print('  fused scan kernel:', s)
+assert s is not None, 'fused scan kernel not loaded — mamba-ssm install or GPU issue'
+print('  fused scan kernel OK:', s.__module__)
+import sys; sys.path.insert(0, '.')
+from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+print('  mamba_ssm.ops.triton import OK')
+import torch; print('  torch', torch.__version__, 'cuda', torch.version.cuda)
 "
 
 echo "[A3] s3fs==2026.2.0 pin holds"


### PR DESCRIPTION
## Summary
Two fixes discovered during Phase B live pod run (H100 80GB HBM3, `6prrshrfoi1768`, torch 2.12.1+cu130):

1. **bootstrap.sh** (`#158`, already merged): `pip install -e ".[cuda-fast]"` fails because `mamba-ssm` setup.py imports torch in pip's isolated build env. Fix: install base cuda first, then `mamba-ssm`/`causal-conv1d` with `--no-build-isolation`.

2. **preflight.sh A1** (this PR): `import mamba_ssm, causal_conv1d` fails on torch 2.12+cu130 due to ABI symbol mismatch (`ib` vs `jb` for `unsigned int` in `c10_cuda_check_implementation`). The **actual code path** (`_fused_scan()`) bypasses `__init__` via a stub and imports `ops.triton.ssd_combined` directly — that works. Preflight A1 now tests what the training code actually calls. `causal_conv1d` falls back to PyTorch conv (minor perf hit; fused SSD scan dominates).

## Test plan
- [x] `bash -n scripts/runpod/m10/preflight.sh` passes
- [x] Verified on live pod: `_fused_scan()` returns kernel, `mamba_ssm.ops.triton.ssd_combined` imports OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HNRoURmdJfJTm2XhZZAUF