### PR TITLE
test(lsp): validate TS-LSP oracle diagnostic completeness — no multi-push race (#211)

### DIFF
--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -626,6 +626,44 @@ notably the stall did not reproduce on this host at all (0 timeouts across 160 r
 single-file soak calls with the mitigation off), so the recycler is a cheap, unit-tested safety net
 rather than a demonstrated before/after fix.
 
+## The TS-LSP oracle's first-push-wins is complete — no multi-push race in practice (#211)
+
+`TsLspOracle.diagnostics()` arms a single `threading.Event` and returns on the **first**
+`textDocument/publishDiagnostics` push for the candidate URI, with **no settle/quiescence window** —
+unlike `OpengrepOracle._rescan`'s `_SETTLE_S`. The open concern (#211): a push-model server that
+publishes a fast **syntactic** pass then a slower **semantic** pass would have the oracle capture the
+early syntactic-only push and **miss the semantic `TS2xxx` errors**, biasing measured LSP lift toward
+"finds nothing" and making the set timing-dependent. That would silently corrupt the phases that trust
+the oracle's diagnostic set (the #201 ablation, and especially #203, LSP-as-diffusion-discriminator).
+
+**Probed, not assumed** (`scripts/probe_ts_lsp_multipush.py`, `results/ts_lsp_multipush_probe.json`).
+The probe re-opens each candidate the oracle sees but registers a *list-append* callback that records
+**every** push for the URI — timestamp + codes — and captures the server's advertised
+`capabilities.diagnosticProvider`. Run over the whole #194 set (96 records, all 4 error classes) plus a
+**crafted candidate carrying both a syntactic (`TS1109`) and a distinct semantic (`TS2322`) defect**,
+with a settle window (3.5 s) wide enough to catch late pushes:
+
+| Signal | Result |
+|---|---|
+| Candidates where the **first** push ≠ the final union of all pushes | **0 / 97** |
+| Candidates where a **semantic** code appeared only in a later push (the race) | **0 / 97** |
+| Candidates where a later push added *any* code | **0 / 97** |
+| Crafted syntax+semantic candidate | **1 push**, carrying `TS1109` **and** `TS2322` together |
+| `capabilities.diagnosticProvider` (pull diagnostics / LSP 3.17) | **absent** on `typescript-language-server` 5.3.0 |
+
+The pinned server *does* emit up to **3** pushes per document (median inter-push gap ~1.2 s), but the
+**first push is always semantically complete** — pushes 2–3 are **idempotent re-publishes** carrying
+the identical code set (tsserver re-emitting after the project settles). The crafted candidate — which
+deliberately mixes a syntactic and a semantic defect, the exact split the race hypothesis needs —
+**coalesces both into one push**, directly refuting a syntactic-then-semantic split for this server.
+
+**Resolution: no production change.** First-push-wins captures the complete set on every candidate and
+every error class, so the current `diagnostics()` is correct as written. The pull-diagnostics fix path
+is moot anyway (5.3.0 advertises no `diagnosticProvider`). The multi-push race remains a **latent**
+risk for a *different* server or config that front-loads a syntactic-only push — the probe script is
+retained so it can be re-run if the pinned toolchain changes — but it is not a live bug, and **#211 is
+closed** on this evidence.
+
 ## Verdict
 
 The persistent-LSP swap is **not a free upgrade over batch `tsc`**: it trades the slow loop's

--- a/results/ts_lsp_multipush_probe.json
+++ b/results/ts_lsp_multipush_probe.json
@@ -1,0 +1,2352 @@
+{
+  "summary": {
+    "server_info": {},
+    "diagnostic_provider": null,
+    "pull_diagnostics_supported": false,
+    "settle_s": 3.5,
+    "max_wait_s": 15.0,
+    "n_candidates": 97,
+    "n_multi_push": 96,
+    "n_semantic_raced": 0,
+    "n_no_push": 0,
+    "max_pushes_single_candidate": 3,
+    "push_count_histogram": {
+      "1": 1,
+      "3": 96
+    },
+    "verdict": "MULTI_PUSH_NO_SEMANTIC_LOSS"
+  },
+  "candidates": [
+    {
+      "n_pushes": 1,
+      "push_ts": [
+        0.479
+      ],
+      "gaps": [],
+      "first_push_codes": [
+        "TS1109",
+        "TS2322"
+      ],
+      "final_codes": [
+        "TS1109",
+        "TS2322"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": false,
+      "got_any": true,
+      "id": "crafted:syntax+semantic"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3917,
+        2.6778,
+        2.7802
+      ],
+      "gaps": [
+        2.2861,
+        0.1024
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-001"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3704,
+        2.682,
+        2.785
+      ],
+      "gaps": [
+        2.3116,
+        0.103
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-002"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3648,
+        2.6864,
+        2.7864
+      ],
+      "gaps": [
+        2.3215,
+        0.1
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-003"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3829,
+        2.6691,
+        2.773
+      ],
+      "gaps": [
+        2.2862,
+        0.1039
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-004"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3698,
+        2.6708,
+        2.7696
+      ],
+      "gaps": [
+        2.301,
+        0.0988
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-005"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.4023,
+        2.6832,
+        2.7865
+      ],
+      "gaps": [
+        2.281,
+        0.1033
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-006"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3586,
+        2.6667,
+        2.7713
+      ],
+      "gaps": [
+        2.3081,
+        0.1046
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-007"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3599,
+        2.6689,
+        2.7701
+      ],
+      "gaps": [
+        2.3091,
+        0.1012
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-008"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3549,
+        2.664,
+        2.7655
+      ],
+      "gaps": [
+        2.3091,
+        0.1015
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-009"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3555,
+        2.6556,
+        2.7561
+      ],
+      "gaps": [
+        2.3001,
+        0.1005
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-010"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3631,
+        2.6686,
+        2.7677
+      ],
+      "gaps": [
+        2.3055,
+        0.0992
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-011"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3573,
+        2.6675,
+        2.7687
+      ],
+      "gaps": [
+        2.3101,
+        0.1013
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-012"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3671,
+        2.6795,
+        2.7851
+      ],
+      "gaps": [
+        2.3124,
+        0.1056
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-013"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3541,
+        2.6597,
+        2.7603
+      ],
+      "gaps": [
+        2.3056,
+        0.1006
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-014"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3545,
+        2.6645,
+        2.767
+      ],
+      "gaps": [
+        2.3101,
+        0.1025
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-015"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3549,
+        2.6729,
+        2.774
+      ],
+      "gaps": [
+        2.318,
+        0.1011
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-016"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.354,
+        2.6694,
+        2.7732
+      ],
+      "gaps": [
+        2.3153,
+        0.1038
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-017"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3638,
+        2.6665,
+        2.7723
+      ],
+      "gaps": [
+        2.3027,
+        0.1058
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-018"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3527,
+        2.665,
+        2.766
+      ],
+      "gaps": [
+        2.3123,
+        0.101
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-019"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3522,
+        2.6645,
+        2.7659
+      ],
+      "gaps": [
+        2.3123,
+        0.1014
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-020"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3593,
+        2.6669,
+        2.7705
+      ],
+      "gaps": [
+        2.3076,
+        0.1036
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-021"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3594,
+        2.6685,
+        2.7694
+      ],
+      "gaps": [
+        2.3091,
+        0.1009
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-022"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3564,
+        2.6636,
+        2.7649
+      ],
+      "gaps": [
+        2.3073,
+        0.1013
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-023"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3586,
+        2.666,
+        2.7696
+      ],
+      "gaps": [
+        2.3074,
+        0.1036
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-024"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3608,
+        2.6678,
+        2.7684
+      ],
+      "gaps": [
+        2.307,
+        0.1006
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-025"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3542,
+        2.665,
+        2.7634
+      ],
+      "gaps": [
+        2.3109,
+        0.0983
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-026"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3537,
+        2.666,
+        2.7672
+      ],
+      "gaps": [
+        2.3122,
+        0.1012
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-027"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.358,
+        2.6648,
+        2.7662
+      ],
+      "gaps": [
+        2.3069,
+        0.1014
+      ],
+      "first_push_codes": [
+        "TS2339"
+      ],
+      "final_codes": [
+        "TS2339"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "member-access-028"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3626,
+        2.6668,
+        2.7653
+      ],
+      "gaps": [
+        2.3043,
+        0.0985
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-001"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3554,
+        2.6641,
+        2.7689
+      ],
+      "gaps": [
+        2.3087,
+        0.1048
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-002"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3704,
+        2.6784,
+        2.7805
+      ],
+      "gaps": [
+        2.3081,
+        0.102
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-003"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3562,
+        2.6694,
+        2.7727
+      ],
+      "gaps": [
+        2.3132,
+        0.1034
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-004"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3654,
+        2.6786,
+        2.7824
+      ],
+      "gaps": [
+        2.3132,
+        0.1038
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-005"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3671,
+        2.6681,
+        2.7712
+      ],
+      "gaps": [
+        2.3011,
+        0.103
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-006"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3533,
+        2.6645,
+        2.7652
+      ],
+      "gaps": [
+        2.3111,
+        0.1007
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-007"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3545,
+        2.666,
+        2.767
+      ],
+      "gaps": [
+        2.3115,
+        0.1011
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-008"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3659,
+        2.6648,
+        2.7665
+      ],
+      "gaps": [
+        2.2989,
+        0.1017
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-009"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3542,
+        2.6648,
+        2.766
+      ],
+      "gaps": [
+        2.3106,
+        0.1012
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-010"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3546,
+        2.6645,
+        2.7679
+      ],
+      "gaps": [
+        2.3099,
+        0.1034
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-011"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3649,
+        2.6715,
+        2.7728
+      ],
+      "gaps": [
+        2.3066,
+        0.1013
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-012"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3549,
+        2.6636,
+        2.7638
+      ],
+      "gaps": [
+        2.3086,
+        0.1002
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-013"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3604,
+        2.664,
+        2.7624
+      ],
+      "gaps": [
+        2.3036,
+        0.0984
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-014"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3663,
+        2.6766,
+        2.7785
+      ],
+      "gaps": [
+        2.3103,
+        0.1019
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-015"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.358,
+        2.657,
+        2.7583
+      ],
+      "gaps": [
+        2.2989,
+        0.1013
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-016"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3544,
+        2.6645,
+        2.7659
+      ],
+      "gaps": [
+        2.3102,
+        0.1013
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-017"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3549,
+        2.6645,
+        2.7663
+      ],
+      "gaps": [
+        2.3096,
+        0.1018
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-018"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3538,
+        2.6629,
+        2.764
+      ],
+      "gaps": [
+        2.3091,
+        0.1012
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-019"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3532,
+        2.6646,
+        2.7668
+      ],
+      "gaps": [
+        2.3115,
+        0.1022
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-020"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3556,
+        2.6629,
+        2.7659
+      ],
+      "gaps": [
+        2.3073,
+        0.103
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-021"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3539,
+        2.6635,
+        2.7702
+      ],
+      "gaps": [
+        2.3096,
+        0.1068
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-022"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3596,
+        2.6703,
+        2.7714
+      ],
+      "gaps": [
+        2.3107,
+        0.1012
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-023"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3646,
+        2.6799,
+        2.7861
+      ],
+      "gaps": [
+        2.3153,
+        0.1062
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-024"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3703,
+        2.6772,
+        2.7849
+      ],
+      "gaps": [
+        2.3069,
+        0.1077
+      ],
+      "first_push_codes": [
+        "TS2304",
+        "TS6133"
+      ],
+      "final_codes": [
+        "TS2304",
+        "TS6133"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-025"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3576,
+        2.6733,
+        2.7747
+      ],
+      "gaps": [
+        2.3156,
+        0.1014
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-026"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3538,
+        2.6635,
+        2.764
+      ],
+      "gaps": [
+        2.3096,
+        0.1006
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-027"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3586,
+        2.6644,
+        2.7636
+      ],
+      "gaps": [
+        2.3059,
+        0.0991
+      ],
+      "first_push_codes": [
+        "TS2304"
+      ],
+      "final_codes": [
+        "TS2304"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "undefined-name-028"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3549,
+        2.6635,
+        2.7655
+      ],
+      "gaps": [
+        2.3086,
+        0.102
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-001"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3547,
+        2.669,
+        2.7733
+      ],
+      "gaps": [
+        2.3142,
+        0.1044
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-002"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3538,
+        2.6626,
+        2.7643
+      ],
+      "gaps": [
+        2.3088,
+        0.1017
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-003"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3668,
+        2.6831,
+        2.7827
+      ],
+      "gaps": [
+        2.3163,
+        0.0996
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-004"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3564,
+        2.6654,
+        2.7665
+      ],
+      "gaps": [
+        2.309,
+        0.1011
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-005"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.353,
+        2.6645,
+        2.7658
+      ],
+      "gaps": [
+        2.3115,
+        0.1013
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-006"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3555,
+        2.665,
+        2.7685
+      ],
+      "gaps": [
+        2.3096,
+        0.1035
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-007"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3539,
+        2.6678,
+        2.7732
+      ],
+      "gaps": [
+        2.3138,
+        0.1055
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-008"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3538,
+        2.6659,
+        2.7662
+      ],
+      "gaps": [
+        2.3122,
+        0.1002
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-009"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3535,
+        2.6649,
+        2.7647
+      ],
+      "gaps": [
+        2.3114,
+        0.0998
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-010"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3531,
+        2.6587,
+        2.7607
+      ],
+      "gaps": [
+        2.3057,
+        0.1019
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-011"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3555,
+        2.6652,
+        2.7659
+      ],
+      "gaps": [
+        2.3097,
+        0.1007
+      ],
+      "first_push_codes": [
+        "TS2554",
+        "TS6138"
+      ],
+      "final_codes": [
+        "TS2554",
+        "TS6138"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-012"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3544,
+        2.6658,
+        2.7671
+      ],
+      "gaps": [
+        2.3113,
+        0.1013
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-013"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3553,
+        2.6649,
+        2.7649
+      ],
+      "gaps": [
+        2.3096,
+        0.1
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-014"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3553,
+        2.6658,
+        2.7668
+      ],
+      "gaps": [
+        2.3104,
+        0.1011
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-015"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3551,
+        2.6658,
+        2.7672
+      ],
+      "gaps": [
+        2.3106,
+        0.1014
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-016"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3544,
+        2.6639,
+        2.7649
+      ],
+      "gaps": [
+        2.3095,
+        0.101
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-017"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3538,
+        2.6677,
+        2.7694
+      ],
+      "gaps": [
+        2.3139,
+        0.1017
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-018"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3585,
+        2.6743,
+        2.7745
+      ],
+      "gaps": [
+        2.3158,
+        0.1002
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-019"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3556,
+        2.6687,
+        2.7705
+      ],
+      "gaps": [
+        2.3131,
+        0.1018
+      ],
+      "first_push_codes": [
+        "TS2554",
+        "TS6133"
+      ],
+      "final_codes": [
+        "TS2554",
+        "TS6133"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-020"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3613,
+        2.6774,
+        2.7763
+      ],
+      "gaps": [
+        2.3161,
+        0.0989
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-021"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3698,
+        2.6603,
+        2.7618
+      ],
+      "gaps": [
+        2.2905,
+        0.1015
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-022"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3615,
+        2.6691,
+        2.7702
+      ],
+      "gaps": [
+        2.3076,
+        0.1012
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-023"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3582,
+        2.6754,
+        2.7807
+      ],
+      "gaps": [
+        2.3172,
+        0.1054
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-024"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3538,
+        2.6649,
+        2.767
+      ],
+      "gaps": [
+        2.3111,
+        0.1021
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-025"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3574,
+        2.6647,
+        2.7657
+      ],
+      "gaps": [
+        2.3073,
+        0.101
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-026"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3572,
+        2.6853,
+        2.7842
+      ],
+      "gaps": [
+        2.3281,
+        0.0989
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-027"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3622,
+        2.666,
+        2.7692
+      ],
+      "gaps": [
+        2.3038,
+        0.1032
+      ],
+      "first_push_codes": [
+        "TS2554"
+      ],
+      "final_codes": [
+        "TS2554"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "arity-mismatch-028"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3579,
+        2.6721,
+        2.7796
+      ],
+      "gaps": [
+        2.3142,
+        0.1075
+      ],
+      "first_push_codes": [
+        "TS1003"
+      ],
+      "final_codes": [
+        "TS1003"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-001"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3615,
+        2.6789,
+        2.7865
+      ],
+      "gaps": [
+        2.3174,
+        0.1076
+      ],
+      "first_push_codes": [
+        "TS1005"
+      ],
+      "final_codes": [
+        "TS1005"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-002"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3608,
+        2.6784,
+        2.7861
+      ],
+      "gaps": [
+        2.3176,
+        0.1077
+      ],
+      "first_push_codes": [
+        "TS1005"
+      ],
+      "final_codes": [
+        "TS1005"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-003"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3616,
+        2.6679,
+        2.7699
+      ],
+      "gaps": [
+        2.3063,
+        0.1021
+      ],
+      "first_push_codes": [
+        "TS1003"
+      ],
+      "final_codes": [
+        "TS1003"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-004"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3709,
+        2.6812,
+        2.7838
+      ],
+      "gaps": [
+        2.3103,
+        0.1026
+      ],
+      "first_push_codes": [
+        "TS1005"
+      ],
+      "final_codes": [
+        "TS1005"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-005"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3593,
+        2.682,
+        2.7788
+      ],
+      "gaps": [
+        2.3227,
+        0.0967
+      ],
+      "first_push_codes": [
+        "TS1003"
+      ],
+      "final_codes": [
+        "TS1003"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-006"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3591,
+        2.6672,
+        2.7729
+      ],
+      "gaps": [
+        2.3082,
+        0.1056
+      ],
+      "first_push_codes": [
+        "TS1005"
+      ],
+      "final_codes": [
+        "TS1005"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-007"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.362,
+        2.6694,
+        2.7716
+      ],
+      "gaps": [
+        2.3075,
+        0.1021
+      ],
+      "first_push_codes": [
+        "TS1003"
+      ],
+      "final_codes": [
+        "TS1003"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-008"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3609,
+        2.6731,
+        2.7761
+      ],
+      "gaps": [
+        2.3122,
+        0.103
+      ],
+      "first_push_codes": [
+        "TS1003"
+      ],
+      "final_codes": [
+        "TS1003"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-009"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3584,
+        2.6726,
+        2.7742
+      ],
+      "gaps": [
+        2.3142,
+        0.1016
+      ],
+      "first_push_codes": [
+        "TS1005"
+      ],
+      "final_codes": [
+        "TS1005"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-010"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3629,
+        2.6691,
+        2.7699
+      ],
+      "gaps": [
+        2.3062,
+        0.1008
+      ],
+      "first_push_codes": [
+        "TS1003"
+      ],
+      "final_codes": [
+        "TS1003"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-011"
+    },
+    {
+      "n_pushes": 3,
+      "push_ts": [
+        0.3631,
+        2.6814,
+        2.7844
+      ],
+      "gaps": [
+        2.3184,
+        0.103
+      ],
+      "first_push_codes": [
+        "TS1005"
+      ],
+      "final_codes": [
+        "TS1005"
+      ],
+      "later_only_codes": [],
+      "semantic_appeared_only_later": [],
+      "raced": false,
+      "multi_push": true,
+      "got_any": true,
+      "id": "clean-control-012"
+    }
+  ]
+}

--- a/scripts/probe_ts_lsp_multipush.py
+++ b/scripts/probe_ts_lsp_multipush.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Probe the TS-LSP oracle's `publishDiagnostics` timing (#211).
+
+`TsLspOracle.diagnostics()` arms a single `threading.Event` and returns on the
+**first** `textDocument/publishDiagnostics` push for a candidate URI, with no
+settle/quiescence window (unlike `OpengrepOracle._rescan`'s `_SETTLE_S`). If
+`typescript-language-server` publishes twice for one document -- a fast syntactic
+pass then a slower semantic pass -- the oracle would capture the early
+syntactic-only push and MISS the semantic `TS2xxx` codes, biasing measured LSP
+lift toward "finds nothing" and making the set timing-dependent.
+
+This script does NOT change production code. It re-opens the same candidates the
+oracle sees, but registers a list-append notification callback (not the one-shot
+Event) that records EVERY push for the URI -- monotonic timestamp + codes -- so we
+can measure: how many pushes arrive, their inter-arrival gaps, and whether a
+semantic (`TS2xxx`) code ever appears ONLY in a later push. It also captures the
+server's advertised `capabilities.diagnosticProvider` (present => LSP 3.17 pull
+diagnostics available), which decides the fix path if a race is confirmed.
+
+Stdlib + above-the-seam repo imports only (no mlx/torch). Skips cleanly with exit
+0 if no `typescript-language-server` toolchain is resolvable.
+
+Usage:
+    .venv/bin/python scripts/probe_ts_lsp_multipush.py \
+        --n 96 --out results/ts_lsp_multipush_probe.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Repo root on sys.path so `src.lsp.*` imports resolve when run as a script.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.lsp.jsonrpc import spawn  # noqa: E402
+from src.lsp.tsc import DEFAULT_TSCONFIG_PATH, SET_DIR  # noqa: E402
+from src.lsp.ts_lsp import resolve_ts_lsp  # noqa: E402
+
+EVAL_JSONL = SET_DIR / "eval.jsonl"
+
+# A crafted candidate carrying BOTH a syntactic defect (TS1xxx) and a distinct
+# semantic type error (TS2xxx), so a syntactic-only early push is unambiguously
+# distinguishable from the complete set. `const x: number = "s";` => TS2322
+# (semantic); `const y = ;` => TS1109 "Expression expected" (syntactic).
+CRAFTED_CANDIDATE = 'const x: number = "s";\nconst y = ;\n'
+
+
+def _codes(diags: List[dict]) -> List[str]:
+    """Format LSP integer codes the same way `_map_diagnostic` does (Trap A)."""
+    return [f"TS{d['code']}" for d in diags if "code" in d]
+
+
+def _is_semantic(code: str) -> bool:
+    """A committed semantic code (the race's victim): anything but the TS1xxx
+    syntax-incompleteness family."""
+    return code.startswith("TS") and not code.startswith("TS1")
+
+
+class _PushRecorder:
+    """Records every `publishDiagnostics` push per URI, with relative timestamps."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._t0: Dict[str, float] = {}
+        self.pushes: Dict[str, List[dict]] = {}   # uri -> [{t, codes, n, severities}]
+        self._active: set = set()
+
+    def arm(self, uri: str, t0: float) -> None:
+        with self._lock:
+            self._t0[uri] = t0
+            self.pushes[uri] = []
+            self._active.add(uri)
+
+    def disarm(self, uri: str) -> None:
+        with self._lock:
+            self._active.discard(uri)
+
+    def count(self, uri: str) -> int:
+        with self._lock:
+            return len(self.pushes.get(uri, []))
+
+    def on_notification(self, msg: dict) -> None:
+        if msg.get("method") != "textDocument/publishDiagnostics":
+            return
+        params = msg.get("params") or {}
+        uri = params.get("uri")
+        if uri is None:
+            return
+        with self._lock:
+            if uri not in self._active:
+                return
+            diags = params.get("diagnostics", [])
+            self.pushes[uri].append({
+                "t": time.monotonic() - self._t0[uri],
+                "codes": _codes(diags),
+                "severities": [d.get("severity", 1) for d in diags],
+                "n": len(diags),
+            })
+
+
+def _collect(recorder: _PushRecorder, uri: str, *, settle: float,
+             max_wait: float) -> None:
+    """Block until pushes for `uri` go quiet for `settle` seconds (after at least
+    one push) or `max_wait` total elapses -- deliberately capturing LATE pushes the
+    one-shot oracle would miss."""
+    start = time.monotonic()
+    last_n = 0
+    last_change = start
+    while True:
+        now = time.monotonic()
+        n = recorder.count(uri)
+        if n != last_n:
+            last_n = n
+            last_change = now
+        if n > 0 and (now - last_change) >= settle:
+            return
+        if (now - start) >= max_wait:
+            return
+        time.sleep(0.02)
+
+
+def _analyze_pushes(pushes: List[dict]) -> dict:
+    """Per-candidate verdict from its ordered push list."""
+    n_pushes = len(pushes)
+    first_codes = set(pushes[0]["codes"]) if pushes else set()
+    all_codes: set = set()
+    for p in pushes:
+        all_codes |= set(p["codes"])
+    later_only = sorted(all_codes - first_codes)
+    semantic_later_only = sorted(c for c in later_only if _is_semantic(c))
+    # Inter-arrival gaps between consecutive pushes.
+    gaps = [round(pushes[i]["t"] - pushes[i - 1]["t"], 4) for i in range(1, n_pushes)]
+    return {
+        "n_pushes": n_pushes,
+        "push_ts": [round(p["t"], 4) for p in pushes],
+        "gaps": gaps,
+        "first_push_codes": sorted(first_codes),
+        "final_codes": sorted(all_codes),
+        "later_only_codes": later_only,
+        "semantic_appeared_only_later": semantic_later_only,
+        "raced": bool(semantic_later_only),   # a semantic code the oracle would miss
+        "multi_push": n_pushes > 1,
+        "got_any": n_pushes > 0,
+    }
+
+
+def _open_and_collect(endpoint, recorder: _PushRecorder, scratch_dir: Path,
+                      cand_id: str, idx: int, source: str, *,
+                      settle: float, max_wait: float) -> dict:
+    path = scratch_dir / f"cand_{idx}.ts"
+    uri = path.as_uri()
+    t0 = time.monotonic()
+    recorder.arm(uri, t0)
+    path.write_text(source, encoding="utf-8")
+    endpoint.notify("textDocument/didOpen", {
+        "textDocument": {"uri": uri, "languageId": "typescript", "version": 1, "text": source},
+    })
+    _collect(recorder, uri, settle=settle, max_wait=max_wait)
+    endpoint.notify("textDocument/didClose", {"textDocument": {"uri": uri}})
+    recorder.disarm(uri)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    verdict = _analyze_pushes(recorder.pushes.get(uri, []))
+    verdict["id"] = cand_id
+    return verdict
+
+
+def _load_candidates(n: Optional[int]) -> List[Tuple[str, str]]:
+    """(id, source) pairs from the #194 set: prompt + error_completion (what the
+    oracle checks in production)."""
+    out: List[Tuple[str, str]] = []
+    if EVAL_JSONL.exists():
+        for line in EVAL_JSONL.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            out.append((str(rec.get("id", f"rec{len(out)}")),
+                        rec["prompt"] + rec["error_completion"]))
+    if n is not None:
+        out = out[:n]
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--n", type=int, default=None, help="max #194 candidates (default all)")
+    ap.add_argument("--out", type=str, default="results/ts_lsp_multipush_probe.json")
+    ap.add_argument("--settle", type=float, default=2.0,
+                    help="quiescence window (s) after the last push before moving on")
+    ap.add_argument("--max-wait", type=float, default=8.0,
+                    help="per-candidate wall cap (s)")
+    ap.add_argument("--timeout", type=float, default=10.0, help="server init timeout (s)")
+    args = ap.parse_args()
+
+    argv = resolve_ts_lsp()
+    if argv is None:
+        print("SKIP: no typescript-language-server toolchain resolvable "
+              f"(need `npm i -D typescript-language-server` in {SET_DIR}).")
+        return 0
+
+    recorder = _PushRecorder()
+    tmp = tempfile.TemporaryDirectory(dir=str(SET_DIR), prefix="lsp_probe_")
+    scratch_dir = Path(tmp.name)
+    (scratch_dir / "tsconfig.json").write_text(
+        DEFAULT_TSCONFIG_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+    proc, endpoint = spawn(argv + ["--stdio"], cwd=str(scratch_dir),
+                           on_notification=recorder.on_notification)
+    # Advertise BOTH push and pull client capabilities so the server reveals
+    # `diagnosticProvider` in its initialize result iff it supports pull.
+    init_result = endpoint.request("initialize", {
+        "processId": os.getpid(),
+        "rootUri": scratch_dir.as_uri(),
+        "capabilities": {"textDocument": {
+            "publishDiagnostics": {},
+            "diagnostic": {"dynamicRegistration": True, "relatedDocumentSupport": True},
+        }},
+        "initializationOptions": {},
+    }, timeout=args.timeout)
+    endpoint.notify("initialized", {})
+
+    server_caps = (init_result or {}).get("capabilities", {})
+    diagnostic_provider = server_caps.get("diagnosticProvider")
+    server_info = (init_result or {}).get("serverInfo", {})
+
+    results: List[dict] = []
+    try:
+        # The crafted both-defects candidate first (idx 0), clearly labelled.
+        results.append(_open_and_collect(
+            endpoint, recorder, scratch_dir, "crafted:syntax+semantic", 0,
+            CRAFTED_CANDIDATE, settle=args.settle, max_wait=args.max_wait))
+
+        for i, (cand_id, source) in enumerate(_load_candidates(args.n), start=1):
+            v = _open_and_collect(endpoint, recorder, scratch_dir, cand_id, i,
+                                  source, settle=args.settle, max_wait=args.max_wait)
+            results.append(v)
+    finally:
+        endpoint.close()
+        try:
+            proc.terminate()
+            proc.wait(timeout=5.0)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+        tmp.cleanup()
+
+    # Aggregate.
+    n_total = len(results)
+    n_multi = sum(1 for r in results if r["multi_push"])
+    n_raced = sum(1 for r in results if r["raced"])
+    n_no_push = sum(1 for r in results if not r["got_any"])
+    max_pushes = max((r["n_pushes"] for r in results), default=0)
+    push_hist: Dict[int, int] = {}
+    for r in results:
+        push_hist[r["n_pushes"]] = push_hist.get(r["n_pushes"], 0) + 1
+
+    summary = {
+        "server_info": server_info,
+        "diagnostic_provider": diagnostic_provider,
+        "pull_diagnostics_supported": diagnostic_provider is not None,
+        "settle_s": args.settle,
+        "max_wait_s": args.max_wait,
+        "n_candidates": n_total,
+        "n_multi_push": n_multi,
+        "n_semantic_raced": n_raced,
+        "n_no_push": n_no_push,
+        "max_pushes_single_candidate": max_pushes,
+        "push_count_histogram": {str(k): push_hist[k] for k in sorted(push_hist)},
+        "verdict": (
+            "MULTI_PUSH_RACE_CONFIRMED" if n_raced > 0 else
+            "MULTI_PUSH_NO_SEMANTIC_LOSS" if n_multi > 0 else
+            "SINGLE_COALESCED_PUSH"),
+    }
+
+    out_path = _REPO_ROOT / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(
+        {"summary": summary, "candidates": results}, indent=2), encoding="utf-8")
+
+    # Human-readable report.
+    print("=" * 72)
+    print("TS-LSP multi-push probe (#211)")
+    print("=" * 72)
+    print(f"server:              {server_info.get('name','?')} {server_info.get('version','?')}")
+    print(f"diagnosticProvider:  {diagnostic_provider!r}")
+    print(f"  -> pull diagnostics (textDocument/diagnostic) supported: "
+          f"{summary['pull_diagnostics_supported']}")
+    print(f"settle / max_wait:   {args.settle}s / {args.max_wait}s")
+    print(f"candidates probed:   {n_total} (1 crafted + {n_total-1} from #194)")
+    print(f"push-count histogram (n_pushes: count): {summary['push_count_histogram']}")
+    print(f"max pushes for one candidate: {max_pushes}")
+    print(f"multi-push candidates:        {n_multi}")
+    print(f"SEMANTIC codes seen ONLY in a later push (the race): {n_raced}")
+    print(f"no-push (would time out):     {n_no_push}")
+    print(f"VERDICT: {summary['verdict']}")
+    crafted = results[0]
+    print("-" * 72)
+    print(f"crafted candidate: n_pushes={crafted['n_pushes']} "
+          f"first={crafted['first_push_codes']} final={crafted['final_codes']} "
+          f"semantic_later_only={crafted['semantic_appeared_only_later']}")
+    if n_raced > 0:
+        print("-" * 72)
+        print("Raced candidates (semantic code the one-shot oracle would MISS):")
+        for r in results:
+            if r["raced"]:
+                print(f"  {r['id']}: pushes={r['n_pushes']} gaps={r['gaps']} "
+                      f"missed={r['semantic_appeared_only_later']}")
+    print("=" * 72)
+    print(f"wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Validates the TS-LSP oracle's diagnostic completeness (#211). `TsLspOracle.diagnostics()` returns on the **first** `publishDiagnostics` push with no settle window; the concern was that a server front-loading a syntactic-only push (then a slower semantic pass) would make the oracle miss semantic `TS2xxx` codes — biasing measured LSP lift and corrupting the phases that trust the set (#201 ablation, #203 diffusion discriminator).

**Probed, not assumed.** New `scripts/probe_ts_lsp_multipush.py` re-opens each candidate the oracle sees, records **every** push per URI (timestamp + codes), and captures the server's `capabilities.diagnosticProvider`. Run over the whole #194 set (96 records, all 4 error classes) + a crafted candidate carrying **both** a syntactic (`TS1109`) and a semantic (`TS2322`) defect, with a settle window wide enough to catch late pushes.

## Finding → no production change needed

| Signal | Result |
|---|---|
| First push ≠ final union of all pushes | **0 / 97** |
| Semantic code appeared only in a later push (the race) | **0 / 97** |
| Later push added *any* code | **0 / 97** |
| Crafted syntax+semantic candidate | **1 push**, `TS1109` + `TS2322` together |
| `diagnosticProvider` (pull diagnostics) | **absent** on ts-language-server 5.3.0 |

The pinned server emits up to 3 pushes/document, but the **first push is always semantically complete** — pushes 2–3 are idempotent re-publishes. First-push-wins is correct as written. The race is **latent** (a risk only for a different server/config), not a live bug; the probe is retained to re-run if the toolchain changes.

## Changes
- `scripts/probe_ts_lsp_multipush.py` — timing/completeness probe (stdlib + above-seam only, skips cleanly without the toolchain).
- `results/ts_lsp_multipush_probe.json` — recorded finding.
- `docs/design/12-lsp-in-the-loop.md` — Stage A oracle section: probe result + resolution.

No source change; no behavior change. `pytest tests/test_ts_lsp.py tests/test_import_guard.py tests/test_lsp_diagnostics.py` green (51 passed).

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)