### PR TITLE
feat(lsp): opengrep stall mitigation + F1 ts/both re-measure (#199)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,6 +240,7 @@ __marimo__/
 # LSP harness: keep JSON summaries (doc provenance), drop bulky per-record transcripts
 results/*.jsonl
 
-# LSP harness tsc scratch dirs (leaked if a run is interrupted mid-compile)
+# LSP harness scratch dirs (leaked if a run is interrupted mid-compile/exec)
 eval_sets/ts_error_injection/lsp_scratch_*
+eval_sets/ts_error_injection/lsp_exec_*
 eval_sets/ts_error_injection/tmp*

--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -487,3 +487,90 @@ real and unresolved risk, and this experiment did not resolve it.**
   saturation is a property of the task, not of model capacity.
 - **Reward hacking**: `SUPPRESSION_RE` (`@ts-ignore`/`as any`) forces not-clean regardless of
   `tsc`'s verdict; zero suppression hacks were observed in any table's transcript.
+
+# Stage A — the real-analysis oracle: persistent TS-LSP + opengrep (#199 follow-up)
+
+Everything above draws its diagnostic signal from `TscRunner` — a fresh `tsc -p` **batch compile per
+check**. Two things motivated replacing it. First, the F1 measurement on real HumanEval-TS (159
+records, functional pass@1 via the reference test suites) sharpened the gap the whole project is
+about: model bodies are **88.7% type-clean but only 50.3% correct** (`results/f1_base.json`,
+baseline) — the failures are logic errors a type checker structurally cannot see. Second, a batch
+compile per check is the wrong model of "LSP-in-the-loop". Stage A (PR #208) replaced the oracle with
+a **persistent TypeScript language server** and an **opengrep** arm carrying a frozen, pre-registered
+12-rule correctness ruleset, behind the same `DiagnoseFn` seam, then re-measured. All three runs
+below are the same protocol: 159 records, `block` budget 256, greedy (temp 0, seed 0),
+`baseline` + `slow-hard`.
+
+## The oracle swap moves the win from the functional axis to the clean axis
+
+| slow-hard vs baseline | `f1_base` (batch `tsc`) | `f1_ts` (persistent LSP) | `f1_both` (LSP + opengrep) |
+|---|---|---|---|
+| clean-rate | 0.887 → 0.906, p=**0.375** (ns) | 0.887 → **0.962**, p=**0.0005** | 0.862 → 0.937, p=**0.0005** |
+| pass@1 | 0.491 → **0.560**, p=**0.001** | 0.491 → 0.503, p=**0.69** (ns) | 0.491 → 0.528, p=**0.109** (ns) |
+| over-repair (synthetic controls) | 0.094 | 0.101 | 0.120 |
+| mean diagnose calls / record | 8.18 | 6.75 | 7.25 |
+
+The batch-`tsc` slow loop delivered a **real functional lift** (pass@1 +6.9 pts, p=0.001, 11 records
+flipped to passing and 0 to failing) but no significant clean-rate lift. Swapping in the persistent
+LSP **inverts this**: a strong clean-rate lift (+7.5 pts, p=0.0005) but the functional lift **vanishes**
+(p=0.69) and the loop now flips 2 correct records to failing. This is the plan's "retune, don't port
+blind" risk, now measured: a language server's diagnostics on an *open/incomplete* document are not
+the batch whole-program diagnostics the `tsc`-tuned loop was calibrated against. The loop cleans more
+aggressively under the LSP and that extra cleaning is not correctness-bearing. (Baseline pass@1 is
+identical — 0.491 — across all three runs, as it must be: baseline generation is greedy and
+oracle-independent; the oracle only affects clean-rate scoring and the slow loop.)
+
+## Does opengrep find a syntactic correctness signal for the clean-but-wrong class?
+
+**Yes — narrow, but with perfect precision on this eval.** On the raw (`baseline`) outputs, the
+12-rule set fired on exactly **4 of 159 records, and all 4 are functionally wrong** (0 false
+positives). That is the direct answer to the question the arm exists for — it is measured as the
+baseline clean-rate dropping from 0.887 (`ts`) to 0.862 (`both`): those 4 records are type-clean but
+rule-flagged, and every one fails its tests.
+
+| Record | Rule | Functionally correct? |
+|---|---|---|
+| `HumanEval_14_all_prefixes` | `loop-bound-off-by-one` | ✗ wrong |
+| `HumanEval_67_fruit_distribution` | `parseint-no-radix` | ✗ wrong |
+| `HumanEval_95_check_dict_case` | `for-in-over-array` | ✗ wrong |
+| `HumanEval_111_histogram` | `for-in-over-array` | ✗ wrong |
+
+Across the whole `both` run only three rules ever fired (`for-in-over-array` ×4, `parseint-no-radix`
+×2, `loop-bound-off-by-one` ×1). The rules the plan flagged as noisy (`sort-without-comparator`,
+etc.) **never fired**, so the feared false-positive tax did not materialize on this set. This exceeds
+the pre-registered calibrated expectation (a near-zero hit-rate was the honest prior); the hit-rate
+*is* low (4/159 ≈ 2.5%), but it is a genuine, precise signal, not noise.
+
+Folding opengrep into the slow loop **partially recovers the pass@1 the LSP swap lost** (0.503 →
+0.528; 8 records flipped to passing vs baseline) but does **not** reach significance (p=0.109) and
+costs more over-repair (0.101 → 0.120; 2 correct records broken). Net: acting on opengrep's findings
+fixes a few real bugs, but the idiom-rule signal is too sparse — HumanEval failures are mostly
+*algorithmic* misunderstanding, which a syntactic AST matcher structurally cannot see — to move the
+functional metric on its own.
+
+## The measurement is trustworthy: the opengrep stall did not corrupt it
+
+A prior stress test had seen a ~10% full-timeout stall under sustained single-file rescanning of one
+long-lived `opengrep lsp` process — a *live-but-unresponsive* process that the dead-process liveness
+check never caught, so a stalled scan was silently counted as a timeout and returned `[]`, **dropping
+findings**. At ~10% that would corrupt any `both` measurement. Since each scan overwrites the whole
+candidate file and is independent of prior calls, respawning changes reliability but never the finding
+set, so `OpengrepOracle` now proactively recycles the process every 32 calls and reactively restarts +
+retries once on a no-response scan (`src/lsp/opengrep.py`; `scripts/opengrep_soak.py` is the soak
+harness). The `both` run's self-reported counters: **`n_timeouts = 0` over 1471 opengrep calls**, 0
+stall recoveries, 45 proactive recycles (~68 s overhead). No findings were silently dropped — and
+notably the stall did not reproduce on this host at all (0 timeouts across 160 rotating + 200
+single-file soak calls with the mitigation off), so the recycler is a cheap, unit-tested safety net
+rather than a demonstrated before/after fix.
+
+## Verdict
+
+The persistent-LSP swap is **not a free upgrade over batch `tsc`**: it trades the slow loop's
+functional benefit for a clean-rate benefit, because open-document diagnostics differ from
+whole-program ones and the `tsc`-tuned gating does not transfer. The opengrep arm delivers a **real
+but narrow** correctness signal (4/4 precision on raw outputs, sparse), which nudges pass@1 up inside
+the slow loop without reaching significance and at a small over-repair cost. The honest read for the
+program gate (#198): the clean-but-wrong gap is real and a syntactic idiom-matcher can *see a corner
+of it precisely* but not enough of it to carry the functional metric — the correctness-bearing signal
+for this class lives in semantics (tests, execution, type-aware analysis), which is where the AR
+harness ablation (#201) and the LSP-verifier reward work (#103) should aim.

--- a/results/f1_base.json
+++ b/results/f1_base.json
@@ -1,0 +1,107 @@
+{
+  "model": "mlx-community/Qwen2.5-Coder-1.5B-bf16",
+  "set": "eval_sets/humaneval_ts/humaneval_ts.jsonl",
+  "n_records": 159,
+  "block_size": 256,
+  "temperature": 0.0,
+  "seed": 0,
+  "functional": true,
+  "summaries": {
+    "baseline": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.8867924528301887,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.0,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 34814,
+      "mean_n_forward_tokens": 218.9559748427673,
+      "total_n_forward_tokens_nocache": 34814,
+      "mean_n_forward_tokens_nocache": 218.9559748427673,
+      "total_n_generated_tokens": 13879,
+      "mean_n_generated_tokens": 87.28930817610063,
+      "total_n_tsc_calls": 0,
+      "mean_n_tsc_calls": 0.0,
+      "total_n_rollbacks": 0,
+      "mean_n_rollbacks": 0.0,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 0,
+      "mean_n_retries": 0.0,
+      "total_wall_s": 347.7106892946176,
+      "mean_wall_s": 2.186859681098224,
+      "total_tsc_wall_s": 0.0,
+      "mean_tsc_wall_s": 0.0,
+      "functional_pass_at_1": 0.49056603773584906
+    },
+    "slow-hard": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.9056603773584906,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.09433962264150944,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 268498,
+      "mean_n_forward_tokens": 1688.6666666666667,
+      "total_n_forward_tokens_nocache": 297237,
+      "mean_n_forward_tokens_nocache": 1869.4150943396226,
+      "total_n_generated_tokens": 16028,
+      "mean_n_generated_tokens": 100.80503144654088,
+      "total_n_tsc_calls": 1301,
+      "mean_n_tsc_calls": 8.182389937106919,
+      "total_n_rollbacks": 113,
+      "mean_n_rollbacks": 0.710691823899371,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 113,
+      "mean_n_retries": 0.710691823899371,
+      "total_wall_s": 1116.2185053778812,
+      "mean_wall_s": 7.020242172187932,
+      "total_tsc_wall_s": 376.06294144969434,
+      "mean_tsc_wall_s": 2.3651757323880145,
+      "functional_pass_at_1": 0.559748427672956
+    }
+  },
+  "comparisons": {
+    "slow-hard": {
+      "clean_vs_baseline": {
+        "n": 159,
+        "key": "clean",
+        "table": {
+          "both_true": 140,
+          "baseline_true_other_false": 1,
+          "baseline_false_other_true": 4,
+          "both_false": 14
+        },
+        "baseline_rate": 0.8867924528301887,
+        "other_rate": 0.9056603773584906,
+        "mcnemar_p": 0.375,
+        "flip_to_true_rate": 0.2222222222222222,
+        "flip_to_false_rate": 0.0070921985815602835
+      },
+      "functional_vs_baseline": {
+        "n": 159,
+        "key": "functional_pass",
+        "table": {
+          "both_true": 78,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 11,
+          "both_false": 70
+        },
+        "baseline_rate": 0.49056603773584906,
+        "other_rate": 0.559748427672956,
+        "mcnemar_p": 0.0009765625,
+        "flip_to_true_rate": 0.13580246913580246,
+        "flip_to_false_rate": 0.0
+      }
+    }
+  },
+  "tsc_wall_s_total": 474.04235208942555,
+  "wall_s_total": 1711.8733257080894
+}

--- a/results/f1_both.json
+++ b/results/f1_both.json
@@ -1,0 +1,120 @@
+{
+  "model": "mlx-community/Qwen2.5-Coder-1.5B-bf16",
+  "set": "eval_sets/humaneval_ts/humaneval_ts.jsonl",
+  "n_records": 159,
+  "block_size": 256,
+  "temperature": 0.0,
+  "seed": 0,
+  "functional": true,
+  "oracle": "both",
+  "sources_active": [
+    "ts",
+    "opengrep"
+  ],
+  "summaries": {
+    "baseline": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.8616352201257862,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.0,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 34814,
+      "mean_n_forward_tokens": 218.9559748427673,
+      "total_n_forward_tokens_nocache": 34814,
+      "mean_n_forward_tokens_nocache": 218.9559748427673,
+      "total_n_generated_tokens": 13879,
+      "mean_n_generated_tokens": 87.28930817610063,
+      "total_n_tsc_calls": 0,
+      "mean_n_tsc_calls": 0.0,
+      "total_n_rollbacks": 0,
+      "mean_n_rollbacks": 0.0,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 0,
+      "mean_n_retries": 0.0,
+      "total_wall_s": 331.32159628288355,
+      "mean_wall_s": 2.083783624420651,
+      "total_tsc_wall_s": 0.0,
+      "mean_tsc_wall_s": 0.0,
+      "functional_pass_at_1": 0.49056603773584906
+    },
+    "slow-hard": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.9371069182389937,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.11949685534591195,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 238753,
+      "mean_n_forward_tokens": 1501.5911949685535,
+      "total_n_forward_tokens_nocache": 260300,
+      "mean_n_forward_tokens_nocache": 1637.1069182389938,
+      "total_n_generated_tokens": 15511,
+      "mean_n_generated_tokens": 97.55345911949685,
+      "total_n_tsc_calls": 1153,
+      "mean_n_tsc_calls": 7.251572327044025,
+      "total_n_rollbacks": 76,
+      "mean_n_rollbacks": 0.4779874213836478,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 76,
+      "mean_n_retries": 0.4779874213836478,
+      "total_wall_s": 1532.889353498991,
+      "mean_wall_s": 9.640813544018812,
+      "total_tsc_wall_s": 867.6825821209059,
+      "mean_tsc_wall_s": 5.457123157993118,
+      "functional_pass_at_1": 0.5283018867924528
+    }
+  },
+  "comparisons": {
+    "slow-hard": {
+      "clean_vs_baseline": {
+        "n": 159,
+        "key": "clean",
+        "table": {
+          "both_true": 137,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 12,
+          "both_false": 10
+        },
+        "baseline_rate": 0.8616352201257862,
+        "other_rate": 0.9371069182389937,
+        "mcnemar_p": 0.00048828125,
+        "flip_to_true_rate": 0.5454545454545454,
+        "flip_to_false_rate": 0.0
+      },
+      "functional_vs_baseline": {
+        "n": 159,
+        "key": "functional_pass",
+        "table": {
+          "both_true": 76,
+          "baseline_true_other_false": 2,
+          "baseline_false_other_true": 8,
+          "both_false": 73
+        },
+        "baseline_rate": 0.49056603773584906,
+        "other_rate": 0.5283018867924528,
+        "mcnemar_p": 0.109375,
+        "flip_to_true_rate": 0.09876543209876543,
+        "flip_to_false_rate": 0.02564102564102564
+      }
+    }
+  },
+  "tsc_wall_s_total": 1037.5462263866502,
+  "wall_s_total": 2245.869320500002,
+  "opengrep": {
+    "n_calls": 1471,
+    "wall_s": 509.16073572277674,
+    "n_timeouts": 0,
+    "n_restarts": 45,
+    "n_recycles": 45,
+    "n_stall_recoveries": 0
+  }
+}

--- a/results/f1_ts.json
+++ b/results/f1_ts.json
@@ -1,0 +1,111 @@
+{
+  "model": "mlx-community/Qwen2.5-Coder-1.5B-bf16",
+  "set": "eval_sets/humaneval_ts/humaneval_ts.jsonl",
+  "n_records": 159,
+  "block_size": 256,
+  "temperature": 0.0,
+  "seed": 0,
+  "functional": true,
+  "oracle": "ts",
+  "sources_active": [
+    "ts"
+  ],
+  "summaries": {
+    "baseline": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.8867924528301887,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.0,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 34814,
+      "mean_n_forward_tokens": 218.9559748427673,
+      "total_n_forward_tokens_nocache": 34814,
+      "mean_n_forward_tokens_nocache": 218.9559748427673,
+      "total_n_generated_tokens": 13879,
+      "mean_n_generated_tokens": 87.28930817610063,
+      "total_n_tsc_calls": 0,
+      "mean_n_tsc_calls": 0.0,
+      "total_n_rollbacks": 0,
+      "mean_n_rollbacks": 0.0,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 0,
+      "mean_n_retries": 0.0,
+      "total_wall_s": 327.93506246063043,
+      "mean_wall_s": 2.0624846695637133,
+      "total_tsc_wall_s": 0.0,
+      "mean_tsc_wall_s": 0.0,
+      "functional_pass_at_1": 0.49056603773584906
+    },
+    "slow-hard": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.9622641509433962,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.10062893081761007,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 224309,
+      "mean_n_forward_tokens": 1410.748427672956,
+      "total_n_forward_tokens_nocache": 233621,
+      "mean_n_forward_tokens_nocache": 1469.314465408805,
+      "total_n_generated_tokens": 15020,
+      "mean_n_generated_tokens": 94.46540880503144,
+      "total_n_tsc_calls": 1073,
+      "mean_n_tsc_calls": 6.748427672955975,
+      "total_n_rollbacks": 33,
+      "mean_n_rollbacks": 0.20754716981132076,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 33,
+      "mean_n_retries": 0.20754716981132076,
+      "total_wall_s": 1025.7592993849248,
+      "mean_wall_s": 6.451316348332861,
+      "total_tsc_wall_s": 385.02752787273494,
+      "mean_tsc_wall_s": 2.421556779073805,
+      "functional_pass_at_1": 0.5031446540880503
+    }
+  },
+  "comparisons": {
+    "slow-hard": {
+      "clean_vs_baseline": {
+        "n": 159,
+        "key": "clean",
+        "table": {
+          "both_true": 141,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 12,
+          "both_false": 6
+        },
+        "baseline_rate": 0.8867924528301887,
+        "other_rate": 0.9622641509433962,
+        "mcnemar_p": 0.00048828125,
+        "flip_to_true_rate": 0.6666666666666666,
+        "flip_to_false_rate": 0.0
+      },
+      "functional_vs_baseline": {
+        "n": 159,
+        "key": "functional_pass",
+        "table": {
+          "both_true": 76,
+          "baseline_true_other_false": 2,
+          "baseline_false_other_true": 4,
+          "both_false": 77
+        },
+        "baseline_rate": 0.49056603773584906,
+        "other_rate": 0.5031446540880503,
+        "mcnemar_p": 0.6875,
+        "flip_to_true_rate": 0.04938271604938271,
+        "flip_to_false_rate": 0.02564102564102564
+      }
+    }
+  },
+  "tsc_wall_s_total": 499.0934100446175,
+  "wall_s_total": 1614.4380865840067
+}

--- a/scripts/eval_lsp_humaneval.py
+++ b/scripts/eval_lsp_humaneval.py
@@ -186,6 +186,10 @@ def main() -> None:
         # anything reading past results JSONs doesn't need to change.
         "tsc_wall_s_total": oracle.wall_s, "wall_s_total": time.monotonic() - t_run,
     }
+    # When the opengrep arm ran, record its reliability counters so the run is
+    # self-describing about completeness (n_timeouts = silently-dropped scans).
+    if oracle.opengrep_stats is not None:
+        results["opengrep"] = oracle.opengrep_stats
     if args.output:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         with open(args.output, "w", encoding="utf-8") as f:

--- a/scripts/opengrep_soak.py
+++ b/scripts/opengrep_soak.py
@@ -1,0 +1,113 @@
+"""Soak harness for `OpengrepOracle` -- validate the restart-on-stall + proactive
+recycle mitigation against the measured ~10% full-timeout stall (see
+`src/lsp/opengrep.py`'s module docstring).
+
+Drives one long-lived oracle through N sequential rescans over a fixed rotating
+set of **synthetic** TypeScript sources (rule fixtures / canary idioms authored
+from the general bug taxonomy -- NEVER eval transcripts, so the contamination
+discipline holds) and prints the reliability counters + stall rate.
+
+Run it twice to demonstrate the drop:
+
+    # pre-mitigation baseline (reproduce the stall):
+    .venv/bin/python scripts/opengrep_soak.py --calls 160 --no-recycle --no-restart-on-stall
+    # mitigation on (defaults):
+    .venv/bin/python scripts/opengrep_soak.py --calls 160
+
+Skips cleanly (exit 0) on a host without the `opengrep` binary. Commits no results
+-- its printed numbers feed the design-doc write-up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+# Allow running as a plain script (repo root on sys.path).
+sys.path.insert(0, __file__.rsplit("/scripts/", 1)[0])
+
+from src.lsp.opengrep import (  # noqa: E402
+    OpengrepOracle, resolve_opengrep, _DEFAULT_RECYCLE_EVERY,
+)
+
+# Synthetic rotating corpus: taxonomy-derived idioms (some fire a rule, some clean),
+# NOT eval records. Repeatedly rescanning the same process is exactly the access
+# pattern that surfaces the stall.
+_SOURCES = [
+    # loop-bound-off-by-one (fires)
+    "function sumAll(a: number[]): number {\n"
+    "  let t = 0;\n  for (let i = 0; i <= a.length; i++) { t += a[i]; }\n  return t;\n}\n",
+    # clean counterpart
+    "function sumAll(a: number[]): number {\n"
+    "  let t = 0;\n  for (let i = 0; i < a.length; i++) { t += a[i]; }\n  return t;\n}\n",
+    # index-at-length (fires)
+    "function last(a: number[]): number {\n  return a[a.length];\n}\n",
+    # parseint-no-radix (fires)
+    "function toNum(s: string): number {\n  return parseInt(s);\n}\n",
+    # clean
+    "function toNum(s: string): number {\n  return parseInt(s, 10);\n}\n",
+    # self-comparison (fires)
+    "function bad(x: number): boolean {\n  return x == x;\n}\n",
+    # typeof-array (fires)
+    "function isArr(x: unknown): boolean {\n  return typeof x === \"array\";\n}\n",
+    # clean, slightly larger body
+    "function fib(n: number): number {\n"
+    "  let a = 0, b = 1;\n  for (let i = 0; i < n; i++) { const c = a + b; a = b; b = c; }\n"
+    "  return a;\n}\n",
+]
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--calls", type=int, default=160, help="sequential rescans to run")
+    p.add_argument("--timeout-s", type=float, default=10.0)
+    p.add_argument("--recycle-every", type=int, default=_DEFAULT_RECYCLE_EVERY,
+                   help="proactive recycle interval (0 disables)")
+    p.add_argument("--no-recycle", action="store_true",
+                   help="shorthand for --recycle-every 0")
+    p.add_argument("--no-restart-on-stall", action="store_true",
+                   help="disable reactive restart-and-retry (reproduce pre-fix behavior)")
+    p.add_argument("--single-index", type=int, default=None,
+                   help="pin one source (index into the corpus) and rescan it repeatedly -- "
+                        "the 'sustained single-file rescan' pattern the stall was measured under")
+    p.add_argument("--progress-every", type=int, default=20)
+    args = p.parse_args()
+
+    if resolve_opengrep() is None:
+        print("opengrep not on PATH -- skipping soak (install per "
+              "eval_sets/opengrep_rules/README.md)")
+        return 0
+
+    recycle_every = 0 if args.no_recycle else args.recycle_every
+    restart_on_stall = not args.no_restart_on_stall
+
+    print(f"soak: calls={args.calls} timeout_s={args.timeout_s} "
+          f"recycle_every={recycle_every} restart_on_stall={restart_on_stall}")
+    t0 = time.monotonic()
+    oracle = OpengrepOracle(timeout_s=args.timeout_s, recycle_every=recycle_every,
+                            restart_on_stall=restart_on_stall)
+    try:
+        for i in range(args.calls):
+            idx = args.single_index if args.single_index is not None else i % len(_SOURCES)
+            src = _SOURCES[idx % len(_SOURCES)]
+            oracle.diagnostics(src)
+            if args.progress_every and (i + 1) % args.progress_every == 0:
+                print(f"  {i + 1}/{args.calls}  n_timeouts={oracle.n_timeouts} "
+                      f"n_restarts={oracle.n_restarts} n_recycles={oracle.n_recycles} "
+                      f"n_stall_recoveries={oracle.n_stall_recoveries}")
+        wall = time.monotonic() - t0
+        rate = oracle.n_timeouts / oracle.n_calls if oracle.n_calls else 0.0
+        print("-" * 60)
+        print(f"n_calls={oracle.n_calls} n_timeouts={oracle.n_timeouts} "
+              f"stall_rate={rate:.1%}")
+        print(f"n_restarts={oracle.n_restarts} n_recycles={oracle.n_recycles} "
+              f"n_stall_recoveries={oracle.n_stall_recoveries}")
+        print(f"wall_s={wall:.1f} (oracle.wall_s={oracle.wall_s:.1f})")
+    finally:
+        oracle.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lsp/opengrep.py
+++ b/src/lsp/opengrep.py
@@ -46,20 +46,27 @@ pattern):
     `_WARMUP_TIMEOUT_S` -- a startup cost paid once per process (construction
     + each restart), never a hang.
 
-**Known residual limitation (measured, not theoretical):** even with both
-fixes above, a stress test of ~80 sequential rescans against one long-lived
-`opengrep lsp` process saw a **~10% rate of a genuine, full-timeout stall**
-(no response at all, confirmed not just "slow" -- raising the per-call timeout
-to 25s did not recover it) that appears to build up under sustained repeated
-single-file rescanning of the same process. `diagnostics()` still never hangs
-past its own `timeout_s` (a stalled call is counted in `n_timeouts` and returns
-`[]`, exactly like any other timeout), but this means the opengrep arm is
-**not yet reliable enough to trust unconditionally at full-run scale** --
-Stage A's shipped default (`--oracle ts` in both drivers, and
-`CompositeOracle(kind="ts")` by default) does not depend on it. `--oracle
-opengrep`/`--oracle both` are implemented and functionally correct when they
-respond, but should be treated as experimental until this is root-caused
-further or fixed upstream.
+**The full-timeout stall (measured) and its mitigation.** A stress test of ~80
+sequential rescans against one long-lived `opengrep lsp` process saw a **~10%
+rate of a genuine, full-timeout stall** (no response at all, confirmed not just
+"slow" -- raising the per-call timeout to 25s did not recover it) that builds up
+under sustained repeated single-file rescanning of the same process. The stalled
+process stays *alive* (`poll()` returns None), so a dead-process liveness check
+never catches it -- a stalled call was simply counted in `n_timeouts` and
+returned `[]`, **silently dropping findings**, which at ~10% would corrupt a
+full-run `both` measurement.
+
+Because each `_rescan` overwrites the whole candidate file and is independent of
+prior calls, respawning the process changes *reliability, never the finding set
+for a given source*. So `diagnostics()` now (a) **proactively recycles** the
+process every `recycle_every` calls (default 32) before the stall builds up, and
+(b) **reactively restarts and retries once** when a scan returns no response at
+all (`restart_on_stall`, default on). A stall that survives both is still counted
+in `n_timeouts` and returns `[]` (never a hang). `n_recycles` / `n_restarts` /
+`n_stall_recoveries` record the reliability activity so a run's results JSON is
+self-describing; validate the residual stall rate with `scripts/opengrep_soak.py`
+before trusting a full run. Set `recycle_every=0, restart_on_stall=False` to
+reproduce the pre-mitigation behavior.
 
 ABOVE THE SEAM -- stdlib only. No `mlx`/`torch` import anywhere in this module
 (guarded by `tests/test_import_guard.py`).
@@ -88,6 +95,7 @@ _WARMUP_TIMEOUT_S = 15.0
 _WARMUP_POLL_S = 1.5
 _POLL_INTERVAL_S = 0.5   # how often _rescan re-checks its own deadline
 _SETTLE_S = 0.3          # grace window to absorb a still-arriving, newer generation
+_DEFAULT_RECYCLE_EVERY = 32   # proactively respawn every N calls (0 disables) -- see stall note
 
 # Self-verifying warmup canary: this ruleset's own `loop-bound-off-by-one` positive
 # fixture (`tests/test_opengrep.py`) -- a known-positive input from the same
@@ -141,7 +149,9 @@ class OpengrepOracle:
     """One persistent `opengrep lsp` process carrying the frozen custom
     ruleset. Same contract/attrs as `TsLspOracle`: `diagnostics`, `codes`,
     `close`, `__enter__`/`__exit__`, `n_calls`, `wall_s`, `n_timeouts`,
-    `n_restarts`. Not safe for concurrent use.
+    `n_restarts`, plus `n_recycles` (proactive respawns) and
+    `n_stall_recoveries` (reactive restart-and-retry respawns). Not safe for
+    concurrent use.
 
     Unlike `TsLspOracle`, this oracle reuses **one** candidate file for its
     whole lifetime (overwritten per call, `TscRunner`-style) rather than a
@@ -152,6 +162,8 @@ class OpengrepOracle:
     def __init__(self, *, timeout_s: float = _DEFAULT_TIMEOUT_S,
                  rules_dir: Path = RULES_DIR,
                  scratch_parent: Path = SET_DIR,
+                 recycle_every: int = _DEFAULT_RECYCLE_EVERY,
+                 restart_on_stall: bool = True,
                  argv: Optional[List[str]] = None) -> None:
         self.argv = argv if argv is not None else resolve_opengrep()
         if self.argv is None:
@@ -159,11 +171,19 @@ class OpengrepOracle:
                                 "and put it on PATH -- see eval_sets/opengrep_rules/README.md)")
         self.timeout_s = timeout_s
         self.rules_dir = rules_dir
+        # Reliability knobs against the measured full-timeout stall (see module
+        # docstring). `recycle_every` proactively respawns the process every N
+        # calls before the stall builds up; `restart_on_stall` reactively respawns
+        # and retries once when a scan comes back empty-with-no-response.
+        self.recycle_every = recycle_every
+        self.restart_on_stall = restart_on_stall
 
         self.n_calls = 0
         self.wall_s = 0.0
         self.n_timeouts = 0
         self.n_restarts = 0
+        self.n_recycles = 0          # proactive recycle_every respawns
+        self.n_stall_recoveries = 0  # reactive restart-and-retry-once respawns
 
         self._tmpdir_obj = tempfile.TemporaryDirectory(dir=str(scratch_parent), prefix="lsp_scratch_")
         self.scratch_dir = Path(self._tmpdir_obj.name)
@@ -230,8 +250,18 @@ class OpengrepOracle:
             "(warmup canary never fired) -- see eval_sets/opengrep_rules/README.md")
 
     def _ensure_alive(self) -> None:
+        """Respawn only if the process has actually *died* (`poll()` non-None).
+        The measured full-timeout stall is a *live-but-unresponsive* process --
+        `poll()` stays None, so this guard never catches it; that case is handled
+        reactively in `diagnostics()` via `restart_on_stall`."""
         if self._proc is not None and self._proc.poll() is None:
             return
+        self._restart()
+
+    def _restart(self) -> None:
+        """Unconditionally tear down and respawn the process (re-paying warmup).
+        Every restart path -- dead-process, proactive recycle, stall recovery --
+        funnels through here so `n_restarts` counts them all."""
         self.n_restarts += 1
         self._teardown_process()
         self._start_server()
@@ -294,10 +324,32 @@ class OpengrepOracle:
     def diagnostics(self, source: str) -> List[Diagnostic]:
         """Rescan the persistent candidate document with `source` and return
         every finding as a `Diagnostic` (`source="opengrep"`). Never raises on
-        timeout or a dead server -- returns `[]` and counts it."""
+        timeout or a dead server -- returns `[]` and counts it.
+
+        Reliability handling for the measured full-timeout stall (module
+        docstring): proactively recycle the process every `recycle_every` calls
+        before the stall builds up, and -- since a stalled scan and a fresh
+        process are deterministic w.r.t. `source` -- reactively respawn and retry
+        **once** when a scan comes back with no response at all. A restart cannot
+        change the finding set for a given source (each `_rescan` overwrites the
+        whole candidate file and is independent of prior calls); it only converts
+        a silently-dropped-to-`[]` stall back into real findings.
+        """
+        # Proactive recycle: respawn on the call-count boundary, before scanning.
+        if self.recycle_every and self.n_calls and self.n_calls % self.recycle_every == 0:
+            self._restart()
+            self.n_recycles += 1
+
         self._ensure_alive()
         t0 = time.monotonic()
         got, payload = self._rescan(source, self.timeout_s)
+
+        # Reactive restart-on-stall: one respawn + one retry against the fresh process.
+        if not got and self.restart_on_stall:
+            self._restart()
+            self.n_stall_recoveries += 1
+            got, payload = self._rescan(source, self.timeout_s)
+
         self.wall_s += time.monotonic() - t0
         self.n_calls += 1
 

--- a/src/lsp/oracle.py
+++ b/src/lsp/oracle.py
@@ -100,6 +100,25 @@ class CompositeOracle:
     def wall_s(self) -> float:
         return sum(o.wall_s for o in self._active_oracles())
 
+    @property
+    def opengrep_stats(self) -> Optional[dict]:
+        """The opengrep arm's reliability/cost counters, or `None` when that arm
+        isn't active (`kind="ts"`, or `"both"` that degraded past opengrep). A
+        `both` run's results JSON reads this to record how many opengrep scans
+        stalled (`n_timeouts` -- silently-dropped findings) versus recovered, so
+        the measurement is self-describing about its own completeness."""
+        if self._opengrep is None:
+            return None
+        og = self._opengrep
+        return {
+            "n_calls": og.n_calls,
+            "wall_s": og.wall_s,
+            "n_timeouts": og.n_timeouts,
+            "n_restarts": og.n_restarts,
+            "n_recycles": og.n_recycles,
+            "n_stall_recoveries": og.n_stall_recoveries,
+        }
+
     def diagnostics(self, source: str) -> List[Diagnostic]:
         """Every arm's findings, UNFILTERED (the caller applies
         `diagnostics.filter_diagnostics`, same as `TscRunner`/`TsLspOracle`),

--- a/tests/test_opengrep_oracle.py
+++ b/tests/test_opengrep_oracle.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import List, Tuple
 
 from src.lsp.opengrep import OpengrepOracle
+from src.lsp.oracle import CompositeOracle
 
 # A minimal well-formed raw LSP finding, enough for `_map_finding` to build a
 # Diagnostic (line/character 0-indexed; maps to offset 0 for any source).
@@ -113,3 +114,30 @@ def test_mitigation_off_reproduces_pre_fix_behavior():
     assert o.n_recycles == 0
     assert o.n_stall_recoveries == 0
     assert o.n_timeouts == 1
+
+
+# --- CompositeOracle.opengrep_stats plumbing (Part 2) ------------------- #
+
+class _FakeArm:
+    n_calls = 5
+    wall_s = 1.25
+    n_timeouts = 1
+    n_restarts = 2
+    n_recycles = 1
+    n_stall_recoveries = 1
+
+
+def test_opengrep_stats_is_none_when_arm_inactive():
+    # kind="ts" (or a degraded "both") -> no opengrep arm -> None.
+    c = object.__new__(CompositeOracle)   # bypass __init__ (would spawn real servers)
+    c._opengrep = None
+    assert c.opengrep_stats is None
+
+
+def test_opengrep_stats_reports_the_arm_counters():
+    c = object.__new__(CompositeOracle)
+    c._opengrep = _FakeArm()
+    assert c.opengrep_stats == {
+        "n_calls": 5, "wall_s": 1.25, "n_timeouts": 1,
+        "n_restarts": 2, "n_recycles": 1, "n_stall_recoveries": 1,
+    }

--- a/tests/test_opengrep_oracle.py
+++ b/tests/test_opengrep_oracle.py
@@ -1,0 +1,115 @@
+"""Deterministic mechanism tests for `OpengrepOracle`'s reliability handling --
+the proactive-recycle + reactive-restart-on-stall logic added to `diagnostics()`
+to survive the measured ~10% full-timeout stall (see `src/lsp/opengrep.py`'s
+module docstring).
+
+These need **no** `opengrep` binary: they bypass the real `__init__`/`_start_server`
+(which would spawn a subprocess) and script `_rescan`'s return values directly, so
+they run in CI on every host. The live-binary validation lives in
+`scripts/opengrep_soak.py`; the ruleset-fixture tests live in `tests/test_opengrep.py`.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from src.lsp.opengrep import OpengrepOracle
+
+# A minimal well-formed raw LSP finding, enough for `_map_finding` to build a
+# Diagnostic (line/character 0-indexed; maps to offset 0 for any source).
+_RAW_FINDING = {
+    "range": {"start": {"line": 0, "character": 0}},
+    "code": "loop-bound-off-by-one",
+    "message": "off-by-one",
+    "severity": 1,
+}
+
+
+class _FakeOracle(OpengrepOracle):
+    """An `OpengrepOracle` whose subprocess-touching pieces are replaced by
+    counters, and whose `_rescan` plays back a scripted list of
+    `(got, payload)` tuples. The real `diagnostics()` / `_restart()` run
+    unchanged -- that is exactly what's under test."""
+
+    def __init__(self, rescan_script: List[Tuple[bool, list]], *,
+                 recycle_every: int, restart_on_stall: bool) -> None:
+        # Deliberately bypass OpengrepOracle.__init__ (no binary, no spawn).
+        self.timeout_s = 5.0
+        self.recycle_every = recycle_every
+        self.restart_on_stall = restart_on_stall
+        self.n_calls = 0
+        self.wall_s = 0.0
+        self.n_timeouts = 0
+        self.n_restarts = 0
+        self.n_recycles = 0
+        self.n_stall_recoveries = 0
+        self._script = list(rescan_script)
+        self.rescan_calls = 0
+        self.starts = 0
+        self.teardowns = 0
+
+    # --- subprocess seam, stubbed to counters -------------------------- #
+    def _ensure_alive(self) -> None:
+        pass  # no real process in the fake
+
+    def _teardown_process(self) -> None:
+        self.teardowns += 1
+
+    def _start_server(self) -> None:
+        self.starts += 1
+
+    def _rescan(self, source: str, timeout_s: float):
+        self.rescan_calls += 1
+        if self._script:
+            return self._script.pop(0)
+        return (True, [])  # default: responded, no findings
+
+
+def test_proactive_recycle_fires_on_the_call_count_boundary():
+    # recycle_every=3: over 7 calls, the boundary (n_calls % 3 == 0, n_calls > 0)
+    # is crossed before call 4 (n_calls==3) and call 7 (n_calls==6) -> 2 recycles.
+    o = _FakeOracle([(True, [])] * 7, recycle_every=3, restart_on_stall=False)
+    for _ in range(7):
+        assert o.diagnostics("x") == []
+    assert o.n_calls == 7
+    assert o.n_recycles == 2
+    assert o.n_restarts == 2          # every recycle funnels through _restart
+    assert o.starts == 2 and o.teardowns == 2
+    assert o.n_stall_recoveries == 0
+    assert o.n_timeouts == 0
+
+
+def test_reactive_restart_recovers_a_single_stall():
+    # First scan stalls (no response), retry against a fresh process succeeds.
+    o = _FakeOracle([(False, []), (True, [_RAW_FINDING])],
+                    recycle_every=0, restart_on_stall=True)
+    diags = o.diagnostics("x")
+    assert len(diags) == 1 and diags[0].code == "loop-bound-off-by-one"
+    assert o.rescan_calls == 2         # original + one retry
+    assert o.n_stall_recoveries == 1
+    assert o.n_restarts == 1
+    assert o.n_timeouts == 0
+    assert o.n_calls == 1              # one *logical* call
+
+
+def test_persistent_stall_is_counted_after_one_retry():
+    # Both the original and the retry stall -> counted as a timeout, returns [].
+    o = _FakeOracle([(False, []), (False, [])],
+                    recycle_every=0, restart_on_stall=True)
+    assert o.diagnostics("x") == []
+    assert o.rescan_calls == 2         # original + one retry, then give up
+    assert o.n_stall_recoveries == 1   # the retry was attempted
+    assert o.n_restarts == 1
+    assert o.n_timeouts == 1
+    assert o.n_calls == 1
+
+
+def test_mitigation_off_reproduces_pre_fix_behavior():
+    # recycle_every=0 + restart_on_stall=False: a stall is a silent [] with no respawn.
+    o = _FakeOracle([(False, [])], recycle_every=0, restart_on_stall=False)
+    assert o.diagnostics("x") == []
+    assert o.rescan_calls == 1         # no retry
+    assert o.n_restarts == 0
+    assert o.n_recycles == 0
+    assert o.n_stall_recoveries == 0
+    assert o.n_timeouts == 1


### PR DESCRIPTION
Refs #199 (Stage A follow-up; issue already closed via #208)

Follow-up to Stage A (PR #208): make the opengrep oracle trustworthy at scale, then run the deferred full 159-record F1 re-measure.

## Reliability fix
The measured ~10% opengrep stall is a **live-but-unresponsive** process — `poll()` stays `None`, so the dead-process-only `_ensure_alive()` never caught it and a stalled scan was silently counted as a timeout and returned `[]`, **dropping findings** (at ~10% that would corrupt a `both` measurement). Since each `_rescan` overwrites the whole candidate file and is independent of prior calls, respawning changes reliability but never the finding set — so `OpengrepOracle` now:
- **proactively recycles** the process every 32 calls (`recycle_every`), and
- **reactively restarts + retries once** on a no-response scan (`restart_on_stall`).

New `n_recycles` / `n_stall_recoveries` counters, surfaced through `CompositeOracle.opengrep_stats` into the results JSON so a run is self-describing. Deterministic mechanism tests (no binary needed) + `scripts/opengrep_soak.py`.

## The re-measure (159 records, block 256, greedy)
`f1_ts` (persistent LSP) and `f1_both` (LSP + frozen 12-rule opengrep) vs the batch-tsc `f1_base`:

| slow-hard vs baseline | f1_base (tsc) | f1_ts (LSP) | f1_both (LSP+opengrep) |
|---|---|---|---|
| clean-rate | 0.906, p=0.375 (ns) | **0.962, p=0.0005** | 0.937, p=0.0005 |
| pass@1 | **0.560, p=0.001** | 0.503, p=0.69 (ns) | 0.528, p=0.109 (ns) |
| over-repair | 0.094 | 0.101 | 0.120 |

- **The oracle swap flips the winning axis**: batch-tsc's slow loop gave a real *functional* lift but no clean lift; the persistent LSP gives a strong *clean* lift but loses the functional lift entirely (and flips 2 correct records to failing). Open-document diagnostics ≠ whole-program `tsc` — the "retune, don't port blind" risk, measured.
- **opengrep finds a narrow but perfectly-precise signal**: fires on **4/159 raw outputs, all 4 functionally wrong (0 false positives)**. The feared-noisy rules (`sort-without-comparator`, …) never fired. Folding it into the slow loop nudges pass@1 to 0.528 (p=0.109, ns) at a modest over-repair cost.
- **Trustworthy measurement**: `opengrep` stats show `n_timeouts=0` over 1471 calls (45 recycles, 0 stalls) — no findings silently dropped. The stall did not reproduce on this host even with the mitigation off, so the recycler is a cheap, unit-tested safety net.

## Scope / notes
- Results committed as `results/f1_{base,ts,both}.json` summaries; `results/*.jsonl` transcripts stay local (gitignored, reproducible by re-running).
- Design-doc Stage A section added (`docs/design/12-lsp-in-the-loop.md`).
- `#198` tracker: `#199` checkbox ticked. Also gitignores the `lsp_exec_*` scratch prefix that leaked when the run was interrupted.

## Testing
- [x] Full suite **811 passed / 7 skipped** (+6 deterministic mechanism tests)
- [x] Soak harness: 0 timeouts across 160 rotating + 200 single-file (mitigation off) + 160 (on, 4 recycles)
- [x] Both 159-record re-measure runs completed; `opengrep` stats block present, `n_timeouts=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRoRJxdHnmsRFN8AGNbMAu