### PR TITLE
docs: record M10 teacher-license/AUP compliance check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,3 +157,23 @@ The smoke gate stresses exactly this round-trip.
   `docs/design/README.md`); `docs/infrastructure.md` is the R2 + RunPod runbook. After completing
   a milestone, tick its box in the relevant tracker (#2 / #65).
 - After finishing a milestone or backend change, run the smoke gate, not just pytest.
+
+## Licensing / usage-policy compliance (M10 distillation)
+
+M10 distils from **`Qwen/Qwen3-4B-Thinking-2507`, licensed plain unmodified Apache-2.0** (no
+distillation or competing-model restriction — confirmed against the live LICENSE file
+2026-07-05) using third-party corpora (the-stack, open-web-math, Wikipedia, OpenCodeReasoning,
+etc.), not Claude-generated content. Anthropic's Usage Policy's "model scraping/distillation"
+clause restricts using **Claude's own** inputs/outputs to train another model without
+authorization — it does not restrict using Claude as a coding assistant to build an ML pipeline
+that distills a *different* (non-Anthropic) model, confirmed against the live Usage Policy the
+same date. On that basis M10 does not appear to cross either line.
+
+**Standing rule — flag before crossing the actual boundary:** if any future task would have
+Claude *generate* text (synthetic examples, code samples, explanations) that gets fed into the
+pretrain/SFT/RL corpus as a training signal for the student model, **stop and flag it for
+review** rather than proceeding — that is the specific thing Anthropic's policy restricts, and
+this project has otherwise been careful to keep the corpus entirely third-party/non-Claude.
+Re-check both the teacher model's license and Anthropic's Usage Policy if either changes, or if
+the teacher model itself ever changes — this assessment is not a legal ruling and is only as
+current as the sources checked on the date above.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ train/distil → serve/chat → eval). **Cloud:** [`docs/infrastructure.md`](doc
 — running the data + training pipeline on object storage + rented GPUs (R2 + RunPod).
 **Design & rationale:** [`docs/design/`](docs/design/README.md).
 
+> **Licensing note.** The distillation program (M10) trains from
+> `Qwen/Qwen3-4B-Thinking-2507`, licensed plain **Apache-2.0** — no distillation or
+> competing-model restriction. The corpus and teacher signal are third-party data (the-stack,
+> Wikipedia, OpenCodeReasoning, etc.) and Qwen's own model outputs, not Claude/Anthropic content.
+> This repo's engineering work is assisted by Claude Code, but no Claude-generated text is part
+> of the training corpus or teacher signal — Anthropic's usage policy separately restricts using
+> *its own* model's outputs to train other models, which is a different thing than using it as a
+> coding assistant to build this pipeline. See `CLAUDE.md`'s "Licensing / usage-policy
+> compliance" section for the full note.
+
 ---
 
 ## TL;DR — what is this?


### PR DESCRIPTION
User asked whether distilling from an open-weight model (Qwen3-4B-Thinking-2507) might push
against Anthropic's or Qwen's terms of use, and to flag it for review if so, and to record the
answer in CLAUDE.md + a public-facing README notice.

## Summary
Checked both live policy texts (2026-07-05):
- **Qwen3-4B-Thinking-2507's LICENSE** is plain, unmodified Apache-2.0 — no distillation or
  competing-model restriction.
- **Anthropic's Usage Policy's** "model scraping/distillation" clause restricts using
  **Claude's own** inputs/outputs to train another model without authorization — not using
  Claude as a coding assistant to build an ML pipeline that distills a *different*
  (non-Anthropic) model. M10's corpus/teacher signal is entirely third-party (Qwen logits +
  third-party datasets: the-stack, Wikipedia, OpenCodeReasoning, etc.), not Claude-generated.

**No violation found on either side.** Adds:
- A `CLAUDE.md` section recording this finding plus a standing rule: flag for review before any
  future task has Claude generate text that gets fed into the training/SFT/RL corpus as a
  training signal — that's the actual boundary the Anthropic policy restricts.
- A matching public-facing note near the top of `README.md` so the repo is up-front about this
  for anyone browsing it, not just Claude Code sessions.

This is not a legal ruling — both docs note the assessment is only as current as the sources
checked on the date above, and to re-check if the teacher model or either policy changes.

## Testing
- [x] Docs-only change, no code/behavior affected.
- [x] N/A — no tests apply.
- [x] Manual verification: both new sections read correctly and cross-reference each other.