### PR TITLE
fix: correct dataset-level licenses in corpus-extension sources

### DIFF
--- a/src/data/distill_sources.py
+++ b/src/data/distill_sources.py
@@ -42,6 +42,14 @@ DEFAULT_CODE_LANGS: List[str] = [
     "shell", "hcl", "powershell", "ruby", "c++", "cmake", "r", "markdown", "lua", "matlab",
 ]
 
+#: Dataset-level (not per-row) licenses for curated single-license sources, confirmed against
+#: the live HF dataset cards (2026-07-03) — these datasets carry no per-row license field, so
+#: probing one always yielded "unknown" before this fix.
+DATASET_LEVEL_LICENSE = {
+    "openwebmath": "odc-by",
+    "library-docs": "cc-by-sa-4.0",
+}
+
 
 # --------------------------------------------------------------------------- #
 # License-field fallback helper
@@ -84,8 +92,8 @@ def iter_the_stack_dedup(langs: Iterable[str]) -> Iterator[Record]:
 
 def iter_the_stack_smol(langs: Iterable[str]) -> Iterator[Record]:
     """Fallback code source (single streaming config, filtered by `row["lang"]`) for when
-    `the-stack-dedup`'s gate/`HF_TOKEN` isn't available. Field names per the dataset card;
-    unverified against the live dataset in this dispatch (see plan)."""
+    `the-stack-dedup`'s gate/`HF_TOKEN` isn't available. Field names verified against the live
+    dataset card (2026-07-03): `content`/`lang`/`licenses` are correct as coded."""
     from datasets import load_dataset  # pragma: no cover - network/optional extra
 
     wanted = {lang.strip().lower() for lang in langs}
@@ -97,7 +105,7 @@ def iter_the_stack_smol(langs: Iterable[str]) -> Iterator[Record]:
         text = row.get("content")
         if not text:
             continue
-        license = _first_license(row, ("licenses", "repository_name"))
+        license = _first_license(row, ("licenses",))
         yield Record(text=text, source="the-stack-smol", lang=lang, license=license,
                     meta={"is_code": True})
 
@@ -106,7 +114,10 @@ def iter_the_stack_smol(langs: Iterable[str]) -> Iterator[Record]:
 # Math — open-web-math
 # --------------------------------------------------------------------------- #
 def iter_open_web_math() -> Iterator[Record]:
-    """Stream `open-web-math/open-web-math` (lazy `datasets`, streaming)."""
+    """Stream `open-web-math/open-web-math` (lazy `datasets`, streaming). Verified against the
+    live dataset card (2026-07-03): the `text` field is correct, but the license is
+    dataset-level (`odc-by`), not a per-row column — rows without a `license` key fall back to
+    `DATASET_LEVEL_LICENSE["openwebmath"]` instead of `"unknown"`."""
     from datasets import load_dataset  # pragma: no cover - network/optional extra
 
     ds = load_dataset("open-web-math/open-web-math", split="train",  # pragma: no cover
@@ -116,14 +127,18 @@ def iter_open_web_math() -> Iterator[Record]:
         if not text:
             continue
         yield Record(text=text, source="openwebmath", lang="en",
-                    license=_first_license(row, ("license",)))
+                    license=row.get("license") or DATASET_LEVEL_LICENSE["openwebmath"])
 
 
 # --------------------------------------------------------------------------- #
 # Docs — code-rag-bench/library-documentation
 # --------------------------------------------------------------------------- #
 def iter_library_documentation() -> Iterator[Record]:
-    """Stream `code-rag-bench/library-documentation` (~62 MB; lazy `datasets`, streaming)."""
+    """Stream `code-rag-bench/library-documentation` (~62 MB; lazy `datasets`, streaming).
+    Verified against the live dataset card (2026-07-03): the `doc_content` field is correct,
+    but there is no per-row `license` column — license is dataset-level (`cc-by-sa-4.0`); rows
+    without a `license` key fall back to `DATASET_LEVEL_LICENSE["library-docs"]` instead of
+    `"unknown"`."""
     from datasets import load_dataset  # pragma: no cover - network/optional extra
 
     ds = load_dataset("code-rag-bench/library-documentation",  # pragma: no cover
@@ -133,7 +148,7 @@ def iter_library_documentation() -> Iterator[Record]:
         if not text:
             continue
         yield Record(text=text, source="library-docs", lang="en",
-                    license=_first_license(row, ("license",)))
+                    license=row.get("license") or DATASET_LEVEL_LICENSE["library-docs"])
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_distill_sources.py
+++ b/tests/test_distill_sources.py
@@ -6,7 +6,8 @@ this only exercises the pure mapper/render/cap/orchestration functions with fabr
 
 from src.data.corpus import Record
 from src.data.distill_sources import (build_extension_records, char_budget_cap,
-                                       messages_to_text)
+                                       iter_library_documentation, iter_open_web_math,
+                                       iter_the_stack_smol, messages_to_text)
 
 
 def test_messages_to_text_renders_role_prefixed_turns():
@@ -131,3 +132,42 @@ def test_build_extension_records_unknown_source_raises():
     stream, _counter = build_extension_records({"conversation": {"sources": ["nope"]}})
     with pytest.raises(ValueError):
         list(stream)
+
+
+# --------------------------------------------------------------------------- #
+# Dataset-level license fallback (#176) — open-web-math / library-documentation have no
+# per-row `license` field; the-stack-smol's `repository_name` fallback was bogus (not a
+# license field). These monkeypatch the lazy `datasets.load_dataset` import site.
+# --------------------------------------------------------------------------- #
+def test_iter_open_web_math_falls_back_to_dataset_level_license(monkeypatch):
+    def fake_load_dataset(*args, **kwargs):
+        return [{"text": "some math text"}]  # no "license" key, as on the real dataset
+
+    monkeypatch.setattr("datasets.load_dataset", fake_load_dataset)
+
+    records = list(iter_open_web_math())
+    assert len(records) == 1
+    assert records[0].license == "odc-by"
+
+
+def test_iter_library_documentation_falls_back_to_dataset_level_license(monkeypatch):
+    def fake_load_dataset(*args, **kwargs):
+        return [{"doc_content": "some docs text"}]  # no "license" key, as on the real dataset
+
+    monkeypatch.setattr("datasets.load_dataset", fake_load_dataset)
+
+    records = list(iter_library_documentation())
+    assert len(records) == 1
+    assert records[0].license == "cc-by-sa-4.0"
+
+
+def test_iter_the_stack_smol_uses_real_licenses_field_not_repository_name(monkeypatch):
+    def fake_load_dataset(*args, **kwargs):
+        return [{"content": "print('hi')", "lang": "python", "licenses": ["mit"],
+                 "repository_name": "foo/bar"}]
+
+    monkeypatch.setattr("datasets.load_dataset", fake_load_dataset)
+
+    records = list(iter_the_stack_smol(["python"]))
+    assert len(records) == 1
+    assert records[0].license == "mit"


### PR DESCRIPTION
Part of #176.

## Summary
- `iter_open_web_math` / `iter_library_documentation` (in `src/data/distill_sources.py`) previously always recorded `license="unknown"` because `open-web-math` and `code-rag-bench/library-documentation` carry no per-row `license` field — license is dataset-level for both. Added a `DATASET_LEVEL_LICENSE` constant (`odc-by`, `cc-by-sa-4.0` respectively) as the fallback, verified against the live HuggingFace dataset cards (2026-07-03).
- `iter_the_stack_smol` dropped a bogus `repository_name` fallback from its license lookup (that field is the repo name, not a license); the real per-row `licenses` field was already correct and remains the only source.
- Updated docstrings that called these fields "unverified" — they're now verified against the live dataset cards.

This is a **partial** slice of #176: it hardens the already-merged (PR #173) corpus-extension source machinery so provenance tracking is correct once the real build runs. It does **not** perform the actual corpus build + R2 push (that step needs `HF_TOKEN`, live network, and hours of Mac compute — a separate user-run operational step), so this PR does not close #176.

## Testing
- [x] Tests added (`tests/test_distill_sources.py`): 3 new hermetic tests monkeypatching the lazy `datasets.load_dataset` import, asserting the dataset-level license fallback and the corrected the-stack-smol behavior.
- [x] All tests passing: `tests/test_distill_sources.py` 15/15, `tests/test_import_guard.py` 2/2, full suite 547 passed / 4 skipped (expected: no CUDA device, datatrove not installed, opt-in code-verifier) / 0 failed.
- [x] No smoke gate needed — change is above-the-seam data-provenance code only, no model/backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)