### PR TITLE
fix(lsp): defer forward-resolvable TS2xxx on non-final block segments (#201)

### DIFF
--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -535,8 +535,41 @@ surfaces — transient committed **`TS2xxx`** semantic codes (e.g. `TS2395` "mer
 all exported or all local") on incomplete multi-segment code, which flow through the normal filter
 (not the `TS1xxx`-only reinstatement) and still trigger rollbacks. On the exemplar `clean-prefix-0020`
 the `TS1146` chasing is gone (5→0) but the trajectory now chases `TS2395`. Extending the same
-"final-segment / transient" reasoning to committed `TS2xxx` is the next hardening step; raw
-over-repair (0.215) won't fall to zero until it's addressed.
+"final-segment / transient" reasoning to committed `TS2xxx` is the next hardening step — done below.
+
+### Forward-resolvable `TS2xxx` deferral — second hardening pass (#201)
+
+Symmetric with the `TS1xxx` final-segment gate, `FORWARD_RESOLVABLE_CODES = {TS2395, TS2449}` are
+**deferred on non-final block segments only** (`diagnostics.py` constant, `harness.py` gate): both are
+artifacts of a not-yet-generated later top-level construct — `TS2395` fires until all merge partners
+are generated, `TS2449` ("used before its declaration") is a forward reference resolved by hoisting —
+so they self-resolve as generation continues. The `cannot-find-name` family (`TS2304`/`TS2552`) is
+**deliberately excluded**: it is the loop's core error-catching competency (and the #194 injected-error
+set's staple), so deferring it would blunt the mechanism to chase a metric. On the final segment these
+codes pass through `filter_diagnostics` unchanged and are still caught.
+
+Re-measured, same protocol (`results/e4_overrepair_realcode_fix2.json`, `results/f1_ts_fix2.json`):
+
+| | before (gate only) | after `TS2xxx` deferral |
+|---|---|---|
+| #201 slow-hard `over_repair_rate` (raw) | 0.215 | **0.215 (flat)** |
+| #201 slow-hard total rollbacks | 161 | **149** |
+| #201 broken-row set (of 200) | 157 rows | **the same 157 rows** (0 flipped either way) |
+| #199 F1 slow-hard clean-rate / pass@1 | 0.962 / 0.503 | **0.962 / 0.503 (byte-identical)** |
+
+**The finding — over-repair on multi-statement real code is *trajectory-bound*, not *trigger-bound*.**
+The deferral does exactly what it says at the event level — `TS2395` repair triggers halve (20→10 on
+slow-hard) — but the aggregate does not move: deferring the early `TS2395` rollback lets generation
+continue down a different path that surfaces an equivalent diagnostic downstream (`TS2449` triggers
+rise 2→16), and **every one of the 200 rows lands in the identical clean/broken state**. So trimming
+the clearly-forward-resolvable subset of triggers is **correct, principled, zero-F1-cost hardening**
+(shipped — it removes provably-spurious rollbacks and is symmetric with #212), but it is **not a lever
+that moves the over-repair metric**. Incremental per-segment repair over-fires on multi-top-level-
+statement code as a structural property of the trajectory, not of any particular code family; the
+signal that would actually close this gap lives in the semantic/training axis (the #201 AR-harness
+ablation on a *trained* model, and the #103 LSP-verifier reward), not in further diagnostic-code
+allowlisting. Chasing zero by deferring `cannot-find-name` would only trade the loop's error-catching
+for a metric that, on this evidence, would not even move.
 
 ## Risks realized (see the original plan for the full list)
 

--- a/results/e4_overrepair_realcode_fix2.json
+++ b/results/e4_overrepair_realcode_fix2.json
@@ -1,0 +1,197 @@
+{
+  "model": "mlx-community/Qwen2.5-Coder-1.5B-bf16",
+  "dtype": null,
+  "set": "eval_sets/ts_error_injection/clean_prefixes.jsonl",
+  "n_records": 200,
+  "budget": "block",
+  "block_size": 256,
+  "temperature": 0.0,
+  "seed": 0,
+  "strip_suggestions": false,
+  "oracle": "ts",
+  "sources_active": [
+    "ts"
+  ],
+  "summaries": {
+    "baseline": {
+      "n": 200,
+      "diagnostic_clean_rate": 0.18,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.0,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 200,
+      "total_n_forward_tokens": 39064,
+      "mean_n_forward_tokens": 195.32,
+      "total_n_forward_tokens_nocache": 39064,
+      "mean_n_forward_tokens_nocache": 195.32,
+      "total_n_generated_tokens": 26235,
+      "mean_n_generated_tokens": 131.175,
+      "total_n_tsc_calls": 0,
+      "mean_n_tsc_calls": 0.0,
+      "total_n_rollbacks": 0,
+      "mean_n_rollbacks": 0.0,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 0,
+      "mean_n_retries": 0.0,
+      "total_wall_s": 652.2659224095987,
+      "mean_wall_s": 3.2613296120479935,
+      "total_tsc_wall_s": 0.0,
+      "mean_tsc_wall_s": 0.0,
+      "extraction_failure_rate": 0.0,
+      "rollback_paths": {
+        "trim": 0,
+        "reprefill": 0,
+        "snapshot": 0,
+        "reprefill_tokens": 0
+      },
+      "snapshot_bytes": 2494464
+    },
+    "slow-hard": {
+      "n": 200,
+      "diagnostic_clean_rate": 0.215,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.215,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 200,
+      "total_n_forward_tokens": 212577,
+      "mean_n_forward_tokens": 1062.885,
+      "total_n_forward_tokens_nocache": 241463,
+      "mean_n_forward_tokens_nocache": 1207.315,
+      "total_n_generated_tokens": 25123,
+      "mean_n_generated_tokens": 125.615,
+      "total_n_tsc_calls": 1562,
+      "mean_n_tsc_calls": 7.81,
+      "total_n_rollbacks": 149,
+      "mean_n_rollbacks": 0.745,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 194,
+      "mean_n_retries": 0.97,
+      "total_wall_s": 1608.6857341653667,
+      "mean_wall_s": 8.043428670826835,
+      "total_tsc_wall_s": 561.9203289876459,
+      "mean_tsc_wall_s": 2.8096016449382297,
+      "extraction_failure_rate": 0.0,
+      "rollback_paths": {
+        "trim": 149,
+        "reprefill": 0,
+        "snapshot": 0,
+        "reprefill_tokens": 0
+      },
+      "snapshot_bytes": 2494464
+    },
+    "slow-both": {
+      "n": 200,
+      "diagnostic_clean_rate": 0.225,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.01,
+      "over_repair_rate": 0.215,
+      "no_progress_rate": 0.26666666666666666,
+      "suggestion_leak_rate": 0.06666666666666667,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 200,
+      "total_n_forward_tokens": 217801,
+      "mean_n_forward_tokens": 1089.005,
+      "total_n_forward_tokens_nocache": 246441,
+      "mean_n_forward_tokens_nocache": 1232.205,
+      "total_n_generated_tokens": 25049,
+      "mean_n_generated_tokens": 125.245,
+      "total_n_tsc_calls": 1574,
+      "mean_n_tsc_calls": 7.87,
+      "total_n_rollbacks": 146,
+      "mean_n_rollbacks": 0.73,
+      "total_n_soft_repairs": 15,
+      "mean_n_soft_repairs": 0.075,
+      "total_n_retries": 200,
+      "mean_n_retries": 1.0,
+      "total_wall_s": 1665.8822966715088,
+      "mean_wall_s": 8.329411483357545,
+      "total_tsc_wall_s": 567.5421185323503,
+      "mean_tsc_wall_s": 2.8377105926617516,
+      "extraction_failure_rate": 0.0,
+      "rollback_paths": {
+        "trim": 295,
+        "reprefill": 0,
+        "snapshot": 0,
+        "reprefill_tokens": 0
+      },
+      "snapshot_bytes": 2494464
+    }
+  },
+  "comparisons": {
+    "slow-hard": {
+      "avoided_vs_baseline": {
+        "n": 0,
+        "key": "avoided",
+        "table": {
+          "both_true": 0,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 0,
+          "both_false": 0
+        },
+        "baseline_rate": NaN,
+        "other_rate": NaN,
+        "mcnemar_p": 1.0,
+        "flip_to_true_rate": NaN,
+        "flip_to_false_rate": NaN
+      },
+      "clean_vs_baseline": {
+        "n": 200,
+        "key": "clean",
+        "table": {
+          "both_true": 28,
+          "baseline_true_other_false": 8,
+          "baseline_false_other_true": 15,
+          "both_false": 149
+        },
+        "baseline_rate": 0.18,
+        "other_rate": 0.215,
+        "mcnemar_p": 0.21003961563110352,
+        "flip_to_true_rate": 0.09146341463414634,
+        "flip_to_false_rate": 0.2222222222222222
+      }
+    },
+    "slow-both": {
+      "avoided_vs_baseline": {
+        "n": 0,
+        "key": "avoided",
+        "table": {
+          "both_true": 0,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 0,
+          "both_false": 0
+        },
+        "baseline_rate": NaN,
+        "other_rate": NaN,
+        "mcnemar_p": 1.0,
+        "flip_to_true_rate": NaN,
+        "flip_to_false_rate": NaN
+      },
+      "clean_vs_baseline": {
+        "n": 200,
+        "key": "clean",
+        "table": {
+          "both_true": 29,
+          "baseline_true_other_false": 7,
+          "baseline_false_other_true": 16,
+          "both_false": 148
+        },
+        "baseline_rate": 0.18,
+        "other_rate": 0.225,
+        "mcnemar_p": 0.0931396484375,
+        "flip_to_true_rate": 0.0975609756097561,
+        "flip_to_false_rate": 0.19444444444444445
+      }
+    }
+  },
+  "tsc_n_calls_total": 3736,
+  "tsc_wall_s_total": 1342.2244357852032,
+  "wall_s_total": 4144.027798166033
+}

--- a/results/f1_ts_fix2.json
+++ b/results/f1_ts_fix2.json
@@ -1,0 +1,111 @@
+{
+  "model": "mlx-community/Qwen2.5-Coder-1.5B-bf16",
+  "set": "eval_sets/humaneval_ts/humaneval_ts.jsonl",
+  "n_records": 159,
+  "block_size": 256,
+  "temperature": 0.0,
+  "seed": 0,
+  "functional": true,
+  "oracle": "ts",
+  "sources_active": [
+    "ts"
+  ],
+  "summaries": {
+    "baseline": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.8867924528301887,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.0,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 34814,
+      "mean_n_forward_tokens": 218.9559748427673,
+      "total_n_forward_tokens_nocache": 34814,
+      "mean_n_forward_tokens_nocache": 218.9559748427673,
+      "total_n_generated_tokens": 13879,
+      "mean_n_generated_tokens": 87.28930817610063,
+      "total_n_tsc_calls": 0,
+      "mean_n_tsc_calls": 0.0,
+      "total_n_rollbacks": 0,
+      "mean_n_rollbacks": 0.0,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 0,
+      "mean_n_retries": 0.0,
+      "total_wall_s": 352.0727293791715,
+      "mean_wall_s": 2.2142938954664872,
+      "total_tsc_wall_s": 0.0,
+      "mean_tsc_wall_s": 0.0,
+      "functional_pass_at_1": 0.49056603773584906
+    },
+    "slow-hard": {
+      "n": 159,
+      "diagnostic_clean_rate": 0.9622641509433962,
+      "error_avoidance_rate": NaN,
+      "exact_gold_rate": 0.0,
+      "over_repair_rate": 0.10062893081761007,
+      "no_progress_rate": NaN,
+      "suggestion_leak_rate": NaN,
+      "n_error_rows": 0,
+      "n_clean_control_rows": 159,
+      "total_n_forward_tokens": 224309,
+      "mean_n_forward_tokens": 1410.748427672956,
+      "total_n_forward_tokens_nocache": 233621,
+      "mean_n_forward_tokens_nocache": 1469.314465408805,
+      "total_n_generated_tokens": 15020,
+      "mean_n_generated_tokens": 94.46540880503144,
+      "total_n_tsc_calls": 1073,
+      "mean_n_tsc_calls": 6.748427672955975,
+      "total_n_rollbacks": 33,
+      "mean_n_rollbacks": 0.20754716981132076,
+      "total_n_soft_repairs": 0,
+      "mean_n_soft_repairs": 0.0,
+      "total_n_retries": 33,
+      "mean_n_retries": 0.20754716981132076,
+      "total_wall_s": 1052.627808836638,
+      "mean_wall_s": 6.620300684507157,
+      "total_tsc_wall_s": 382.9919900565874,
+      "mean_tsc_wall_s": 2.4087546544439458,
+      "functional_pass_at_1": 0.5031446540880503
+    }
+  },
+  "comparisons": {
+    "slow-hard": {
+      "clean_vs_baseline": {
+        "n": 159,
+        "key": "clean",
+        "table": {
+          "both_true": 141,
+          "baseline_true_other_false": 0,
+          "baseline_false_other_true": 12,
+          "both_false": 6
+        },
+        "baseline_rate": 0.8867924528301887,
+        "other_rate": 0.9622641509433962,
+        "mcnemar_p": 0.00048828125,
+        "flip_to_true_rate": 0.6666666666666666,
+        "flip_to_false_rate": 0.0
+      },
+      "functional_vs_baseline": {
+        "n": 159,
+        "key": "functional_pass",
+        "table": {
+          "both_true": 76,
+          "baseline_true_other_false": 2,
+          "baseline_false_other_true": 4,
+          "both_false": 77
+        },
+        "baseline_rate": 0.49056603773584906,
+        "other_rate": 0.5031446540880503,
+        "mcnemar_p": 0.6875,
+        "flip_to_true_rate": 0.04938271604938271,
+        "flip_to_false_rate": 0.02564102564102564
+      }
+    }
+  },
+  "tsc_wall_s_total": 496.89738815726014,
+  "wall_s_total": 1661.571378958004
+}

--- a/src/lsp/diagnostics.py
+++ b/src/lsp/diagnostics.py
@@ -74,6 +74,30 @@ _TS1XXX_RE = re.compile(r"^TS1\d{3}$")
 # `is_incomplete` tells apart "still typing" TS1xxx from a genuine defect.
 _CONTROL_FLOW_COMPLETENESS_CODES = frozenset({"TS2355", "TS2366"})
 
+# Forward-resolvable semantic codes (#201, second hardening pass — the sibling of
+# `_CONTROL_FLOW_COMPLETENESS_CODES` for TS2xxx). #212's final-segment gate cut the
+# transient-TS1xxx over-repair and surfaced a second source: committed TS2xxx
+# *semantic* codes that fire only because a LATER top-level construct hasn't been
+# generated yet, and self-resolve as generation continues. On multi-top-level-
+# statement real code (forward references, hoisting, merged declarations) a
+# diagnostic committed at segment k is routinely resolved by segment k+1 — the same
+# greedy generation reaches a clean final artifact, so the loop's rollback is pure
+# over-repair. The harness defers these on NON-FINAL block segments only (symmetric
+# with #212's TS1xxx final-segment reinstatement); on the final segment they pass
+# through `filter_diagnostics` unchanged and are still caught.
+#
+# Deliberately NARROW — each member is an artifact of a not-yet-generated later
+# construct, NOT a genuine defect:
+#   - TS2395 "individual declarations in merged declaration must be all exported or
+#     all local" — fires until all merge partners are generated.
+#   - TS2449 "class/block-scoped variable used before its declaration" — a forward
+#     reference resolved when the declaration is generated later (hoisting).
+# The `cannot-find-name` family (TS2304/TS2552) is EXCLUDED on purpose: it is the
+# loop's core error-catching competency (and the #194 injected-error set's staple),
+# so deferring it would blunt the mechanism to chase a metric. TS7006 (noImplicitAny
+# lint) and TS2366 (already in _CONTROL_FLOW_COMPLETENESS_CODES) are also out.
+FORWARD_RESOLVABLE_CODES = frozenset({"TS2395", "TS2449"})
+
 # Module-resolution diagnostics. Real TypeScript `import`s things, and under the
 # pinned isolated tsconfig those raise TS2307 ("cannot find module") etc. For the
 # real-code over-repair probe (#201) the files are selected to compile clean *ignoring*

--- a/src/lsp/harness.py
+++ b/src/lsp/harness.py
@@ -42,9 +42,9 @@ from typing import Callable, Dict, List, Optional, Sequence, Tuple
 import numpy as np
 
 from ..serve.sampling import sample
-from .diagnostics import (Diagnostic, SUPPRESSION_RE, close_open_delimiters,
-                           filter_diagnostics, is_incomplete, is_source_balanced,
-                           statement_boundary, strip_suggestion)
+from .diagnostics import (Diagnostic, FORWARD_RESOLVABLE_CODES, SUPPRESSION_RE,
+                           close_open_delimiters, filter_diagnostics, is_incomplete,
+                           is_source_balanced, statement_boundary, strip_suggestion)
 from .lm import LMAdapter, token_index_at
 
 DiagnoseFn = Callable[[str], List[Diagnostic]]
@@ -462,6 +462,17 @@ def generate_slow_loop(
             raw = _diag(source)
             filtered = filter_diagnostics(raw, frontier=frontier, generation_start=segment_start,
                                           source=source)
+            if not is_final_segment:
+                # Symmetric with the TS1xxx reinstatement below (#201/#212): a committed
+                # forward-resolvable TS2xxx (merged-declaration / used-before-declaration)
+                # at an INTERMEDIATE boundary is an artifact of a later top-level construct
+                # not yet generated, so it self-resolves as generation continues -- rolling
+                # back on it is over-repair. Defer it here, on non-final segments only; on
+                # the final segment it flows through `filter_diagnostics` unchanged above
+                # and is still caught. `filter_diagnostics` stays is_final_segment-agnostic;
+                # the harness owns that signal. (Mutually exclusive with the block below,
+                # which fires only when is_final_segment is True.)
+                filtered = [d for d in filtered if d.code not in FORWARD_RESOLVABLE_CODES]
             if hit_boundary and not filtered and is_source_balanced(source) and is_final_segment:
                 # filter_diagnostics unconditionally drops TS1xxx as mid-generation
                 # "still typing" noise -- correct while more tokens might still be

--- a/tests/test_lsp_diagnostics.py
+++ b/tests/test_lsp_diagnostics.py
@@ -6,7 +6,8 @@ Real-compiler format pinning lives in `test_lsp_tsc.py`; this file only exercise
 
 from __future__ import annotations
 
-from src.lsp.diagnostics import (Diagnostic, MODULE_RESOLUTION_CODES, SUPPRESSION_RE,
+from src.lsp.diagnostics import (Diagnostic, FORWARD_RESOLVABLE_CODES,
+                                  MODULE_RESOLUTION_CODES, SUPPRESSION_RE,
                                   close_open_delimiters, drop_codes, filter_diagnostics,
                                   is_incomplete, is_source_balanced, line_col_to_offset,
                                   parse_tsc_output, statement_boundary, strip_suggestion)
@@ -309,6 +310,18 @@ def test_module_resolution_codes_membership():
     assert "TS2305" in MODULE_RESOLUTION_CODES        # no exported member
     # A genuine type error is NOT in the ignore set.
     assert "TS2339" not in MODULE_RESOLUTION_CODES     # property does not exist
+
+
+def test_forward_resolvable_codes_membership():
+    # #201 second hardening pass: codes whose firing is an artifact of a not-yet-generated
+    # later top-level construct (deferred on non-final block segments by the harness).
+    assert "TS2395" in FORWARD_RESOLVABLE_CODES        # merged-declaration export mismatch
+    assert "TS2449" in FORWARD_RESOLVABLE_CODES        # used before its declaration (hoisting)
+    # The cannot-find-name family is DELIBERATELY EXCLUDED (the loop's core error-catching
+    # competency), as is the noImplicitAny lint.
+    assert "TS2304" not in FORWARD_RESOLVABLE_CODES     # cannot find name
+    assert "TS2552" not in FORWARD_RESOLVABLE_CODES     # cannot find name (did you mean)
+    assert "TS7006" not in FORWARD_RESOLVABLE_CODES     # parameter implicitly 'any' (lint)
 
 
 def test_drop_codes_filters_only_the_named_codes():

--- a/tests/test_lsp_harness.py
+++ b/tests/test_lsp_harness.py
@@ -250,6 +250,68 @@ def test_stmt_budget_still_reinstates_genuine_ts1xxx():
     assert result.n_rollbacks > 0 or result.unrepaired is True
 
 
+# --------------------------------------------------------------------------- #
+# forward-resolvable committed-TS2xxx deferral: non-final block segments (#201)
+# --------------------------------------------------------------------------- #
+
+def _merged_decl_diag(source: str) -> List[Diagnostic]:
+    """A forward-resolvable TS2395 that fires while a merged declaration's later
+    partner hasn't been generated yet -- a *transient* semantic code the next
+    segment resolves (mirrors `export const Foo` before its `namespace Foo` merge
+    partner). Unlike a TS1xxx, `filter_diagnostics` does NOT drop it, so pre-fix it
+    reaches the rollback path at an intermediate boundary (over-repair)."""
+    i = source.find("Foo")
+    if i == -1 or "namespace" in source:
+        return []
+    return [Diagnostic(code="TS2395", line=1, col=i + 1,
+                        message="merged declaration must be all exported or all local",
+                        offset=i)]
+
+
+def test_forward_resolvable_ts2xxx_deferred_on_non_final_segment():
+    # Segment 1 ("export const Foo\n") commits a TS2395 at a balanced boundary with block
+    # budget headroom; segment 2 ("namespace Foo {}\n") generates the merge partner and the
+    # TS2395 vanishes. Non-final segment => the forward-resolvable code is DEFERRED, not
+    # rolled back. Fails on pre-fix code: TS2395 isn't a TS1xxx, so filter_diagnostics keeps
+    # it and the loop over-repairs the still-forming declaration.
+    lm = ScriptedFakeLM(_linear_script("export const Foo\n"),
+                        alt_script=_linear_script("namespace Foo {}\n"),
+                        alt_trigger="export const Foo")
+    result = generate_slow_loop(lm, _merged_decl_diag, "", repair="hard",
+                                 budget="block", block_size=34, max_retries=5)
+    assert result.n_rollbacks == 0                    # forward-resolvable code was deferred
+    assert "export const Foo" in result.completion    # generation continued past segment 1
+    assert "namespace Foo" in result.completion        # the merge partner was generated
+
+
+def test_forward_resolvable_ts2xxx_still_caught_on_final_segment():
+    # The SAME forward-resolvable code at the block's FINAL segment (budget exhausts on a
+    # one-token boundary segment) must still be caught -- deferral is non-final-only. The
+    # merge partner never comes (persistent TS2395), so on the final segment the loop acts.
+    persistent = lambda source: (
+        [Diagnostic(code="TS2395", line=1, col=1,
+                    message="merged declaration must be all exported or all local",
+                    offset=source.find("Foo"))] if "Foo" in source else [])
+    lm = ScriptedFakeLM(_linear_script(";\n"))         # first token ';' is a boundary
+    result = generate_slow_loop(lm, persistent, "export const Foo", repair="hard",
+                                 budget="block", block_size=1, max_retries=3)
+    # is_final_segment is True (this one boundary segment exhausts block_size=1), so the
+    # committed TS2395 is NOT deferred -> the loop acts on it (rolls back or gives up).
+    assert result.n_rollbacks > 0 or result.unrepaired is True
+
+
+def test_cannot_find_name_still_repaired_on_non_final_segment():
+    # TS2304 (cannot-find-name) is DELIBERATELY EXCLUDED from FORWARD_RESOLVABLE_CODES: it is
+    # the loop's core error-catching competency, so it must STILL be rolled back at an
+    # intermediate (non-final) boundary even though it's a committed TS2xxx. Guards that the
+    # non-final deferral does not leak into the excluded family.
+    lm = ScriptedFakeLM(_linear_script("bad\n"))
+    diagnose = _contains_diagnose("bad", code="TS2304")
+    result = generate_slow_loop(lm, diagnose, "", repair="hard",
+                                 budget="block", block_size=6, max_retries=3)
+    assert result.n_rollbacks > 0                     # the excluded family is still caught early
+
+
 def test_suppression_hack_with_no_diagnostic_does_not_crash():
     # A suppression hack (`as any`) makes `_is_clean` return False, but the diagnose
     # fn reports NO diagnostics -> `filtered` is empty. Hard repair is diagnostic-guided


### PR DESCRIPTION
## Summary

Second hardening pass on slow-loop over-repair (#201), following #212's `TS1xxx` final-segment gate. #212 surfaced a residual source: committed **`TS2xxx`** *semantic* codes that fire on incomplete multi-top-level-statement real code (forward references, hoisting, merged declarations) and — unlike `TS1xxx` — flow through `filter_diagnostics` and still trigger rollbacks.

Adds `FORWARD_RESOLVABLE_CODES = {TS2395, TS2449}`, deferred on **non-final block segments only** (symmetric with #212): they're artifacts of a not-yet-generated later construct, so they self-resolve as generation continues. On the final segment they pass through unchanged and are still caught. The `cannot-find-name` family (`TS2304`/`TS2552`) is **deliberately excluded** — it's the loop's core error-catching competency. `filter_diagnostics` stays `is_final_segment`-agnostic; the harness owns that signal.

## Re-measure (the go/no-go)

**F1 HARD GUARD — byte-identical** (`results/f1_ts_fix2.json`): slow-hard clean-rate **0.962** / pass@1 **0.503** unchanged vs `results/f1_ts.json`. The deferral never fires on single-function HumanEval-TS bodies (unbalanced at intermediate boundaries), so the whole F1 run is unchanged — exactly as #212 was. **Zero F1 cost.**

**Over-repair** (`results/e4_overrepair_realcode_fix2.json`, #201 clean-prefix set):

| | gate only | + TS2xxx deferral |
|---|---|---|
| slow-hard `over_repair_rate` (raw) | 0.215 | **0.215 (flat)** |
| slow-hard total rollbacks | 161 | **149** |
| broken-row set (of 200) | 157 | **same 157** (0 flipped) |

### Honest finding: over-repair here is *trajectory-bound*, not *trigger-bound*

The deferral halves `TS2395` repair triggers (20→10) but the aggregate doesn't move: deferring the early rollback lets generation continue down a path that surfaces an equivalent diagnostic downstream (`TS2449` rises 2→16), and **every one of the 200 rows lands in the identical clean/broken state**. So this is **correct, principled, zero-F1-cost hardening** (removes provably-spurious rollbacks; symmetric with #212) — but not a lever that moves the over-repair metric. The gap-closing signal lives in the semantic/training axis (the #201 AR-harness ablation on a *trained* model, and #103 LSP-verifier reward), not in further diagnostic-code allowlisting.

## Changes
- `src/lsp/diagnostics.py` — `FORWARD_RESOLVABLE_CODES` constant + structural rationale.
- `src/lsp/harness.py` — deferral gate in `generate_slow_loop` (non-final segments only).
- `tests/test_lsp_harness.py`, `tests/test_lsp_diagnostics.py` — 4 tests: deferral on a non-final boundary (fails pre-fix), still-caught on the final segment, excluded `cannot-find-name` family still repaired, membership.
- `docs/design/12-lsp-in-the-loop.md`, `results/*fix2.json` — re-measure + finding.

Full suite green (828 passed, 6 skipped) + seam guard.

Refs #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)