### PR TITLE
fix(lsp): final-segment gate cuts slow-loop over-repair, zero F1 cost (#201)

### DIFF
--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -507,6 +507,37 @@ partly offset because the loop also fixes genuinely-broken continuations. This i
 trained-model ablation (#201's blocked half) and any reward design (#103) must weigh, and it points
 at the frontier/`is_source_balanced` transient-diagnostic handling as the first thing to harden.
 
+### The final-segment gate — first hardening pass (#201)
+
+The mechanism above says the reinstatement fires at *every* balanced boundary with no notion of
+whether more segments are still coming. The fix: reinstate a committed `TS1xxx` **only on the
+genuinely final segment of the block** (`is_final_segment` = `budget=="stmt"`, or EOS, or this
+segment exhausts the block budget, or a stop string fired), threading a new `eos_hit` out of
+`_extend_to_boundary_or_budget`. A transient `TS1xxx` and a genuine one are indistinguishable *at*
+the prefix — the only discriminator is whether generation continues — so the final-segment condition
+is not a heuristic but the actual invariant.
+
+Re-measured (same protocol; `results/e4_overrepair_realcode_fix.json`, `results/f1_ts_fix.json`):
+
+| | before | after gate |
+|---|---|---|
+| #201 slow-hard `over_repair_rate` (raw) | 0.260 | **0.215** |
+| #201 conditioned true over-repair (rollback \| continuation clean) | 13/36 = 0.36 | **7/36 = 0.194** |
+| #199 F1 slow-hard clean-rate / pass@1 | 0.962 / 0.503 | **0.962 / 0.503 (byte-identical)** |
+
+The conditioned over-repair — the honest signal — **nearly halves**, at **zero F1 cost**: the gate
+never fires on HumanEval-TS (single open-function bodies are unbalanced at intermediate boundaries,
+so the reinstatement never fired there to begin with), so the whole F1 run is byte-identical. The
+change is confined to multi-top-level-statement real code, exactly the over-repair case.
+
+**Residual (honest):** the gate cuts the `TS1xxx`-transient rollbacks, but a *second* source
+surfaces — transient committed **`TS2xxx`** semantic codes (e.g. `TS2395` "merged declaration must be
+all exported or all local") on incomplete multi-segment code, which flow through the normal filter
+(not the `TS1xxx`-only reinstatement) and still trigger rollbacks. On the exemplar `clean-prefix-0020`
+the `TS1146` chasing is gone (5→0) but the trajectory now chases `TS2395`. Extending the same
+"final-segment / transient" reasoning to committed `TS2xxx` is the next hardening step; raw
+over-repair (0.215) won't fall to zero until it's addressed.
+
 ## Risks realized (see the original plan for the full list)
 
 - **Tool-call-as-base-model risk, confirmed as predicted**: toolcall-k1 and slow-soft land on

--- a/results/e4_overrepair_realcode_fix.json
+++ b/results/e4_overrepair_realcode_fix.json
@@ -1,0 +1,197 @@
+{
+  "model": "mlx-community/Qwen2.5-Coder-1.5B-bf16",
+  "dtype": null,
+  "set": "eval_sets/ts_error_injection/clean_prefixes.jsonl",
+  "n_records": 200,
+  "budget": "block",
+  "block_size": 256,
+  "temperature": 0.0,
+  "seed": 0,
+  "strip_suggestions": false,
+  "oracle": "ts",
+  "sources_active": [
+    "ts"
+  ],
+  "summaries": {
+    "baseline": {
+      "n": 200,
+      "diagnostic_clean_rate": 0.18,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.0,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 200,
+      "total_n_forward_tokens": 39064,
+      "mean_n_forward_tokens": 195.32,
+      "total_n_forward_tokens_nocache": 39064,
+      "mean_n_forward_tokens_nocache": 195.32,
+      "total_n_generated_tokens": 26235,
+      "mean_n_generated_tokens": 131.175,
+      "total_n_tsc_calls": 0,
+      "mean_n_tsc_calls": 0.0,
+      "total_n_rollbacks": 0,
+      "mean_n_rollbacks": 0.0,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 0,
+      "mean_n_retries": 0.0,
+      "total_wall_s": 660.7412537555792,
+      "mean_wall_s": 3.303706268777896,
+      "total_tsc_wall_s": 0.0,
+      "mean_tsc_wall_s": 0.0,
+      "extraction_failure_rate": 0.0,
+      "rollback_paths": {
+        "trim": 0,
+        "reprefill": 0,
+        "snapshot": 0,
+        "reprefill_tokens": 0
+      },
+      "snapshot_bytes": 2494464
+    },
+    "slow-hard": {
+      "n": 200,
+      "diagnostic_clean_rate": 0.215,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.215,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 200,
+      "total_n_forward_tokens": 218618,
+      "mean_n_forward_tokens": 1093.09,
+      "total_n_forward_tokens_nocache": 249114,
+      "mean_n_forward_tokens_nocache": 1245.57,
+      "total_n_generated_tokens": 25492,
+      "mean_n_generated_tokens": 127.46,
+      "total_n_tsc_calls": 1585,
+      "mean_n_tsc_calls": 7.925,
+      "total_n_rollbacks": 161,
+      "mean_n_rollbacks": 0.805,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 190,
+      "mean_n_retries": 0.95,
+      "total_wall_s": 1611.2734896661714,
+      "mean_wall_s": 8.056367448330857,
+      "total_tsc_wall_s": 565.9642354160314,
+      "mean_tsc_wall_s": 2.829821177080157,
+      "extraction_failure_rate": 0.0,
+      "rollback_paths": {
+        "trim": 161,
+        "reprefill": 0,
+        "snapshot": 0,
+        "reprefill_tokens": 0
+      },
+      "snapshot_bytes": 2494464
+    },
+    "slow-both": {
+      "n": 200,
+      "diagnostic_clean_rate": 0.225,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.01,
+      "over_repair_rate": 0.215,
+      "no_progress_rate": 0.15384615384615385,
+      "suggestion_leak_rate": 0.07692307692307693,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 200,
+      "total_n_forward_tokens": 223583,
+      "mean_n_forward_tokens": 1117.915,
+      "total_n_forward_tokens_nocache": 253833,
+      "mean_n_forward_tokens_nocache": 1269.165,
+      "total_n_generated_tokens": 25418,
+      "mean_n_generated_tokens": 127.09,
+      "total_n_tsc_calls": 1599,
+      "mean_n_tsc_calls": 7.995,
+      "total_n_rollbacks": 158,
+      "mean_n_rollbacks": 0.79,
+      "total_n_soft_repairs": 13,
+      "mean_n_soft_repairs": 0.065,
+      "total_n_retries": 196,
+      "mean_n_retries": 0.98,
+      "total_wall_s": 1639.8595917500497,
+      "mean_wall_s": 8.199297958750249,
+      "total_tsc_wall_s": 571.7964462671371,
+      "mean_tsc_wall_s": 2.8589822313356854,
+      "extraction_failure_rate": 0.0,
+      "rollback_paths": {
+        "trim": 319,
+        "reprefill": 0,
+        "snapshot": 0,
+        "reprefill_tokens": 0
+      },
+      "snapshot_bytes": 2494464
+    }
+  },
+  "comparisons": {
+    "slow-hard": {
+      "avoided_vs_baseline": {
+        "n": 0,
+        "key": "avoided",
+        "table": {
+          "both_true": 0,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 0,
+          "both_false": 0
+        },
+        "baseline_rate": NaN,
+        "other_rate": NaN,
+        "mcnemar_p": 1.0,
+        "flip_to_true_rate": NaN,
+        "flip_to_false_rate": NaN
+      },
+      "clean_vs_baseline": {
+        "n": 200,
+        "key": "clean",
+        "table": {
+          "both_true": 28,
+          "baseline_true_other_false": 8,
+          "baseline_false_other_true": 15,
+          "both_false": 149
+        },
+        "baseline_rate": 0.18,
+        "other_rate": 0.215,
+        "mcnemar_p": 0.21003961563110352,
+        "flip_to_true_rate": 0.09146341463414634,
+        "flip_to_false_rate": 0.2222222222222222
+      }
+    },
+    "slow-both": {
+      "avoided_vs_baseline": {
+        "n": 0,
+        "key": "avoided",
+        "table": {
+          "both_true": 0,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 0,
+          "both_false": 0
+        },
+        "baseline_rate": NaN,
+        "other_rate": NaN,
+        "mcnemar_p": 1.0,
+        "flip_to_true_rate": NaN,
+        "flip_to_false_rate": NaN
+      },
+      "clean_vs_baseline": {
+        "n": 200,
+        "key": "clean",
+        "table": {
+          "both_true": 29,
+          "baseline_true_other_false": 7,
+          "baseline_false_other_true": 16,
+          "both_false": 148
+        },
+        "baseline_rate": 0.18,
+        "other_rate": 0.225,
+        "mcnemar_p": 0.0931396484375,
+        "flip_to_true_rate": 0.0975609756097561,
+        "flip_to_false_rate": 0.19444444444444445
+      }
+    }
+  },
+  "tsc_n_calls_total": 3784,
+  "tsc_wall_s_total": 1350.3837792324193,
+  "wall_s_total": 4127.254089833994
+}

--- a/results/f1_ts_fix.json
+++ b/results/f1_ts_fix.json
@@ -1,0 +1,111 @@
+{
+  "model": "mlx-community/Qwen2.5-Coder-1.5B-bf16",
+  "set": "eval_sets/humaneval_ts/humaneval_ts.jsonl",
+  "n_records": 159,
+  "block_size": 256,
+  "temperature": 0.0,
+  "seed": 0,
+  "functional": true,
+  "oracle": "ts",
+  "sources_active": [
+    "ts"
+  ],
+  "summaries": {
+    "baseline": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.8867924528301887,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.0,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 34814,
+      "mean_n_forward_tokens": 218.9559748427673,
+      "total_n_forward_tokens_nocache": 34814,
+      "mean_n_forward_tokens_nocache": 218.9559748427673,
+      "total_n_generated_tokens": 13879,
+      "mean_n_generated_tokens": 87.28930817610063,
+      "total_n_tsc_calls": 0,
+      "mean_n_tsc_calls": 0.0,
+      "total_n_rollbacks": 0,
+      "mean_n_rollbacks": 0.0,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 0,
+      "mean_n_retries": 0.0,
+      "total_wall_s": 344.5289609559404,
+      "mean_wall_s": 2.1668488110436503,
+      "total_tsc_wall_s": 0.0,
+      "mean_tsc_wall_s": 0.0,
+      "functional_pass_at_1": 0.49056603773584906
+    },
+    "slow-hard": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.9622641509433962,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.10062893081761007,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 224309,
+      "mean_n_forward_tokens": 1410.748427672956,
+      "total_n_forward_tokens_nocache": 233621,
+      "mean_n_forward_tokens_nocache": 1469.314465408805,
+      "total_n_generated_tokens": 15020,
+      "mean_n_generated_tokens": 94.46540880503144,
+      "total_n_tsc_calls": 1073,
+      "mean_n_tsc_calls": 6.748427672955975,
+      "total_n_rollbacks": 33,
+      "mean_n_rollbacks": 0.20754716981132076,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 33,
+      "mean_n_retries": 0.20754716981132076,
+      "total_wall_s": 1068.7783738709695,
+      "mean_wall_s": 6.721876565226223,
+      "total_tsc_wall_s": 389.86972133399104,
+      "mean_tsc_wall_s": 2.4520108259999436,
+      "functional_pass_at_1": 0.5031446540880503
+    }
+  },
+  "comparisons": {
+    "slow-hard": {
+      "clean_vs_baseline": {
+        "n": 159,
+        "key": "clean",
+        "table": {
+          "both_true": 141,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 12,
+          "both_false": 6
+        },
+        "baseline_rate": 0.8867924528301887,
+        "other_rate": 0.9622641509433962,
+        "mcnemar_p": 0.00048828125,
+        "flip_to_true_rate": 0.6666666666666666,
+        "flip_to_false_rate": 0.0
+      },
+      "functional_vs_baseline": {
+        "n": 159,
+        "key": "functional_pass",
+        "table": {
+          "both_true": 76,
+          "baseline_true_other_false": 2,
+          "baseline_false_other_true": 4,
+          "both_false": 77
+        },
+        "baseline_rate": 0.49056603773584906,
+        "other_rate": 0.5031446540880503,
+        "mcnemar_p": 0.6875,
+        "flip_to_true_rate": 0.04938271604938271,
+        "flip_to_false_rate": 0.02564102564102564
+      }
+    }
+  },
+  "tsc_wall_s_total": 504.50926897270256,
+  "wall_s_total": 1671.6558454170008
+}

--- a/src/lsp/harness.py
+++ b/src/lsp/harness.py
@@ -390,11 +390,14 @@ def generate_slow_loop(
         ban_table: Dict[Tuple[int, ...], set] = {}
 
         # --- generate this segment, up to `remaining` tokens or a statement boundary ---
-        def _extend_to_boundary_or_budget(n_max: int) -> Tuple[bool, bool]:
-            """Returns (hit_boundary, hit_budget). An EOS token also ends the segment as a
-            boundary — in real-code (block) generation the model closes the function with
-            EOS, and without stopping there the body runs on into literal `<|endoftext|>`
-            text that breaks both tsc and the functional run."""
+        def _extend_to_boundary_or_budget(n_max: int) -> Tuple[bool, bool, bool]:
+            """Returns (hit_boundary, eos_hit, hit_budget). An EOS token also ends the
+            segment as a boundary — in real-code (block) generation the model closes the
+            function with EOS, and without stopping there the body runs on into literal
+            `<|endoftext|>` text that breaks both tsc and the functional run. `eos_hit`
+            distinguishes that EOS boundary from a plain statement boundary, so the
+            committed-TS1xxx reinstatement can tell a genuinely-final segment from an
+            intermediate one (see the `is_final_segment` gate below)."""
             nonlocal logits
             for _ in range(n_max):
                 key = tuple(gen_ids)
@@ -406,16 +409,16 @@ def generate_slow_loop(
                 tok = sample(step_logits, temperature=temperature, rng=rng,
                              previous_tokens=gen_ids)
                 if tok in eos_ids:
-                    return True, False
+                    return True, True, False
                 logits = lm.step(tok)
                 gen_ids.append(tok)
                 logits_history.append(logits)
                 text = lm.decode(gen_ids)
                 if statement_boundary(text) is not None:
-                    return True, False
-            return False, True
+                    return True, False, False
+            return False, False, True
 
-        hit_boundary, hit_budget = _extend_to_boundary_or_budget(remaining)
+        hit_boundary, eos_hit, hit_budget = _extend_to_boundary_or_budget(remaining)
         segment_is_final_partial = hit_budget and not hit_boundary  # budget ran out mid-statement
 
         n_retry_rounds = 0
@@ -439,16 +442,33 @@ def generate_slow_loop(
                 # by construction, so their own syntax noise is dropped for free.
                 frontier = segment_start + (len(lm.decode(gen_ids[:-1])) if gen_ids else 0)
 
+            # Is this the genuinely LAST segment of the block? The reinstatement below
+            # only holds when no more text is legitimately coming for the whole BLOCK
+            # (not merely the current attempt). Under budget="block" the outer loop runs
+            # once per statement boundary, so a committed TS1xxx at an INTERMEDIATE
+            # balanced boundary (e.g. `export const\n` -> TS1146) is usually transient --
+            # the next segment completes it -- and reinstating it there rolls back correct
+            # code (measured: #201 over_repair_rate 0.26). A transient TS1xxx and a genuine
+            # one (`u.)`) are indistinguishable AT the prefix; the only discriminator is
+            # whether generation continues, i.e. whether this is the final segment.
+            is_final_segment = (
+                budget == "stmt"                                       # single-segment block
+                or eos_hit                                             # model closed the body
+                or committed_tokens + len(gen_ids) >= total_budget     # this segment exhausts budget
+                or (bool(stop_strings)
+                    and _first_stop(committed_completion + gen_text, stop_strings) is not None)
+            )
+
             raw = _diag(source)
             filtered = filter_diagnostics(raw, frontier=frontier, generation_start=segment_start,
                                           source=source)
-            if hit_boundary and not filtered and is_source_balanced(source):
+            if hit_boundary and not filtered and is_source_balanced(source) and is_final_segment:
                 # filter_diagnostics unconditionally drops TS1xxx as mid-generation
                 # "still typing" noise -- correct while more tokens might still be
-                # coming, but this segment just reached a genuine statement
-                # boundary: there ISN'T any more text coming for this attempt, so a
-                # committed TS1xxx (e.g. `u.)` -- "Identifier expected") is a real
-                # defect, not noise, and must not be waved through as clean.
+                # coming, but this is the genuinely final segment: there ISN'T any more
+                # text coming for the block, so a committed TS1xxx (e.g. `u.)` --
+                # "Identifier expected") is a real defect, not noise, and must not be
+                # waved through as clean.
                 #
                 # BUT gated on `is_source_balanced`: #199 Stage A finding (confirmed
                 # empirically on real HumanEval-TS block-budget generation) -- a
@@ -517,7 +537,7 @@ def generate_slow_loop(
                     ban_table.setdefault(tuple(gen_ids), set()).add(banned_tok)
                 result.events.append({"kind": "hard_repair", "code": diag.code,
                                        "offset": diag.offset, "rolled_back_to": tok_idx})
-                hit_boundary, hit_budget = _extend_to_boundary_or_budget(
+                hit_boundary, eos_hit, hit_budget = _extend_to_boundary_or_budget(
                     total_budget - committed_tokens - len(gen_ids))
                 segment_is_final_partial = hit_budget and not hit_boundary
             else:
@@ -532,7 +552,7 @@ def generate_slow_loop(
                 gen_ids = []
                 logits_history = [logits]
                 ban_table = {}
-                hit_boundary, hit_budget = _extend_to_boundary_or_budget(
+                hit_boundary, eos_hit, hit_budget = _extend_to_boundary_or_budget(
                     total_budget - committed_tokens)
                 segment_is_final_partial = hit_budget and not hit_boundary
 

--- a/tests/test_lsp_harness.py
+++ b/tests/test_lsp_harness.py
@@ -193,6 +193,63 @@ def test_hard_repair_retry_cap_terminates_and_marks_unrepaired():
     assert result.n_retries == 3
 
 
+# --------------------------------------------------------------------------- #
+# committed-TS1xxx reinstatement: only on the genuinely final block segment (#201)
+# --------------------------------------------------------------------------- #
+
+def _dangling_const_diag(source: str) -> List[Diagnostic]:
+    """A TS1xxx that fires only while a `const` declaration is dangling (no `=`
+    yet) -- a *transient* incompleteness that the next segment resolves, mirroring
+    the real `export const\\n` -> TS1146 case."""
+    i = source.find("const")
+    if i == -1 or "=" in source:
+        return []
+    return [Diagnostic(code="TS1146", line=1, col=i + 1,
+                        message="Declaration expected", offset=i)]
+
+
+def test_transient_ts1xxx_at_intermediate_boundary_is_not_reinstated():
+    # Segment 1 ("export const\n") ends at a balanced-but-incomplete boundary with
+    # budget headroom left; the next segment ("x = 1;") completes the declaration and
+    # the TS1146 vanishes. The loop must NOT reinstate the transient code and roll back.
+    # (Fails on pre-#201 code, which reinstates at every balanced boundary.)
+    # alt_script kicks in once "export const" is in the context (segment 2+), so the
+    # second segment actually completes the declaration instead of repeating segment 1.
+    lm = ScriptedFakeLM(_linear_script("export const\n"),
+                        alt_script=_linear_script("x = 1;\n"), alt_trigger="export const")
+    result = generate_slow_loop(lm, _dangling_const_diag, "", repair="hard",
+                                 budget="block", block_size=19, max_retries=5)
+    assert result.n_rollbacks == 0                 # transient code was not chased
+    assert "export const" in result.completion     # generation continued past segment 1
+    assert "x = 1" in result.completion            # the declaration was completed
+
+
+def test_genuine_ts1xxx_at_final_segment_is_still_reinstated():
+    # A genuine, persistent TS1xxx at the block's FINAL segment (budget exhausts on a
+    # one-token boundary segment) must still be caught -- the #199 F1 defect-catch the
+    # reinstatement exists for. `u.` never resolves, so diagnose keeps flagging it.
+    persistent = lambda source: (
+        [Diagnostic(code="TS1003", line=1, col=1, message="Identifier expected",
+                    offset=source.find("u.") + 1)] if "u." in source else [])
+    lm = ScriptedFakeLM(_linear_script(";\n"))     # first token ';' is a boundary
+    result = generate_slow_loop(lm, persistent, "const x = u.", repair="hard",
+                                 budget="block", block_size=1, max_retries=3)
+    # is_final_segment is True (this one boundary segment exhausts block_size=1), so the
+    # committed TS1003 is reinstated -> the loop acts on it (rolls back or gives up).
+    assert result.n_rollbacks > 0 or result.unrepaired is True
+
+
+def test_stmt_budget_still_reinstates_genuine_ts1xxx():
+    # budget="stmt" is a single (final) segment, so reinstatement is unchanged by #201.
+    persistent = lambda source: (
+        [Diagnostic(code="TS1003", line=1, col=1, message="Identifier expected",
+                    offset=source.find("u.") + 1)] if "u." in source else [])
+    lm = ScriptedFakeLM(_linear_script(";\n"))
+    result = generate_slow_loop(lm, persistent, "const x = u.", repair="hard",
+                                 budget="stmt", max_retries=3)
+    assert result.n_rollbacks > 0 or result.unrepaired is True
+
+
 def test_suppression_hack_with_no_diagnostic_does_not_crash():
     # A suppression hack (`as any`) makes `_is_clean` return False, but the diagnose
     # fn reports NO diagnostics -> `filtered` is empty. Hard repair is diagnostic-guided


### PR DESCRIPTION
Refs #201 (over-repair hardening; the #201 issue's parser-based-probe half was resolved in #210, its fast/slow/both ablation half stays blocked on #200's trained model).

Cuts the LSP slow loop's real-code over-repair at its root, following the #201 measurement (over_repair_rate 0.26).

## The fix
The slow loop reinstated committed `TS1xxx` syntax-incompleteness codes at **every** balanced segment boundary, with no notion of whether more segments were still coming. Under `budget="block"` a bracket-balanced-but-statement-incomplete prefix (`export const\n` → `TS1146`) tripped it, but the next segment completes the statement and the code vanishes — so the rollback was over-repair (exemplar `clean-prefix-0020`: 6 rollbacks on code the baseline finished clean).

A transient `TS1xxx` and a genuine one (`u.)`) are indistinguishable **at** the prefix; the only discriminator is whether generation continues. So the reinstatement now fires **only on the genuinely final segment of the block** — `is_final_segment` = `budget=="stmt"` ∨ EOS ∨ this segment exhausts the block budget ∨ a stop string fired — threading a new `eos_hit` out of `_extend_to_boundary_or_budget`. `budget="stmt"` and single-segment blocks are unchanged; only intermediate segments of multi-segment blocks stop chasing transient codes.

## Results (same protocol)
| | before | after |
|---|---|---|
| #201 conditioned true over-repair (rollback \| continuation genuinely clean) | 13/36 = **0.36** | 7/36 = **0.194** (nearly halved) |
| #201 raw `over_repair_rate` (slow-hard) | 0.260 | 0.215 |
| **#199 F1 slow-hard clean / pass@1** | 0.962 / 0.503 | **0.962 / 0.503 — byte-identical** |

**Zero F1 regression by design:** the gate never fires on single-function HumanEval-TS bodies (unbalanced at intermediate boundaries), so the whole F1 run is byte-identical. The change is confined to multi-top-level-statement real code — the over-repair case.

## Honest residual
The gate cuts the `TS1xxx`-transient rollbacks but reveals a **second** source — transient committed `TS2xxx` semantic codes (e.g. `TS2395` "merged declaration must be all exported or all local") on incomplete multi-segment code, which flow through the normal filter, not the `TS1xxx`-only reinstatement. On `clean-prefix-0020` the `TS1146` chasing is gone (5→0) but the trajectory now chases `TS2395`. Extending the same reasoning to committed `TS2xxx` is the next hardening step (documented in E4); raw over-repair won't hit zero until then.

## Testing
- [x] Full suite **824 passed / 6 skipped** (+3 regression tests; the transient-not-reinstated test provably fails without the gate)
- [x] Re-measure: over-repair down, #199 F1 byte-identical (`results/e4_overrepair_realcode_fix.json`, `results/f1_ts_fix.json`)
- [x] E4 design-doc section updated with before/after + the residual

Also on the tracker (separate): filed #211 (LSP-oracle multi-push race) and linked it from #198's P1 tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRoRJxdHnmsRFN8AGNbMAu