### PR TITLE
fix(data): #177 append-precompute preflight audit — fix blocking val-split bug + harden preflight checks

### DIFF
--- a/docs/runbooks/m10-phase-bprime-append.md
+++ b/docs/runbooks/m10-phase-bprime-append.md
@@ -181,13 +181,16 @@ pair.
 - Flip the local PHASE marker → `B′:append-done` (the ops-state convention recorded in
   `~/.claude/monica-runpod-ops/` from prior pod runs — reuse it, don't invent a new mechanism).
 - **Repoint the sweep at the extended cache.** The two sweep manifests
-  (`config/manifests/student-1b-attn-{hi,lo}.yaml`) currently pin
-  `teacher_outputs: poc-distill/teacher-outputs/topk-logits` (the base-only cache). Two ways to
-  point the Step 4 sweep (in `m10-pod-chain.md`) at the extended one instead:
-  - **Recommended — CLI override, keeps manifests stable:** pass
-    `--teacher-outputs s3://monica-training/poc-distill/teacher-outputs/topk-logits-ext-merged`
-    (or the local synced copy) to `scripts/distill.py` instead of relying on the manifest field.
-  - **Alternative:** edit both manifests' `teacher_outputs:` field to the new `-ext-merged` prefix.
+  (`config/manifests/student-1b-attn-{hi,lo}.yaml`) list
+  `teacher_outputs: poc-distill/teacher-outputs/topk-logits` (the base-only cache), but
+  `scripts/distill.py` never actually reads that field — `--teacher-outputs` on the CLI is the
+  **sole** source of truth (mandatory whenever the `logit-distill` stage runs), not an override of
+  a manifest default. So the only real way to point the Step 4 sweep (in `m10-pod-chain.md`) at
+  the extended cache is:
+  - Pass `--teacher-outputs s3://monica-training/poc-distill/teacher-outputs/topk-logits-ext-merged`
+    (or the local synced copy) to `scripts/distill.py`.
+  - Editing the manifests' `teacher_outputs:` field is **decorative only** — `distill.py` won't
+    pick it up; do it for documentation/record-keeping if you like, but it has no effect on the run.
 
 ## Sizing
 

--- a/docs/runbooks/m10-phase-bprime-append.md
+++ b/docs/runbooks/m10-phase-bprime-append.md
@@ -24,7 +24,10 @@ banner; this doc replaces its Step 3 for the *extension* leg), [`m10-pod-chain.m
   across **14 sources** spanning 8 domains (code: `the-stack-dedup`; math: `openwebmath`; docs:
   `starcoder2-docs`; wiki: `wikipedia`; conversation: `ultrachat` + `oasst1`; reasoning: `mot` +
   `openthoughts2`; code_problems: `opencodereasoning` + `rosetta-code` + `mceval` + `kodcode`;
-  code_instruct: `opencodeinstruct` + `codefeedback`). 3,262,881 documents, 409,755 sequences.
+  code_instruct: `opencodeinstruct` + `codefeedback`). 3,262,881 documents, 409,755 sequences
+  (this is the `tokens / 8192` **window** count — the packed-teacher-cache reader strides
+  `SEQ_LEN+1 = 8193` per chunk, so the actual precomputed-chunk count is **409,704**, an
+  8,088-token tail dropped; informational, not a bug — don't change any commands over this).
   Pushed to a **separate top-level R2 prefix**, not nested under `poc-distill`:
   **`s3://monica-training/poc-distill-ext/corpus/tokenized/qwen3-8k`** (61 files, 16.784 GB) +
   `s3://monica-training/poc-distill-ext/corpus/cleaned/` (28 parquet shards, 3.830 GB
@@ -160,11 +163,21 @@ frozen 230,318-chunk prefix (via **copy-prefix-then-rename**, not `os.truncate` 
 MooseFS mount silently no-ops truncate, corrupting resumed writes), builds a flat `train.bin` from
 the extension shards, concatenates the two into the combined corpus, and **stream-merges** the
 frozen shard-0 (from R2) with the new shard-1 straight to the new R2 prefix — avoiding
-materializing the ≈1.57 TB combined set locally. It self-verifies at the end that `DistillLoader`
-opens the combined `(train.bin, merged teacher-outputs)` pair.
+materializing the ≈1.57 TB combined set locally. The default `--splits train,val` is correct and
+complete as shown above: **`train` merges** shard-0 (frozen base) + shard-1 (freshly precomputed
+extension chunks), while **`val` is passed through unchanged** from the base cache — Step 3 never
+precomputes a val shard for the extension (there's no new val data to add), so `val`'s teacher
+outputs stream straight from shard-0 to the new `-ext-merged` prefix with its `.meta.json` copied
+verbatim. It self-verifies at the end that `DistillLoader` opens **both** the combined
+`(train.bin, merged teacher-outputs)` pair and the `(base val.bin, passed-through teacher-outputs)`
+pair.
 
 ## Step 5 — finalize
 
+- **The merged `-ext-merged` cache now carries both splits**: `train` merged, `val` passed through
+  from the base cache. The base `val.bin` regenerated in Step 2 (`/vol/fineweb-split/val.bin`) is
+  `val`'s positional partner for the sweep — the extension contributes no val chunks, so the
+  sweep's val-loss is computed against the same 305 frozen FineWeb val chunks as the base run.
 - Flip the local PHASE marker → `B′:append-done` (the ops-state convention recorded in
   `~/.claude/monica-runpod-ops/` from prior pod runs — reuse it, don't invent a new mechanism).
 - **Repoint the sweep at the extended cache.** The two sweep manifests

--- a/docs/runbooks/m10-pod-chain.md
+++ b/docs/runbooks/m10-pod-chain.md
@@ -43,6 +43,14 @@ set -a; . ./.env; set +a                     # R2 creds + HF_TOKEN (HF_TOKEN opt
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True   # required for the MOHAWK O(L^2) stage-1 (see below)
 ```
 
+> **`cuda` vs `cuda-fast`, not a contradiction.** `scripts/runpod/m10/bootstrap.sh` actually runs
+> `pip install -e ".[dev,data,cuda]"` followed by a separate `pip install "mamba-ssm>=2.0"
+> "causal-conv1d>=1.0" --no-build-isolation` — `mamba-ssm`'s `setup.py` imports `torch` at build
+> time, which pip's isolated build env for a plain `.[cuda-fast]` extra doesn't have, so the
+> one-line extras form fails there. `bootstrap.sh`'s two-step sequence is the documented
+> workaround for that pip build-isolation issue, not a different/lesser install — it lands the
+> same fused Triton scan + `causal-conv1d` as `.[dev,data,cuda-fast]` above.
+
 ### Step 3 — teacher precompute (the dominant $, run ONCE; both layouts reuse it)
 Needs an **Ampere+ 80 GB** card (A100/H100) for the bf16 / seq-8192 path. Bench a small slice first.
 **Prefer H100** — a single card run in sequence for cost simplicity, or an **8× H100 cluster for
@@ -70,6 +78,17 @@ Two sibling manifests, **same** corpus + teacher outputs, only `layout` differs.
 stages run in order (mixing-match → hidden-align → logit-distill). This is the "sweep" — two
 manifests × three stages → a Phase-2 winner pick; it is one team-Workflow call away once the pod
 exists (no repo runner needed — it's the loop below).
+
+> **`--teacher-outputs` is the sole source, not an override.** `scripts/distill.py` never reads a
+> `teacher_outputs` field out of the manifest at all — the CLI flag below is mandatory whenever
+> the `logit-distill` stage runs and is the *only* place the path comes from. More generally, the
+> manifest fields `corpus`, `teacher_outputs`, `sft`, `rl`, `schedule` are parsed by the manifest
+> loader (`src/train/distill_manifest.py`) but currently **ignored** by `distill.py` (decorative —
+> everything it actually needs is passed on the CLI: `--corpus`, `--teacher-outputs`, etc.). Also
+> note there are **two separate per-layout file families** that must be kept manually in sync when
+> tuning a layout: `config/manifests/student-1b-attn-{hi,lo}.yaml` (read by this Step-4 sweep) vs.
+> the flat `config/student-1b-attn-{hi,lo}.yaml` at the config root (resolved `MambaConfig` YAMLs
+> read by Step-5's `scripts/sft.py`/`scripts/rlvr.py`, **not** by `distill.py`).
 ```bash
 for M in student-1b-attn-hi student-1b-attn-lo; do
   python scripts/distill.py --manifest config/manifests/$M.yaml \

--- a/scripts/append_new_chunks.py
+++ b/scripts/append_new_chunks.py
@@ -19,8 +19,10 @@ Recipe:
      write the combined `.meta.json` (summed `n_tokens`).
   5. Merge teacher top-k shards via the stream-to-R2 pattern (download frozen shard-0 from R2,
      keep the freshly-precomputed shard-1 local, concatenate streaming straight to a new R2
-     prefix — avoiding materializing the ~1.1 TB combined set locally); verify shard-0's
-     `n_chunks == 230318` with no stray `start_chunk` offset.
+     prefix — avoiding materializing the ~1.57 TB combined set locally); verify shard-0's
+     `n_chunks == 230318` with no stray `start_chunk` offset. Splits with no shard-1 counterpart
+     (Step 3 only ever precomputes `train` for the new chunks) are passed through unchanged from
+     shard-0 rather than merged.
   6. Verify `DistillLoader` opens the combined `(train.bin, merged teacher-outputs)` pair.
 
 Pod-only (network + big local volumes); authored here (Mac, Phase A') for Phase B' to run.
@@ -31,7 +33,7 @@ import argparse
 import json
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 #: The frozen FineWeb cache's chunk count / geometry (positionally binds the existing
 #: 566 GB teacher-outputs cache — see teacher_outputs.py's DistillLoader n_chunks assert).
@@ -64,13 +66,15 @@ def trim_file_prefix_copy(path: Path, keep_bytes: int) -> None:
 
 
 def regenerate_fineweb_train(shard_dir: Path, out_dir: Path,
-                             val_tokens: int = 10_000_000) -> Path:
+                             val_tokens: int = 10_000_000) -> Tuple[Path, Path]:
     """Step 1: rebuild FineWeb's flat `train.bin`/`val.bin` via `split.split_shards` and assert
-    the frozen chunk count. Raises `SystemExit` (abort -> full re-precompute) on drift."""
+    the frozen chunk count. Raises `SystemExit` (abort -> full re-precompute) on drift. Returns
+    `(train_path, val_path)` — `val_path` is the base cache's positional partner for the `val`
+    split (never trimmed/combined; the extension contributes train data only)."""
     from src.data.pack import open_packed
     from src.data.split import split_shards
 
-    train_path, _val_path = split_shards(shard_dir, out_dir, val_tokens)
+    train_path, val_path = split_shards(shard_dir, out_dir, val_tokens)
     n_tokens = int(open_packed(train_path).shape[0])
     n_chunks = n_tokens // STRIDE
     if n_chunks != FINEWEB_N_CHUNKS:
@@ -78,7 +82,7 @@ def regenerate_fineweb_train(shard_dir: Path, out_dir: Path,
             f"regenerated FineWeb train.bin has n_chunks={n_chunks}, expected "
             f"{FINEWEB_N_CHUNKS} — the corpus has drifted from the frozen 566 GB cache's "
             "positional binding; abort and run a full re-precompute instead of an append")
-    return train_path
+    return train_path, val_path
 
 
 def trim_to_frozen_chunks(train_path: Path) -> None:
@@ -143,16 +147,40 @@ def _remote_topk_paths(prefix: str, split: str) -> dict:
     return {"vals": f"{base}.topk_vals", "idx": f"{base}.topk_idx", "meta": f"{base}.meta.json"}
 
 
+def _stream_copy(src: Path, fs, dst_path: str) -> None:
+    """Stream-copy one local file to an fsspec destination in bounded-memory chunks."""
+    with fs.open(dst_path, "wb") as dst, open(src, "rb") as src_f:
+        while True:
+            buf = src_f.read(256 * 1024 * 1024)
+            if not buf:
+                break
+            dst.write(buf)
+
+
 def merge_teacher_shards_stream_to_r2(shard0_r2: str, shard1_local: Path, splits: List[str],
                                       push: str) -> None:
     """Step 5: merge the frozen shard-0 (566 GB, downloaded from R2) with the freshly
     precomputed shard-1 (new chunks, local) by concatenating streaming straight to `push` — no
-    ~1.1 TB local materialization. Verifies shard-0 is the whole unshifted frozen cache (no
-    stray `start_chunk`, `n_chunks == FINEWEB_N_CHUNKS`) before merging."""
+    ~1.57 TB local materialization. Verifies shard-0 is the whole unshifted frozen cache (no
+    stray `start_chunk`, `n_chunks == FINEWEB_N_CHUNKS`) before merging.
+
+    Splits with no shard-1 counterpart are **passed through unchanged** rather than merged: Step
+    3 only ever precomputes `train` for the new chunks (the frozen base `val` chunks have no
+    extension counterpart), so a shard-1-less split streams shard-0's `topk_vals`/`topk_idx`
+    straight to `push` and copies its `.meta.json` verbatim — counts stay shard-0's, not summed.
+    This makes the default `--splits train,val` complete out of the box: `train` merges,
+    `val` passes through from the base cache.
+    """
     from src.data.r2_sync import _fs_for, download_dir
 
-    local_root = shard1_local.parent / "_shard0_cache"
-    download_dir(shard0_r2, str(local_root))
+    if str(shard0_r2).startswith("s3://"):
+        local_root = shard1_local.parent / "_shard0_cache"
+        download_dir(shard0_r2, str(local_root))
+    else:
+        # `--topk-dir` is already a local filesystem path (e.g. Step 1 already downloaded it for
+        # the alignment gate) — `_fs_for` resolves any non-`s3://` URI to the local FS, so reuse
+        # the path directly instead of an ~566 GB local->local re-copy into `local_root`.
+        local_root = Path(shard0_r2)
 
     fs, root = _fs_for(push)
     root = root.rstrip("/")
@@ -169,12 +197,24 @@ def merge_teacher_shards_stream_to_r2(shard0_r2: str, shard1_local: Path, splits
             raise SystemExit(
                 f"shard-0 {split} n_chunks={shard0_meta['n_chunks']} != {FINEWEB_N_CHUNKS}")
 
-        shard1_meta = json.loads((shard1_local / f"teacher-{split}.meta.json").read_text())
+        out_paths = _remote_topk_paths(push, split)
+        shard1_meta_path = shard1_local / f"teacher-{split}.meta.json"
+
+        if not shard1_meta_path.exists():
+            # Passthrough: no shard-1 counterpart for this split. Stream shard-0's files
+            # unchanged and copy its .meta.json verbatim (counts = shard-0's own, not summed).
+            for kind, out_path in (("vals", out_paths["vals"]), ("idx", out_paths["idx"])):
+                _stream_copy(local_root / f"teacher-{split}.topk_{kind}", fs, out_path)
+            with fs.open(out_paths["meta"], "w") as f:
+                f.write((local_root / f"teacher-{split}.meta.json").read_text())
+            n_rows_total += shard0_meta["n_rows"]
+            continue
+
+        shard1_meta = json.loads(shard1_meta_path.read_text())
         total_rows = shard0_meta["n_rows"] + shard1_meta["n_rows"]
         total_chunks = shard0_meta["n_chunks"] + shard1_meta["n_chunks"]
         n_rows_total += total_rows
 
-        out_paths = _remote_topk_paths(push, split)
         for kind, out_path in (("vals", out_paths["vals"]), ("idx", out_paths["idx"])):
             src_paths = [local_root / f"teacher-{split}.topk_{kind}",
                         shard1_local / f"teacher-{split}.topk_{kind}"]
@@ -238,7 +278,8 @@ def main() -> None:
 
     splits = [s for s in args.splits.split(",") if s]
 
-    train_path = regenerate_fineweb_train(args.fineweb_shards, args.work_dir, args.val_tokens)
+    train_path, val_path = regenerate_fineweb_train(args.fineweb_shards, args.work_dir,
+                                                     args.val_tokens)
     trim_to_frozen_chunks(train_path)
 
     new_train = args.work_dir / "new" / "train.bin"
@@ -252,7 +293,13 @@ def main() -> None:
     local_merged = args.work_dir / "_merged_meta_check"
     from src.data.r2_sync import download_dir
     download_dir(args.push, str(local_merged))
-    verify_combined(combined_path, local_merged, "train", args.seq_len)
+    if "train" in splits:
+        verify_combined(combined_path, local_merged, "train", args.seq_len)
+    if "val" in splits:
+        # `val` is passed through unchanged from the base cache (no extension counterpart), so
+        # its positional partner is the base val.bin regenerate_fineweb_train wrote — NOT the
+        # combined train.bin.
+        verify_combined(val_path, local_merged, "val", args.seq_len)
 
     print(f"append complete: combined train.bin -> {combined_path}, merged teacher -> {args.push}")
 

--- a/scripts/append_new_chunks.py
+++ b/scripts/append_new_chunks.py
@@ -193,22 +193,29 @@ def merge_teacher_shards_stream_to_r2(shard0_r2: str, shard1_local: Path, splits
         if shard0_meta.get("start_chunk") not in (None, 0):
             raise SystemExit(
                 f"shard-0 {split} has a stray start_chunk={shard0_meta['start_chunk']}")
-        if shard0_meta["n_chunks"] != FINEWEB_N_CHUNKS:
-            raise SystemExit(
-                f"shard-0 {split} n_chunks={shard0_meta['n_chunks']} != {FINEWEB_N_CHUNKS}")
 
         out_paths = _remote_topk_paths(push, split)
         shard1_meta_path = shard1_local / f"teacher-{split}.meta.json"
 
         if not shard1_meta_path.exists():
-            # Passthrough: no shard-1 counterpart for this split. Stream shard-0's files
-            # unchanged and copy its .meta.json verbatim (counts = shard-0's own, not summed).
+            # Passthrough: no shard-1 counterpart for this split. No FINEWEB_N_CHUNKS check
+            # here -- that invariant binds only the frozen FineWeb TRAIN prefix (the thing a new
+            # shard-1 gets appended after); `val` is a separate, much smaller held-out cache
+            # (e.g. 305 chunks, not 230,318) with no shard-1 counterpart to align against, so
+            # there is nothing to verify beyond the start_chunk check above. Stream shard-0's
+            # files unchanged and copy its .meta.json verbatim (counts = shard-0's own).
             for kind, out_path in (("vals", out_paths["vals"]), ("idx", out_paths["idx"])):
                 _stream_copy(local_root / f"teacher-{split}.topk_{kind}", fs, out_path)
             with fs.open(out_paths["meta"], "w") as f:
                 f.write((local_root / f"teacher-{split}.meta.json").read_text())
             n_rows_total += shard0_meta["n_rows"]
             continue
+
+        # Merging: this split's shard-0 IS the frozen FineWeb prefix a new shard-1 is being
+        # appended after, so it must still be exactly the frozen chunk count before concatenating.
+        if shard0_meta["n_chunks"] != FINEWEB_N_CHUNKS:
+            raise SystemExit(
+                f"shard-0 {split} n_chunks={shard0_meta['n_chunks']} != {FINEWEB_N_CHUNKS}")
 
         shard1_meta = json.loads(shard1_meta_path.read_text())
         total_rows = shard0_meta["n_rows"] + shard1_meta["n_rows"]

--- a/scripts/append_new_chunks.py
+++ b/scripts/append_new_chunks.py
@@ -194,7 +194,10 @@ def merge_teacher_shards_stream_to_r2(shard0_r2: str, shard1_local: Path, splits
             raise SystemExit(
                 f"shard-0 {split} has a stray start_chunk={shard0_meta['start_chunk']}")
 
-        out_paths = _remote_topk_paths(push, split)
+        # Use the protocol-stripped `root` (from `_fs_for(push)` above), not the raw `push`
+        # URI -- matches the established pattern elsewhere in this codebase (e.g.
+        # src/data/corpus.py's shard writer) for building fs.open() destinations.
+        out_paths = _remote_topk_paths(root, split)
         shard1_meta_path = shard1_local / f"teacher-{split}.meta.json"
 
         if not shard1_meta_path.exists():

--- a/scripts/append_new_chunks.py
+++ b/scripts/append_new_chunks.py
@@ -267,8 +267,11 @@ def main() -> None:
     ap.add_argument("--work-dir", type=Path, required=True,
                     help="scratch dir for the regenerated/trimmed/combined train.bin")
     ap.add_argument("--val-tokens", type=int, default=10_000_000)
-    ap.add_argument("--topk-dir", type=Path, required=True,
-                    help="the frozen topk-logits-merged dir (R2 prefix; shard-0 for the merge)")
+    ap.add_argument("--topk-dir", required=True,
+                    help="the frozen topk-logits-merged dir (R2 prefix; shard-0 for the merge). "
+                         "Kept as a plain str, not Path — Path() collapses 's3://' to 's3:/', "
+                         "breaking the s3:// vs. local-path detection in "
+                         "merge_teacher_shards_stream_to_r2.")
     ap.add_argument("--shard1-local", type=Path, required=True,
                     help="the freshly precomputed teacher-outputs shard for the new chunks")
     ap.add_argument("--push", required=True, help="R2 prefix for the merged teacher-outputs")

--- a/scripts/append_new_chunks.py
+++ b/scripts/append_new_chunks.py
@@ -173,14 +173,19 @@ def merge_teacher_shards_stream_to_r2(shard0_r2: str, shard1_local: Path, splits
     """
     from src.data.r2_sync import _fs_for, download_dir
 
-    if str(shard0_r2).startswith("s3://"):
+    shard0_fs, shard0_root = _fs_for(shard0_r2)
+    shard0_protocol = shard0_fs.protocol
+    shard0_protocols = (shard0_protocol,) if isinstance(shard0_protocol, str) else shard0_protocol
+    if "file" in shard0_protocols or "local" in shard0_protocols:
+        # `--topk-dir` is already a local filesystem path (bare path or `file://`, e.g. Step 1
+        # already downloaded it for the alignment gate) -- resolve via `_fs_for` (not a raw
+        # `str.startswith("s3://")` check, which mishandles `file://` since `Path("file://...")`
+        # collapses to a bogus non-existent path) and reuse the resolved root directly instead of
+        # an ~566 GB local->local re-copy.
+        local_root = Path(shard0_root)
+    else:
         local_root = shard1_local.parent / "_shard0_cache"
         download_dir(shard0_r2, str(local_root))
-    else:
-        # `--topk-dir` is already a local filesystem path (e.g. Step 1 already downloaded it for
-        # the alignment gate) — `_fs_for` resolves any non-`s3://` URI to the local FS, so reuse
-        # the path directly instead of an ~566 GB local->local re-copy into `local_root`.
-        local_root = Path(shard0_r2)
 
     fs, root = _fs_for(push)
     root = root.rstrip("/")

--- a/scripts/runpod/m10/preflight.sh
+++ b/scripts/runpod/m10/preflight.sh
@@ -56,6 +56,15 @@ echo "  r2_sync round-trip OK"
 echo "[A5] Ampere+ card required for bf16 at seq 8192 (A100/H100)"
 nvidia-smi | grep -E "A100|H100" || { echo "FAIL: expected A100 or H100 in nvidia-smi — bf16 at seq 8192 needs Ampere+"; exit 1; }
 
+echo "[A6] /vol volume capacity >= 2 TB free (combined ≈1.57 TB cache + append/merge scratch, #177)"
+_VOL_FREE_KB=$(df -Pk /vol | tail -1 | awk '{print $4}')
+_VOL_FLOOR_KB=$((2 * 1024 * 1024 * 1024))
+if [ "$_VOL_FREE_KB" -lt "$_VOL_FLOOR_KB" ]; then
+  echo "FAIL: /vol has only $((_VOL_FREE_KB / 1024 / 1024)) GB free, need >= 2048 GB (2 TB) — see docs/runbooks/m10-phase-bprime-append.md Prereqs"
+  exit 1
+fi
+echo "  /vol free: $((_VOL_FREE_KB / 1024 / 1024)) GB (>= 2048 GB floor) OK"
+
 echo "── A PASS $(date) ──"
 
 # ─── B. Corpus integrity (cheap — before the dominant-cost precompute) ────────
@@ -71,11 +80,15 @@ echo "[B2] split --shards -> train.bin / val.bin"
 python -m src.data.split \
   --shards /vol/corpus8k --out /vol/split8k --val-tokens 10000000
 
-echo "[B3] assert: dtype=uint32, .bounds present, max token id < 151669 (Qwen3 effective vocab)"
+echo "[B3] assert: dtype=uint32, .bounds present, max token id < 151669 (Qwen3 effective vocab), train/val provably disjoint"
 python -c "
 import json, numpy as np
 from pathlib import Path
 
+corpus_man = json.loads((Path('/vol/corpus8k') / 'manifest.json').read_text())
+corpus_total = int(corpus_man['n_tokens'])
+
+split_total = 0
 for split in ('train', 'val'):
     meta = json.loads((Path('/vol/split8k') / f'{split}.meta.json').read_text())
     assert meta['dtype'] == 'uint32', f'{split} dtype={meta[\"dtype\"]} (expected uint32)'
@@ -87,11 +100,44 @@ for split in ('train', 'val'):
         f'the vocab-bound check from #153/#154 may not have been applied at build time'
     )
     print(f'  {split}: dtype=uint32  n_tokens={meta[\"n_tokens\"]:,}  max_id={max_id}')
+    split_total += int(meta['n_tokens'])
+
+# Disjointness: split_shards() (src/data/split.py) holds out the last val_tokens as a
+# contiguous tail and concatenates everything before it into train -- disjoint by
+# construction PROVIDED nothing was double-counted or silently dropped. The cheapest
+# correct on-pod check is the token-count identity: train + val must account for exactly
+# the whole corpus, no more, no less.
+assert split_total == corpus_total, (
+    f'train+val tokens ({split_total:,}) != corpus tokens ({corpus_total:,}) -- '
+    'the split is not a clean disjoint partition of the corpus'
+)
+print(f'  train+val == corpus total ({corpus_total:,} tokens): disjoint OK')
 
 # doc-boundary .bounds sidecars are required for the SSM state-reset (#68)
 bounds = list(Path('/vol/corpus8k').glob('*.bounds'))
 assert bounds, 'no .bounds sidecars in /vol/corpus8k — doc-boundary reset (#68) broken'
 print(f'  .bounds: {len(bounds)} shards ok')
+"
+
+echo "[B4] append-input integrity (#177): existence/meta only, no full download"
+python -c "
+from src.data.r2_sync import _fs_for
+
+def check(prefix, label):
+    uri = f's3://monica-training/{prefix}'
+    fs, root = _fs_for(uri)
+    root = root.rstrip('/')
+    files = fs.find(root)
+    assert files, f'{label}: no files found under {uri} — #177 append cannot proceed'
+    manifest = f'{root}/manifest.json'
+    assert fs.exists(manifest), f'{label}: manifest.json missing at {manifest}'
+    size = fs.info(manifest)['size']
+    print(f'  {label}: {len(files)} files under {uri}, manifest.json {size} bytes OK')
+
+# the corpus extension (#176/#182) — append_new_chunks.py's --extension-shards source
+check('poc-distill-ext/corpus/tokenized/qwen3-8k', 'extension corpus')
+# the frozen base teacher cache — append_new_chunks.py's --topk-dir / shard-0 source
+check('poc-distill/teacher-outputs/topk-logits-merged', 'frozen base teacher cache')
 "
 
 echo "── B PASS $(date) ──"
@@ -135,6 +181,42 @@ python scripts/precompute_teacher.py \
   --data /tmp/m10-smoke/split \
   --out /tmp/m10-smoke/teacher-outputs \
   --backend cuda --k 8 --synthetic
+
+echo "[C2b] precompute_teacher REAL (non-synthetic) tiny slice — confirms Qwen3-4B-Thinking-2507"
+echo "      itself loads on CUDA (per-head QK RMSNorm, no QKV bias, rope_theta 5e6) BEFORE the"
+echo "      dominant-cost precompute spend. [C2] above only proves the synthetic cache-write path."
+# Real qwen3 tokenizer (network, cheap) + 2 tiny chunks at seq_len=32 -- small enough to be
+# pennies on the already-rented pod, but a real (not synthetic) teacher.topk_logits() forward.
+python -c "
+from pathlib import Path
+from src.data.corpus import ingest_dummy
+from src.data.distill_corpus import build_distill_corpus
+from src.data.split import split_shards
+from src.data import storage
+out = Path('/tmp/m10-real-teacher-smoke')
+build_distill_corpus(ingest_dummy(400, source='smoke'), out, tokenizer='qwen3',
+                     seq_len=32, byte_fallback=False)
+tok_dir = storage.corpus_tokenized_dir(out, 'qwen3', 32)
+split_shards(tok_dir, Path('/tmp/m10-real-teacher-smoke/split'), val_tokens=0)
+print('tiny real-tokenizer split ready (seq_len=32, train only)')
+"
+cat > /tmp/m10-real-teacher-manifest.yaml <<'YAML'
+# Minimal manifest for the preflight real-teacher probe only -- precompute_teacher.py reads just
+# conversion_teacher + seq_len from it (layout/stages/init are unused on this path).
+student: preflight-real-teacher-probe
+conversion_teacher: Qwen/Qwen3-4B-Thinking-2507
+tokenizer: qwen3
+seq_len: 32
+init: mohawk
+stages: [logit-distill]
+layout: {}
+YAML
+python scripts/precompute_teacher.py \
+  --manifest /tmp/m10-real-teacher-manifest.yaml \
+  --data /tmp/m10-real-teacher-smoke/split --splits train \
+  --out /tmp/m10-real-teacher-smoke/teacher-outputs \
+  --backend cuda --k 8 --batch-size 2
+echo "  real Qwen3-4B-Thinking-2507 teacher forward OK"
 
 echo "[C3] pytest tests/test_cuda_parity.py (torch-backend SSM + forward/step parity)"
 python -m pytest tests/test_cuda_parity.py -q

--- a/scripts/runpod/m10/preflight.sh
+++ b/scripts/runpod/m10/preflight.sh
@@ -127,12 +127,15 @@ def check(prefix, label):
     uri = f's3://monica-training/{prefix}'
     fs, root = _fs_for(uri)
     root = root.rstrip('/')
-    files = fs.find(root)
-    assert files, f'{label}: no files found under {uri} — #177 append cannot proceed'
+    # non-recursive top-level listing -- fs.find() would recursively walk every object under
+    # the prefix (slow + many LIST calls on the 566 GB base teacher cache); existence only needs
+    # one level.
+    entries = fs.ls(root, detail=False)
+    assert entries, f'{label}: no entries found under {uri} — #177 append cannot proceed'
     manifest = f'{root}/manifest.json'
     assert fs.exists(manifest), f'{label}: manifest.json missing at {manifest}'
     size = fs.info(manifest)['size']
-    print(f'  {label}: {len(files)} files under {uri}, manifest.json {size} bytes OK')
+    print(f'  {label}: {len(entries)} top-level entries under {uri}, manifest.json {size} bytes OK')
 
 # the corpus extension (#176/#182) — append_new_chunks.py's --extension-shards source
 check('poc-distill-ext/corpus/tokenized/qwen3-8k', 'extension corpus')

--- a/tests/test_append_new_chunks.py
+++ b/tests/test_append_new_chunks.py
@@ -188,3 +188,31 @@ def test_local_shard0_path_is_reused_without_recopy(tmp_path, monkeypatch):
 
     assert not called["download_dir"]
     assert (push_dir / "teacher-train.meta.json").exists()
+
+
+def test_file_uri_shard0_path_is_reused_without_recopy(tmp_path, monkeypatch):
+    """A `file://` URI (not just a bare path) must also be treated as local and reused directly
+    -- `Path("file://...")` collapses to a bogus, nonexistent path (e.g. `'file:/vol/...'`), so
+    the local-vs-remote check must resolve via `_fs_for`'s protocol, not a raw string prefix."""
+    import scripts.append_new_chunks as anc
+
+    shard0_dir = tmp_path / "shard0"
+    shard1_dir = tmp_path / "shard1_local"
+    push_dir = tmp_path / "push"
+
+    _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
+    _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
+
+    called = {"download_dir": False}
+
+    def _fail_if_called(*args, **kwargs):
+        called["download_dir"] = True
+        raise AssertionError("download_dir should not be called for a file:// shard0 path")
+
+    monkeypatch.setattr("src.data.r2_sync.download_dir", _fail_if_called)
+
+    anc.merge_teacher_shards_stream_to_r2(f"file://{shard0_dir}", shard1_dir, ["train"],
+                                         str(push_dir))
+
+    assert not called["download_dir"]
+    assert (push_dir / "teacher-train.meta.json").exists()

--- a/tests/test_append_new_chunks.py
+++ b/tests/test_append_new_chunks.py
@@ -26,6 +26,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.append_new_chunks import FINEWEB_N_CHUNKS, merge_teacher_shards_stream_to_r2
 
+#: The frozen base cache's real val chunk count (docs/runbooks/m10-phase-bprime-append.md: "305
+#: val chunks") — deliberately NOT FINEWEB_N_CHUNKS. val is a separate, much smaller held-out
+#: cache with its own geometry; using a distinct value here exercises that the passthrough path
+#: does not (and must not) assert val's n_chunks against the train-specific FINEWEB_N_CHUNKS.
+VAL_N_CHUNKS = 305
+
 
 def _write_topk(out_dir: Path, split: str, *, n_rows: int, n_chunks: int, k: int = 4,
                 seq_len: int = 4, vocab_size: int = 32, seed: int = 0) -> dict:
@@ -34,7 +40,8 @@ def _write_topk(out_dir: Path, split: str, *, n_rows: int, n_chunks: int, k: int
     fields `split/k/n_rows/n_chunks/seq_len/vals_dtype/idx_dtype/vocab_size/src_packed/
     src_n_tokens`). `n_rows` intentionally need not equal `n_chunks*seq_len` here — the merge
     function only reads/propagates the meta fields, it does not cross-check them against actual
-    array shape (that positional cross-check is `DistillLoader`'s job, exercised elsewhere)."""
+    array shape (that positional cross-check is `DistillLoader`'s job, exercised elsewhere).
+    `src_packed` is per-split (`fineweb/{split}.bin`), matching real precompute metas."""
     out_dir.mkdir(parents=True, exist_ok=True)
     rng = np.random.default_rng(seed)
     vals = rng.random((n_rows, k), dtype=np.float32).astype(np.float16)
@@ -43,7 +50,7 @@ def _write_topk(out_dir: Path, split: str, *, n_rows: int, n_chunks: int, k: int
     idx.tofile(out_dir / f"teacher-{split}.topk_idx")
     meta = {"split": split, "k": k, "n_rows": n_rows, "n_chunks": n_chunks, "seq_len": seq_len,
             "vals_dtype": "float16", "idx_dtype": "uint32", "vocab_size": vocab_size,
-            "src_packed": "fineweb/train.bin", "src_n_tokens": n_rows}
+            "src_packed": f"fineweb/{split}.bin", "src_n_tokens": n_rows}
     (out_dir / f"teacher-{split}.meta.json").write_text(json.dumps(meta, indent=2))
     return meta
 
@@ -57,7 +64,7 @@ def test_default_splits_train_val_with_train_only_shard1_does_not_crash(tmp_path
     push_dir = tmp_path / "push"
 
     _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
-    _write_topk(shard0_dir, "val", n_rows=6, n_chunks=FINEWEB_N_CHUNKS, seed=1)
+    _write_topk(shard0_dir, "val", n_rows=6, n_chunks=VAL_N_CHUNKS, seed=1)
     _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
     # Deliberately no teacher-val.* under shard1_dir.
 
@@ -78,7 +85,7 @@ def test_val_passthrough_is_byte_identical_to_shard0(tmp_path):
     push_dir = tmp_path / "push"
 
     _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
-    shard0_val_meta = _write_topk(shard0_dir, "val", n_rows=6, n_chunks=FINEWEB_N_CHUNKS, seed=1)
+    shard0_val_meta = _write_topk(shard0_dir, "val", n_rows=6, n_chunks=VAL_N_CHUNKS, seed=1)
     _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
 
     merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train", "val"], str(push_dir))
@@ -90,9 +97,11 @@ def test_val_passthrough_is_byte_identical_to_shard0(tmp_path):
 
     dst_meta = json.loads((push_dir / "teacher-val.meta.json").read_text())
     assert dst_meta == shard0_val_meta
-    # Explicitly not summed with any shard-1 val (there is none): counts are shard0's own.
+    # Explicitly not summed with any shard-1 val (there is none): counts are shard0's own. Also
+    # confirms the passthrough path does NOT assert val's (deliberately non-FINEWEB_N_CHUNKS)
+    # n_chunks against the train-specific frozen count.
     assert dst_meta["n_rows"] == 6
-    assert dst_meta["n_chunks"] == FINEWEB_N_CHUNKS
+    assert dst_meta["n_chunks"] == VAL_N_CHUNKS
 
 
 def test_train_still_merges_shard0_plus_shard1(tmp_path):
@@ -103,7 +112,7 @@ def test_train_still_merges_shard0_plus_shard1(tmp_path):
     push_dir = tmp_path / "push"
 
     _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
-    _write_topk(shard0_dir, "val", n_rows=6, n_chunks=FINEWEB_N_CHUNKS, seed=1)
+    _write_topk(shard0_dir, "val", n_rows=6, n_chunks=VAL_N_CHUNKS, seed=1)
     _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
 
     merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train", "val"], str(push_dir))

--- a/tests/test_append_new_chunks.py
+++ b/tests/test_append_new_chunks.py
@@ -20,6 +20,7 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -149,11 +150,8 @@ def test_shard0_n_chunks_mismatch_aborts(tmp_path):
     _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS - 1)
     _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
 
-    try:
+    with pytest.raises(SystemExit, match="n_chunks"):
         merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train"], str(push_dir))
-        assert False, "expected SystemExit on n_chunks mismatch"
-    except SystemExit as e:
-        assert "n_chunks" in str(e)
 
 
 def test_local_shard0_path_is_reused_without_recopy(tmp_path, monkeypatch):

--- a/tests/test_append_new_chunks.py
+++ b/tests/test_append_new_chunks.py
@@ -1,0 +1,183 @@
+"""Unit tests for the #177 append-merge (scripts/append_new_chunks.py), Tier-1 fix.
+
+Drives `merge_teacher_shards_stream_to_r2` directly against synthetic, hand-built
+`teacher-{train,val}.topk_vals`/`.topk_idx`/`.meta.json` files in a temp dir — no real R2, no
+GPU, no network. `_fs_for` (src/data/r2_sync.py) resolves any non-`s3://` URI to the local
+filesystem, so a bare local path exercises the exact same code path a real R2 prefix would.
+
+The bug this guards: Step 3 (`precompute_teacher.py`) only ever precomputes a **train-only**
+shard-1 for the new chunks (the frozen base `val` chunks have no extension counterpart). The old
+`merge_teacher_shards_stream_to_r2` unconditionally read `shard1_local/teacher-{split}.meta.json`
+for every split in `--splits` (default `train,val`), so the default invocation crashed with
+`FileNotFoundError` on `val` — after the expensive precompute already ran. The fix passes
+shard-1-less splits through unchanged from shard-0 instead of requiring a merge counterpart.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.append_new_chunks import FINEWEB_N_CHUNKS, merge_teacher_shards_stream_to_r2
+
+
+def _write_topk(out_dir: Path, split: str, *, n_rows: int, n_chunks: int, k: int = 4,
+                seq_len: int = 4, vocab_size: int = 32, seed: int = 0) -> dict:
+    """Hand-build one split's `teacher-<split>.{topk_vals,topk_idx,meta.json}` trio, matching
+    the on-disk schema `src/data/teacher_outputs.py` reads/writes (fp16 vals, uint32 idx; meta
+    fields `split/k/n_rows/n_chunks/seq_len/vals_dtype/idx_dtype/vocab_size/src_packed/
+    src_n_tokens`). `n_rows` intentionally need not equal `n_chunks*seq_len` here — the merge
+    function only reads/propagates the meta fields, it does not cross-check them against actual
+    array shape (that positional cross-check is `DistillLoader`'s job, exercised elsewhere)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(seed)
+    vals = rng.random((n_rows, k), dtype=np.float32).astype(np.float16)
+    idx = rng.integers(0, vocab_size, size=(n_rows, k)).astype(np.uint32)
+    vals.tofile(out_dir / f"teacher-{split}.topk_vals")
+    idx.tofile(out_dir / f"teacher-{split}.topk_idx")
+    meta = {"split": split, "k": k, "n_rows": n_rows, "n_chunks": n_chunks, "seq_len": seq_len,
+            "vals_dtype": "float16", "idx_dtype": "uint32", "vocab_size": vocab_size,
+            "src_packed": "fineweb/train.bin", "src_n_tokens": n_rows}
+    (out_dir / f"teacher-{split}.meta.json").write_text(json.dumps(meta, indent=2))
+    return meta
+
+
+def test_default_splits_train_val_with_train_only_shard1_does_not_crash(tmp_path):
+    """(a) shard0 has both train+val; shard1_local has ONLY train (no val files) — the real
+    Step-3 shape. Calling the merge with the default splits=["train", "val"] must not raise, and
+    must emit both `teacher-train.*` and `teacher-val.*` at the push destination."""
+    shard0_dir = tmp_path / "shard0"
+    shard1_dir = tmp_path / "shard1_local"
+    push_dir = tmp_path / "push"
+
+    _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
+    _write_topk(shard0_dir, "val", n_rows=6, n_chunks=FINEWEB_N_CHUNKS, seed=1)
+    _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
+    # Deliberately no teacher-val.* under shard1_dir.
+
+    merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train", "val"], str(push_dir))
+
+    for split in ("train", "val"):
+        assert (push_dir / f"teacher-{split}.topk_vals").exists()
+        assert (push_dir / f"teacher-{split}.topk_idx").exists()
+        assert (push_dir / f"teacher-{split}.meta.json").exists()
+    assert (push_dir / "manifest.json").exists()
+
+
+def test_val_passthrough_is_byte_identical_to_shard0(tmp_path):
+    """(b) the passed-through `val` bytes + meta at the push destination equal shard0's
+    original val files unchanged (proving passthrough, not corruption or accidental merge)."""
+    shard0_dir = tmp_path / "shard0"
+    shard1_dir = tmp_path / "shard1_local"
+    push_dir = tmp_path / "push"
+
+    _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
+    shard0_val_meta = _write_topk(shard0_dir, "val", n_rows=6, n_chunks=FINEWEB_N_CHUNKS, seed=1)
+    _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
+
+    merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train", "val"], str(push_dir))
+
+    for kind in ("topk_vals", "topk_idx"):
+        src_bytes = (shard0_dir / f"teacher-val.{kind}").read_bytes()
+        dst_bytes = (push_dir / f"teacher-val.{kind}").read_bytes()
+        assert dst_bytes == src_bytes, f"val {kind} passthrough is not byte-identical to shard0"
+
+    dst_meta = json.loads((push_dir / "teacher-val.meta.json").read_text())
+    assert dst_meta == shard0_val_meta
+    # Explicitly not summed with any shard-1 val (there is none): counts are shard0's own.
+    assert dst_meta["n_rows"] == 6
+    assert dst_meta["n_chunks"] == FINEWEB_N_CHUNKS
+
+
+def test_train_still_merges_shard0_plus_shard1(tmp_path):
+    """(c) `train` (which DOES have a shard1 counterpart) still merges: n_rows/n_chunks in the
+    merged output equal the shard0+shard1 sums (existing merge behavior preserved)."""
+    shard0_dir = tmp_path / "shard0"
+    shard1_dir = tmp_path / "shard1_local"
+    push_dir = tmp_path / "push"
+
+    _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
+    _write_topk(shard0_dir, "val", n_rows=6, n_chunks=FINEWEB_N_CHUNKS, seed=1)
+    _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
+
+    merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train", "val"], str(push_dir))
+
+    dst_meta = json.loads((push_dir / "teacher-train.meta.json").read_text())
+    assert dst_meta["n_rows"] == 8 + 3
+    assert dst_meta["n_chunks"] == FINEWEB_N_CHUNKS + 17
+    assert dst_meta["merged_from_shards"] == 2
+
+    # The merged train topk_vals/idx bytes are shard0's prefix followed by shard1's (streamed
+    # concatenation, not a passthrough).
+    expected_vals = ((shard0_dir / "teacher-train.topk_vals").read_bytes()
+                     + (shard1_dir / "teacher-train.topk_vals").read_bytes())
+    assert (push_dir / "teacher-train.topk_vals").read_bytes() == expected_vals
+
+    manifest = json.loads((push_dir / "manifest.json").read_text())
+    assert manifest["splits"] == ["train", "val"]
+    assert manifest["n_rows_total"] == (8 + 3) + 6
+
+
+def test_splits_train_only_still_works_without_val(tmp_path):
+    """`--splits train` (no val at all requested) still works — the pre-existing single-split
+    path is unaffected by the passthrough branch."""
+    shard0_dir = tmp_path / "shard0"
+    shard1_dir = tmp_path / "shard1_local"
+    push_dir = tmp_path / "push"
+
+    _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
+    _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
+
+    merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train"], str(push_dir))
+
+    assert (push_dir / "teacher-train.meta.json").exists()
+    assert not (push_dir / "teacher-val.meta.json").exists()
+
+
+def test_shard0_n_chunks_mismatch_aborts(tmp_path):
+    """A shard-0 whose recorded `n_chunks` doesn't match the frozen `FINEWEB_N_CHUNKS` must abort
+    (corpus drift guard) rather than silently merging against a misaligned base cache."""
+    shard0_dir = tmp_path / "shard0"
+    shard1_dir = tmp_path / "shard1_local"
+    push_dir = tmp_path / "push"
+
+    _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS - 1)
+    _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
+
+    try:
+        merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train"], str(push_dir))
+        assert False, "expected SystemExit on n_chunks mismatch"
+    except SystemExit as e:
+        assert "n_chunks" in str(e)
+
+
+def test_local_shard0_path_is_reused_without_recopy(tmp_path, monkeypatch):
+    """Optional hardening: when `--topk-dir` (shard0_r2) is already a local filesystem path (not
+    an `s3://` URI), the merge must NOT re-download/re-copy it into `_shard0_cache` — it should
+    read straight from the given local path. Assert `download_dir` is never called in this case."""
+    import scripts.append_new_chunks as anc
+
+    shard0_dir = tmp_path / "shard0"
+    shard1_dir = tmp_path / "shard1_local"
+    push_dir = tmp_path / "push"
+
+    _write_topk(shard0_dir, "train", n_rows=8, n_chunks=FINEWEB_N_CHUNKS)
+    _write_topk(shard1_dir, "train", n_rows=3, n_chunks=17, seed=2)
+
+    called = {"download_dir": False}
+
+    def _fail_if_called(*args, **kwargs):
+        called["download_dir"] = True
+        raise AssertionError("download_dir should not be called for a local shard0 path")
+
+    monkeypatch.setattr("src.data.r2_sync.download_dir", _fail_if_called)
+
+    anc.merge_teacher_shards_stream_to_r2(str(shard0_dir), shard1_dir, ["train"], str(push_dir))
+
+    assert not called["download_dir"]
+    assert (push_dir / "teacher-train.meta.json").exists()


### PR DESCRIPTION
Part of #177 — this is a cheap-first preflight audit (no GPU/pod involved) of the append-precompute chain before it's fired on a rented A100/H100. It does not run the append or close #177; it makes the chain safe to fire.

## Summary

- **Blocking fix** in `scripts/append_new_chunks.py`: `merge_teacher_shards_stream_to_r2` required a `shard1_local` counterpart for every split, but Step 3 only ever precomputes a train-only shard-1 (no val). The default `--splits train,val` either crashed with `FileNotFoundError` on `val`, or silently produced a val-less merged cache that the self-verify never caught — both failure modes only surface *after* the expensive teacher precompute has already run. Fixed by detecting per-split whether a shard-1 counterpart exists: merge as before if so, else pass shard-0's split through unchanged. `regenerate_fineweb_train`'s val path (previously discarded) is now threaded through so `main()` verifies both splits.
- **New tests** (`tests/test_append_new_chunks.py`, 6 cases): drive the merge function directly against hand-built synthetic teacher-output files in a temp dir — no R2/GPU needed. Covers the crash bug, val-passthrough byte-identity, existing train-merge behavior, `--splits train` alone, the corpus-drift guard, and the local-path re-copy skip.
- **Preflight hardening** (`scripts/runpod/m10/preflight.sh`): adds 4 checks that were missing before GPU spend — `/vol` ≥2 TB volume floor, train/val disjointness assertion, extension-corpus + frozen-base-teacher-cache existence checks, and a real (non-synthetic) tiny Qwen3-4B-Thinking teacher forward on CUDA (the existing check only exercised the synthetic cache-write path, never actually loading the real teacher).
- **Docs**: reconciles stale `~1.1 TB` → `~1.57 TB`, `cuda` vs `cuda-fast` install wording, softens misleading "override" framing for `--teacher-outputs` (manifest's `teacher_outputs` field is actually inert — CLI is the sole source), and clarifies a sequences-vs-chunks count discrepancy.
- Updated GitHub issue #177's body to the corrected corpus-extension sizing (previously stale).

## Testing
- [x] Tests added (`tests/test_append_new_chunks.py`, 6 new cases)
- [x] Full suite passing: 631 passed, 4 pre-existing skips (no datatrove / no CUDA ×2 / opt-in code-verifier), 0 failed
- [x] `bash -n scripts/runpod/m10/preflight.sh` syntax check passed
- [ ] Actual pod-gated run (still pending — out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)