### PR TITLE
feat(eval): add BFCL harness + schema-validate tool-use SFT calls (#102)

### DIFF
--- a/scripts/eval_bfcl.py
+++ b/scripts/eval_bfcl.py
@@ -60,6 +60,7 @@ def main() -> None:
     import numpy as np
 
     from src.data.chat_template import render
+    from src.data.instruct_sft import _effective_vocab_size
     from src.data.tokenize import (
         ByteTokenizer,
         load_olmo_tokenizer,
@@ -91,10 +92,13 @@ def main() -> None:
     else:
         tok = load_olmo_tokenizer()
     # A tokenizer that can emit ids >= the model vocab would crash deep in the
-    # embedding lookup; fail here with a clear message instead.
-    if tok.vocab_size > cfg.vocab_size:
+    # embedding lookup; fail here with a clear message instead. Use the effective
+    # vocab (len(tok)) rather than tok.vocab_size, since added special tokens
+    # (e.g. Qwen3's <|im_start|>/<|im_end|>) can have ids past vocab_size.
+    eff_vocab = _effective_vocab_size(tok)
+    if eff_vocab is not None and eff_vocab > cfg.vocab_size:
         raise SystemExit(
-            f"tokenizer vocab {tok.vocab_size} exceeds model vocab "
+            f"tokenizer vocab {eff_vocab} exceeds model vocab "
             f"{cfg.vocab_size} ({args.config}) — use a matching config, or "
             f"--byte-fallback only with toy-scale configs.")
 

--- a/scripts/eval_bfcl.py
+++ b/scripts/eval_bfcl.py
@@ -1,0 +1,125 @@
+"""Tier-2 BFCL-style function-calling eval over the MLX backend (#102).
+
+Wires config -> MLXMambaModel -> tokenizer -> src/eval/bfcl_adapter.evaluate_bfcl,
+mirroring scripts/eval_olmes.py's structure (config -> model -> tokenizer -> adapter,
+mlx imported locally so the seam stays clean). There is no BFCL dataset loader yet
+(BFCL is eval-only and off the critical path per #102), so this runs the small
+hand-authored `bfcl_adapter.BFCL_FIXTURE` (simple/parallel/abstention) by default;
+point `examples` at a real loaded BFCL split later without touching the harness.
+
+Generation stops at EOS (no forced "</tool_call>" stop string): truncating the
+decoded text at that string would strip the closing tag itself, which
+`bfcl_adapter.parse_tool_calls` needs to find a well-formed block. `--max-gen-toks`
+bounds the completion instead; parsing tolerates trailing text after the block.
+
+Judge by "runs end to end": with random-init or 100M-scale weights, accuracy will
+sit near chance — that is expected and fine for the POC.
+
+    .venv/bin/python scripts/eval_bfcl.py --config config/poc-qwen.yaml --limit 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=Path("config/poc-qwen.yaml"))
+    ap.add_argument("--weights", type=Path, default=None,
+                    help="portable .safetensors checkpoint; RANDOM INIT if omitted")
+    ap.add_argument("--tokenizer", choices=("qwen3", "qwen25", "olmo"), default="qwen25",
+                    help="tokenizer matching the config's vocab (default: qwen25, the "
+                         "from-scratch poc-qwen reserve; use qwen3 for the distillation "
+                         "student config/student-1b.yaml, olmo for config/poc.yaml)")
+    ap.add_argument("--byte-fallback", action="store_true",
+                    help="offline ByteTokenizer (toy config only; not OLMo/Qwen-compatible)")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="cap the number of fixture examples (default: all)")
+    ap.add_argument("--max-gen-toks", type=int, default=128,
+                    help="generation budget per example")
+    ap.add_argument("--output", type=Path, default=None, help="write results JSON here")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    # MLX-only imports kept local so the seam stays clean for portable hosts.
+    try:
+        import mlx.core as mx
+    except ModuleNotFoundError as e:
+        if e.name != "mlx":
+            raise
+        raise SystemExit(
+            "mlx not found — run with the project venv on Apple Silicon:\n"
+            "    .venv/bin/python scripts/eval_bfcl.py ...\n"
+            "(mlx installs only on Apple Silicon via the '[mlx]' extra; a bare "
+            "`python` likely points at a different interpreter.)"
+        ) from e
+    import numpy as np
+
+    from src.data.chat_template import render
+    from src.data.tokenize import (
+        ByteTokenizer,
+        load_olmo_tokenizer,
+        load_qwen25_tokenizer,
+        load_qwen3_tokenizer,
+    )
+    from src.eval.bfcl_adapter import BFCL_FIXTURE, evaluate_bfcl
+    from src.eval.olmes_adapter import generate_until_texts
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+
+    cfg = load_config(str(args.config))
+    mx.random.seed(args.seed)
+    model = MLXMambaModel(cfg)
+    if args.weights:
+        model.load(str(args.weights))
+        print(f"loaded weights: {args.weights}")
+    else:
+        print("=" * 70)
+        print("RANDOM INIT — no --weights given; scores will be chance level.")
+        print("=" * 70)
+
+    if args.byte_fallback:
+        tok = ByteTokenizer()
+    elif args.tokenizer == "qwen3":
+        tok = load_qwen3_tokenizer()
+    elif args.tokenizer == "qwen25":
+        tok = load_qwen25_tokenizer()
+    else:
+        tok = load_olmo_tokenizer()
+    # A tokenizer that can emit ids >= the model vocab would crash deep in the
+    # embedding lookup; fail here with a clear message instead.
+    if tok.vocab_size > cfg.vocab_size:
+        raise SystemExit(
+            f"tokenizer vocab {tok.vocab_size} exceeds model vocab "
+            f"{cfg.vocab_size} ({args.config}) — use a matching config, or "
+            f"--byte-fallback only with toy-scale configs.")
+
+    examples = list(BFCL_FIXTURE)
+    if args.limit is not None:
+        examples = examples[:args.limit]
+
+    def generate_fn(prompt_or_messages) -> str:
+        prompt = (prompt_or_messages if isinstance(prompt_or_messages, str)
+                  else render(prompt_or_messages, add_generation_prompt=True))
+        gen_kwargs = {"max_gen_toks": args.max_gen_toks}
+        return generate_until_texts(
+            model, tok, [(prompt, gen_kwargs)], max_length=cfg.seq_len,
+            to_numpy=lambda a: np.array(a), seed=args.seed)[0]
+
+    summary = evaluate_bfcl(examples, generate_fn)
+    print(f"bfcl: {summary['n_examples']} examples, accuracy={summary['accuracy']:.3f}, "
+          f"schema_valid_rate={summary['schema_valid_rate']:.3f}")
+    print(f"per-category accuracy: {summary['per_category_accuracy']}")
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, "w") as f:
+            json.dump(summary, f, indent=2, default=str)
+        print(f"results -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data/tool_sft.py
+++ b/src/data/tool_sft.py
@@ -37,11 +37,12 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, Iterator, List, Optional
 
 from . import chat_template, storage
 from .instruct_sft import _effective_vocab_size
-from .tool_sources import TOOL_CALL_OPEN, TOOLS_OPEN, TOOLS_CLOSE
+from .tool_sources import (TOOL_CALL_OPEN, TOOL_CALL_CLOSE, TOOLS_OPEN, TOOLS_CLOSE,
+                           validate_call_against_tools)
 
 
 def _valid_rows(rows: Iterable[dict]) -> List[dict]:
@@ -76,11 +77,9 @@ def _is_abstention(messages: List[dict]) -> bool:
     return TOOL_CALL_OPEN not in (messages[-1].get("content") or "")
 
 
-def _has_distractors(messages: List[dict]) -> bool:
-    """Heuristic audit flag: the system turn lists more tools than the row's calls reference.
-    Count <tool_call> blocks across assistant turns vs tool entries in the system <tools> list."""
-    # Extract tool names from the system turn's <tools>[...] block
-    system_tools: List[str] = []
+def _row_tools(messages: List[dict]) -> List[dict]:
+    """The row's declared tools: parsed out of the (first) system turn's
+    `<tools>[...]</tools>` block. Empty list if absent/malformed."""
     for m in messages:
         if m.get("role") == "system":
             content = m.get("content") or ""
@@ -89,37 +88,55 @@ def _has_distractors(messages: List[dict]) -> bool:
             if start != -1 and end != -1 and end > start:
                 body = content[start + len(TOOLS_OPEN):end].strip()
                 try:
-                    tool_list = json.loads(body)
-                    system_tools = [t.get("name", "") for t in tool_list if isinstance(t, dict)]
+                    tools = json.loads(body)
+                    return [t for t in tools if isinstance(t, dict)]
                 except (json.JSONDecodeError, ValueError):
-                    pass
+                    return []
             break
+    return []
 
-    # Collect tool names actually called across all assistant turns
-    called_names: set = set()
+
+def _iter_calls(messages: List[dict]) -> Iterator[dict]:
+    """Yield every parsed `<tool_call>{json}</tool_call>` block across assistant
+    turns (each a dict with at least a "name" key). Malformed JSON blocks are
+    skipped, never raised — shared by `_has_distractors` and the schema-validation
+    gate in `build_tool_sft`."""
     for m in messages:
-        if m.get("role") == "assistant":
-            content = m.get("content") or ""
-            pos = 0
-            while True:
-                s = content.find(TOOL_CALL_OPEN, pos)
-                if s == -1:
-                    break
-                e = content.find("</tool_call>", s)
-                if e == -1:
-                    break
-                block = content[s + len(TOOL_CALL_OPEN):e].strip()
-                try:
-                    call = json.loads(block)
-                    if isinstance(call, dict) and "name" in call:
-                        called_names.add(call["name"])
-                except (json.JSONDecodeError, ValueError):
-                    pass
-                pos = e + len("</tool_call>")
+        if m.get("role") != "assistant":
+            continue
+        content = m.get("content") or ""
+        pos = 0
+        while True:
+            s = content.find(TOOL_CALL_OPEN, pos)
+            if s == -1:
+                break
+            e = content.find(TOOL_CALL_CLOSE, s)
+            if e == -1:
+                break
+            block = content[s + len(TOOL_CALL_OPEN):e].strip()
+            try:
+                call = json.loads(block)
+                if isinstance(call, dict) and "name" in call:
+                    yield call
+            except (json.JSONDecodeError, ValueError):
+                pass
+            pos = e + len(TOOL_CALL_CLOSE)
 
-    # Has distractors if there are more listed tools than called tools
-    listed_names = set(n for n in system_tools if n)
+
+def _has_distractors(messages: List[dict]) -> bool:
+    """Heuristic audit flag: the system turn lists more tools than the row's calls reference."""
+    listed_names = {t.get("name", "") for t in _row_tools(messages)}
+    listed_names.discard("")
+    called_names = {c["name"] for c in _iter_calls(messages)}
     return len(listed_names) > len(called_names)
+
+
+def _row_schema_valid(messages: List[dict]) -> bool:
+    """True iff every call in the row's assistant turns validates against the row's
+    declared `<tools>` list (see `tool_sources.validate_call_against_tools`).
+    Abstention rows (no calls at all) are vacuously valid."""
+    tools = _row_tools(messages)
+    return all(validate_call_against_tools(c, tools) for c in _iter_calls(messages))
 
 
 def build_tool_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwen3",
@@ -135,6 +152,15 @@ def build_tool_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwen3",
     tokenized_path = tok_dir / "tool.jsonl"
 
     valid = _valid_rows(rows)
+
+    n_schema_invalid = 0
+    schema_ok: List[dict] = []
+    for row in valid:
+        if _row_schema_valid(row["messages"]):
+            schema_ok.append(row)
+        else:
+            n_schema_invalid += 1
+    valid = schema_ok
 
     cleaned_path.parent.mkdir(parents=True, exist_ok=True)
     with open(cleaned_path, "w", encoding="utf-8", newline="\n") as f:
@@ -187,6 +213,7 @@ def build_tool_sft(rows: Iterable[dict], out_root, *, tokenizer: str = "qwen3",
         "max_seq_len": max_seq_len,
         "n_records": n_records,
         "n_skipped": n_skipped,
+        "n_schema_invalid": n_schema_invalid,
         "n_tokens": n_tokens,
         "n_abstention": n_abstention,
         "n_with_distractors": n_with_distractors,
@@ -218,7 +245,8 @@ def main() -> None:
     m = build_tool_sft(rows, args.out_root, tokenizer=args.tokenizer, model_id=args.model_id,
                        seq_len=args.seq_len, byte_fallback=args.byte_fallback,
                        max_seq_len=args.max_seq_len)
-    print(f"tool sft: {m['n_records']} records ({m['n_skipped']} skipped, {m['n_tokens']} tokens, "
+    print(f"tool sft: {m['n_records']} records ({m['n_skipped']} skipped, "
+          f"{m['n_schema_invalid']} schema-invalid, {m['n_tokens']} tokens, "
           f"{m['n_abstention']} abstention, {m['n_with_distractors']} with distractors, "
           f"sources={m['sources']}) -> {m['tokenized_path']}")
 

--- a/src/data/tool_sources.py
+++ b/src/data/tool_sources.py
@@ -16,8 +16,10 @@ Primary sources:
 
 BFCL is eval-only (shared/eval/), intentionally absent from _LOADERS.
 
-Runtime schema-validation is out of scope; the corpus only guarantees
-`json.dumps`-round-trippable call JSON. Mappers return None to skip malformed rows.
+Calls are schema-validated against each row's declared tools via
+`validate_call_against_tools` (name known + required args present), wired into
+`tool_sft.build_tool_sft`; invalid rows are dropped and counted (`n_schema_invalid`).
+Mappers themselves still just return None to skip malformed/unparseable rows.
 
 ABOVE THE SEAM — stdlib only; `datasets` is imported lazily inside the HF loaders.
 Offline path: `handauthored_tool_records()` + `--byte-fallback`.
@@ -79,6 +81,29 @@ def format_tool_response(results: Sequence) -> str:
         payload = r if isinstance(r, str) else json.dumps(r)
         blocks.append(f"{TOOL_RESPONSE_OPEN}\n{payload}\n{TOOL_RESPONSE_CLOSE}")
     return "\n".join(blocks)
+
+
+# --------------------------------------------------------------------------- #
+# Schema validation (closes the "calls schema-validated" claim from #102 box #1)
+# --------------------------------------------------------------------------- #
+
+def validate_call_against_tools(call: dict, tools: List[dict]) -> bool:
+    """True iff `call` ({"name", "arguments"}) is a legal call against `tools`:
+    `call["name"]` must name a tool in `tools`, and every name in that tool's
+    `parameters["required"]` must be a key of `call["arguments"]`. Lenient by
+    design — JSON-level presence only, no type/value checking — so this catches
+    hallucinated tool names and missing required args (the two failure modes that
+    actually corrupt training signal) without rejecting a correct call over a
+    string-vs-int nit. Reused by both the SFT builder (`tool_sft.py`) and the
+    BFCL eval harness (`src/eval/bfcl_adapter.py`)."""
+    name = call.get("name")
+    by_name = {t.get("name"): t for t in tools if isinstance(t, dict)}
+    tool = by_name.get(name)
+    if tool is None:
+        return False
+    required = (tool.get("parameters") or {}).get("required") or []
+    arguments = call.get("arguments") or {}
+    return all(r in arguments for r in required)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/data/tool_sources.py
+++ b/src/data/tool_sources.py
@@ -102,7 +102,11 @@ def validate_call_against_tools(call: dict, tools: List[dict]) -> bool:
     if tool is None:
         return False
     required = (tool.get("parameters") or {}).get("required") or []
-    arguments = call.get("arguments") or {}
+    if not isinstance(required, list):
+        return False
+    arguments = call.get("arguments")
+    if not isinstance(arguments, dict):
+        return False
     return all(r in arguments for r in required)
 
 

--- a/src/eval/bfcl_adapter.py
+++ b/src/eval/bfcl_adapter.py
@@ -221,6 +221,7 @@ BFCL_FIXTURE: List[dict] = [
         "category": "parallel",
         "tools": [_WEATHER_TOOL, _TIMER_TOOL],
         "messages": [
+            {"role": "system", "content": render_tool_system([_WEATHER_TOOL, _TIMER_TOOL])},
             {"role": "user", "content": "What's the weather in Tokyo, and set a 5 minute timer?"},
         ],
         "gold": [
@@ -232,6 +233,7 @@ BFCL_FIXTURE: List[dict] = [
         "category": "abstention",
         "tools": [_WEATHER_TOOL],
         "messages": [
+            {"role": "system", "content": render_tool_system([_WEATHER_TOOL])},
             {"role": "user", "content": "Translate 'hello' into French."},
         ],
         "gold": [],

--- a/src/eval/bfcl_adapter.py
+++ b/src/eval/bfcl_adapter.py
@@ -1,0 +1,239 @@
+"""BFCL-style function-calling scorer (#102) — the tool-use eval harness.
+
+Berkeley Function-Calling Leaderboard (BFCL) scores whether a model calls the right
+tool(s) with the right arguments, or correctly abstains when no tool applies. This
+module is the pure scoring core (parse / match / score / aggregate), mirroring
+`olmes_adapter.py`'s split: heavy tokenizer/generation happens below the seam
+(injected as a `generate_fn` callable), scoring logic is pure stdlib and testable
+anywhere.
+
+Categories (BFCL naming) drive the scoring rule in `score_example`:
+  * "simple"              — exactly one gold call; the prediction must be exactly
+    that one call.
+  * "parallel"/"multiple" — a set of gold calls; the prediction must match as a
+    multiset (order-insensitive, but count-sensitive — duplicates matter).
+  * "abstention"/"relevance" — no tool applies; correct iff the prediction makes
+    NO call (a spurious call is wrong; so is a missing call when one IS expected —
+    scored symmetrically by simply comparing `pred_calls == []`).
+
+Argument matching (`match_call`) is deliberately lenient: BFCL's "possible answers"
+sometimes list several acceptable values for one argument (represented here as a
+Python list on the gold side); an exact-dict match would be too strict and report
+near-zero accuracy even for a correct model. Optional prediction args absent from
+gold are ignored (BFCL scores required/expected args, not every key a model chooses
+to add).
+
+`parse_tool_calls` reuses the exact `<tool_call>{json}</tool_call>` tag convention
+from `src.data.tool_sources` (the SFT corpus renders calls the same way — see
+`tool_sources.format_tool_call`), so the harness scores generations in the same
+format the student was trained to emit.
+
+ABOVE THE SEAM — stdlib only (+ `src.data.tool_sources`, itself portable). No
+`mlx`/`torch` import anywhere in this module (guarded by
+`tests/test_import_guard.py`). `evaluate_bfcl` takes `generate_fn` as an injected
+seam callable; the MLX-backed generation lives in `scripts/eval_bfcl.py`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Callable, Dict, List, Sequence
+
+from ..data.tool_sources import (TOOL_CALL_CLOSE, TOOL_CALL_OPEN, render_tool_system,
+                                 validate_call_against_tools)
+
+_ABSTENTION_CATEGORIES = {"abstention", "relevance"}
+_PARALLEL_CATEGORIES = {"parallel", "multiple"}
+
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+
+def parse_tool_calls(text: str) -> List[dict]:
+    """Extract every `<tool_call>{json}</tool_call>` block from a decoded string.
+
+    Tolerates malformed JSON (or a block missing "name") by skipping it — a model
+    that emits broken JSON should score as "no valid call there", not crash the
+    harness. Blocks are returned in the order they appear."""
+    calls: List[dict] = []
+    pos = 0
+    while True:
+        s = text.find(TOOL_CALL_OPEN, pos)
+        if s == -1:
+            break
+        e = text.find(TOOL_CALL_CLOSE, s)
+        if e == -1:
+            break
+        block = text[s + len(TOOL_CALL_OPEN):e].strip()
+        pos = e + len(TOOL_CALL_CLOSE)
+        try:
+            call = json.loads(block)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(call, dict) and "name" in call:
+            calls.append(call)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# Matching
+# --------------------------------------------------------------------------- #
+
+def match_call(pred: dict, gold: dict) -> bool:
+    """True iff `pred` matches `gold`: names equal, and every gold argument is
+    satisfied. A gold value that is a `list` means "any of these is an acceptable
+    answer" (BFCL's multi-possible-answer convention); any other gold value must
+    match exactly. Predicted arguments not present in `gold` are ignored (BFCL
+    scores the expected args, not every extra key a model happens to add)."""
+    if pred.get("name") != gold.get("name"):
+        return False
+    pred_args = pred.get("arguments") or {}
+    gold_args = gold.get("arguments") or {}
+    for key, gold_val in gold_args.items():
+        if key not in pred_args:
+            return False
+        pred_val = pred_args[key]
+        if isinstance(gold_val, list):
+            if pred_val not in gold_val:
+                return False
+        elif pred_val != gold_val:
+            return False
+    return True
+
+
+def _match_multiset(pred_calls: Sequence[dict], gold_calls: Sequence[dict]) -> bool:
+    """Order-insensitive, count-sensitive match between two call lists: every gold
+    call must be matched (via `match_call`) by exactly one distinct predicted call,
+    with none left over on either side (so counts/duplicates matter)."""
+    if len(pred_calls) != len(gold_calls):
+        return False
+    remaining = list(gold_calls)
+    for p in pred_calls:
+        idx = next((i for i, g in enumerate(remaining) if match_call(p, g)), None)
+        if idx is None:
+            return False
+        remaining.pop(idx)
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Scoring
+# --------------------------------------------------------------------------- #
+
+def score_example(pred_calls: List[dict], gold_example: dict) -> dict:
+    """Score one example's predicted calls against its gold, dispatching on
+    `gold_example["category"]` (BFCL naming — see module docstring for the rule
+    per category; unknown categories fall back to "simple"'s single-call rule).
+
+    Also reports `schema_valid`: True iff every predicted call validates against
+    the example's declared `tools` (`validate_call_against_tools`) — schema
+    validity and correctness are independent axes (a call can be schema-valid but
+    the wrong call, or vice versa in principle). Vacuously True when no calls were
+    predicted.
+
+    Returns `{"correct": bool, "category": str, "schema_valid": bool}`.
+    """
+    category = gold_example.get("category", "simple")
+    gold_calls = gold_example.get("gold", [])
+    tools = gold_example.get("tools", [])
+
+    if category in _ABSTENTION_CATEGORIES:
+        correct = pred_calls == []
+    elif category in _PARALLEL_CATEGORIES:
+        correct = _match_multiset(pred_calls, gold_calls)
+    else:  # "simple" (default)
+        correct = (len(pred_calls) == 1 and len(gold_calls) == 1
+                   and match_call(pred_calls[0], gold_calls[0]))
+
+    schema_valid = all(validate_call_against_tools(c, tools) for c in pred_calls)
+    return {"correct": correct, "category": category, "schema_valid": schema_valid}
+
+
+# --------------------------------------------------------------------------- #
+# Aggregation + the seam
+# --------------------------------------------------------------------------- #
+
+def evaluate_bfcl(examples: Sequence[dict], generate_fn: Callable) -> dict:
+    """Run BFCL-style scoring over `examples`, each a dict with at least
+    `messages` (or `prompt`), `gold` (list of gold calls), `category`, `tools`.
+
+    `generate_fn(prompt_or_messages) -> decoded_text` is the seam callable:
+    generation happens below the seam, exactly like `olmes_adapter`'s injected
+    `generate_until_texts` — this function only parses and aggregates. Each
+    example's `messages` (if present) is passed to `generate_fn` in preference to
+    `prompt`, so a caller free to choose either representation.
+
+    Returns a summary dict: overall `accuracy`, `per_category_accuracy`, the
+    `schema_valid_rate` (fraction of examples whose predicted calls are all
+    schema-valid), and the per-example `results` for debugging.
+    """
+    results = []
+    for ex in examples:
+        prompt_or_messages = ex.get("messages", ex.get("prompt"))
+        text = generate_fn(prompt_or_messages)
+        pred_calls = parse_tool_calls(text)
+        results.append(score_example(pred_calls, ex))
+
+    n = len(results)
+    by_category: Dict[str, List[dict]] = {}
+    for r in results:
+        by_category.setdefault(r["category"], []).append(r)
+    per_category_accuracy = {
+        cat: sum(1 for r in rows if r["correct"]) / len(rows)
+        for cat, rows in by_category.items()
+    }
+
+    return {
+        "n_examples": n,
+        "accuracy": (sum(1 for r in results if r["correct"]) / n) if n else float("nan"),
+        "per_category_accuracy": per_category_accuracy,
+        "schema_valid_rate": (sum(1 for r in results if r["schema_valid"]) / n) if n else float("nan"),
+        "results": results,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Offline fixture — hand-authored, CC0, covers simple/parallel/abstention
+# --------------------------------------------------------------------------- #
+
+_WEATHER_TOOL = {"name": "get_weather", "description": "Get current weather for a city",
+                 "parameters": {"type": "object",
+                                "properties": {"city": {"type": "string"}},
+                                "required": ["city"]}}
+_TIMER_TOOL = {"name": "set_timer", "description": "Set a countdown timer",
+               "parameters": {"type": "object",
+                              "properties": {"seconds": {"type": "integer"}},
+                              "required": ["seconds"]}}
+
+BFCL_FIXTURE: List[dict] = [
+    {
+        "category": "simple",
+        "tools": [_WEATHER_TOOL],
+        "messages": [
+            {"role": "system", "content": render_tool_system([_WEATHER_TOOL])},
+            {"role": "user", "content": "What's the weather in Boston?"},
+        ],
+        # "Boston" or "Boston, MA" both count as the right city (BFCL possible-answers style).
+        "gold": [{"name": "get_weather", "arguments": {"city": ["Boston", "Boston, MA"]}}],
+    },
+    {
+        "category": "parallel",
+        "tools": [_WEATHER_TOOL, _TIMER_TOOL],
+        "messages": [
+            {"role": "user", "content": "What's the weather in Tokyo, and set a 5 minute timer?"},
+        ],
+        "gold": [
+            {"name": "get_weather", "arguments": {"city": "Tokyo"}},
+            {"name": "set_timer", "arguments": {"seconds": 300}},
+        ],
+    },
+    {
+        "category": "abstention",
+        "tools": [_WEATHER_TOOL],
+        "messages": [
+            {"role": "user", "content": "Translate 'hello' into French."},
+        ],
+        "gold": [],
+    },
+]

--- a/tests/test_bfcl_adapter.py
+++ b/tests/test_bfcl_adapter.py
@@ -1,0 +1,263 @@
+"""BFCL-style eval harness tests (#102): parse / match / score / aggregate.
+
+Offline via a fake `generate_fn` returning canned decoded strings (no network, no
+backend — this module never imports mlx/torch, guarded by test_import_guard.py)."""
+
+import json
+
+from src.data.tool_sources import TOOL_CALL_CLOSE, TOOL_CALL_OPEN
+from src.eval.bfcl_adapter import (
+    BFCL_FIXTURE,
+    evaluate_bfcl,
+    match_call,
+    parse_tool_calls,
+    score_example,
+)
+
+
+def _block(call: dict) -> str:
+    return f"{TOOL_CALL_OPEN}\n{json.dumps(call)}\n{TOOL_CALL_CLOSE}"
+
+
+# --------------------------------------------------------------------------- #
+# parse_tool_calls: stacked/parallel blocks + malformed JSON
+# --------------------------------------------------------------------------- #
+
+def test_parse_tool_calls_single_block():
+    text = _block({"name": "get_weather", "arguments": {"city": "Paris"}})
+    calls = parse_tool_calls(text)
+    assert calls == [{"name": "get_weather", "arguments": {"city": "Paris"}}]
+
+
+def test_parse_tool_calls_stacked_parallel_blocks():
+    c1 = {"name": "get_weather", "arguments": {"city": "Tokyo"}}
+    c2 = {"name": "set_timer", "arguments": {"seconds": 300}}
+    text = _block(c1) + "\n" + _block(c2)
+    calls = parse_tool_calls(text)
+    assert calls == [c1, c2]
+
+
+def test_parse_tool_calls_no_blocks_returns_empty():
+    assert parse_tool_calls("Sure, here's the answer with no calls.") == []
+
+
+def test_parse_tool_calls_malformed_json_is_skipped():
+    good = {"name": "get_weather", "arguments": {"city": "Paris"}}
+    text = f"{TOOL_CALL_OPEN}\nnot json at all\n{TOOL_CALL_CLOSE}\n" + _block(good)
+    calls = parse_tool_calls(text)
+    assert calls == [good]
+
+
+def test_parse_tool_calls_missing_name_key_is_skipped():
+    text = f"{TOOL_CALL_OPEN}\n{json.dumps({'arguments': {'city': 'Paris'}})}\n{TOOL_CALL_CLOSE}"
+    assert parse_tool_calls(text) == []
+
+
+def test_parse_tool_calls_unclosed_block_is_ignored():
+    text = f"{TOOL_CALL_OPEN}\n{json.dumps({'name': 'x', 'arguments': {}})}"  # no closing tag
+    assert parse_tool_calls(text) == []
+
+
+# --------------------------------------------------------------------------- #
+# match_call: scalar and list-valued (BFCL "possible answers") gold values
+# --------------------------------------------------------------------------- #
+
+def test_match_call_scalar_exact_match():
+    pred = {"name": "get_weather", "arguments": {"city": "Paris"}}
+    gold = {"name": "get_weather", "arguments": {"city": "Paris"}}
+    assert match_call(pred, gold) is True
+
+
+def test_match_call_scalar_mismatch():
+    pred = {"name": "get_weather", "arguments": {"city": "London"}}
+    gold = {"name": "get_weather", "arguments": {"city": "Paris"}}
+    assert match_call(pred, gold) is False
+
+
+def test_match_call_name_mismatch():
+    pred = {"name": "get_time", "arguments": {"city": "Paris"}}
+    gold = {"name": "get_weather", "arguments": {"city": "Paris"}}
+    assert match_call(pred, gold) is False
+
+
+def test_match_call_list_valued_gold_accepts_any_member():
+    gold = {"name": "get_weather", "arguments": {"city": ["Boston", "Boston, MA"]}}
+    assert match_call({"name": "get_weather", "arguments": {"city": "Boston"}}, gold) is True
+    assert match_call({"name": "get_weather", "arguments": {"city": "Boston, MA"}}, gold) is True
+    assert match_call({"name": "get_weather", "arguments": {"city": "NYC"}}, gold) is False
+
+
+def test_match_call_extra_pred_args_ignored():
+    pred = {"name": "get_weather", "arguments": {"city": "Paris", "units": "celsius"}}
+    gold = {"name": "get_weather", "arguments": {"city": "Paris"}}
+    assert match_call(pred, gold) is True
+
+
+def test_match_call_missing_pred_arg_fails():
+    pred = {"name": "get_weather", "arguments": {}}
+    gold = {"name": "get_weather", "arguments": {"city": "Paris"}}
+    assert match_call(pred, gold) is False
+
+
+# --------------------------------------------------------------------------- #
+# score_example: simple / parallel / abstention, correct + incorrect
+# --------------------------------------------------------------------------- #
+
+def test_score_example_simple_correct():
+    gold_ex = {"category": "simple", "tools": [],
+               "gold": [{"name": "get_weather", "arguments": {"city": "Paris"}}]}
+    pred_calls = [{"name": "get_weather", "arguments": {"city": "Paris"}}]
+    result = score_example(pred_calls, gold_ex)
+    assert result["correct"] is True
+    assert result["category"] == "simple"
+
+
+def test_score_example_simple_wrong_call():
+    gold_ex = {"category": "simple", "tools": [],
+               "gold": [{"name": "get_weather", "arguments": {"city": "Paris"}}]}
+    pred_calls = [{"name": "get_weather", "arguments": {"city": "London"}}]
+    assert score_example(pred_calls, gold_ex)["correct"] is False
+
+
+def test_score_example_simple_extra_call_is_wrong():
+    gold_ex = {"category": "simple", "tools": [],
+               "gold": [{"name": "get_weather", "arguments": {"city": "Paris"}}]}
+    pred_calls = [{"name": "get_weather", "arguments": {"city": "Paris"}},
+                  {"name": "set_timer", "arguments": {"seconds": 10}}]
+    assert score_example(pred_calls, gold_ex)["correct"] is False
+
+
+def test_score_example_parallel_order_insensitive():
+    gold_ex = {"category": "parallel", "tools": [], "gold": [
+        {"name": "get_weather", "arguments": {"city": "Tokyo"}},
+        {"name": "set_timer", "arguments": {"seconds": 300}},
+    ]}
+    # predicted in the opposite order -> still correct (order-insensitive)
+    pred_calls = [
+        {"name": "set_timer", "arguments": {"seconds": 300}},
+        {"name": "get_weather", "arguments": {"city": "Tokyo"}},
+    ]
+    assert score_example(pred_calls, gold_ex)["correct"] is True
+
+
+def test_score_example_parallel_count_sensitive_duplicate():
+    gold_ex = {"category": "parallel", "tools": [],
+               "gold": [{"name": "get_weather", "arguments": {"city": "Tokyo"}}]}
+    # duplicate predicted call when gold only has one -> wrong (count-sensitive)
+    pred_calls = [{"name": "get_weather", "arguments": {"city": "Tokyo"}},
+                  {"name": "get_weather", "arguments": {"city": "Tokyo"}}]
+    assert score_example(pred_calls, gold_ex)["correct"] is False
+
+
+def test_score_example_abstention_correct_when_no_call():
+    gold_ex = {"category": "abstention", "tools": [], "gold": []}
+    assert score_example([], gold_ex)["correct"] is True
+
+
+def test_score_example_abstention_wrong_when_spurious_call():
+    gold_ex = {"category": "abstention", "tools": [], "gold": []}
+    pred_calls = [{"name": "get_weather", "arguments": {"city": "Paris"}}]
+    assert score_example(pred_calls, gold_ex)["correct"] is False
+
+
+def test_score_example_relevance_alias_behaves_like_abstention():
+    gold_ex = {"category": "relevance", "tools": [], "gold": []}
+    assert score_example([], gold_ex)["correct"] is True
+    assert score_example([{"name": "x", "arguments": {}}], gold_ex)["correct"] is False
+
+
+# --------------------------------------------------------------------------- #
+# schema_valid reporting
+# --------------------------------------------------------------------------- #
+
+def test_score_example_schema_valid_true_for_conforming_call():
+    tools = [{"name": "get_weather", "parameters": {"type": "object",
+                                                     "properties": {"city": {"type": "string"}},
+                                                     "required": ["city"]}}]
+    gold_ex = {"category": "simple", "tools": tools,
+               "gold": [{"name": "get_weather", "arguments": {"city": "Paris"}}]}
+    pred_calls = [{"name": "get_weather", "arguments": {"city": "Paris"}}]
+    result = score_example(pred_calls, gold_ex)
+    assert result["schema_valid"] is True
+    assert result["correct"] is True
+
+
+def test_score_example_schema_valid_false_for_missing_required_arg():
+    tools = [{"name": "get_weather", "parameters": {"type": "object",
+                                                     "properties": {"city": {"type": "string"}},
+                                                     "required": ["city"]}}]
+    gold_ex = {"category": "simple", "tools": tools,
+               "gold": [{"name": "get_weather", "arguments": {"city": "Paris"}}]}
+    # A call that happens to match gold's own city loosely but omits "city" outright
+    # can't score correct anyway; use a schema-invalid-but-name-matching call instead.
+    pred_calls = [{"name": "get_weather", "arguments": {}}]
+    result = score_example(pred_calls, gold_ex)
+    assert result["schema_valid"] is False
+
+
+def test_score_example_schema_valid_vacuously_true_for_no_calls():
+    gold_ex = {"category": "abstention", "tools": [{"name": "x", "parameters": {}}], "gold": []}
+    assert score_example([], gold_ex)["schema_valid"] is True
+
+
+# --------------------------------------------------------------------------- #
+# evaluate_bfcl: end-to-end aggregation with a fake generate_fn + the inline fixture
+# --------------------------------------------------------------------------- #
+
+def _perfect_generate_fn(prompt_or_messages) -> str:
+    """Fake generator that always emits the gold answer for whichever fixture example
+    is being asked about (keyed by the user turn's content, robust to fixture order)."""
+    text = json.dumps(prompt_or_messages)
+    if "Boston" in text:
+        return _block({"name": "get_weather", "arguments": {"city": "Boston"}})
+    if "5 minute timer" in text:
+        return (_block({"name": "get_weather", "arguments": {"city": "Tokyo"}}) + "\n"
+                + _block({"name": "set_timer", "arguments": {"seconds": 300}}))
+    if "Translate" in text:
+        return "I don't have a translation tool, but 'hello' in French is 'bonjour'."
+    return "I don't know."
+
+
+def test_evaluate_bfcl_perfect_generation_scores_100_percent():
+    summary = evaluate_bfcl(BFCL_FIXTURE, _perfect_generate_fn)
+    assert summary["n_examples"] == len(BFCL_FIXTURE)
+    assert summary["accuracy"] == 1.0
+    assert summary["schema_valid_rate"] == 1.0
+    assert set(summary["per_category_accuracy"]) == {"simple", "parallel", "abstention"}
+    for acc in summary["per_category_accuracy"].values():
+        assert acc == 1.0
+
+
+def _always_wrong_generate_fn(prompt_or_messages) -> str:
+    """Fake generator that always calls the wrong tool with the wrong args — including
+    on the abstention example, where any call at all is wrong."""
+    return _block({"name": "nonexistent_tool", "arguments": {"foo": "bar"}})
+
+
+def test_evaluate_bfcl_all_wrong_generation_scores_0_percent():
+    summary = evaluate_bfcl(BFCL_FIXTURE, _always_wrong_generate_fn)
+    assert summary["accuracy"] == 0.0
+    for acc in summary["per_category_accuracy"].values():
+        assert acc == 0.0
+    # nonexistent_tool never appears in any fixture example's declared tools.
+    assert summary["schema_valid_rate"] == 0.0
+
+
+def test_evaluate_bfcl_uses_prompt_when_messages_absent():
+    examples = [{"category": "abstention", "tools": [], "gold": [], "prompt": "hi"}]
+    seen = []
+
+    def gen(prompt_or_messages):
+        seen.append(prompt_or_messages)
+        return "no calls here"
+
+    summary = evaluate_bfcl(examples, gen)
+    assert seen == ["hi"]
+    assert summary["accuracy"] == 1.0
+
+
+def test_evaluate_bfcl_empty_examples_reports_nan_not_crash():
+    summary = evaluate_bfcl([], lambda p: "")
+    assert summary["n_examples"] == 0
+    assert summary["accuracy"] != summary["accuracy"]  # NaN != NaN
+    assert summary["per_category_accuracy"] == {}

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -78,6 +78,7 @@ PORTABLE_MODULES = [
     "src.eval.quantize",
     "src.eval.long_context",
     "src.eval.olmes_adapter",
+    "src.eval.bfcl_adapter",
     "src.eval.retrieval_probe",
     "src.eval.probes",
     "src.conformance.forward_step_parity",

--- a/tests/test_tool_sft.py
+++ b/tests/test_tool_sft.py
@@ -22,6 +22,7 @@ from src.data.tool_sources import (
     iter_tool_sft,
     sample_distractors,
     toolace_row_to_messages,
+    validate_call_against_tools,
     when2call_row_to_messages,
     xlam_row_to_messages,
 )
@@ -176,6 +177,7 @@ def test_build_tool_sft_end_to_end(tmp_path):
     assert manifest["sources"].get("handauthored") == n
     assert manifest["n_abstention"] >= 1
     assert manifest["n_with_distractors"] >= 1
+    assert manifest["n_schema_invalid"] == 0  # handauthored set is clean
     loader = SFTLoader(tok_dir / "tool.jsonl", seq_len=8192, batch_size=2)
     inputs, targets, mask = next(loader.epoch())
     assert inputs.shape == targets.shape == mask.shape
@@ -192,6 +194,24 @@ def test_over_length_tool_examples_dropped(tmp_path):
     m = build_tool_sft([huge], tmp_path, tokenizer="qwen25", byte_fallback=True,
                        seq_len=8192, max_seq_len=50)
     assert m["n_records"] == 0 and m["n_skipped"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Schema-invalid rows: dropped and counted, not silently kept (#102 box #1)
+# --------------------------------------------------------------------------- #
+
+def test_schema_invalid_row_dropped_and_counted(tmp_path):
+    weather = {"name": "get_weather", "parameters": {"type": "object",
+                                                      "properties": {"city": {"type": "string"}},
+                                                      "required": ["city"]}}
+    # The call omits the required "city" argument -> schema-invalid.
+    bad = build_tool_messages([weather], "What's the weather?",
+                              [{"name": "get_weather", "arguments": {}}])
+    good = build_tool_messages([weather], "Weather in Paris?",
+                               [{"name": "get_weather", "arguments": {"city": "Paris"}}])
+    m = build_tool_sft([bad, good], tmp_path, tokenizer="qwen25", byte_fallback=True, seq_len=8192)
+    assert m["n_schema_invalid"] == 1
+    assert m["n_records"] == 1
 
 
 # --------------------------------------------------------------------------- #
@@ -248,6 +268,32 @@ def test_row_mappers_offline():
     assert trec is not None
     assert trec["source"] == "toolace"
     assert TOOL_CALL_OPEN in trec["messages"][-1]["content"]
+
+
+# --------------------------------------------------------------------------- #
+# validate_call_against_tools: name known + required args present (#102 box #1)
+# --------------------------------------------------------------------------- #
+
+def test_validate_call_against_tools_valid_call():
+    tools = [{"name": "get_weather", "parameters": {"type": "object",
+                                                     "properties": {"city": {"type": "string"}},
+                                                     "required": ["city"]}}]
+    call = {"name": "get_weather", "arguments": {"city": "Paris"}}
+    assert validate_call_against_tools(call, tools) is True
+
+
+def test_validate_call_against_tools_missing_required():
+    tools = [{"name": "get_weather", "parameters": {"type": "object",
+                                                     "properties": {"city": {"type": "string"}},
+                                                     "required": ["city"]}}]
+    call = {"name": "get_weather", "arguments": {}}
+    assert validate_call_against_tools(call, tools) is False
+
+
+def test_validate_call_against_tools_unknown_name():
+    tools = [{"name": "get_weather", "parameters": {"type": "object", "required": []}}]
+    call = {"name": "send_email", "arguments": {"to": "a@b.com"}}
+    assert validate_call_against_tools(call, tools) is False
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #102

## Summary
- Add `validate_call_against_tools()` to `src/data/tool_sources.py` and wire it into `tool_sft.py`'s builder — schema-invalid calls are now detected, invalid rows dropped, and counted via a new `n_schema_invalid` manifest field. Closes the literal "calls schema-validated" gap in acceptance box #1 (records themselves were already built by #152/#154).
- Add a new portable `src/eval/bfcl_adapter.py`: a BFCL-style function-calling scorer (`parse_tool_calls`, `match_call`, `score_example` with per-category dispatch for simple/parallel/abstention, `evaluate_bfcl` aggregation) that stays backend-free by taking generation as an injected `generate_fn` seam callable, mirroring `olmes_adapter.py`'s pure-core pattern. Includes an inline offline fixture.
- Add `scripts/eval_bfcl.py`, an MLX-gated runner mirroring `scripts/eval_olmes.py` (local mlx imports only, never at module scope).
- Register `src.eval.bfcl_adapter` in `tests/test_import_guard.py`'s `PORTABLE_MODULES` (seam guard).
- Add 27 new offline unit tests in `tests/test_bfcl_adapter.py` plus additional schema-validation tests in `tests/test_tool_sft.py`.

Both #102 acceptance checkboxes are now closed.

## Testing
- [x] Tests added/updated
- [x] All tests passing (`pytest -q`: 584 passed, 4 skipped)
- [x] Manual testing completed (`scripts/eval_bfcl.py` run end-to-end against `config/toy.yaml` with `--byte-fallback` + random-init weights; offline `tool_sft` builder run confirms `n_schema_invalid: 0` on the clean handauthored set)