### PR TITLE
docs: stage the #177 Phase B' append-precompute runbook + hi-layout config

### DIFF
--- a/config/student-1b-attn-hi.yaml
+++ b/config/student-1b-attn-hi.yaml
@@ -1,0 +1,31 @@
+# ~1B Mamba-2 HYBRID student — higher-attention sibling of student-1b-attn-lo.yaml
+# (student-1b-attn-hi sweep variant). Same d_model/n_layers; higher attention fraction
+# (attn_every 8 -> 3 of 28 layers = ~10.7%) + narrower state (d_state 128), matching
+# student-1b.yaml's architecture exactly (that file is the sweep seed and numerically
+# already IS this layout). Added for hi/lo naming symmetry: -lo has a named config here;
+# -hi previously existed only as config/manifests/student-1b-attn-hi.yaml. Derived from the
+# manifest layout in config/manifests/student-1b-attn-hi.yaml (manifest_to_config maps
+# attention_every -> attn_every, state_size -> d_state). Needed by scripts/sft.py and
+# scripts/rlvr.py at post-training time — those drivers take a config yaml, not a manifest.
+d_model: 2048
+n_layers: 28
+d_state: 128           # narrower state — the higher attention fraction carries more recall
+expand: 2
+d_conv: 4
+head_dim: 64           # Mamba-2/SSD: 4096/64 = 64 heads (scalar A per head)
+dt_rank: auto
+
+attn_every: 8           # 3 of 28 layers attention (~10.7%) — the higher-attention sibling
+n_attn_heads: 16         # must divide d_model 2048 -> attn_head_dim = 128
+
+vocab_size: 151669     # Qwen3 — FIXED by the conversion teacher; uint32 packing (#90)
+seq_len: 8192
+tie_embeddings: true
+precision: bf16
+chunk_size: null
+grad_checkpoint: true  # required at this depth
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/docs/path-b-run.md
+++ b/docs/path-b-run.md
@@ -1,5 +1,15 @@
 # Path B run — session handoff (full-scale M10 distillation, ~1B student)
 
