### PR TITLE
docs: reframe M10/distillation → M12 code model (MoE spine + SSI)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 A proof-of-concept **Mamba-2 hybrid** (selective state-space + a few attention layers)
 language model, developed and validated on **Apple Silicon with MLX**, architected behind
 **one hardware seam** so it migrates to **CUDA** for a larger run with minimal rewrite. The
-active program is to **distil** a compact **~1B** hybrid student from a larger frozen teacher
-(`Qwen/Qwen3-4B-Thinking-2507`, Qwen3 tokenizer ~151,669; thinking-mode CoT is the headline lever),
-sweep a few architecture layouts cheaply, then post-train the winner for reasoning — tracked in
-[issue #65](https://github.com/travisgalloway/monica/issues/65). The original from-scratch
-pretrain path (OLMo tokenizer) is complete and is the validated foundation / production reserve.
-POC success is a smoothly decreasing held-out validation-perplexity curve plus a local-hardware
-win (context length + tok/s) — not benchmark scores.
+**active program is M12** — a from-scratch, **TypeScript-first Mamba-2 hybrid Mixture-of-Experts
+(MoE) code model** (the "MHM" spine): a mostly Mamba-2/SSD backbone with ~12.5% attention layers
+for cross-file recall and Jamba-style MoE on the MLPs, trained on a general multilingual
+Essential-Web + Stack-v2 corpus with its own byte-level BPE and FIM, at two sizes (small
+~120M-active/700M-total; large "Large A" ~700M-active/3.5B-total, sparse-upcycled from the small
+dense checkpoint). A **secondary axis (SSI)** studies feeding language-server / static-analysis
+signal into the model — a *validated clean-rate tool with a found functional ceiling*, not the
+lever for functional correctness (see `docs/design/13-code-model-moe.md`). Tracked in
+[issue #198](https://github.com/travisgalloway/monica/issues/198); design record in
+`docs/design/13-code-model-moe.md`. **Reserve/history:** the M10 distillation program (distil a
+~1B student from a frozen `Qwen/Qwen3-4B-Thinking-2507` teacher, #65) was dropped 2026-07-19 — its
+machinery is built and its design record kept under `docs/reserve/`. The original from-scratch
+pretrain path (OLMo tokenizer) is complete and is a validated foundation / production reserve.
+POC success is a smoothly improving curve plus a local-hardware win (context length + tok/s), with
+**BPB** the primary small-model metric — not benchmark scores.
 
 ## Commands
 
@@ -77,8 +85,9 @@ Consequences of the seam that shape how code is written:
 Model dims and run params live in `config/toy.yaml` and `config/poc.yaml`, loaded into
 `MambaConfig` (`src/model/blocks.py`). `MambaConfig.validate()` enforces cross-cutting
 invariants; **token packing is dtype-aware (#90)** — `vocab < 65536` packs as **uint16**
-(the original POC: OLMo-7B-hf), at/above it packs as **uint32** (the distillation student:
-Qwen3, vocab 151,669 — see `config/student-1b.yaml` and `docs/design/10-distillation.md`).
+(the original POC: OLMo-7B-hf), at/above it packs as **uint32** (the reserve distillation
+student: Qwen3, vocab 151,669 — see `config/student-1b.yaml` and
+`docs/reserve/10-distillation.md`).
 The ceiling `validate()` enforces is now uint32 (`2**32`). The YAML **comments are the
 decision record** — read them before changing values. Key locked decisions:
 
@@ -88,9 +97,9 @@ decision record** — read them before changing values. Key locked decisions:
   confirmed `<65536`, uint16), `precision fp16` + (dynamic) loss scaling (~16% faster than bf16
   on Metal per the M1 micro-benchmark — **do not assume bf16**), tied embedding **mandatory**
   (~38M of ~127M params), `grad_checkpoint: true` (required at this depth — see below).
-- **poc-qwen.yaml** (the **active ~205M POC run**): `poc.yaml`'s layers retargeted to
-  `vocab_size 151646` (Qwen2.5, uint32) so it trains on the distillation corpus
-  (`s3://monica-training/reserve-pretrain`) and mirrors the ~1B student's tokenizer/data path.
+- **poc-qwen.yaml** (the **completed ~205M POC run**, now reserve — val-ppl 75.7): `poc.yaml`'s
+  layers retargeted to `vocab_size 151646` (Qwen2.5, uint32) so it trained on the reserve corpus
+  (`s3://monica-training/reserve-pretrain`) and mirrored the (reserve) ~1B student's data path.
   Layers are unchanged (~88M); the larger tied embedding (~116M) dominates → **~205M total**,
   embedding-heavy (a deliberate trade for tokenizer alignment, not a clean 100M). Runs on CUDA
   via RunPod (see `config/poc-qwen.yaml`'s header runbook); split the R2 shard corpus into
@@ -148,54 +157,37 @@ The smoke gate stresses exactly this round-trip.
   serving/rewind, and the **CUDA backend (M8, A40-verified)**. **M9 post-training is done** —
   SFT/DPO/GRPO machinery on MLX with CUDA step-factory parity. The full 2–5B-token from-scratch
   run is still pending (user-driven).
-- The **active program is M10 — distillation** (**GitHub issue #65**, the live tracker): distil a
-  compact Mamba-2 hybrid student from a frozen teacher, sweep layouts, post-train the winner. The
-  core machinery is implemented — teacher loader (#93), student init (#99), staged distill loss
-  (#100), sweep harness (#98), and the distillation driver `scripts/distill.py` (#81). The
-  **remaining work is pod-gated runs**, not builds: the 8k corpus build, the teacher top-k
-  precompute (#94), the two-layout sweep (#81), and post-training/eval — per the #65 ordered chain.
+- The **active program is M12 — the from-scratch Mamba-2 hybrid MoE code model** (**GitHub issue
+  #198**, the live tracker; design record `docs/design/13-code-model-moe.md`): the "MHM" spine
+  (own BPE #191 → Essential-Web + Stack-v2 corpus #193 → aux-loss-free MoE router #213 → CUDA MoE
+  backend #214 → FIM/curriculum/eval build → ablation sweep #219 → small full run #222 →
+  sparse-upcycled large run #223), with **SSI** (structural-signal integration) as a secondary
+  measurement/training-signal axis (completion-list logit masking #226, diagnostic supervision
+  #227, RLVR/opengrep verifier reward #230, under the #225 measurement contract + escape-hatch
+  gate). The bulk of the net-new work is the MoE build (#213/#214) — MoE is MLX-toy-only today.
+- **Reserve/history — M10 distillation (#65) was dropped 2026-07-19.** Its machinery is built
+  (teacher loader #93, student init #99, staged loss #100, sweep #98, `scripts/distill.py` #81)
+  and its design record + corpus/decontamination guidance + pod runbooks live under `docs/reserve/`
+  (e.g. `docs/reserve/10-distillation.md`). Do **not** describe distillation as active work.
 - `docs/design/` documents the design choices and rationale (start at
   `docs/design/README.md`); `docs/infrastructure.md` is the R2 + RunPod runbook. After completing
-  a milestone, tick its box in the relevant tracker (#2 / #65).
+  a milestone, tick its box in the relevant tracker (#2 / #198).
 - After finishing a milestone or backend change, run the smoke gate, not just pytest.
-- **The corpus-extension domains that chain multiple named sources under one pooled
-  `char_budget_cap`** (`conversation`, `reasoning`, `code_problems`, `code_instruct` in
-  `src/data/distill_sources.py`) **only exercise later sources in the list once the earlier
-  ones exhaust their real data** — a large source (e.g. `ultrachat`, `mot`, `opencodereasoning`,
-  `opencodeinstruct`) can single-handedly consume the whole pooled budget and starve its
-  siblings entirely (confirmed live, 2026-07-05: the first real corpus-extension build silently
-  produced zero docs from `oasst1`/`openthoughts2`/`rosetta-code`/`mceval`/`kodcode`/
-  `codefeedback`). To guarantee a specific source contributes, run it **alone** in its own
-  `distill_corpus_from_jsonl.py` invocation with its own token budget, then merge (renumber
-  shards to continue the existing manifest's sequence, merge `manifest.json`'s `shards` list +
-  aggregate counts, merge `provenance.json` — see the merge done for `poc-distill-ext`,
-  2026-07-05).
-- **Before trusting a new corpus-extension domain, decontamination-check it against the real
-  eval sets** (MATH-500, AIME25, LiveCodeBench, IFEval, or whichever this project's actual eval
-  axes are), not just against the license/field-shape dry run — a source named after or derived
-  from a benchmark (e.g. McEval-Instruct/McEval) is a contamination risk even when its license is
-  fine. Checked 2026-07-05 for the `poc-distill-ext` corpus: zero overlap for LiveCodeBench/
-  AIME25/IFEval; **5/500 MATH-500 problems (1%) matched `openwebmath`** (verbatim AoPS-forum
-  content that any large web crawl picks up — a known, low-severity, expected issue for this
-  class of source, not specific to a bad choice here). Accepted as-is; re-check if `openwebmath`
-  or the eval suite changes.
 
-## Licensing / usage-policy compliance (M10 distillation)
-
-M10 distils from **`Qwen/Qwen3-4B-Thinking-2507`, licensed plain unmodified Apache-2.0** (no
-distillation or competing-model restriction — confirmed against the live LICENSE file
-2026-07-05) using third-party corpora (the-stack, open-web-math, Wikipedia, OpenCodeReasoning,
-etc.), not Claude-generated content. Anthropic's Usage Policy's "model scraping/distillation"
-clause restricts using **Claude's own** inputs/outputs to train another model without
-authorization — it does not restrict using Claude as a coding assistant to build an ML pipeline
-that distills a *different* (non-Anthropic) model, confirmed against the live Usage Policy the
-same date. On that basis M10 does not appear to cross either line.
+## Licensing / usage-policy compliance
 
 **Standing rule — flag before crossing the actual boundary:** if any future task would have
 Claude *generate* text (synthetic examples, code samples, explanations) that gets fed into the
-pretrain/SFT/RL corpus as a training signal for the student model, **stop and flag it for
-review** rather than proceeding — that is the specific thing Anthropic's policy restricts, and
-this project has otherwise been careful to keep the corpus entirely third-party/non-Claude.
-Re-check both the teacher model's license and Anthropic's Usage Policy if either changes, or if
-the teacher model itself ever changes — this assessment is not a legal ruling and is only as
-current as the sources checked on the date above.
+pretrain/SFT/RL corpus as a training signal, **stop and flag it for review** rather than
+proceeding — that is the specific thing Anthropic's Usage Policy restricts. This project keeps
+its training corpus entirely third-party/non-Claude, and that must hold for M12 too (including any
+SSI reward / SFT corpus, e.g. #230's RLVR data). Anthropic's policy restricts training a model on
+**Claude's own** inputs/outputs; it does not restrict using Claude as a coding assistant to build
+the pipeline. Re-check the Usage Policy if it changes; this is not a legal ruling and is only as
+current as the last check.
+
+**Reserve (M10 distillation, dropped 2026-07-19):** the earlier assessment cleared distilling from
+**`Qwen/Qwen3-4B-Thinking-2507`, plain unmodified Apache-2.0** (no distillation/competing-model
+restriction — confirmed against the live LICENSE 2026-07-05) using third-party corpora, not
+Claude-generated content. Retained under `docs/reserve/` for the record; re-check both the teacher
+license and the Usage Policy if that path is ever revived.

--- a/README.md
+++ b/README.md
@@ -2,27 +2,33 @@
 
 A proof-of-concept **Mamba-2 hybrid** language model, developed and validated on
 **Apple Silicon with MLX**, architected behind **one hardware seam** so a successful POC
-migrates to **CUDA** for a larger run with minimal rewrite. The current program is to
-**distil** a compact **~1B** hybrid student from a larger frozen teacher, sweep a few
-architecture layouts cheaply, then post-train the winner for reasoning. (1B is the single
-target model — the `poc` is the cheap architecture-validation rung, run at ~205M with the
-Qwen2.5 tokenizer (`config/poc-qwen.yaml`) to mirror the student's data path; a ~127M OLMo
-variant, `config/poc.yaml`, stays in reserve.)
+migrates to **CUDA** for a larger run with minimal rewrite. The current program (**M12**) is a
+from-scratch, **TypeScript-first Mamba-2 hybrid Mixture-of-Experts (MoE) code model**: a mostly
+Mamba-2/SSD backbone with ~12.5% attention layers for cross-file recall and Jamba-style MoE on the
+MLPs, trained on a general multilingual Essential-Web + Stack-v2 corpus with its own byte-level
+BPE and fill-in-the-middle, at two sizes (small ~120M-active/700M-total; large "Large A"
+~700M-active/3.5B-total, sparse-upcycled from the small dense checkpoint). A **secondary axis**
+studies feeding language-server / static-analysis signal into the model. See
+[`docs/design/13-code-model-moe.md`](docs/design/13-code-model-moe.md) and
+[issue #198](https://github.com/travisgalloway/monica/issues/198).
+
+> The earlier **M10 distillation program** (distil a ~1B student from a frozen
+> `Qwen/Qwen3-4B-Thinking-2507` teacher) was dropped 2026-07-19; its machinery is built and its
+> design record is kept under [`docs/reserve/`](docs/reserve/10-distillation.md). The from-scratch
+> OLMo pretrain path is complete and stays in reserve.
 
 **Usage:** [`docs/usage.md`](docs/usage.md) — end-to-end commands (install → data →
-train/distil → serve/chat → eval). **Cloud:** [`docs/infrastructure.md`](docs/infrastructure.md)
+train → serve/chat → eval). **Cloud:** [`docs/infrastructure.md`](docs/infrastructure.md)
 — running the data + training pipeline on object storage + rented GPUs (R2 + RunPod).
 **Design & rationale:** [`docs/design/`](docs/design/README.md).
 
-> **Licensing note.** The distillation program (M10) trains from
-> `Qwen/Qwen3-4B-Thinking-2507`, licensed plain **Apache-2.0** — no distillation or
-> competing-model restriction. The corpus and teacher signal are third-party data (the-stack,
-> Wikipedia, OpenCodeReasoning, etc.) and Qwen's own model outputs, not Claude/Anthropic content.
-> This repo's engineering work is assisted by Claude Code, but no Claude-generated text is part
-> of the training corpus or teacher signal — Anthropic's usage policy separately restricts using
-> *its own* model's outputs to train other models, which is a different thing than using it as a
-> coding assistant to build this pipeline. See `CLAUDE.md`'s "Licensing / usage-policy
-> compliance" section for the full note.
+> **Licensing note.** This project keeps its training corpus entirely **third-party/non-Claude**
+> (Essential-Web, Stack-v2, Wikipedia, etc.). Anthropic's Usage Policy restricts training a model
+> on *Claude's own* inputs/outputs — a different thing than using Claude Code as a coding
+> assistant to build this pipeline, which is what happens here. No Claude-generated text enters the
+> training corpus (this must hold for any M12 SSI reward / SFT data too). See `CLAUDE.md`'s
+> "Licensing / usage-policy compliance" section for the full note, including the reserve M10
+> teacher-license assessment.
 
 ---
 
@@ -38,29 +44,31 @@ weak at _exact_ recall (copying a variable name, quoting a number), so Monica is
 **hybrid**: it mixes in a _few_ ordinary attention layers (roughly one in eight) to recover
 precise lookup where it matters — math and code.
 
-**How it learns.** Training a model from scratch is enormously expensive. Instead, Monica
-**learns from a bigger, already-trained "teacher" model** — a technique called
-**distillation**. The student watches what the teacher would predict and learns to match it,
-reaching useful capability for a _tiny fraction_ of the data a from-scratch run needs. Because
-each student is cheap to train, we can **try several small designs** (how much attention, where
-to place it, how big the state is) and keep the best one.
+**How it's built.** Monica is a **code model trained from scratch**. To get strong capability
+per parameter it uses a **Mixture-of-Experts (MoE)**: many small "expert" sub-networks of which
+only a few fire per token, so the model holds a lot of knowledge while staying cheap to run. It's
+**TypeScript-first**, trained with **fill-in-the-middle** (so it learns to complete code from both
+sides, not just left-to-right), and comes in two sizes — a small rung and a larger one
+**sparse-upcycled** from it (the small dense model is grown into the big sparse one instead of
+training the big one from zero).
 
 **The intended process, in order:**
 
-1. **Precompute the teacher's signal once** — tokenize a corpus and record the teacher's
-   predictions. This is the expensive part, and it's done a single time.
-2. **Sweep student layouts** — train several cheap candidate students against that frozen
-   signal and pick the layout that wins on math/code _and_ on the local speed/long-context
-   advantage.
-3. **Post-train the winner** — teach it to follow instructions and to reason
-   (`<think>…</think>` style), with optional tool-use and a final reinforcement-learning polish.
+1. **Build the corpus + tokenizer** — a general multilingual code+text mixture (Essential-Web +
+   Stack-v2) and Monica's own byte-level BPE trained on it.
+2. **Build the MoE architecture & harness** — load-balancing router, the CUDA MoE backend,
+   fill-in-the-middle, a length curriculum, and the evals (bits-per-byte is the primary metric).
+3. **Sweep small designs, then run** — cheaply ablate attention ratio / state size / routing,
+   train the small model, then sparse-upcycle to the large one.
 4. **Run it locally** — serve it on Apple Silicon, where the constant-memory design pays off.
+
+Alongside this, a **secondary axis** asks whether feeding a language server's diagnostics into
+generation helps — a validated way to raise type-cleanliness, though (so far) not functional
+correctness; see [`docs/design/13-code-model-moe.md`](docs/design/13-code-model-moe.md).
 
 This is a **proof of concept**: success is a smoothly improving learning curve plus a clear
 local-hardware win (context length and tokens/sec that a same-size Transformer can't match), not a
-leaderboard score. The from-scratch training path is fully built and validated; the
-**distillation stage is in progress** (the building blocks exist; the end-to-end cloud run is
-being wired up — see [issue #65](https://github.com/travisgalloway/monica/issues/65)).
+leaderboard score. The tracker is [issue #198](https://github.com/travisgalloway/monica/issues/198).
 
 ---
 
@@ -104,9 +112,12 @@ docs/usage.md              usage guide   docs/infrastructure.md  cloud runbook  
 ## Status
 
 The POC core is **implemented and verified on Apple Silicon**, and the **CUDA backend is now
-done and verified on a rented A40** (full suite green on both). The active program is **M10 —
-distillation** ([issue #65](https://github.com/travisgalloway/monica/issues/65)); the M1–M8
-core was tracked in [issue #2](https://github.com/travisgalloway/monica/issues/2).
+done and verified on a rented A40** (full suite green on both). The active program is **M12 — the
+from-scratch Mamba-2 hybrid MoE code model**
+([issue #198](https://github.com/travisgalloway/monica/issues/198)); the M1–M8 core was tracked in
+[issue #2](https://github.com/travisgalloway/monica/issues/2). The earlier M10 distillation program
+(#65) was **dropped 2026-07-19** — machinery built, kept as reserve under
+[`docs/reserve/`](docs/reserve/10-distillation.md).
 
 | Milestone                 | State                                                                             |
 | ------------------------- | --------------------------------------------------------------------------------- |
@@ -119,25 +130,29 @@ core was tracked in [issue #2](https://github.com/travisgalloway/monica/issues/2
 | 7 Serving + chat + rewind | done — CLI generate/chat over `SessionStore` + `RewindTree`                       |
 | 8 CUDA backend            | **done** — pure-PyTorch Mamba-2/SSD + optional mamba-ssm fast paths; A40-verified |
 | 9 Post-training           | **done** — SFT / DPO / GRPO machinery on MLX (+ CUDA step-factory parity)         |
-| 10 Distillation           | **in progress** — teacher loader, student init, staged loss, sweep harness built  |
+| 10 Distillation           | machinery **built, then dropped** 2026-07-19 (reserve; see `docs/reserve/`)        |
+| 12 MoE code model         | **active** — MoE build (#213/#214) is the net-new work; SSI signal secondary       |
 
-**M10 distillation — where it stands.** The frozen-artifact strategy and its building blocks
-are in place: the frozen conversion teacher (`Qwen/Qwen3-4B-Thinking-2507`, loaded by
-`src/model/mlx_teacher.py` / `cuda_teacher.py`), student initialization
-(`src/model/mlx_student_init.py` — Mamba-in-the-Llama / MOHAWK), the staged distillation loss
-(`src/model/mlx_distill.py` — mixing-match → hidden-align → logit-distill), the manifest parser
-(`src/train/distill_manifest.py`), the sweep table (`scripts/sweep.py`), and the run driver
-(`scripts/distill.py`). **Pending:** the corpus re-tokenize to the Qwen3 vocab + corpus-scale
-teacher-logit precompute ([#94](https://github.com/travisgalloway/monica/issues/94)), the R2 +
-RunPod plumbing ([#80](https://github.com/travisgalloway/monica/issues/80)), and the end-to-end
-cloud distill run at full scale ([#81](https://github.com/travisgalloway/monica/issues/81); the
-runbook is [`docs/path-b-run.md`](docs/path-b-run.md)).
+**M12 — the active program.** A from-scratch **TypeScript-first Mamba-2 hybrid MoE code model**
+(tracker [#198](https://github.com/travisgalloway/monica/issues/198); design record
+[`docs/design/13-code-model-moe.md`](docs/design/13-code-model-moe.md)). The spine: own byte-level
+BPE (#191) → Essential-Web + Stack-v2 corpus (#193) → aux-loss-free MoE router (#213) → CUDA MoE
+backend (#214) → FIM / length curriculum / evals → ablation sweep (#219) → small full run (#222) →
+sparse-upcycled large run (#223). The bulk of the net-new work is the MoE build — MoE is
+MLX-toy-only today. A **secondary axis (SSI)** studies language-server / static-analysis signal:
+a validated clean-rate tool with a found functional ceiling (#225/#226/#227/#230).
 
-**Two training paths.** The original **from-scratch pretrain** path (`scripts/train.py`,
-OLMo tokenizer, uint16) is complete and validated — it's the POC's foundation and the
+**Reserve — M10 distillation (dropped 2026-07-19).** The frozen-teacher machinery is built (teacher
+loader `src/model/mlx_teacher.py`, student init `src/model/mlx_student_init.py`, staged loss
+`src/model/mlx_distill.py`, manifest parser, sweep table, `scripts/distill.py`) but the program is
+no longer active; the design record and run playbook are kept under
+[`docs/reserve/`](docs/reserve/path-b-run.md).
+
+**Two training paths (both reserve now).** The original **from-scratch pretrain** path
+(`scripts/train.py`, OLMo tokenizer, uint16) is complete and validated — the POC's foundation and
 production-reserve route ([#75](https://github.com/travisgalloway/monica/issues/75)). The
-**distillation** path (Qwen3 tokenizer, uint32, `config/student-1b.yaml`) is the current
-focus and the cheaper route to a capable model.
+**distillation** path (Qwen3 tokenizer, uint32, `config/student-1b.yaml`) is reserve. M12 trains a
+new code model from scratch on its own BPE.
 
 ## Hybrid architecture
 
@@ -148,7 +163,9 @@ fraction of layers are **causal attention** instead of Mamba, config-gated by `a
 Optional **sparse MoE** FFN layers are likewise gated by `moe_every` / `n_experts` / `top_k`.
 Both are off by default (pure Mamba) and live behind the seam. Sizing and the attention-fraction
 sweep are in [`docs/design/09-hybrid-architectures.md`](docs/design/09-hybrid-architectures.md);
-the distillation rationale is in [`docs/design/10-distillation.md`](docs/design/10-distillation.md).
+the M12 MoE code-model plan is in
+[`docs/design/13-code-model-moe.md`](docs/design/13-code-model-moe.md), and the reserve
+distillation rationale in [`docs/reserve/10-distillation.md`](docs/reserve/10-distillation.md).
 
 Reference configs: `config/poc.yaml` = d_model 768 / 24 layers / d_state 16 / head_dim 64 (24
 heads) / seq 1024 / ~3B tokens / OLMo vocab (pure Mamba). `config/student-1b.yaml` = d_model
@@ -201,7 +218,7 @@ For a **real corpus** and the full train → serve → eval flow, see
 [`docs/usage.md`](docs/usage.md); for the **cloud** (R2 + RunPod) pipeline, see
 [`docs/infrastructure.md`](docs/infrastructure.md). To **validate every stage locally** in one
 offline command — and for the small local-training configs (`config/small.yaml`,
-`config/poc-small.yaml`) and the local Qwen3 teacher — see
+`config/poc-small.yaml`) — see
 [`docs/local-development.md`](docs/local-development.md):
 
 ```bash
@@ -234,19 +251,19 @@ python scripts/train.py --config config/poc.yaml --data data/split --out runs/po
 **POC success = a smoothly decreasing `val_perplexity` in `runs/poc/metrics.jsonl`** with a
 stable `grad_norm` — not a benchmark score.
 
-### Distillation (in progress)
+### Distillation (reserve — dropped 2026-07-19)
 
-The distillation corpus, teacher loader, student init, and staged loss exist; the cloud run
-harness is being wired up. Inspect a candidate sweep over attention fraction / placement / state
-size:
+The distillation corpus, teacher loader, student init, and staged loss exist but the program is
+**no longer active**. The machinery still runs — a candidate sweep over attention fraction /
+placement / state size:
 
 ```bash
 python scripts/sweep.py                    # all of config/manifests/
 python scripts/sweep.py config/manifests/student-1b-attn-lo.yaml config/manifests/student-1b-attn-hi.yaml
 ```
 
-See [`docs/usage.md`](docs/usage.md#3-train) and
-[`docs/design/10-distillation.md`](docs/design/10-distillation.md) for the full picture.
+See [`docs/reserve/10-distillation.md`](docs/reserve/10-distillation.md) for the full (reserve)
+picture.
 
 ### Post-training (M9)
 

--- a/docs/design/08-corpus-pipeline.md
+++ b/docs/design/08-corpus-pipeline.md
@@ -2,14 +2,26 @@
 
 [← Index](README.md)
 
+> **Status note (2026-07-19).** This doc records the `datatrove` + R2 + RunPod corpus
+> foundation built for the M10 distillation program (issue #65, **dropped 2026-07-19** —
+> design record moved to [`../reserve/10-distillation.md`](../reserve/10-distillation.md)).
+> The stages, common schema, and R2 layout below are reusable infrastructure and still apply;
+> the **live program is M12** ([issue #198](https://github.com/travisgalloway/monica/issues/198)),
+> which re-anchors the corpus to a general multilingual **Essential-Web + Stack-v2** mixture
+> ([#193](https://github.com/travisgalloway/monica/issues/193)) with its **own byte-level BPE**
+> ([#191](https://github.com/travisgalloway/monica/issues/191)) instead of the Qwen3-aligned
+> tokenizer described below — see [`13-code-model-moe.md`](13-code-model-moe.md) for the
+> current plan.
+
 How the scale-up corpus is built, stored, and post-trained. The offline
 [`src/data/`](../../src/data/) stages ([data pipeline](04-data-pipeline.md)) are the
 laptop-scale version of this; at scale the same shape runs on **Hugging Face
 [`datatrove`](https://github.com/huggingface/datatrove)**, stores intermediates on
-**Cloudflare R2**, and processes on **RunPod**. This doc is the decision record for that
-flow; the GitHub tracker is [issue #65](https://github.com/travisgalloway/monica/issues/65)
-and its phase children (#69–#81). Model choice is in
-[hybrid architectures](09-hybrid-architectures.md).
+**Cloudflare R2**, and processes on **RunPod**. This doc is the decision record for the
+M10-era flow (now reserve); the GitHub tracker was [issue #65](https://github.com/travisgalloway/monica/issues/65)
+and its phase children (#69–#81). Model choice for that reserve plan is in
+[hybrid architectures](09-hybrid-architectures.md); the live M12 model plan is
+[`13-code-model-moe.md`](13-code-model-moe.md).
 
 Like everything above the [seam](01-architecture-seam.md), the pipeline is **portable** —
 no `mlx`/`torch` import. It produces shards; the trainer consumes them.
@@ -72,14 +84,16 @@ it early (only the IDs stream from the Hub; the blobs come from SWH S3).
 
 ## Tokenize + shard (Phase 3, #74)
 
-> **Superseded by the distillation pivot ([10](10-distillation.md)).** The tokenizer is now
-> **fixed to Qwen3 (vocab ~151,669)** by the conversion teacher (token-aligned with Qwen2.5 plus
-> the `<think>`/`</think>` ids) — it intentionally *exceeds* the uint16 bound, so packing is
-> **uint32** (#90, now implemented: dtype-aware `pack.py` + relaxed `MambaConfig.validate()`). The
-> StarCoder2/uint16 reasoning below is the historical record of the from-scratch plan; the #75
-> production-reserve corpus reuses these clean-corpus *stages* under **uint32 packing** (the
-> already-built reserve corpus uses Qwen2.5; re-tokenize to Qwen3 to match the student) — so
-> StarCoder2/uint16 is fully superseded.
+> **Reserve note.** Under the M10 distillation reserve plan
+> ([`../reserve/10-distillation.md`](../reserve/10-distillation.md)), the tokenizer was **fixed
+> to Qwen3 (vocab ~151,669)** by the conversion teacher (token-aligned with Qwen2.5 plus the
+> `<think>`/`</think>` ids) — it intentionally *exceeds* the uint16 bound, so packing is
+> **uint32** (#90, implemented: dtype-aware `pack.py` + relaxed `MambaConfig.validate()`). The
+> StarCoder2/uint16 reasoning below is the historical record of the original from-scratch plan;
+> the #75 production-reserve corpus reuses these clean-corpus *stages* under **uint32 packing**
+> (the already-built reserve corpus uses Qwen2.5). **M12** (the live program) sidesteps this
+> tokenizer question with its **own byte-level BPE** trained on the M12 mixture (#191) — see
+> [`13-code-model-moe.md`](13-code-model-moe.md).
 
 - **Tokenizer:** reuse a mixed prose+code tokenizer, chosen with the **uint16 packing bound
   (`vocab < 65536`)** in mind — enforced by `src/data/pack.py` and `MambaConfig.validate()`
@@ -93,12 +107,14 @@ it early (only the IDs stream from the Hub; the blobs come from SWH S3).
 - **Shard:** high-hundreds-of-MB to low-GB shards (few large files → fewer R2 Class A ops),
   written to R2 alongside the cleaned text.
 
-## R2 storage layout
+## R2 storage layout (reserve — M10 distillation)
 
-The distillation pivot adopts a **three-class** layout (#97), so the student layout stays
-downstream of every frozen artifact. `src/data/storage.py` is the single source of truth for these
-prefixes; the data drivers (`distill_corpus.py`, `instruct_sft.py`, `reasoning_sft.py`) build their
-paths through it, and #80 points the R2 `s3fs` readers/writers at the same prefixes.
+The M10 distillation reserve plan adopted a **three-class** layout (#97), so the student layout
+stayed downstream of every frozen artifact. `src/data/storage.py` is the single source of truth
+for these prefixes; the data drivers (`distill_corpus.py`, `instruct_sft.py`, `reasoning_sft.py`)
+build their paths through it, and #80 pointed the R2 `s3fs` readers/writers at the same prefixes.
+This layout is kept as reserve/example; the live M12 corpus build (#193) has no frozen-teacher
+class to isolate, so it may adopt a simpler layout.
 
 ```
 r2://<bucket>/
@@ -117,7 +133,7 @@ Two rules the layout enforces: **cleaned text and RL problems stay tokenizer-agn
 name-pins tokenizer + seq_len** (`<tok>-<k>`, e.g. `qwen3-8k`) so multiple tokenized views coexist.
 Dedup/decontam produce `cleaned/` once; the tokenized views are cheap to regenerate.
 
-## Training flow (Phases 4–5, #81 / #75)
+## Training flow (Phases 4–5, #81 / #75) — reserve (M10)
 
 - **Phase 4 (#81):** the 100M smoke run on a cheap GPU pod (T4/L4). Bring the pod up in
   this order so a config or throughput problem surfaces *before* the long run:
@@ -163,10 +179,12 @@ Dedup/decontam produce `cleaned/` once; the tokenized views are cheap to regener
   [checkpointing](05-training.md); success is a smoothly decreasing held-out val-perplexity curve
   at scale.
 
-## Post-training (Phase 6, #76–#78)
+## Post-training (Phase 6, #76–#78) — reserve (M10)
 
 Clean-license, extending the M9 SFT+DPO machinery (#57). See those issues for dataset detail;
-the licensing reframe is the load-bearing part:
+the licensing reframe is the load-bearing part. (The live M12 post-training arms are #101/#103,
+currently parked — see [`11-post-training.md`](11-post-training.md) and
+[`13-code-model-moe.md`](13-code-model-moe.md).)
 
 - **SFT (#76):** OASST1 (multi-turn, Apache-2.0), Dolly (CC-BY-SA, flagged), FLAN, plus a
   small hand-authored in-format set; synthetic top-up only from *permissive* open models.
@@ -181,6 +199,7 @@ the licensing reframe is the load-bearing part:
 ## Related
 
 - [Data pipeline](04-data-pipeline.md) — the offline `src/data/` stages this scales up.
-- [Hybrid architectures](09-hybrid-architectures.md) — the ~1B model the corpus trains (100M poc is the validation rung).
+- [Hybrid architectures](09-hybrid-architectures.md) — the reserve ~1B model this corpus was built to train (100M poc is the validation rung).
 - [Training](05-training.md) — the portable loop + checkpoint/resume the cloud runs reuse.
 - [Architecture: the hardware seam](01-architecture-seam.md) — why the pipeline stays portable.
+- [`13-code-model-moe.md`](13-code-model-moe.md) — the live M12 program this corpus foundation now feeds (#193, #191).

--- a/docs/design/09-hybrid-architectures.md
+++ b/docs/design/09-hybrid-architectures.md
@@ -3,12 +3,14 @@
 [← Index](README.md)
 
 Why the scale-up model is a **Mamba-2 *hybrid*** — mostly SSD blocks with a small fraction
-of attention layers — and how it is sized. The target is a **single ~1B model** (the cheap
-100M `poc` is the architecture-validation rung; the earlier 2B/4B tiers were dropped). This is
-the model companion to the [corpus pipeline](08-corpus-pipeline.md); the GitHub tracker is
-[issue #65](https://github.com/travisgalloway/monica/issues/65) (arch children #66–#68). The
-SSD block itself is documented in [model: the Mamba block](02-model-ssm.md); this doc is
-about what to add to it at scale.
+of attention layers — and how it is sized. This hybrid rationale is **foundation** that the live
+M12 code model builds on (its MoE spine + sizing are in
+[13-code-model-moe.md](13-code-model-moe.md), tracker
+[issue #198](https://github.com/travisgalloway/monica/issues/198)); the SSD block itself is in
+[model: the Mamba block](02-model-ssm.md). The single-~1B-model sizing discussed below was the
+**reserve M10** target (arch children #66–#68, epic
+[#65](https://github.com/travisgalloway/monica/issues/65), dropped 2026-07-19) — read it for the
+attention-fraction reasoning, which carries over to the M12 MoE model.
 
 ## Why a hybrid, not pure SSD
 
@@ -53,23 +55,23 @@ earlier 2B/4B scale tiers — and a 16B candidate before them — were dropped f
 | tier | d_model | n_layers | head_dim | ≈ params | bf16 weights | train GPU |
 |---|---|---|---|---|---|---|
 | **100M** (poc — OLMo, reserve) | 768 | 24 | 64 | ~127M | ~0.25 GB | T4 16 GB / L4 24 GB |
-| **205M** (poc-qwen — Qwen2.5, active POC run) | 768 | 24 | 64 | ~205M | ~0.4 GB | T4 16 GB / L4 24 GB |
+| **205M** (poc-qwen — Qwen2.5, completed POC run, reserve) | 768 | 24 | 64 | ~205M | ~0.4 GB | T4 16 GB / L4 24 GB |
 | **1B** (target — from scratch) | 2048 | 36 | 64 | ~1.03B | ~2 GB | L4 / A10 24 GB |
-| **1B** (target — distillation student, hybrid) | 2048 | 28 | 64 | ~1.03B | ~2 GB | L4 / A10 24 GB |
+| **1B** (reserve distillation student, hybrid) | 2048 | 28 | 64 | ~1.03B | ~2 GB | L4 / A10 24 GB |
 
-Both ~1B configs land within ±5% of the 1B target (verify with the sizing tool). The
-**distillation student** ([`config/student-1b.yaml`](../../config/student-1b.yaml)) uses **28
+Both ~1B configs land within ±5% of the 1B target (verify with the sizing tool). The **reserve
+distillation student** ([`config/student-1b.yaml`](../../config/student-1b.yaml)) uses **28
 layers** — matching the teacher's 28 transformer layers so the Mamba-in-the-Llama init maps
-layer-to-layer (see [distillation](10-distillation.md)) — while the **from-scratch** 1B
-([`config/1b.yaml`](../../config/1b.yaml), OLMo vocab) uses 36 layers for the same param budget
-(its smaller vocab leaves more room in the layer stack). The 100M tier is the validated
-[`poc.yaml`](07-configs-and-decisions.md) (OLMo). The **active POC run** uses
-[`poc-qwen.yaml`](../../config/poc-qwen.yaml) — the same layers retargeted to the Qwen2.5 vocab
-(151,646) so the POC exercises a tokenizer/data path token-aligned with the distillation student's
-(the student is on the Qwen3 vocab 151,669, which is token-aligned with Qwen2.5); the larger
-tied embedding (~116M) then dominates, making it ~205M, embedding-heavy. (At the student's
-d_model 2048 that same embedding is a negligible ~11%, so the vocab is "free" there — it only
-dominates a narrow 768-wide model.) The sizing tool is a portable closed-form
+layer-to-layer (see [distillation, reserve](../reserve/10-distillation.md)) — while the
+**from-scratch** 1B ([`config/1b.yaml`](../../config/1b.yaml), OLMo vocab) uses 36 layers for the
+same param budget (its smaller vocab leaves more room in the layer stack). The 100M tier is the
+validated [`poc.yaml`](07-configs-and-decisions.md) (OLMo). The now-**completed POC run** (reserve)
+used [`poc-qwen.yaml`](../../config/poc-qwen.yaml) — the same layers retargeted to the Qwen2.5
+vocab (151,646) so the POC exercised a tokenizer/data path token-aligned with the (reserve)
+distillation student's (the student is on the Qwen3 vocab 151,669, which is token-aligned with
+Qwen2.5); the larger tied embedding (~116M) then dominates, making it ~205M, embedding-heavy. (At
+the student's d_model 2048 that same embedding is a negligible ~11%, so the vocab is "free" there
+— it only dominates a narrow 768-wide model.) The sizing tool is a portable closed-form
 param/memory calculator (`src/model/sizing.py` + `scripts/model_size.py`, #66), cross-checked
 against the built model's portable state-dict param sum. Training memory ≈ 8 B/param
 (weights+grad+AdamW), or **~10 B/param with 8-bit Adam** — the VRAM-tight lever used in
@@ -116,8 +118,8 @@ honest laptop question is the inverse — "how many tokens fit in a day?" — wh
 
 These are first-principles estimates (generic `6·N·D`, not the SSM/attention split);
 the real per-step cost is what `scripts/bench_train_step.py` (MLX) and
-`scripts/bench_cuda_train_step.py` (CUDA) measure. The short distillation runs in
-particular need ≪ Chinchilla tokens — see [distillation](10-distillation.md).
+`scripts/bench_cuda_train_step.py` (CUDA) measure. The short (reserve) distillation runs in
+particular needed ≪ Chinchilla tokens — see [distillation, reserve](../reserve/10-distillation.md).
 
 ### Precision differs from the POC
 
@@ -127,8 +129,8 @@ where **bf16 is native** and needs no loss scaling — so `config/1b.yaml` and
 `config/student-1b.yaml` set `precision: bf16` (`scaler_for_precision` already returns `None`
 for bf16). `tie_embeddings`
 and `grad_checkpoint` stay on; vocab follows the chosen tokenizer and sets the packed dtype —
-uint16 below 65536 (POC), uint32 for Qwen3 (the distillation student, #90; see
-[distillation](10-distillation.md)).
+uint16 below 65536 (POC), uint32 for Qwen3 (the reserve distillation student, #90; see
+[distillation, reserve](../reserve/10-distillation.md)).
 
 ## Verifying the attention fraction
 

--- a/docs/design/11-post-training.md
+++ b/docs/design/11-post-training.md
@@ -2,13 +2,25 @@
 
 [← Index](README.md)
 
-Once a capable hybrid base exists (via [distillation](10-distillation.md)), post-training builds
-**three capability layers in order**. Instruct is the substrate that makes the model usable at
-all; thinking is the headline skill of this POC; tool use is the extensibility layer enabled when
-the product needs it. All three are taught by **SFT** on data from the shared post-training track,
-with **GRPO** as a final reinforcement pass on the thinking layer. The tracker is
-[issue #65](https://github.com/travisgalloway/monica/issues/65); the data lives under the
-`shared/` prefix ([corpus pipeline](08-corpus-pipeline.md)) and reuses the M9 SFT/DPO machinery
+> **Status note (2026-07-19).** This is a design record; the base model it post-trains does not
+> exist yet under either plan. It was written against the M10 distillation program (issue #65,
+> **dropped 2026-07-19** — reserve under
+> [`../reserve/10-distillation.md`](../reserve/10-distillation.md)). The live program is **M12**
+> ([issue #198](https://github.com/travisgalloway/monica/issues/198)), whose post-training arms
+> are **#101 (SFT)** and **#103 (RLVR)**, currently **parked** behind the MHM spine
+> (corpus/tokenizer/MoE backend/ablation sweep/full run — see
+> [`13-code-model-moe.md`](13-code-model-moe.md)). The instruct → thinking → GRPO shape and the
+> chat-template invariant below carry over regardless of which base model they land on.
+
+Once a capable hybrid base exists (via the **M12 MoE base run**, or as originally envisioned via
+[distillation, reserve](../reserve/10-distillation.md)), post-training builds **three capability
+layers in order**. Instruct is the substrate that makes the model usable at all; thinking is the
+headline skill of this POC; tool use is the extensibility layer enabled when the product needs it.
+All three are taught by **SFT** on data from the shared post-training track, with **GRPO** as a
+final reinforcement pass on the thinking layer. This design record was tracked under
+[issue #65](https://github.com/travisgalloway/monica/issues/65) (reserve); live tracking is under
+issue #198's #101/#103. The data lives under the `shared/` prefix
+([corpus pipeline](08-corpus-pipeline.md)) and reuses the M9 SFT/DPO machinery
 (`make_sft_train_step`, `make_dpo_train_step`, the response-masked loaders).
 
 The order matters: instruct is assumed by everything later, thinking is the point, tool use is
@@ -91,5 +103,8 @@ precomputed once and reused everywhere.
 ## Related
 
 - [Corpus pipeline](08-corpus-pipeline.md) — the `shared/` SFT corpora and verifiable RL sets.
-- [Distillation](10-distillation.md) — how the base these layers post-train is built.
+- [Distillation, reserve](../reserve/10-distillation.md) — how the base these layers post-train
+  was envisioned to be built under the (dropped) M10 program.
+- [`13-code-model-moe.md`](13-code-model-moe.md) — the live M12 program; #101/#103 are these
+  layers' current (parked) tracking.
 - [Training](05-training.md) — the SFT/DPO machinery (M9) these layers reuse.

--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -8,7 +8,9 @@ regenerate) beats re-reading diagnostics as tool-call tokens. **#199 is the gate
 program**: build a `tsc`-in-the-loop autoregressive harness on an off-the-shelf model (no
 training) and measure it against the [#194 eval set](../../eval_sets/ts_error_injection/README.md)
 before funding the P1 tier (#191/#192/#193/#200/#201/#101/#103/#104). This doc is the design
-record and the measurement.
+record, the measurement, and — at the end — the **arc-level assessment/conclusion**. For where
+this sits in the live program, see [`13-code-model-moe.md`](13-code-model-moe.md) (M12, #198),
+which demotes this LSP signal to a secondary axis on the strength of the conclusion below.
 
 **Model**: `mlx-community/Qwen2.5-Coder-1.5B-bf16` (base, not instruct — see risks below).
 **Locked decisions** (user): build and run locally on MLX-LM; implement both hard and soft
@@ -708,3 +710,49 @@ program gate (#198): the clean-but-wrong gap is real and a syntactic idiom-match
 of it precisely* but not enough of it to carry the functional metric — the correctness-bearing signal
 for this class lives in semantics (tests, execution, type-aware analysis), which is where the AR
 harness ablation (#201) and the LSP-verifier reward work (#103) should aim.
+
+## Assessment / conclusion (arc-level)
+
+Rolling the whole arc up, the answer is partly negative and useful:
+
+- **Proven — a clean-rate tool.** Diagnostic-guided rollback/regeneration reliably raises
+  *type-cleanliness*: the persistent-LSP swap moved it **0.887 → 0.962 (p=0.0005)**, robust and
+  well-instrumented, with over-repair understood and mostly neutralized (#212 final-segment gate,
+  the forward-resolvable TS2xxx deferral, and #211 confirming the oracle isn't dropping
+  diagnostics).
+- **Bounded — it can't touch the functional gap.** The gap this program exists to close is
+  clean-but-wrong: bodies are **88.7% type-clean but only 50.3% functionally correct**. Persistent
+  LSP leaves **pass@1 flat (0.503, p=0.69, ns)** because the failures are *algorithmic*, which a
+  type/lint checker structurally cannot see. opengrep sees a genuine but far-too-sparse corner
+  (4/159, 4/4 precise). And over-repair on multi-statement code is **trajectory-bound, not
+  trigger-bound** (this session's A1): specific triggers trim at zero F1 cost, but the aggregate
+  and per-row outcomes don't budge — the over-firing is structural to incremental repair.
+- **The unexplained bright spot.** Batch `tsc` *did* move **pass@1 (0.491 → 0.560, p=0.001)** where
+  open-document LSP did not — attributed to whole-program vs open-document diagnostics. This
+  **tsc-vs-LSP divergence is the single most information-rich loose end** in the arc: either a real
+  signal (whole-program view catching cross-statement errors) or a gating artifact.
+
+**Bottom line:** inference-time type/lint-guided rollback on a *frozen* model is a validated
+clean-rate tool, **not** the lever for the functional gap. The correctness-bearing signal lives in
+semantics/execution, and the untested high-value question is whether it helps as a **training
+signal** rather than an inference-time patch.
+
+**Next-steps ledger (evidence-to-cost order):**
+
+1. **Resolve the tsc-vs-LSP pass@1 divergence** — one targeted study of why whole-program `tsc`
+   moved functional correctness when open-document LSP didn't. Cheap, could flip the conclusion and
+   redirect the program. Do first.
+2. **Put the signal in training** — the oracle as a reward (#230 / the parked #103) and/or the
+   fast/slow/both ablation (#201) on a *trained* model, not the frozen base coder. This is where
+   the value proposition actually lives; it costs a training run and a Track-B decision.
+3. **Swap in a semantic/execution oracle** — execution against tests/spec as the `DiagnoseFn`;
+   pairs naturally with (2) as a train-time reward.
+4. **Exploratory** — the #203 diffusion discriminator (diagnostic-guided denoising); #211 cleared
+   its prerequisite.
+5. **The honest #198 gate call** — write up "validated clean-rate tool, functional ceiling found,
+   functional signal needs semantics-as-training" and shelve. A legitimate, well-earned outcome.
+
+Recommendation: do (1) as a small immediate experiment, then use its result to choose between
+committing to (2)+(3) as the serious next thrust or making the (5) gate call. With M10 off the
+plan, this is also the moment to decide whether LSP-in-the-loop becomes a headline **training**
+program (i.e. (2)) or stays exploratory.

--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -727,10 +727,19 @@ Rolling the whole arc up, the answer is partly negative and useful:
   (4/159, 4/4 precise). And over-repair on multi-statement code is **trajectory-bound, not
   trigger-bound** (this session's A1): specific triggers trim at zero F1 cost, but the aggregate
   and per-row outcomes don't budge — the over-firing is structural to incremental repair.
-- **The unexplained bright spot.** Batch `tsc` *did* move **pass@1 (0.491 → 0.560, p=0.001)** where
-  open-document LSP did not — attributed to whole-program vs open-document diagnostics. This
-  **tsc-vs-LSP divergence is the single most information-rich loose end** in the arc: either a real
-  signal (whole-program view catching cross-statement errors) or a gating artifact.
+- **The bright spot, resolved — it is exploration variance, not detection.** Batch `tsc` moved
+  **pass@1 (0.491 → 0.560, p=0.001)** where open-document LSP did not (0.503). Investigated directly
+  (`scripts/analyze_tsc_lsp_divergence.py`, `scripts/probe_tsc_lsp_divergence_subcause.py`,
+  `results/tsc_lsp_divergence*.json`): the gap is **9 records LSP finishes `clean` but functionally
+  wrong** (76 vs tsc's 67 of 159), and tsc does **3.4× more rollbacks** (0.711 vs 0.208). But driving
+  tsc's winning trajectory and querying both oracles on identical text yields **0/10 forks** (tsc
+  never flags where LSP is clean — LSP in fact emits *more* codes on incomplete candidates, doing
+  error-recovery semantic analysis tsc can't), and running batch tsc on LSP's 9 clean-but-wrong final
+  artifacts **clears all 9**: the wrong code type-checks *even to the whole-program compiler*. So both
+  loops bottom out at **type-clean endpoints the type oracle cannot rank**; tsc's edge is
+  **trajectory/exploration variance** (≈ best-of-N via more regeneration), **not** a correctness
+  signal — which only sharpens the "bounded" bullet above. The "gating artifact" branch wins; the
+  "whole-program catches real cross-statement errors" branch is refuted.
 
 **Bottom line:** inference-time type/lint-guided rollback on a *frozen* model is a validated
 clean-rate tool, **not** the lever for the functional gap. The correctness-bearing signal lives in
@@ -739,9 +748,9 @@ signal** rather than an inference-time patch.
 
 **Next-steps ledger (evidence-to-cost order):**
 
-1. **Resolve the tsc-vs-LSP pass@1 divergence** — one targeted study of why whole-program `tsc`
-   moved functional correctness when open-document LSP didn't. Cheap, could flip the conclusion and
-   redirect the program. Do first.
+1. ~~**Resolve the tsc-vs-LSP pass@1 divergence**~~ — **DONE** (see the "bright spot, resolved"
+   bullet above): it was exploration variance among type-clean endpoints, not a real signal. It did
+   not flip the conclusion — it reinforced it, and killed the "stricter LSP stopping gate" lever.
 2. **Put the signal in training** — the oracle as a reward (#230 / the parked #103) and/or the
    fast/slow/both ablation (#201) on a *trained* model, not the frozen base coder. This is where
    the value proposition actually lives; it costs a training run and a Track-B decision.
@@ -752,7 +761,9 @@ signal** rather than an inference-time patch.
 5. **The honest #198 gate call** — write up "validated clean-rate tool, functional ceiling found,
    functional signal needs semantics-as-training" and shelve. A legitimate, well-earned outcome.
 
-Recommendation: do (1) as a small immediate experiment, then use its result to choose between
-committing to (2)+(3) as the serious next thrust or making the (5) gate call. With M10 off the
-plan, this is also the moment to decide whether LSP-in-the-loop becomes a headline **training**
-program (i.e. (2)) or stays exploratory.
+Recommendation: with (1) now resolved — and resolved *against* a cheap inference-time fix — the
+fork is between (2)+(3) as the serious next thrust and the (5) gate call. The divergence result
+removes the last hope that oracle tuning alone moves the functional metric, so the honest read is
+that LSP-in-the-loop only becomes worth more investment as a **training** signal ((2)/(3),
+semantics/execution as a reward); absent appetite for that training run, (5) is the well-earned
+shelve. With M10 off the plan, this is the moment to make that call.

--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -1,0 +1,114 @@
+# The M12 code model — Mamba-2 hybrid MoE (MHM) + structural signal (SSI)
+
+[← Index](README.md)
+
+This is the **live program** ([issue #198](https://github.com/travisgalloway/monica/issues/198),
+the 2026-07-18 "MHM fold"). It supersedes the M10 distillation program (#65), whose design record
+now lives under [`../reserve/`](../reserve/10-distillation.md). Where the earlier docs describe
+distilling a ~1B student from a frozen Qwen teacher, that path is **reserve**; the active plan is a
+from-scratch code model, described below.
+
+## What this is
+
+A from-scratch, **TypeScript-first Mamba-2 hybrid Mixture-of-Experts (MoE) code model**. The
+backbone is mostly Mamba-2/SSD state-space layers with a **minority (~12.5%) of full-attention
+layers** for the cross-file symbol recall that pure SSMs are weak at, and **MoE on the MLP layers**
+(Jamba-style: fine-grained experts, top-k routing, one shared expert, aux-loss-free load
+balancing). It targets two sizes — a **small** rung (~120M active / ~700M total) and a **large**
+rung ("Large A", ~700M active / ~3.5B total, the default), the large one **sparse-upcycled** from
+the small dense checkpoint. It trains on a general multilingual **Essential-Web + Stack-v2**
+mixture with its **own byte-level BPE** and **fill-in-the-middle (FIM)**. Success stays the POC
+bar: a smoothly improving curve plus a local-hardware win (context length + tok/s), with **BPB**
+elevated to the primary small-model metric — not leaderboard scores.
+
+## The MHM spine (the program's phases)
+
+Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
+
+- **MHM-P0 — Decisions.** From-scratch, own BPE, RunPod (CUDA) + M1 (MLX) dev. Carried decisions:
+  D4 Jamba-vs-Routing-Mamba, D5 Large A vs Large B, vocab size.
+- **MHM-P1 — Corpus** (#193): general multilingual Essential-Web + Stack-v2 mixture, repo-context
+  packing, decontamination blocklist. (Rescopes the earlier FineWeb-Edu + Stack-v1 corpus.)
+- **MHM-P1b — Tokenizer** (#191): own byte-level BPE trained on the final mixture. Blocks
+  everything downstream.
+- **MHM-P2 — Architecture & harness build** (the large net-new engineering): aux-loss-free
+  balancing router (#213, *land first*) → CUDA MoE backend (#214: dropless routing, shared expert,
+  FSDP, sparse-upcycle init) → FIM collator (#215), length curriculum + dataloader-state resume
+  (#216), routing instrumentation (#217), pure-PyTorch Mamba-2 reference for laptop parity (#218).
+- **MHM-P2e — Evals** (build first): code eval suite (#221), BPB (#192, primary).
+- **MHM-P3 — Small-model ablation sweep** (#219, ~$80–120 each): attention ratio 8/12/16%,
+  d_state 128 vs 256, Jamba vs Routing-Mamba.
+- **MHM-P4 — Small-model full run** (#222, 50–70B tokens → the dense checkpoint to upcycle).
+- **MHM-P5 — Large-model run** (#223): sparse-upcycle from the dense ckpt, Large A default,
+  ~150B tokens; gated on P4 + D5.
+- **Cross-cutting:** rented-pod ops runbook (#224). **Parked:** post-training SFT (#101) / RLVR
+  (#103).
+
+Today the MoE is **MLX-only** (the MLX router is a toy dense softmax-top-k; the CUDA backend
+explicitly rejects MoE), so scaling on RunPod requires the #213/#214 build — this is the bulk of
+the net-new work.
+
+## The SSI fold (structural signal integration — secondary)
+
+"Does feeding language-server / static-analysis signal into the model help?" — retained as a
+**secondary measurement-and-training-signal** axis riding on the MoE model, under a formal
+measurement contract:
+
+- **SSI-M — measurement contract** (#225): one variable per arm, ≥3 seeds + paired
+  Wilcoxon/McNemar, repo-level contamination split, availability-vs-use null arms, and a shared
+  **escape-hatch lint gate** (extends `SUPPRESSION_RE` in `src/lsp/diagnostics.py` with
+  `as unknown as`, `@ts-nocheck`, non-null `!`, empty bodies, `throw …not implemented`, `declare`
+  stubs, deletion-of-target).
+- **Surviving arms:** completion-list logit masking / constrained decode (#226), diagnostic
+  supervision — rejection-sampled FT + contrastive hard negatives (#227), and **RLVR/GRPO with an
+  LSP/opengrep verifier reward** (#230).
+- **Dropped arms:** two-clock "slow-clock structural state" (conflicts with the MoE spine) and the
+  diffusion path.
+
+### Why SSI is secondary — the recorded assessment
+
+The LSP-in-the-loop experiment (design record + measurement in
+[`12-lsp-in-the-loop.md`](12-lsp-in-the-loop.md)) reached a partly-negative but useful conclusion:
+
+- **Validated clean-rate tool.** Diagnostic-guided rollback/regeneration is a reliable
+  *type-cleanliness* improver — the persistent-LSP swap moved clean-rate **0.887 → 0.962
+  (p=0.0005)**, robust and well-instrumented, with the over-repair failure mode understood and
+  mostly neutralized (#212 final-segment gate, forward-resolvable TS2xxx deferral, #211 confirmed
+  the oracle isn't dropping diagnostics).
+- **But not the lever for the functional gap.** The project's target gap is clean-but-wrong —
+  bodies are **88.7% type-clean but only 50.3% functionally correct**. Persistent LSP leaves
+  **pass@1 flat (0.503, p=0.69, ns)**: the failures are *algorithmic*, which a type/lint checker
+  structurally cannot see. opengrep catches a genuine but far-too-sparse corner (4/159, 4/4
+  precise), and over-repair on multi-statement code is **trajectory-bound, not trigger-bound** —
+  structural to incremental repair, not tunable away.
+
+So: inference-time type/lint-guided rollback on a **frozen** model is a validated clean-rate tool,
+**not** the lever for functional correctness. The correctness-bearing signal lives in
+semantics/execution — which is why the MHM fold makes model quality the primary axis and holds the
+structural signal as a secondary program.
+
+### The open fork (stated, not resolved)
+
+With M10 off the plan, the #198 gate faces a real choice, in evidence-to-cost order:
+
+1. **Resolve the tsc-vs-LSP pass@1 divergence** — batch `tsc` moved pass@1 **0.491 → 0.560
+   (p=0.001)** where open-document LSP did not; the doc attributes this to whole-program vs
+   open-document diagnostics. Cheapest, highest-information; could flip the conclusion. Do first.
+2. **Put the signal in training** — the oracle as a reward (#230 / the parked #103) and/or the
+   fast/slow/both ablation on a *trained* model instead of the frozen base coder. Tests whether a
+   signal that barely moves a frozen model at inference can shape one toward correctness.
+3. **Swap in a semantic/execution oracle** — execution against tests/spec as the `DiagnoseFn`,
+   which naturally pairs with (2) as a train-time reward (expensive, test-gated).
+4. **Exploratory** — the #203 diffusion discriminator (diagnostic-guided denoising); #211 cleared
+   its prerequisite.
+5. **The honest gate call** — "validated clean-rate tool, functional ceiling found, functional
+   signal needs semantics-as-training" — and shelve, a legitimate well-earned outcome.
+
+## See also
+
+- [`12-lsp-in-the-loop.md`](12-lsp-in-the-loop.md) — the LSP harness design record + its
+  assessment/conclusion (the source of the numbers above).
+- [`09-hybrid-architectures.md`](09-hybrid-architectures.md) — why the backbone is a Mamba-2
+  hybrid and how attention placement sizes it.
+- [`../reserve/10-distillation.md`](../reserve/10-distillation.md) — the superseded M10
+  distillation design record (reserve).

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -4,13 +4,15 @@ Why the Mamba-2 Hybrid POC is built the way it is. These files explain the **des
 choices and their rationale** — the *what* and *why*. The POC core (M1–M7), the **CUDA
 backend (M8, A40-verified)**, and the **post-training machinery (M9, SFT/DPO/GRPO)** are
 implemented and verified; the M1–M8 milestones were tracked in
-[issue #2](https://github.com/travisgalloway/monica/issues/2). The **active program is M10 —
-distillation** ([issue #65](https://github.com/travisgalloway/monica/issues/65)). For the
+[issue #2](https://github.com/travisgalloway/monica/issues/2). The **active program is M12 — the
+from-scratch Mamba-2 hybrid MoE code model** ([issue #198](https://github.com/travisgalloway/monica/issues/198));
+see topic 13 below. (The earlier M10 distillation program, #65, was dropped 2026-07-19 — reserve
+under [`../reserve/`](../reserve/10-distillation.md).) For the
 project overview, see the root [`README.md`](../../README.md); for end-to-end commands
 (install → data → train → serve/chat → eval) see [`../usage.md`](../usage.md), for the
 cloud (R2 + RunPod) runbook see [`../infrastructure.md`](../infrastructure.md), and for the
-local Apple-Silicon dev loop (one-command validation, small training configs, local Qwen3
-teacher) see [`../local-development.md`](../local-development.md).
+local Apple-Silicon dev loop (one-command validation, small training configs) see
+[`../local-development.md`](../local-development.md).
 
 Every claim here is sourced from a docstring or config comment in the code, with a
 `src/...` or `config/...` path so you can jump to the source of truth.
@@ -34,38 +36,38 @@ Every claim here is sourced from a docstring or config comment in the code, with
 7. [Configs & locked decisions](07-configs-and-decisions.md) — `toy.yaml` /
    `poc.yaml` in full, plus the precision benchmark and sizing math.
 8. [Corpus pipeline](08-corpus-pipeline.md) — the clean-license data flow: `datatrove`
-   stages, the common schema, R2 storage layout, RunPod topology. Now the **teacher
-   corpus + production-reserve** path (its uint16/StarCoder2 from-scratch framing is
-   superseded by the distillation pivot — see 10).
+   stages, the common schema, R2 storage layout, RunPod topology. The reusable foundation for
+   the M12 corpus (Essential-Web + Stack-v2, #193).
 9. [Hybrid architectures](09-hybrid-architectures.md) — why the model is a Mamba-2
    hybrid (config-gated attention) and how it sizes.
-10. [Distillation (teacher → hybrid student)](10-distillation.md) — the **distillation-first
-    pivot**: distil a compact **~1B** hybrid from a frozen `Qwen/Qwen3-4B-Thinking-2507`
-    teacher (Qwen3 tokenizer ~151,669 → uint32 packing, #90), precompute teacher artifacts once,
-    sweep student layouts cheaply (#98).
+10. **[Distillation → moved to reserve](../reserve/10-distillation.md)** — the M10 distillation
+    design record (distil a ~1B hybrid from a frozen `Qwen/Qwen3-4B-Thinking-2507` teacher).
+    **Dropped 2026-07-19**; kept under [`../reserve/`](../reserve/10-distillation.md) as history.
 11. [Post-training](11-post-training.md) — instruct SFT → reasoning-trace SFT → optional
-    tool-use → GRPO, the Qwen `<|im_end|>` chat-template invariant, shared with production.
-12. [LSP-in-the-loop (no-training validation)](12-lsp-in-the-loop.md) — M12's Phase-0 gate
-    (#199): a `tsc`-in-the-loop repair harness on an off-the-shelf model, and the measurement
-    that decides the P1 tier. Hard-ban (logit mask) roughly doubles diagnostic-clean rate on a
-    free-running budget and beats the tool-call baseline; the pre-registered `error_avoidance`
-    axis turned out saturated, which is itself a finding about the #194 eval set.
+    tool-use → GRPO, the chat-template invariant. Design record; the M12 arms are #101/#103.
+12. [LSP-in-the-loop (measurement + assessment)](12-lsp-in-the-loop.md) — the `tsc`-in-the-loop
+    repair harness (#199), its measurement, and the **arc-level assessment**: a validated
+    clean-rate tool (0.887→0.962) that leaves functional pass@1 flat (0.503) — the recorded
+    rationale for demoting the LSP signal to secondary.
+13. **[The M12 code model — Mamba-2 hybrid MoE + SSI](13-code-model-moe.md)** — the **live
+    program** (#198): the MHM spine (own BPE → Essential-Web + Stack-v2 → aux-loss-free MoE →
+    CUDA MoE backend → FIM/curriculum/evals → ablation sweep → sparse-upcycled large run) and the
+    secondary SSI structural-signal fold (#225/#226/#227/#230).
 
-> Topics 8–11 are the **scale-up / distillation** design record (epic
-> [#65](https://github.com/travisgalloway/monica/issues/65)). Much of the machinery now exists —
-> the corpus stages, hybrid attention (#67), #90 uint32 packing, the distillation corpus (#92),
-> teacher loader (#93), student init (#99), staged distill loss (#100), the sweep harness (#98),
-> and the post-training steps (#76/#77/#78). **Pending:** corpus-scale teacher-logit precompute
-> (#94), the R2 + RunPod plumbing (#80), and the end-to-end cloud distill run (#81). The plan is
-> **distillation-first** (10/11); the from-scratch pretraining in 08 is deferred to a production
-> reserve (#75).
+> **The live program is topic 13** (M12, [#198](https://github.com/travisgalloway/monica/issues/198)):
+> a from-scratch Mamba-2 hybrid **MoE code model** with the structural-signal (SSI) fold as a
+> secondary axis (topic 12 is its measurement record + assessment). Topics 8/9/11 are reusable
+> **foundation** (corpus pipeline, hybrid-architecture sizing, post-training design). Topic 10 (the
+> M10 distillation design record, epic #65) was **dropped 2026-07-19** and moved to
+> [`../reserve/`](../reserve/10-distillation.md); its machinery still exists but the program is not
+> active. The from-scratch pretraining in 08 remains a production reserve (#75).
 
 ## Locked decisions at a glance
 
 | Decision | Choice | Why | Source |
 |---|---|---|---|
 | Hardware isolation | one seam (`ModelInterface`) | clean MLX→CUDA migration | `src/model/interface.py` |
-| Token storage | uint16/uint32 packing (per vocab, #90) | uint16 when vocab < 65536 (POC), uint32 for the Qwen3 distillation vocab (151,669) | `src/data/pack.py` |
+| Token storage | uint16/uint32 packing (per vocab, #90) | uint16 when vocab < 65536, uint32 at/above it (e.g. the M12 code BPE, or the reserve Qwen3 vocab 151,669) | `src/data/pack.py` |
 | Tokenizer (POC) | `allenai/OLMo-7B-hf` (vocab 50280) | fits uint16; matches AI2 for comparison | `src/data/tokenize.py` |
 | Embedding | tied (input = output) | ~38M of ~100M budget at POC scale | `config/poc.yaml` |
 | dt-bias init | inverse-softplus, log-uniform (per head) | **load-bearing** — model can't learn recall without it | `src/model/mlx_backend.py` |
@@ -78,8 +80,9 @@ Every claim here is sourced from a docstring or config comment in the code, with
 | Checkpoints | portable weights + separate resume bundle | weights port across backends; optimizer state doesn't need to | `src/train/checkpoint.py` |
 | Success metric | held-out val perplexity (Tier-1) | a smoothly decreasing curve *is* the POC goal | `src/eval/val_loss.py` |
 | OLMES / lm-eval | implemented (Tier-2); scores near chance at POC scale | loglikelihood + generative tasks run end-to-end | `src/eval/olmes_adapter.py` |
-| Build method | **distillation** from a frozen teacher (not pretrain) | reaches capability at <1% of from-scratch tokens; cheap layout sweep | `docs/design/10-distillation.md` |
-| Scale-up tokenizer | **Qwen3** (vocab ~151,669) | fixed by the conversion teacher for logit/hidden matching; token-aligned with Qwen2.5 + the `<think>`/`</think>` ids; uint32 packing (#90). POC stays OLMo. | `docs/design/10-distillation.md` |
-| Conversion teacher | `Qwen/Qwen3-4B-Thinking-2507` (Apache-2.0) | thinking-mode CoT (the above-weight-class lever), token-aligned Qwen3 vocab; 4B→~1B size gap bridged by adaptive init (Qwen3.5-4B rejected: 250k vocab breaks aligned KD) | `docs/design/10-distillation.md` |
-| Scale-up model | single **~1B** Mamba-2 hybrid student (28 layers; teacher is 36, bridged by adaptive init) | attention layers close the SSM retrieval gap; no-KV-cache local inference; size ladder is an open question (#65) | `docs/design/10-distillation.md` |
-| Data framework | `datatrove` + R2 + RunPod | builds the teacher corpus + production-reserve from-scratch data (#75) | `docs/design/08-corpus-pipeline.md` |
+| Build method (M12) | **from-scratch** Mamba-2 hybrid **MoE** code model (not distillation) | model quality is the primary axis; MoE = capability per active param | `docs/design/13-code-model-moe.md` |
+| Tokenizer (M12) | **own byte-level BPE** on the final mixture (#191) | code-first vocab, no external-teacher alignment constraint; uint32 packing (#90) | `docs/design/13-code-model-moe.md` |
+| Model sizes (M12) | small ~120M-act/700M-tot; large "Large A" ~700M-act/3.5B-tot | large is **sparse-upcycled** from the small dense ckpt; ablation sweep picks the layout (#219) | `docs/design/13-code-model-moe.md` |
+| Structural signal (M12, secondary) | LSP/opengrep as measurement + training signal (SSI) | validated clean-rate tool, functional ceiling found; #225/#226/#227/#230 | `docs/design/13-code-model-moe.md` |
+| Data framework | `datatrove` + R2 + RunPod | builds the M12 corpus (Essential-Web + Stack-v2, #193) + reserve data | `docs/design/08-corpus-pipeline.md` |
+| Build method (reserve) | **distillation** from a frozen teacher — Qwen3 vocab, `Qwen/Qwen3-4B-Thinking-2507`, ~1B student | M10 program, **dropped 2026-07-19**; machinery built, kept as history | `docs/reserve/10-distillation.md` |

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -3,28 +3,37 @@
 This is the operational runbook for taking the data and training pipeline off a laptop and onto
 **durable object storage + on-demand GPU hosts**. It is written **generically first** (any
 S3-compatible store + any CUDA host), then with the **specifics we use: Cloudflare R2 + RunPod**.
+The generic topology, R2 specifics, and RunPod pod-role split below are reusable foundation for
+any cloud run, including the live M12 program; the **distillation-specific stages** (frozen
+teacher-signal precompute, the three-class `poc-distill/` layout, the Path B run) are **reserve**,
+inherited from the dropped M10 program.
 
 For the *why* behind the corpus design, see
-[`design/08-corpus-pipeline.md`](design/08-corpus-pipeline.md); for the distillation strategy
-these artifacts feed, see [`design/10-distillation.md`](design/10-distillation.md).
+[`design/08-corpus-pipeline.md`](design/08-corpus-pipeline.md); for the (reserve) distillation
+strategy these artifacts fed, see [`reserve/10-distillation.md`](reserve/10-distillation.md); for
+the live M12 plan, see [`design/13-code-model-moe.md`](design/13-code-model-moe.md).
 
 > **Status.** The storage **layout** is implemented and is the single source of truth
 > ([`src/data/storage.py`](../src/data/storage.py)); the same path strings are valid local
-> directories *and* object-store prefixes. The actual **R2/RunPod readers/writers and the cloud
-> run harness are in progress** ([#80](https://github.com/travisgalloway/monica/issues/80),
-> [#81](https://github.com/travisgalloway/monica/issues/81)). What follows is the **intended**
-> flow — build and unit-test it locally first, then rent a pod for the few stages that need one.
+> directories *and* object-store prefixes. The **R2/RunPod readers/writers and the M10 cloud run
+> harness** described below were **never finished** — they were mid-build
+> ([#80](https://github.com/travisgalloway/monica/issues/80),
+> [#81](https://github.com/travisgalloway/monica/issues/81)) when M10 was dropped 2026-07-19 —
+> treat those pieces as reserve, not a live build target. What follows is the **M10-era intended**
+> flow, kept for its generic R2/RunPod topology; build and unit-test locally first, then rent a
+> pod for the few stages that need one.
 
 ---
 
 ## Principle: cloud is on-demand
 
 Almost the entire stack is **Mac-doable today** (MLX, or CUDA-on-torch-CPU for conformance):
-the data pipeline on a slice, the manifest/sizing tooling, the teacher loader and student init
-at toy scale, the distillation loss + train step, and the SFT/DPO/GRPO machinery. **Build and
-unit-test all of it locally before renting anything.**
+the data pipeline on a slice, the manifest/sizing tooling, the SFT/DPO/GRPO machinery, and — for
+the reserve M10 path — the teacher loader, student init at toy scale, and the distillation loss +
+train step. **Build and unit-test all of it locally before renting anything.** This principle
+carries over to M12; the paid-stage table below is the M10-era example (reserve).
 
-Rent a pod only for the handful of stages that genuinely need one:
+Rent a pod only for the handful of stages that genuinely need one (M10-era example, reserve):
 
 | Paid stage | Why it needs a pod | Issue |
 |---|---|---|
@@ -56,10 +65,11 @@ provider:
    outputs to a fast local/volume disk, trains, and **pushes checkpoints back** to the store.
 4. **Keep compute network-close to storage** so the train-time pull is fast and egress is cheap.
 
-### The three-class storage layout
+### The three-class storage layout (reserve — M10 distillation)
 
 One layout keeps the **student architecture downstream of every frozen artifact**, so a layout
-sweep invalidates nothing upstream (the whole point of the distillation strategy):
+sweep invalidates nothing upstream (the whole point of the M10 distillation strategy — kept here
+as reserve/example; the live M12 corpus build, #193, has no frozen-teacher class to isolate):
 
 ```
 <store>://<bucket>/
@@ -206,11 +216,12 @@ A40); the fused kernels auto-detect at runtime and degrade gracefully when absen
 
 ---
 
-## End-to-end intended flow (once #80/#81 land)
+## End-to-end intended flow (M10-era, reserve — #80/#81 never fully landed before the pivot)
 
-For the concrete, command-by-command Path B execution of this flow (the full-scale ~1B distillation
-run — exact commands, pod sizing, R2 paths, cost, and the Path A gotchas), see
-[`path-b-run.md`](path-b-run.md). The steps below are the generic shape.
+This flow is specific to the (dropped) M10 distillation program; kept as reserve/history, not a
+live target. For the concrete, command-by-command Path B execution of this flow (the full-scale
+~1B distillation run — exact commands, pod sizing, R2 paths, cost, and the Path A gotchas), see
+[`reserve/path-b-run.md`](reserve/path-b-run.md). The steps below are the generic shape.
 
 1. **Local (Mac):** build + unit-test the data pipeline on a slice, the teacher loader, student
    init, distillation loss, and the manifest/sweep — all at toy scale.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,17 +1,16 @@
 # Local development on Apple Silicon (MLX)
 
-MLX is the **dev/validation backend**: it exists so you can prove a change correct, generate
-small amounts of teacher signal, and train test-scale models *locally* before paying for a CUDA
-cloud run. Scale training itself runs on CUDA/RunPod (see
-[`docs/infrastructure.md`](infrastructure.md)) — so this page is about **developer velocity**, not
-throughput. (The MLX *train-step throughput* optimizations were deliberately retired; see issue
-#30's decision record before reopening that.)
+MLX is the **dev/validation backend**: it exists so you can prove a change correct and train
+test-scale models *locally* before paying for a CUDA cloud run. Scale training itself runs on
+CUDA/RunPod (see [`docs/infrastructure.md`](infrastructure.md)) — so this page is about
+**developer velocity**, not throughput. (The MLX *train-step throughput* optimizations were
+deliberately retired; see issue #30's decision record before reopening that.)
 
 Three things live here:
 
 1. [Validate every stage locally in one command](#1-validate-every-stage-locally)
 2. [Train test models locally (`small.yaml`, `poc-small.yaml`)](#2-train-test-models-locally)
-3. [Generate teacher signal locally (Qwen3 via MLX, or LM Studio)](#3-generate-teacher-signal-locally)
+3. [Generate teacher signal locally (Qwen3 via MLX, or LM Studio) — reserve, M10 distillation](#3-generate-teacher-signal-locally)
 
 All commands assume the Apple-Silicon install (`pip install -e ".[dev,data,mlx]"`) and the venv
 at `.venv`.
@@ -31,12 +30,13 @@ One offline command (no network / HF / weights) that fails fast through every pi
 | 1 data | `download --dummy` → `tokenize --byte-fallback` → `pack` → `split` | the data pipeline end-to-end |
 | 2 smoke | `scripts/smoke_test.py` on a **fresh** byte split | resume is bit-exact + val eval runs (fp32) |
 | 3 train | `scripts/train.py --config config/small.yaml` | the real fp16 + loss-scaling training path |
-| 4 distill | `scripts/distill_smoke.py` | the 3 staged losses (mixing-match → hidden-align → logit-distill) |
-| 5 teacher | `scripts/precompute_teacher.py --backend mlx --synthetic --compile` | the #94 precompute + the `mx.compile` lever |
+| 4 distill (reserve) | `scripts/distill_smoke.py` | the 3 staged losses (mixing-match → hidden-align → logit-distill), M10 machinery |
+| 5 teacher (reserve) | `scripts/precompute_teacher.py --backend mlx --synthetic --compile` | the #94 precompute + the `mx.compile` lever, M10 machinery |
 
 Knobs (env vars): `PYTHON` (default `.venv/bin/python`), `WORK` (default `runs/local-validate`),
 `STEPS` (default 20), `KEEP=1` to keep the work dir. Use this as the pre-push gate for any change
-to the loop, the SSD scan, mixed precision, checkpointing, or the distill stages.
+to the loop, the SSD scan, mixed precision, checkpointing, or (for stages 4–5) the reserve distill
+stages.
 
 > The smoke gate must run on a **freshly built byte split**, not the real `data/split` (which is
 > the OLMo-vocab corpus) — `local_validate.sh` builds one for you.
@@ -74,10 +74,18 @@ scale). Both carry their measured step-time in the YAML header.
 
 ---
 
-## 3. Generate teacher signal locally
+## 3. Generate teacher signal locally (reserve — M10 distillation)
 
-The distillation student trains against **cached teacher top-k logits** (the #94 precompute), then
-the `logit-distill` stage matches them with KL. You can produce that signal locally two ways.
+> **Reserve.** This section describes the M10 distillation program's teacher-signal precompute
+> (issue #65, **dropped 2026-07-19** — design record at
+> [`reserve/10-distillation.md`](reserve/10-distillation.md)). It is not part of the live M12
+> dev loop (sections 1–2 above); it is kept because the machinery still works and may be useful
+> reference. See [`design/13-code-model-moe.md`](design/13-code-model-moe.md) for the current
+> program.
+
+The (reserve) distillation student trained against **cached teacher top-k logits** (the #94
+precompute), then the `logit-distill` stage matched them with KL. You can still produce that
+signal locally two ways.
 
 ### 3a. Real Qwen3 teacher via MLX — *the recommended path*
 
@@ -134,5 +142,7 @@ is already serving.
 
 ---
 
-See also: [`docs/usage.md`](usage.md) (full flow), [`docs/design/10-distillation.md`](design/10-distillation.md)
-(distillation design), [`docs/infrastructure.md`](infrastructure.md) (cloud R2 + RunPod).
+See also: [`docs/usage.md`](usage.md) (full flow),
+[`docs/design/13-code-model-moe.md`](design/13-code-model-moe.md) (the live M12 plan),
+[`docs/reserve/10-distillation.md`](reserve/10-distillation.md) (reserve distillation design),
+[`docs/infrastructure.md`](infrastructure.md) (cloud R2 + RunPod).

--- a/docs/reserve/10-distillation.md
+++ b/docs/reserve/10-distillation.md
@@ -1,12 +1,18 @@
 # Distillation (teacher → hybrid student)
 
-[← Index](README.md)
+> **⛔ Reserve / historical (M10 distillation, superseded 2026-07-19).** This program is no longer
+> active — see [`../design/13-code-model-moe.md`](../design/13-code-model-moe.md) and
+> [issue #198](https://github.com/travisgalloway/monica/issues/198) for the live M12 code-model
+> arc. Retained as a design record and as the inventory of R2 assets (corpus + ~566 GB teacher
+> cache) that may still occupy paid storage.
+
+[← Design index](../design/README.md)
 
 Why the POC **distills** a compact Mamba-2 hybrid from a frozen transformer teacher instead of
 pretraining from scratch, and how that makes an architecture search cheap. The tracker is
 [issue #65](https://github.com/travisgalloway/monica/issues/65); the corpus + teacher-output
-storage is in [corpus pipeline](08-corpus-pipeline.md); the model is in
-[hybrid architectures](09-hybrid-architectures.md).
+storage is in [corpus pipeline](../design/08-corpus-pipeline.md); the model is in
+[hybrid architectures](../design/09-hybrid-architectures.md).
 
 ## Why distill, not pretrain
 
@@ -149,7 +155,7 @@ few added control tokens incl. the `<think>`/`</think>` pair, so the student can
 delimiters as **native ids** (the headline lever). It is token-aligned with the Qwen2.5 family, so
 the prior Qwen2.5 teachers stay usable. Adopted for the production model too, which collapses the
 POC-to-production tokenizer question. This exceeds the uint16 bound → **uint32 packing** (#90,
-unchanged: ~151,669 < 2³²); see [corpus pipeline](08-corpus-pipeline.md). The tokenizer key is
+unchanged: ~151,669 < 2³²); see [corpus pipeline](../design/08-corpus-pipeline.md). The tokenizer key is
 `qwen3` (`src/train/distill_manifest.py`, `src/data/tokenize.py`).
 
 ## Precompute once, sweep students cheaply (#94, #98)
@@ -162,7 +168,7 @@ time and reused by every trial:
   with doc-boundary sidecars and a corpus manifest — the exact path the manifests below name.
 - **Teacher outputs** over it: top-50..100 logits + indices per token (#94); optionally hidden
   states for MOHAWK matching. The teacher forward pass is the dominant cost — paid **once**.
-- The shared SFT corpora and verifiable RL sets ([post-training](11-post-training.md)).
+- The shared SFT corpora and verifiable RL sets ([post-training](../design/11-post-training.md)).
 
 Each student trial is then a lightweight **manifest** naming the frozen artifacts + the layout:
 
@@ -213,7 +219,7 @@ until then.
 
 ## Related
 
-- [Corpus pipeline](08-corpus-pipeline.md) — the distillation corpus, teacher outputs, storage layout.
-- [Hybrid architectures](09-hybrid-architectures.md) — the student the teacher converts into.
-- [Post-training](11-post-training.md) — the three capability layers applied after conversion.
-- [Training](05-training.md) — the backend-free loop the distill train step plugs into.
+- [Corpus pipeline](../design/08-corpus-pipeline.md) — the distillation corpus, teacher outputs, storage layout.
+- [Hybrid architectures](../design/09-hybrid-architectures.md) — the student the teacher converts into.
+- [Post-training](../design/11-post-training.md) — the three capability layers applied after conversion.
+- [Training](../design/05-training.md) — the backend-free loop the distill train step plugs into.

--- a/docs/reserve/path-b-run.md
+++ b/docs/reserve/path-b-run.md
@@ -1,5 +1,11 @@
 # Path B run — session handoff (full-scale M10 distillation, ~1B student)
 
+> **⛔ Reserve / historical (M10 distillation, superseded 2026-07-19).** This program is no longer
+> active — see [`../design/13-code-model-moe.md`](../design/13-code-model-moe.md) and
+> [issue #198](https://github.com/travisgalloway/monica/issues/198) for the live M12 code-model
+> arc. Retained as a design record and as the inventory of R2 assets (corpus + ~566 GB teacher
+> cache) that may still occupy paid storage.
+
 > **Update (2026-07-03) — Steps 1 & 3 are DONE for the base corpus; don't re-run them as-is.**
 > The base 8k corpus build (Step 1) and the base teacher precompute (Step 3) both completed
 > 2026-07-02 (566 GB merged cache at `poc-distill/teacher-outputs/topk-logits-merged/`, 230,318
@@ -23,10 +29,10 @@ at **full scale and seq_len 8192**, retargeted to the new **Qwen3-4B-Thinking-25
 eval tokenizer selection (#139, extended to `qwen3` under #65). **There is no code to write — this is
 execution** (the one data step the switch adds is re-tokenizing the corpus to the Qwen3 vocab, Step 1).
 
-Related: [`infrastructure.md`](infrastructure.md) (generic R2 + RunPod flow; this doc is its concrete
-Path B companion), [`design/10-distillation.md`](design/10-distillation.md) (why distil / the staged
-loss), [`config/manifests/student-1b-attn-hi.yaml`](../config/manifests/student-1b-attn-hi.yaml) +
-[`student-1b-attn-lo.yaml`](../config/manifests/student-1b-attn-lo.yaml) (the two sweep trials).
+Related: [`infrastructure.md`](../infrastructure.md) (generic R2 + RunPod flow; this doc is its concrete
+Path B companion), [`design/10-distillation.md`](10-distillation.md) (why distil / the staged
+loss), [`config/manifests/student-1b-attn-hi.yaml`](../../config/manifests/student-1b-attn-hi.yaml) +
+[`student-1b-attn-lo.yaml`](../../config/manifests/student-1b-attn-lo.yaml) (the two sweep trials).
 
 ## Current state (already done)
 

--- a/docs/reserve/runbooks/m10-phase-bprime-append.md
+++ b/docs/reserve/runbooks/m10-phase-bprime-append.md
@@ -1,5 +1,11 @@
 # M10 Phase B′ — append-only teacher precompute for the corpus extension (#177)
 
+> **⛔ Reserve / historical (M10 distillation, superseded 2026-07-19).** This program is no longer
+> active — the runbook below is **parked**, not live. See
+> [`../../design/13-code-model-moe.md`](../../design/13-code-model-moe.md) and
+> [issue #198](https://github.com/travisgalloway/monica/issues/198) for the live M12 code-model
+> arc. Retained as the inventory of the frozen ~566 GB teacher top-k cache on R2 (paid storage).
+
 Ready-to-fire runbook for **#177**: extend the frozen 566 GB Qwen3-4B-Thinking teacher top-k cache
 to cover the multi-domain corpus extension (#176/#182, built 2026-07-05) **without re-precomputing the
 ~230,318 unchanged FineWeb chunks**. All machinery is merged
@@ -10,7 +16,7 @@ no prior context.
 Related: [`../path-b-run.md`](../path-b-run.md) (the authoritative Path B runbook — see its update
 banner; this doc replaces its Step 3 for the *extension* leg), [`m10-pod-chain.md`](m10-pod-chain.md)
 (precompute + sweep staging, steps 3–4 — this runbook's output feeds its Step 3),
-[`../infrastructure.md`](../infrastructure.md) (generic R2 + RunPod flow).
+[`../infrastructure.md`](../../infrastructure.md) (generic R2 + RunPod flow).
 
 ## State (as of 2026-07-05)
 

--- a/docs/reserve/runbooks/m10-pod-chain.md
+++ b/docs/reserve/runbooks/m10-pod-chain.md
@@ -1,5 +1,12 @@
 # M10 pod-chain — ready-to-fire staging (steps 3–4)
 
+> **⛔ Reserve / historical (M10 distillation, superseded 2026-07-19).** This program is no longer
+> active — the "ready-to-fire" chain below is **parked**, not live. See
+> [`../../design/13-code-model-moe.md`](../../design/13-code-model-moe.md) and
+> [issue #198](https://github.com/travisgalloway/monica/issues/198) for the live M12 code-model
+> arc. Retained as the inventory of R2 assets (corpus + ~566 GB teacher cache) that may still
+> occupy paid storage.
+
 > **Update (2026-07-03).** Step 3 (teacher precompute) below completed for the **base** corpus on
 > 2026-07-02. The corpus was then extended with new domains (#176); extending the teacher cache to
 > cover those new chunks is a separate **append** step (3′) that must run **before** Step 4, reusing
@@ -13,7 +20,7 @@ gives the exact copy-paste block to fire steps 3–4 the moment a pod is up.
 
 It is intentionally short and defers all reasoning (cost, sizing, gotchas, the full step-by-step) to
 **[`../path-b-run.md`](../path-b-run.md)**, the authoritative Path B runbook. Read that for *why*;
-read this to *go fast*. See also [`../infrastructure.md`](../infrastructure.md) (generic R2 + RunPod).
+read this to *go fast*. See also [`../infrastructure.md`](../../infrastructure.md) (generic R2 + RunPod).
 
 ## Status: staging validated (no pod, no GPU run)
 

--- a/docs/reserve/runpod-poc-run.md
+++ b/docs/reserve/runpod-poc-run.md
@@ -1,9 +1,15 @@
 # RunPod POC run — session handoff (`poc-qwen`, ~205M)
 
+> **⛔ Reserve / historical (M10 distillation, superseded 2026-07-19).** This program is no longer
+> active — see [`../design/13-code-model-moe.md`](../design/13-code-model-moe.md) and
+> [issue #198](https://github.com/travisgalloway/monica/issues/198) for the live M12 code-model
+> arc. The ~205M `poc-qwen` run this documents is **complete** (val-ppl 75.7); kept as a RunPod
+> provisioning/run record and R2 asset inventory.
+
 Self-contained runbook to train the ~205M Qwen2.5 POC on a RunPod GPU pod, eval it, and sync
 checkpoints to R2. Written so a fresh session (or a clean pod clone) can execute it with no prior
-context. Related: [`infrastructure.md`](infrastructure.md) (general pod flow),
-[`config/poc-qwen.yaml`](../config/poc-qwen.yaml) (the config + its header runbook).
+context. Related: [`infrastructure.md`](../infrastructure.md) (general pod flow),
+[`config/poc-qwen.yaml`](../../config/poc-qwen.yaml) (the config + its header runbook).
 
 ## Current state (already done)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,11 +5,20 @@ serve/chat → eval**. For *why* the project is built this way, see
 [`design/`](design/README.md); for running this pipeline on cloud storage + rented GPUs
 (R2 + RunPod), see [`infrastructure.md`](infrastructure.md).
 
-The project has **two training paths**:
+> **Status note (2026-07-19).** The **live program is M12** — a from-scratch TypeScript-first
+> Mamba-2 hybrid **MoE** code model ([issue #198](https://github.com/travisgalloway/monica/issues/198),
+> design: [`design/13-code-model-moe.md`](design/13-code-model-moe.md)). The M10 distillation
+> program (issue #65) was **dropped 2026-07-19**; its design record moved to
+> [`reserve/10-distillation.md`](reserve/10-distillation.md). M12's own commands (own-BPE
+> tokenizer #191, Essential-Web + Stack-v2 corpus #193, MoE training) land as that work is built
+> out. The two paths below remain accurate for what they cover; the distillation path is now
+> **reserve**, not active.
 
-- **Distillation (current focus)** — build a compact **~1B** Mamba-2 hybrid student from a
-  larger frozen teacher (Qwen3 tokenizer → uint32 packing). *In progress:* the building
-  blocks exist; the end-to-end run harness is being wired up.
+The project has **two training paths** (see the status note above for which is active):
+
+- **Distillation (reserve)** — build a compact **~1B** Mamba-2 hybrid student from a
+  larger frozen teacher (Qwen3 tokenizer → uint32 packing). The building blocks exist; the
+  end-to-end run harness was never fully wired up before the program was dropped.
 - **From-scratch pretrain (validated foundation / production reserve)** — train a ~100M POC
   from scratch (OLMo tokenizer → uint16). Complete and exercised by the smoke gate.
 
@@ -39,8 +48,8 @@ needs network once):
 
 - **OLMo** (`allenai/OLMo-7B-hf`, vocab 50,280 < 65,536) → **uint16** packing — the
   from-scratch POC path.
-- **Qwen3** (vocab ~151,669 ≥ 65,536) → **uint32** packing — the distillation path, fixed by
-  the conversion teacher (`Qwen/Qwen3-4B-Thinking-2507`).
+- **Qwen3** (vocab ~151,669 ≥ 65,536) → **uint32** packing — the (reserve) distillation path,
+  fixed by the conversion teacher (`Qwen/Qwen3-4B-Thinking-2507`).
 
 Run the tests to confirm the install (on Linux the MLX-only tests skip, not fail):
 
@@ -52,7 +61,7 @@ Run the tests to confirm the install (on Linux the MLX-only tests skip, not fail
 
 ## 2. Build a corpus
 
-### 2a. Distillation corpus (current focus — Qwen3, uint32)
+### 2a. Distillation corpus (reserve — Qwen3, uint32)
 
 [`src/data/distill_corpus.py`](../src/data/distill_corpus.py) is a thin orchestrator that
 builds the **frozen** distillation corpus every student trial consumes: it cleans text into
@@ -165,13 +174,16 @@ The smaller `config/toy.yaml` (vocab 256, fp32) backs the exact-resume smoke gat
 .venv/bin/python scripts/smoke_test.py --data data/split    # use a byte-fallback split
 ```
 
-### 3b. Distillation (in progress)
+### 3b. Distillation (reserve)
 
 Distillation builds a hybrid student from a **frozen teacher**, reaching capability at <1% of
-from-scratch tokens — so several architecture layouts can be swept cheaply. The pieces exist
-today; the **single end-to-end run driver and the cloud plumbing are still being built**
+from-scratch tokens — so several architecture layouts can be swept cheaply. This was the M10
+program (issue #65), **dropped 2026-07-19** in favor of M12
+([`design/13-code-model-moe.md`](design/13-code-model-moe.md)) before its end-to-end run driver
+and cloud plumbing were fully wired up
 ([#80](https://github.com/travisgalloway/monica/issues/80),
-[#81](https://github.com/travisgalloway/monica/issues/81)):
+[#81](https://github.com/travisgalloway/monica/issues/81)). The pieces below remain in the tree
+and functional as reserve machinery:
 
 | Piece | Module | Role |
 |---|---|---|
@@ -193,7 +205,7 @@ state size). Sibling manifests must share one frozen teacher signal:
 A manifest names the frozen artifacts (corpus, teacher outputs, SFT/RL sets) and the swept
 layout; the student layout is **downstream of every frozen artifact**, so changing it
 invalidates nothing upstream. See
-[`design/10-distillation.md`](design/10-distillation.md) for the full rationale.
+[`reserve/10-distillation.md`](reserve/10-distillation.md) for the full rationale (reserve).
 
 ### 3c. Post-training (M9) — SFT → DPO → RLVR
 


### PR DESCRIPTION
Refs #198 (does not close the tracker — this is the docs/memory reframe under it).

Reframes the repo docs and CLAUDE.md away from the dropped M10 distillation program (#65,
dropped 2026-07-19) onto the live M12 program (#198): a from-scratch TypeScript-first Mamba-2
hybrid **MoE** code model (the "MHM" spine) with LSP/opengrep **structural-signal integration
(SSI)** as a secondary axis.

## Summary
- **Archive** the distillation-specific docs to `docs/reserve/` via `git mv` (history preserved
  as renames), each with a "⛔ Reserve / historical (M10, superseded)" banner:
  `10-distillation.md`, `path-b-run.md`, `runpod-poc-run.md`, `runbooks/m10-*.md`. Fixed the
  intra-doc links the move broke.
- **New anchor** `docs/design/13-code-model-moe.md`: the MHM spine (P0→P5) + the SSI fold,
  including the recorded LSP-in-the-loop assessment (validated clean-rate tool 0.887→0.962, but
  pass@1 flat 0.503 — not the functional lever) and the open #198 fork.
- **Appended** an arc-level assessment/conclusion to `docs/design/12-lsp-in-the-loop.md`.
- **Reframed in place** (keeping foundation content): `CLAUDE.md`, `README.md`,
  `docs/design/README.md`, docs 08/09/11, `usage.md`, `infrastructure.md`, `local-development.md`.
  Kept the standing "no Claude-generated training corpus" guardrail (extended to M12's SSI data).

## Verification
- [x] Every relative doc link resolves (live + reserve)
- [x] No live "active program = distillation" framing outside `docs/reserve/`
- [x] Every M10/#65 mention is marked reserve/history
- [x] Docs only — no code/config changes

> **Note (post-commit):** a memory update landed after this branch was committed indicating the
> tsc-vs-LSP pass@1 divergence — framed here as an *open* loose end (doc 12/13) per the decision
> at commit time — may now be **resolved** (exploration/trajectory variance, not detection). A
> follow-up commit may be warranted to flip that framing. See PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyMCMap3EqNo8mgTXRmM73