### PR TITLE
fix: cluster-mode val split is sliced by num_shards in precompute_teacher.py, not run in full on shard-0

### DIFF
--- a/scripts/precompute_teacher.py
+++ b/scripts/precompute_teacher.py
@@ -174,7 +174,13 @@ def main() -> None:
         if total_chunks == 0:
             raise ValueError(f"{split}.bin too small for one chunk (seq_len={seq_len})")
 
-        if cluster:
+        # `val` is never shard-divided: shard 0 owns the whole val split (the launcher only
+        # gives val to shard 0). Other shards skip it entirely. `train` IS sharded across pods.
+        split_cluster = cluster and split != "val"
+        if cluster and split == "val" and shard_id != 0:
+            print(f"[shard {shard_id}] skipping val (owned by shard 0)", flush=True)
+            continue
+        if split_cluster:
             per_shard, remainder = divmod(total_chunks, num_shards)
             start_chunk = shard_id * per_shard + min(shard_id, remainder)
             this_chunks = per_shard + (1 if shard_id < remainder else 0)

--- a/tests/test_precompute_teacher.py
+++ b/tests/test_precompute_teacher.py
@@ -46,10 +46,10 @@ def _write_manifest(path: Path):
         "layout: {d_model: 16, n_layers: 2}\n")
 
 
-def _build_split(data_dir: Path, n_chunks: int):
+def _build_split(data_dir: Path, n_chunks: int, val_chunks: int = 2):
     data_dir.mkdir(parents=True, exist_ok=True)
     stride = SEQ_LEN + 1
-    for split, n in (("train", n_chunks), ("val", 2)):
+    for split, n in (("train", n_chunks), ("val", val_chunks)):
         ids = (np.arange(n * stride + 1) % VOCAB).astype(np.uint16)
         pack_ids(ids, data_dir / f"{split}.bin", dtype=np.uint16)
 
@@ -85,3 +85,34 @@ def test_precompute_cli_offline(tmp_path):
     inputs, targets, vals, idx = next(iter(loader.epoch()))
     assert inputs.shape == (2, SEQ_LEN) and vals.shape == (2, SEQ_LEN, 8)
     assert idx.min() >= 0 and idx.max() < VOCAB
+
+
+def test_precompute_val_full_on_shard0(tmp_path):
+    """(#174) `val` must never be shard-divided in cluster mode: shard 0 owns the full val
+    split (the launcher only assigns val to shard 0), while `train` IS sharded across pods."""
+    backend = _backend()
+    data = tmp_path / "split"
+    out = tmp_path / "teacher-outputs"
+    n_chunks = 8
+    val_chunks = 6
+    _build_split(data, n_chunks, val_chunks=val_chunks)
+    manifest = tmp_path / "toy.yaml"
+    _write_manifest(manifest)
+
+    res = subprocess.run(
+        [sys.executable, "scripts/precompute_teacher.py",
+         "--manifest", str(manifest), "--data", str(data), "--out", str(out),
+         "--backend", backend, "--k", "8", "--batch-size", "2", "--synthetic",
+         "--shard-id", "0", "--num-shards", "4"],
+        cwd=REPO, capture_output=True, text=True,
+        env={"PYTHONPATH": str(REPO), "PATH": __import__("os").environ.get("PATH", "")},
+    )
+    assert res.returncode == 0, f"precompute failed:\n{res.stdout}\n{res.stderr}"
+
+    shard0 = out / "shard-0"
+    val_meta = read_teacher_meta(shard0, "val")
+    assert val_meta["n_chunks"] == val_chunks, (
+        f"val must be processed in full on shard 0, not sliced by num_shards "
+        f"(got {val_meta['n_chunks']}, expected {val_chunks})")
+    train_meta = read_teacher_meta(shard0, "train")
+    assert train_meta["n_chunks"] == n_chunks // 4, "train IS still sharded across pods"


### PR DESCRIPTION
Closes #174

## Summary
- `scripts/precompute_teacher.py`: `val` is no longer shard-divided in cluster mode — shard 0 now processes the entire val split; other shards skip it. `train` is still sharded across pods as before.
- `tests/test_precompute_teacher.py`: added `test_precompute_val_full_on_shard0`, which builds train=8/val=6 chunks and asserts under `--shard-id 0 --num-shards 4` that val comes out whole (6 chunks) while train is still sharded (2 of 8).

This fixes the bug where the completed Phase-B precompute run recorded val = 305 chunks instead of the expected 1220 (305 ≈ 1220 // 4), which would hard-fail `DistillLoader`'s `n_chunks` assertion the moment Phase C constructs a val loader.

Note: the real val-only re-precompute + re-merge against the qwen3-8k corpus (to get the full 1220 val chunks) is pod-gated and out of scope for this PR — tracked as the remaining unchecked item on #174.

## Testing
- [x] Tests added/updated
- [x] All tests passing (`tests/test_precompute_teacher.py`: 2 passed; full suite: 544 passed, 4 skipped, no regressions)
- [ ] Manual testing completed (pod-gated real re-precompute is out of scope for this PR)