### PR TITLE
docs: update #177 runbook with real corpus-extension sizes

### DIFF
--- a/docs/path-b-run.md
+++ b/docs/path-b-run.md
@@ -272,6 +272,48 @@ length + tok/s vs a same-size transformer, #104) — *not* benchmark scores.
 
 Whole run is **order \$100s** on A100/H100 (issue #141). Bench Step 3 before committing.
 
+### Time & $ estimate — prefer H100 (single, in sequence; cluster only if needed)
+
+Model: `6·N·D` training FLOPs (student ~1.03B) + `2·N·D` inference FLOPs (4B teacher forward),
+divided by each card's achieved throughput at the repo's **40% MFU** convention (H100 bf16 dense
+peak ~990 TFLOPS → ~396 eff TFLOP/s single-card; an 8-GPU cluster scales at ×8×0.85). This
+reproduces the repo's own calibrated anchor in `docs/design/09-hybrid-architectures.md` (1B
+Chinchilla pretrain: 1×H100 = 3.7 d, 8×H100 = 13.2 h), so the extension below rests on the same
+basis. **$/hr are external ~2026 RunPod market rates, not stored in-repo** — H100 ≈ \$2.79/GPU-hr,
+A100 ≈ \$1.60/GPU-hr (fallback, ~2× slower than H100 at similar $/FLOP) — re-price before
+committing spend.
+
+| Phase | 1× H100 | 8× H100 | ~$ |
+|---|---|---|---|
+| Teacher precompute (4B fwd, dominant $ — extension only, base already cached) | ~1–7 d | ~3–27 h | \$150–1,100 |
+| Student sweep (2 layouts × 3 stages) | 3–7 h | — | \$30–60 |
+| Post-train SFT (2 epochs) | 3–6 h | — | \$20–50 |
+| Eval (long-context + OLMES) | 2–6 h | — | ~\$10 |
+| **Total** | **~2–8 d** | **~1–2 d** | **~\$400–900 (realistic)** |
+
+**Recommendation:** run phases on a **single H100 in sequence** — cheapest and simplest, and
+correctness gates (alignment check, val-ppl curve) are easiest to babysit one pod at a time.
+Escalate to an **8× H100 cluster only for the teacher-precompute phase**, since it's
+embarrassingly parallel over corpus chunks and is the one phase where wall-clock (days → hours)
+actually matters. A100 is a viable fallback at similar total $ but ~2× the wall-clock.
+
+**The precompute phase is the swing factor** (~6× cost range) because its real MFU is unmeasured:
+at the repo's 40% MFU convention it lands near \$150–250 (the "order \$100s" line above); at the
+naive throughput implied by Path A's measured 7B-teacher forward (~7 s/batch, seq 1024, batch
+8 — roughly ~5% MFU at that shape) it lands near \$700–1,100. **Bench a small slice of Step 3
+first** (as already instructed above) before committing to a multi-day/multi-hundred-dollar pod
+reservation. Only the 3.357B-token corpus extension remains — the 1.897B base corpus is already
+precomputed and cached.
+
+**Reserve alternative — from-scratch 1B pretrain** (20.67B Chinchilla tokens, no teacher/distill):
+~\$250–300 either way — 3.7 d on 1× H100, or 13 h on an 8× H100 cluster. Compute-bound, so cost is
+roughly flat across cards; only wall-clock changes.
+
+**Local Apple-Silicon training is not viable at this scale** — a full run is months of wall-clock
+even on the newest Mac hardware, and the seq-8192 logit tensor (~40 GB fp32 at batch 8) OOMs
+Metal. Mac's role here stays what it already is per `docs/local-development.md`: toy/small POC
+iteration, small-split local dry-runs, and running eval (Step 6 above).
+
 ## Gotchas (carried from Path A)
 
 - **MOHAWK stage-1 O(L²) OOM** — small micro-batch + `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`