+> **Update (2026-07-03) — Steps 1 & 3 are DONE for the base corpus; don't re-run them as-is.**
+> The base 8k corpus build (Step 1) and the base teacher precompute (Step 3) both completed
+> 2026-07-02 (566 GB merged cache at `poc-distill/teacher-outputs/topk-logits-merged/`, 230,318
+> train chunks). The "Current state" section below predates that and is stale. Since then the
+> corpus was **extended** with new domains (#176) — extending the teacher cache for those new
+> chunks is an **append**, not a full re-precompute: see
+> [`runbooks/m10-phase-bprime-append.md`](runbooks/m10-phase-bprime-append.md) (#177) and run it
+> **before** Step 4 below. Only fall back to this doc's Step 3 if the append's alignment gate
+> fails (see that runbook's "Why append, not re-precompute").
+
 Self-contained runbook to execute the **real M10 deliverable** ([issue #141](https://github.com/travisgalloway/monica/issues/141),
 parent tracker [#65](https://github.com/travisgalloway/monica/issues/65)): distil a compact ~1B
 Mamba-2 hybrid student from the frozen `Qwen/Qwen3-4B-Thinking-2507` teacher, sweep the two attention
@@ -143,6 +153,11 @@ winner.
 
 ## Step 3 — teacher precompute at scale (GPU pod — the dominant cost)
 
+> **Already done for the base corpus (2026-07-02).** If you're extending an already-precomputed
+> corpus (the #176 domain extension), use the **append** flow instead —
+> [`runbooks/m10-phase-bprime-append.md`](runbooks/m10-phase-bprime-append.md) (#177) — which
+> reuses this cache rather than re-running the full 4B forward below.
+
 The 4B forward over the whole corpus. Done **once**; both students reuse it (the manifests share
 `teacher_outputs`). **Bench on a small slice first** to size the card and cost before the long run.
 
@@ -167,6 +182,11 @@ python scripts/precompute_teacher.py \
   to get the real s/batch**, then multiply by token count.
 
 ## Step 4 — student sweep (GPU pod — reuse the one precompute)
+
+> **Run the #177 append first** if the corpus extension (#176) hasn't been merged into the
+> teacher cache yet — see [`runbooks/m10-phase-bprime-append.md`](runbooks/m10-phase-bprime-append.md).
+> Otherwise the sweep below trains only against the base FineWeb-derived corpus, not the full
+> extended blend.
 
 Two sibling manifests, **same** corpus + teacher outputs, only `layout` differs:
 `attn-hi` (`attention_every 8` → 3/28 attn ≈10.7%, `state_size 128`) vs

--- a/docs/runbooks/m10-phase-bprime-append.md
+++ b/docs/runbooks/m10-phase-bprime-append.md
@@ -1,0 +1,207 @@
+# M10 Phase B′ — append-only teacher precompute for the corpus extension (#177)
+
+Ready-to-fire runbook for **#177**: extend the frozen 566 GB Qwen3-4B-Thinking teacher top-k cache
+to cover the multi-domain corpus extension (#176, built 2026-07-03) **without re-precomputing the
+~230,318 unchanged FineWeb chunks**. All machinery is merged
+(`scripts/verify_teacher_alignment.py`, `scripts/append_new_chunks.py`, `scripts/precompute_teacher.py`)
+— this is a **run**, not a build. Written so a fresh session (or a clean pod clone) can fire it with
+no prior context.
+
+Related: [`../path-b-run.md`](../path-b-run.md) (the authoritative Path B runbook — see its update
+banner; this doc replaces its Step 3 for the *extension* leg), [`m10-pod-chain.md`](m10-pod-chain.md)
+(precompute + sweep staging, steps 3–4 — this runbook's output feeds its Step 3),
+[`../infrastructure.md`](../infrastructure.md) (generic R2 + RunPod flow).
+
+## State (as of 2026-07-03)
+
+- **Base corpus + base teacher precompute: DONE (2026-07-02).** 4× A100-SXM4-80GB pods ran the
+  4B-teacher top-k forward (k=50, seq_len=8192) over the base 1.897B-token FineWeb-derived corpus
+  and merged: **230,318 train chunks (~1.887B rows), 305 val chunks**, at
+  `s3://monica-training/poc-distill/teacher-outputs/topk-logits-merged/` (IDX 377 GB + VALS 189 GB
+  ≈ 566 GB total). Pod terminated.
+- **Corpus extension: DONE (2026-07-03, #176).** ~1.9B new pretrain tokens blended across five
+  domains (code, math, docs, conversation, reasoning) pushed to R2 alongside the base corpus
+  (`s3://monica-training/poc-distill/corpus/tokenized/qwen3-8k`) — confirm the exact extension
+  shard prefix from `provenance.json` written by #176's run (not hard-coded here since it wasn't
+  captured in this session).
+- **This runbook (#177): not yet run.** It is the remaining step before the two-layout sweep (#81)
+  can train against the *full* extended ~3.8B blend.
+
+## Why append, not re-precompute (enforced by code, not a guess)
+
+The 566 GB cache is **positionally bound** to FineWeb's `train.bin` — chunk `i` reads row `i×8192`
+(`teacher_outputs.py`'s `DistillLoader` asserts `n_chunks == 230318`). The extension is packed as
+new shards **after** the frozen FineWeb prefix, so every FineWeb chunk keeps its position and its
+already-computed logits — only the new chunks need a fresh teacher forward. Three guards abort into
+a full re-precompute if violated:
+
+1. The regenerated FineWeb `train.bin` must still yield exactly `n_chunks == 230318` (no silent
+   corpus drift).
+2. The frozen shard-0 must show `n_chunks == 230318` with no stray `start_chunk` offset before
+   merging.
+3. `verify_teacher_alignment.py` — a **live** teacher forward over probe chunks (0 / 100000 /
+   230317) must show **≥0.99 top-k index-set agreement** with the cached logits, and
+   `effective_vocab_size == 151669`.
+
+**If the alignment gate fails**, the fallback is a full re-precompute over the combined corpus
+(real $/time) — the gate exists to catch this cheaply (one teacher forward over 3 probe chunks)
+*before* committing to the append.
+
+## Prereqs (pod)
+
+- **GPU: Ampere+ 80 GB (A100/H100)** — the alignment gate and the new-chunk precompute both need a
+  live CUDA teacher forward; bf16 needs Ampere+.
+- **Volume: ≥1.2 TB.** Combined footprint estimate ≈ 566 GB (existing) + ~475 GB (new chunks) ≈
+  **~1.05 TB** — recompute exactly once the real new-chunk count is known from #176's
+  `provenance.json`, and size the volume with headroom (the merge also needs scratch space for the
+  regenerated/trimmed/combined `train.bin`).
+
+```bash
+git clone https://github.com/travisgalloway/monica && cd monica
+pip install -e ".[dev,data,cuda-fast]"      # fused Mamba Triton scan + causal-conv1d (#40)
+pip install "s3fs==2026.2.0"                 # pin to fsspec; a bare install upgrades fsspec and breaks datasets
+set -a; . ./.env; set +a                     # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_ENDPOINT_URL_S3, R2_BUCKET=monica-training
+#   HF_TOKEN optional — Qwen/Qwen3-4B-Thinking-2507 is Apache-2.0 and openly downloadable.
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+```
+
+## Step 1 — pull inputs from R2
+
+```bash
+# regenerated FineWeb corpus (the ORIGINAL base corpus — must still tokenize to 230318 chunks):
+python -m src.data.r2_sync down s3://monica-training/poc-distill/corpus/tokenized/qwen3-8k /vol/fineweb-shards
+
+# the new-source corpus extension (#176) — confirm the exact prefix from #176's provenance.json:
+python -m src.data.r2_sync down s3://monica-training/poc-distill/corpus/tokenized/<extension-prefix> /vol/extension-shards
+
+# the frozen base teacher cache (shard-0 for the merge):
+python -m src.data.r2_sync down s3://monica-training/poc-distill/teacher-outputs/topk-logits-merged /vol/topk-logits-merged
+```
+
+## Step 2 — the alignment gate (run FIRST, abort on FAIL)
+
+`verify_teacher_alignment.py --data` takes an actual regenerated `train.bin` **file**, not the
+shard dir — regenerate it first via `src.data.split` (the same call `path-b-run.md`'s Step 3 uses
+for the base corpus):
+
+```bash
+python -m src.data.split --shards /vol/fineweb-shards --out /vol/fineweb-split --val-tokens 10000000
+#   -> /vol/fineweb-split/{train.bin,val.bin} — MUST regenerate to exactly n_chunks == 230318;
+#   if it doesn't, the corpus has drifted and the append is unsafe (STOP here, do not proceed).
+
+python scripts/verify_teacher_alignment.py \
+    --data /vol/fineweb-split/train.bin \
+    --topk-dir /vol/topk-logits-merged \
+    --split train --probe-chunks 0,100000,230317 \
+    --backend cuda
+#   --min-agreement 0.99 (default) — nonzero exit => STOP, fall back to a full re-precompute
+#   over the combined corpus (see "Why append, not re-precompute" above). Do not proceed to
+#   Step 3 on a FAIL.
+```
+
+## Step 3 — precompute teacher top-k for ONLY the new chunks
+
+**Positional alignment warning:** Step 4's `append_new_chunks.py` builds its own flat `train.bin`
+from `--extension-shards` internally (`build_flat_new_train`), concatenating **every** shard's
+tokens with **no val holdout**. The split you precompute over here must produce the *exact same*
+token stream in the *exact same* order, or shard1-local won't line up with the combined corpus.
+Use `--val-tokens 0` — **not** the `10000000` used for the base FineWeb split — so nothing is held
+out (the frozen 305 val chunks already come from the base corpus; the extension contributes train
+data only):
+
+```bash
+python -m src.data.split --shards /vol/extension-shards --out /vol/extension-split --val-tokens 0
+#   --val-tokens 0 is deliberate here (unlike the base-corpus split in Step 2, which holds out
+#   10,000,000) — split_shards() reads shards in manifest order and holds out the tail
+#   `val_tokens` into val.bin; build_flat_new_train() reads the SAME manifest order but flattens
+#   ALL tokens with no holdout. A nonzero --val-tokens here would silently drop the tail chunks
+#   from shard1-new relative to what Step 4 reconstructs, misaligning every chunk after the cut.
+
+python scripts/precompute_teacher.py \
+    --manifest config/manifests/student-1b-attn-hi.yaml \
+    --data /vol/extension-split --splits train \
+    --backend cuda --k 50 --batch-size 8 \
+    --out /vol/teacher-outputs/shard1-new
+#   the manifest here only supplies conversion_teacher + seq_len (identical across hi/lo) —
+#   same reason one precompute serves both layouts in the base run.
+```
+
+`/vol/teacher-outputs/shard1-new` becomes `--shard1-local` in Step 4.
+
+## Step 4 — append-merge
+
+```bash
+python scripts/append_new_chunks.py \
+    --fineweb-shards /vol/fineweb-shards \
+    --extension-shards /vol/extension-shards \
+    --work-dir /vol/append-work \
+    --topk-dir /vol/topk-logits-merged \
+    --shard1-local /vol/teacher-outputs/shard1-new \
+    --push s3://monica-training/poc-distill/teacher-outputs/topk-logits-ext-merged \
+    --val-tokens 10000000
+```
+
+This single script performs the full recipe: regenerates + trims FineWeb's `train.bin` to the
+frozen 230,318-chunk prefix (via **copy-prefix-then-rename**, not `os.truncate` — RunPod's `/vol`
+MooseFS mount silently no-ops truncate, corrupting resumed writes), builds a flat `train.bin` from
+the extension shards, concatenates the two into the combined corpus, and **stream-merges** the
+frozen shard-0 (from R2) with the new shard-1 straight to the new R2 prefix — avoiding
+materializing the ~1.1 TB combined set locally. It self-verifies at the end that `DistillLoader`
+opens the combined `(train.bin, merged teacher-outputs)` pair.
+
+## Step 5 — finalize
+
+- Flip the local PHASE marker → `B′:append-done` (the ops-state convention recorded in
+  `~/.claude/monica-runpod-ops/` from prior pod runs — reuse it, don't invent a new mechanism).
+- **Repoint the sweep at the extended cache.** The two sweep manifests
+  (`config/manifests/student-1b-attn-{hi,lo}.yaml`) currently pin
+  `teacher_outputs: poc-distill/teacher-outputs/topk-logits` (the base-only cache). Two ways to
+  point the Step 4 sweep (in `m10-pod-chain.md`) at the extended one instead:
+  - **Recommended — CLI override, keeps manifests stable:** pass
+    `--teacher-outputs s3://monica-training/poc-distill/teacher-outputs/topk-logits-ext-merged`
+    (or the local synced copy) to `scripts/distill.py` instead of relying on the manifest field.
+  - **Alternative:** edit both manifests' `teacher_outputs:` field to the new `-ext-merged` prefix.
+
+## Sizing
+
+| Stage | Cost driver | Output |
+|---|---|---|
+| Step 2 (alignment gate) | 1 live teacher forward × 3 probe chunks — cheap, the point of the gate | pass/fail |
+| Step 3 (new-chunk precompute) | 4B forward over ~475 GB-equivalent new tokens — the real $ of this runbook | `/vol/teacher-outputs/shard1-new` |
+| Step 4 (append-merge) | I/O-bound (streaming merge), not compute-bound | `topk-logits-ext-merged` on R2, ~1.05 TB |
+
+## Gotchas
+
+- **Positional alignment is everything** — if the regenerated FineWeb `train.bin` doesn't yield
+  exactly 230,318 chunks, or shard-0 shows a stray `start_chunk` offset, the append is unsafe;
+  the script's guards catch this, but don't skip Step 2.
+- **`os.truncate` silently no-ops on RunPod's `/vol` MooseFS mount** — `append_new_chunks.py`
+  already uses the safe copy-prefix-then-rename trim; don't hand-roll a truncate-based variant.
+- **`s3fs==2026.2.0` pin** — must match fsspec (`datasets` caps `fsspec<=2026.2.0`); a bare
+  `pip install s3fs` upgrades fsspec and breaks `datasets`.
+- **`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`** carries forward into the Step 4 sweep
+  (MOHAWK stage-1 OOM risk at seq 8192) — set it once at the top of the session and keep it set.
+
+## Exit criteria
+
+- [ ] Merged extended teacher-outputs cache on R2 at the new `-ext-merged` prefix.
+- [ ] PHASE marker flipped → `B′:append-done`.
+- [ ] Unblocks the two-layout student sweep (#81), now trainable against the full extended ~3.8B
+      blend — proceed to [`m10-pod-chain.md`](m10-pod-chain.md) Step 4.
+
+## After this: the rest of the chain
+
+This runbook covers only the append leg. Downstream:
+
+- **Sweep (#81):** [`m10-pod-chain.md`](m10-pod-chain.md) Step 4 — repoint `--teacher-outputs` as
+  above, then run the hi/lo sweep as documented there.
+- **Post-train the winner (#101 instruct SFT, #103 GRPO):** see
+  [`../path-b-run.md`](../path-b-run.md) Step 5. Use `--config config/student-1b-attn-hi.yaml` if
+  the hi layout wins, `--config config/student-1b-attn-lo.yaml` if lo wins — both are resolved
+  MambaConfig YAMLs (not manifests) for `scripts/sft.py`/`scripts/rlvr.py`'s `--config` flag.
+  **Known gap, not fixed here:** `scripts/rlvr.py` (#103) wires only math/exact-match rewards and
+  takes **no `--backend` flag** (MLX-only, via the serving recurrence) — the code-sandbox
+  `CodeVerifier` mentioned in #103's scope is not wired into the driver. A ~1B GRPO run on Mac/MLX
+  is slow; resolve the CUDA-backend gap via #103 before the RL pass, or accept the slower MLX run.
+- **Headline eval (#104):** `docs/path-b-run.md` Step 6, plus `scripts/bench_context.py` (added in
+  PR #179) for the throughput-vs-context-length measurement once the winner is post-trained.

--- a/docs/runbooks/m10-pod-chain.md
+++ b/docs/runbooks/m10-pod-chain.md
@@ -1,5 +1,11 @@
 # M10 pod-chain — ready-to-fire staging (steps 3–4)
 
+> **Update (2026-07-03).** Step 3 (teacher precompute) below completed for the **base** corpus on
+> 2026-07-02. The corpus was then extended with new domains (#176); extending the teacher cache to
+> cover those new chunks is a separate **append** step (3′) that must run **before** Step 4, reusing
+> the base cache rather than re-running Step 3 from scratch — see
+> [`m10-phase-bprime-append.md`](m10-phase-bprime-append.md) (#177).
+
 The pod-gated stages of the M10 distillation chain — **teacher precompute** (#94) and the
 **two-layout student sweep** (#81) — are the only steps that need a rented CUDA pod. This doc is
 the *staging* companion: it records the plumbing validations that were run **without** a pod, and
@@ -52,6 +58,10 @@ Footprint ≈ 6·k bytes/token (k=50 → ~300 B/token). The manifest here only s
 `conversion_teacher` + `seq_len` (identical across hi/lo), which is why one precompute serves both.
 
 ### Step 4 — the two-layout sweep (reuses the single precompute)
+> Run **Step 3′ — the #177 append** first if the corpus extension (#176) hasn't been merged into
+> the teacher cache yet: [`m10-phase-bprime-append.md`](m10-phase-bprime-append.md). Otherwise this
+> sweep trains only against the base FineWeb-derived corpus.
+
 Two sibling manifests, **same** corpus + teacher outputs, only `layout` differs. The three distill
 stages run in order (mixing-match → hidden-align → logit-distill). This is the "sweep" — two
 manifests × three stages → a Phase-2 winner pick; it is one team-Workflow call away once the pod


### PR DESCRIPTION
Part of #177.

## Summary

Follow-up to the `/work 'p1 issues' auto` run: #177 (Phase B' append-only teacher precompute) is
the next executable step in the #65 chain and is pod-gated — all machinery is merged
(`verify_teacher_alignment.py`, `precompute_teacher.py`, `append_new_chunks.py`), but there was
**no runbook** for it. This PR is run-prep, not the run.

- Adds `docs/runbooks/m10-phase-bprime-append.md`: a copy-paste runbook for the append-only flow
  (regenerate + verify the base FineWeb `train.bin` → alignment gate → precompute the *new chunks
  only* → append-merge → verify). Every command was cross-checked against each script's actual
  argparse (no invented flags). Caught and fixed one real positional-alignment bug while writing
  it: `append_new_chunks.py`'s internal flat-train builder concatenates *all* extension tokens
  with no val holdout, so the split used to precompute the new chunks must use `--val-tokens 0`
  (not the `10000000` used for the base corpus) or the new-chunk precompute silently misaligns
  with what the append step reconstructs.
- Adds `config/student-1b-attn-hi.yaml`: the resolved architecture config for the higher-attention
  sweep layout (`attn_every: 8`, `d_state: 128`), matching `student-1b-attn-lo.yaml`'s naming so
  both sweep layouts have a real config file for `sft.py`/`rlvr.py`'s `--config` flag at
  post-training time (those drivers take a config YAML, not a manifest). Verified it loads via
  `MambaConfig.validate()` and differs from `-lo` only in `attn_every`/`d_state`.
- Adds reconciliation banners to `docs/path-b-run.md` and `docs/runbooks/m10-pod-chain.md` — both
  predate the base corpus + teacher precompute completing (2026-07-02) and the corpus extension
  (#176), so their Step 3 (full re-precompute) is now the wrong thing to run; the banners point to
  the new append runbook instead.

**#177 stays open** — this only stages the runbook + config so the append run is one copy-paste
away once a pod is up.

## Testing
- [x] `config/student-1b-attn-hi.yaml` loads via `load_config()` + `MambaConfig.validate()`;
      confirmed it differs from `-lo` only in `attn_every` (8 vs 14) / `d_state` (128 vs 192)
- [x] `.venv/bin/python -m pytest -q` → 553 passed, 4 skipped (unchanged — docs + one config)
- [x] Every CLI flag in the new runbook cross-checked against the four scripts' argparse
- [x] All relative markdown links in the new/edited docs resolve to real files