--- a/docs/runbooks/m10-phase-bprime-append.md
+++ b/docs/runbooks/m10-phase-bprime-append.md
@@ -27,7 +27,8 @@ banner; this doc replaces its Step 3 for the *extension* leg), [`m10-pod-chain.m
   code_instruct: `opencodeinstruct` + `codefeedback`). 3,262,881 documents, 409,755 sequences.
   Pushed to a **separate top-level R2 prefix**, not nested under `poc-distill`:
   **`s3://monica-training/poc-distill-ext/corpus/tokenized/qwen3-8k`** (61 files, 16.784 GB) +
-  `.../poc-distill-ext/corpus/cleaned/` (28 parquet shards, 3.830 GB pre-tokenization text).
+  `s3://monica-training/poc-distill-ext/corpus/cleaned/` (28 parquet shards, 3.830 GB
+  pre-tokenization text).
   Decontamination-checked against MATH-500/AIME25/LiveCodeBench/IFEval: zero overlap on three of
   four; 5/500 MATH-500 problems (1%) matched `openwebmath` (expected/low-severity web-crawl
   leakage, accepted as-is — see CLAUDE.md). One build gotcha worth knowing: the domains that

--- a/docs/runbooks/m10-phase-bprime-append.md
+++ b/docs/runbooks/m10-phase-bprime-append.md
@@ -1,7 +1,7 @@
 # M10 Phase B′ — append-only teacher precompute for the corpus extension (#177)
 
 Ready-to-fire runbook for **#177**: extend the frozen 566 GB Qwen3-4B-Thinking teacher top-k cache
-to cover the multi-domain corpus extension (#176, built 2026-07-03) **without re-precomputing the
+to cover the multi-domain corpus extension (#176/#182, built 2026-07-05) **without re-precomputing the
 ~230,318 unchanged FineWeb chunks**. All machinery is merged
 (`scripts/verify_teacher_alignment.py`, `scripts/append_new_chunks.py`, `scripts/precompute_teacher.py`)
 — this is a **run**, not a build. Written so a fresh session (or a clean pod clone) can fire it with
@@ -12,20 +12,31 @@ banner; this doc replaces its Step 3 for the *extension* leg), [`m10-pod-chain.m
 (precompute + sweep staging, steps 3–4 — this runbook's output feeds its Step 3),
 [`../infrastructure.md`](../infrastructure.md) (generic R2 + RunPod flow).
 
-## State (as of 2026-07-03)
+## State (as of 2026-07-05)
 
 - **Base corpus + base teacher precompute: DONE (2026-07-02).** 4× A100-SXM4-80GB pods ran the
   4B-teacher top-k forward (k=50, seq_len=8192) over the base 1.897B-token FineWeb-derived corpus
   and merged: **230,318 train chunks (~1.887B rows), 305 val chunks**, at
   `s3://monica-training/poc-distill/teacher-outputs/topk-logits-merged/` (IDX 377 GB + VALS 189 GB
   ≈ 566 GB total). Pod terminated.
-- **Corpus extension: DONE (2026-07-03, #176).** ~1.9B new pretrain tokens blended across five
-  domains (code, math, docs, conversation, reasoning) pushed to R2 alongside the base corpus
-  (`s3://monica-training/poc-distill/corpus/tokenized/qwen3-8k`) — confirm the exact extension
-  shard prefix from `provenance.json` written by #176's run (not hard-coded here since it wasn't
-  captured in this session).
+- **Corpus extension: DONE (2026-07-05), real numbers confirmed — bigger than the original
+  estimate.** **3,356,712,960 new tokens (~3.36B)** — not the ~1.9B originally estimated (#176) —
+  across **14 sources** spanning 8 domains (code: `the-stack-dedup`; math: `openwebmath`; docs:
+  `starcoder2-docs`; wiki: `wikipedia`; conversation: `ultrachat` + `oasst1`; reasoning: `mot` +
+  `openthoughts2`; code_problems: `opencodereasoning` + `rosetta-code` + `mceval` + `kodcode`;
+  code_instruct: `opencodeinstruct` + `codefeedback`). 3,262,881 documents, 409,755 sequences.
+  Pushed to a **separate top-level R2 prefix**, not nested under `poc-distill`:
+  **`s3://monica-training/poc-distill-ext/corpus/tokenized/qwen3-8k`** (61 files, 16.784 GB) +
+  `.../poc-distill-ext/corpus/cleaned/` (28 parquet shards, 3.830 GB pre-tokenization text).
+  Decontamination-checked against MATH-500/AIME25/LiveCodeBench/IFEval: zero overlap on three of
+  four; 5/500 MATH-500 problems (1%) matched `openwebmath` (expected/low-severity web-crawl
+  leakage, accepted as-is — see CLAUDE.md). One build gotcha worth knowing: the domains that
+  chain multiple sources under one pooled token budget (`conversation`/`reasoning`/
+  `code_problems`/`code_instruct`) only exercise later-listed sources once earlier ones exhaust —
+  six sources initially got silently starved and had to be rebuilt separately then merged in
+  (also recorded in CLAUDE.md).
 - **This runbook (#177): not yet run.** It is the remaining step before the two-layout sweep (#81)
-  can train against the *full* extended ~3.8B blend.
+  can train against the *full* extended **~5.25B-token** blend (1.897B base + 3.357B extension).
 
 ## Why append, not re-precompute (enforced by code, not a guess)
 
@@ -51,10 +62,11 @@ a full re-precompute if violated:
 
 - **GPU: Ampere+ 80 GB (A100/H100)** — the alignment gate and the new-chunk precompute both need a
   live CUDA teacher forward; bf16 needs Ampere+.
-- **Volume: ≥1.2 TB.** Combined footprint estimate ≈ 566 GB (existing) + ~475 GB (new chunks) ≈
-  **~1.05 TB** — recompute exactly once the real new-chunk count is known from #176's
-  `provenance.json`, and size the volume with headroom (the merge also needs scratch space for the
-  regenerated/trimmed/combined `train.bin`).
+- **Volume: ≥2 TB** (revised 2026-07-05 — up from the original ≥1.2 TB estimate, since the real
+  extension is 1.77× bigger than planned). Base cache is 566 GB for 1.897B tokens (≈298 B/token);
+  applying that same ratio to the real 3,356,712,960-token extension gives a new-chunk cache of
+  **≈1.00 TB**, for a combined footprint of **≈1.57 TB** — the ≥2 TB floor leaves headroom for the
+  merge's scratch space (regenerated/trimmed/combined `train.bin`).
 
 ```bash
 git clone https://github.com/travisgalloway/monica && cd monica
@@ -71,8 +83,9 @@ export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 # regenerated FineWeb corpus (the ORIGINAL base corpus — must still tokenize to 230318 chunks):
 python -m src.data.r2_sync down s3://monica-training/poc-distill/corpus/tokenized/qwen3-8k /vol/fineweb-shards
 
-# the new-source corpus extension (#176) — confirm the exact prefix from #176's provenance.json:
-python -m src.data.r2_sync down s3://monica-training/poc-distill/corpus/tokenized/<extension-prefix> /vol/extension-shards
+# the new-source corpus extension (#176/#182, real numbers confirmed 2026-07-05) -- note this is
+# a SEPARATE top-level prefix, not nested under poc-distill:
+python -m src.data.r2_sync down s3://monica-training/poc-distill-ext/corpus/tokenized/qwen3-8k /vol/extension-shards
 
 # the frozen base teacher cache (shard-0 for the merge):
 python -m src.data.r2_sync down s3://monica-training/poc-distill/teacher-outputs/topk-logits-merged /vol/topk-logits-merged
@@ -146,7 +159,7 @@ frozen 230,318-chunk prefix (via **copy-prefix-then-rename**, not `os.truncate` 
 MooseFS mount silently no-ops truncate, corrupting resumed writes), builds a flat `train.bin` from
 the extension shards, concatenates the two into the combined corpus, and **stream-merges** the
 frozen shard-0 (from R2) with the new shard-1 straight to the new R2 prefix — avoiding
-materializing the ~1.1 TB combined set locally. It self-verifies at the end that `DistillLoader`
+materializing the ≈1.57 TB combined set locally. It self-verifies at the end that `DistillLoader`
 opens the combined `(train.bin, merged teacher-outputs)` pair.
 
 ## Step 5 — finalize
@@ -167,8 +180,8 @@ opens the combined `(train.bin, merged teacher-outputs)` pair.
 | Stage | Cost driver | Output |
 |---|---|---|
 | Step 2 (alignment gate) | 1 live teacher forward × 3 probe chunks — cheap, the point of the gate | pass/fail |
-| Step 3 (new-chunk precompute) | 4B forward over ~475 GB-equivalent new tokens — the real $ of this runbook | `/vol/teacher-outputs/shard1-new` |
-| Step 4 (append-merge) | I/O-bound (streaming merge), not compute-bound | `topk-logits-ext-merged` on R2, ~1.05 TB |
+| Step 3 (new-chunk precompute) | 4B forward over 3,356,712,960 new tokens (≈1.00 TB-equivalent teacher cache) — the real $ of this runbook, ~1.77× the original estimate | `/vol/teacher-outputs/shard1-new` |
+| Step 4 (append-merge) | I/O-bound (streaming merge), not compute-bound | `topk-logits-ext-merged` on R2, ≈1.57 TB |
 
 ## Gotchas
 
@@ -186,8 +199,9 @@ opens the combined `(train.bin, merged teacher-outputs)` pair.
 
 - [ ] Merged extended teacher-outputs cache on R2 at the new `-ext-merged` prefix.
 - [ ] PHASE marker flipped → `B′:append-done`.
-- [ ] Unblocks the two-layout student sweep (#81), now trainable against the full extended ~3.8B
-      blend — proceed to [`m10-pod-chain.md`](m10-pod-chain.md) Step 4.
+- [ ] Unblocks the two-layout student sweep (#81), now trainable against the full extended
+      **~5.25B-token** blend (1.897B base + 3.357B extension) — proceed to
+      [`m10-pod-chain.md`](m10-pod-chain.md) Step 4.
 
 ## After this: the rest of the chain
 

--- a/docs/runbooks/m10-phase-bprime-append.md
+++ b/docs/runbooks/m10-phase-bprime-append.md
@@ -184,6 +184,13 @@ opens the combined `(train.bin, merged teacher-outputs)` pair.
 | Step 3 (new-chunk precompute) | 4B forward over 3,356,712,960 new tokens (≈1.00 TB-equivalent teacher cache) — the real $ of this runbook, ~1.77× the original estimate | `/vol/teacher-outputs/shard1-new` |
 | Step 4 (append-merge) | I/O-bound (streaming merge), not compute-bound | `topk-logits-ext-merged` on R2, ≈1.57 TB |
 
+Step 3's 3,356,712,960-token extension precompute is the real \$ of this runbook: **~\$100 (8×
+H100 cluster) to ~\$700 (single A100), depending on measured MFU — bench a small slice first.**
+**Prefer H100** — single card in sequence, or an 8× H100 cluster for this phase specifically,
+since it's the one embarrassingly-parallel-over-chunks step where cluster wall-clock pays off. See
+[`../path-b-run.md`](../path-b-run.md) §"Time & \$ estimate" for the full derivation and the
+from-scratch-pretrain comparison.
+
 ## Gotchas
 
 - **Positional alignment is everything** — if the regenerated FineWeb `train.bin` doesn't yield

--- a/docs/runbooks/m10-pod-chain.md
+++ b/docs/runbooks/m10-pod-chain.md
@@ -45,6 +45,10 @@ export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True   # required for the MOH
 
 ### Step 3 — teacher precompute (the dominant $, run ONCE; both layouts reuse it)
 Needs an **Ampere+ 80 GB** card (A100/H100) for the bf16 / seq-8192 path. Bench a small slice first.
+**Prefer H100** — a single card run in sequence for cost simplicity, or an **8× H100 cluster for
+this phase only** (embarrassingly parallel over chunks) when wall-clock matters. See
+[`../path-b-run.md`](../path-b-run.md) §"Time & \$ estimate" for the full time/$ table
+(~\$150–1,100 depending on measured MFU — bench first).
 ```bash
 python -m src.data.r2_sync down s3://monica-training/poc-distill/corpus/tokenized/qwen3-8k /vol/corpus8k
 python -m src.data.split --shards /vol/corpus8k --out /vol/split8k --val-tokens 10000000   # seq_len stays 8192


### PR DESCRIPTION
Part of #65/#177. The extension corpus (poc-distill-ext) is now actually built and pushed to
R2 (PRs #182-#185) -- this updates the #177 append runbook's sizing estimates from the
original ~1.9B-token plan to the real, confirmed numbers before anyone rents a pod against
the stale estimate.

## Summary
- **Real token count:** 3,356,712,960 (~3.36B) -- 1.77x the original ~1.9B estimate.
- **Real R2 prefix fixed:** `s3://monica-training/poc-distill-ext/corpus/tokenized/qwen3-8k`
  -- a separate top-level prefix, not nested under `poc-distill` as the old placeholder
  (`<extension-prefix>`) implied.
- **Recomputed teacher-cache sizing** proportionally from the base's known
  566GB/1.897B-token ratio: new-chunk cache ~1.00TB (was estimated ~475GB), combined
  ~1.57TB (was ~1.05TB) -- volume floor raised from >=1.2TB to >=2TB.
- **Extended blend is ~5.25B tokens** (1.897B base + 3.357B extension), not ~3.8B.
- Noted the decontamination check + source-exhaustion build gotcha (both already recorded
  in CLAUDE.md) in the runbook's State section for context.

## Testing
- [x] Docs-only change, no code/behavior affected.
- [x] N/A -- no tests apply.
- [x] Manual verification: cross-checked every updated number against the live R2 corpus
      state (file counts, manifest.json totals) confirmed earlier this session.