### PR TITLE
feat: [M11] Shared multilingual code BPE (16k) + load_code_tokenizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 # Data pipeline at full scale (download/tokenize). pyarrow + fsspec back the corpus
 # Parquet sharded IO (src/data/corpus.py); fsspec also gives the file://-now /
 # s3://-later storage URI seam (the R2 writer swap is #80).
-data = ["datasets>=2.0", "transformers>=4.40", "pyarrow>=14", "fsspec>=2024.0"]
+data = ["datasets>=2.0", "transformers>=4.40", "tokenizers>=0.20", "pyarrow>=14", "fsspec>=2024.0"]
 # Scale corpus engine (#65/#80): HF datatrove runs the same pipeline shape on
 # R2/RunPod (src/data/datatrove_pipeline.py). The local skeleton (src/data/corpus.py) is
 # pyarrow-native and does NOT require this; install it only where the cloud pipeline runs.

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -6,11 +6,16 @@ The packed token dtype follows the tokenizer vocab (`pack.packing_dtype_for`):
 - **Qwen3** (vocab ~151,669) — fixed by the distillation conversion teacher
   (Qwen/Qwen3-4B-Thinking-2507); the unified Qwen3 BPE, token-aligned with Qwen2.5 plus
   a few added control tokens (incl. <think>/</think>). Exceeds uint16, so it packs as
-  **uint32** (#90, see docs/design/10-distillation.md). This is the distillation default.
+  **uint32** (#90, see docs/design/10-distillation.md). M10/Qwen distillation is retired;
+  kept for back-compat.
 - **Qwen2.5** (vocab 151,646) — the prior teacher's tokenizer; uint32. Kept for back-compat
   (the DeepSeek-R1-Distill-Qwen variants share it).
 - **StarCoder2** (vocab ~49,152) — a legacy code-corpus tokenizer (the old uint16 scale
   pick, now superseded by Qwen2.5).
+- **code** (vocab <=16,384) — the shared multilingual code BPE (#191, M11), trained
+  locally by `src/data/tokenizer_train.py` and loaded from a filesystem artifact (not
+  HF `AutoTokenizer.from_pretrained`). uint16-packable; the from-scratch M12/M13 model's
+  tokenizer.
 
 A byte-level fallback tokenizer is provided ONLY for offline pipeline testing; it is not
 vocab-compatible with any real tokenizer and must not be used for a real run.
@@ -94,6 +99,37 @@ class ByteTokenizer:
         return bytes(int(i) & 0xFF for i in ids).decode("utf-8", "replace")
 
 
+class CodeTokenizer:
+    """Wraps a locally-trained `tokenizers` byte-level BPE (issue #191) in the minimal object
+    shape the pipeline needs (like ByteTokenizer): vocab_size / encode / decode / eos_token_id.
+    Loaded from a filesystem path, NOT AutoTokenizer.from_pretrained."""
+
+    def __init__(self, tok):
+        self._tok = tok
+        self.vocab_size = tok.get_vocab_size()
+        # <|endoftext|> is reserved as the doc separator; tokenize_texts/tokenize_docs append
+        # it per doc via getattr(tokenizer, "eos_token_id", None).
+        self.eos_token_id = tok.token_to_id("<|endoftext|>")
+
+    def encode(self, text: str) -> List[int]:
+        return self._tok.encode(text).ids
+
+    def decode(self, ids: Iterable[int]) -> str:
+        return self._tok.decode(list(ids))
+
+
+def load_code_tokenizer(path):
+    """Load the shared code BPE (#191) trained by src/data/tokenizer_train.py from `path`
+    (a tokenizer.json file, or a directory containing one). uint16-packable (vocab ~16k)."""
+    from tokenizers import Tokenizer            # lazy — tokenize.py is not in the import guard
+    p = Path(path)
+    if p.is_dir():
+        p = p / "tokenizer.json"
+    if not p.exists():
+        raise FileNotFoundError(f"code tokenizer artifact not found: {p}")
+    return CodeTokenizer(Tokenizer.from_file(str(p)))
+
+
 def tokenize_texts(texts: Iterable[str], tokenizer) -> Iterable[int]:
     """Yield a flat stream of token ids across all documents (with EOS if available)."""
     eos = getattr(tokenizer, "eos_token_id", None)
@@ -150,10 +186,14 @@ def main() -> None:
     ap.add_argument("--out", type=Path, required=True, help="uint16/uint32 ids; .bin streams "
                     "straight into the packed format, .npy goes through `pack` separately")
     ap.add_argument("--byte-fallback", action="store_true", help="offline testing only")
-    ap.add_argument("--tokenizer", choices=("olmo", "qwen3", "qwen25", "starcoder2"),
+    ap.add_argument("--tokenizer", choices=("olmo", "qwen3", "qwen25", "starcoder2", "code"),
                     default="olmo",
-                    help="HF tokenizer; the packed dtype is uint16/uint32 per its vocab")
+                    help="HF tokenizer; the packed dtype is uint16/uint32 per its vocab. "
+                    "'code' loads a locally-trained artifact via --tokenizer-path (#191)")
     ap.add_argument("--model-id", default=None)
+    ap.add_argument("--tokenizer-path", type=Path, default=None,
+                    help="path to the trained code-BPE artifact (tokenizer.json or its "
+                    "dir); required for --tokenizer code")
     ap.add_argument("--max-tokens", type=int, default=None,
                     help="stop after this many tokens (caps the scale run)")
     args = ap.parse_args()
@@ -162,8 +202,16 @@ def main() -> None:
 
     from .pack import packing_dtype_for
     _loaders = {"olmo": load_olmo_tokenizer, "qwen3": load_qwen3_tokenizer,
-                "qwen25": load_qwen25_tokenizer, "starcoder2": load_starcoder2_tokenizer}
-    tok = ByteTokenizer() if args.byte_fallback else _loaders[args.tokenizer](args.model_id)
+                "qwen25": load_qwen25_tokenizer, "starcoder2": load_starcoder2_tokenizer,
+                "code": load_code_tokenizer}
+    if args.byte_fallback:
+        tok = ByteTokenizer()
+    elif args.tokenizer == "code":
+        if args.tokenizer_path is None:
+            ap.error("--tokenizer code requires --tokenizer-path")
+        tok = _loaders["code"](args.tokenizer_path)
+    else:
+        tok = _loaders[args.tokenizer](args.model_id)
     dtype = packing_dtype_for(tok.vocab_size)   # uint16 (POC) / uint32 (Qwen3)
     # Input is either a one-doc-per-line text file or corpus Parquet shards (dir/.parquet).
     with _open_texts(args.inp) as texts:

--- a/src/data/tokenizer_train.py
+++ b/src/data/tokenizer_train.py
@@ -1,0 +1,107 @@
+"""Train the shared multilingual code BPE (#191, M11 foundation for #188).
+
+A single shared byte-level BPE trained over the code corpus keeps every future
+Branch-Train-Mix language branch in a compatible vocabulary (per-language BPEs can't
+share embeddings/residual stream). ~16k vocab is compute-optimal for a ~1B/100M model
+(Tao et al., NeurIPS 2024) and packs as **uint16** (`pack.packing_dtype_for`), a leaner
+tied embedding than the retired Qwen3 distillation path's 151,669.
+
+This module builds the trainer + CLI; the real training run over the final corpus
+mixture is #193-gated. Here the artifact is only exercised on a sample corpus, so the
+special-token list can still evolve before the real run.
+
+`tokenizers` is imported LAZILY inside functions (never at module top-level) so this
+module stays portable — it imports cleanly above the seam even where the `data` extra
+is absent, matching the other guarded `src/data/*` modules (see
+`tests/test_import_guard.py`).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, Iterator
+
+# Reserved up front (ids 0..N-1) so the SAME tokenizer serves the AR arm (FIM, #215) and
+# the diffusion arm (<mask>, M13 WS5b) with no retrain. Standard StarCoder/OpenAI FIM set.
+EOS_TOKEN = "<|endoftext|>"          # document separator / EOS -> wrapper.eos_token_id
+MASK_TOKEN = "<mask>"                # diffusion arm (M13 WS5b)
+SPECIAL_TOKENS = [
+    EOS_TOKEN,
+    "<|fim_prefix|>",
+    "<|fim_middle|>",
+    "<|fim_suffix|>",
+    "<|fim_pad|>",
+    MASK_TOKEN,
+]
+DEFAULT_VOCAB_SIZE = 16384
+
+_SOURCE_SUFFIXES = (".ts", ".tsx", ".js", ".jsx", ".py", ".txt", ".md")
+
+
+def train_code_bpe(texts: Iterable[str], vocab_size: int = DEFAULT_VOCAB_SIZE,
+                    special_tokens=SPECIAL_TOKENS):
+    """Train a byte-level BPE over `texts` (iterable of str). Returns a tokenizers.Tokenizer.
+
+    Byte-level + full 256-byte initial alphabet + unk_token=None => lossless round-trip on
+    any UTF-8 input (no <unk>)."""
+    from tokenizers import Tokenizer                       # lazy (seam/guard)
+    from tokenizers.models import BPE
+    from tokenizers.trainers import BpeTrainer
+    from tokenizers.pre_tokenizers import ByteLevel
+    from tokenizers.decoders import ByteLevel as ByteLevelDecoder
+
+    tok = Tokenizer(BPE(unk_token=None))
+    tok.pre_tokenizer = ByteLevel(add_prefix_space=False)
+    tok.decoder = ByteLevelDecoder()
+    trainer = BpeTrainer(
+        vocab_size=vocab_size,
+        special_tokens=list(special_tokens),
+        initial_alphabet=ByteLevel.alphabet(),   # all 256 bytes -> no <unk>, full round-trip
+        show_progress=False,
+    )
+    tok.train_from_iterator(texts, trainer=trainer)
+    return tok
+
+
+def save_tokenizer(tok, out_path) -> Path:
+    """Write the tokenizer to a single JSON file. Accepts a dir (-> out/tokenizer.json) or a
+    .json path. Returns the file path written."""
+    out = Path(out_path)
+    if out.suffix != ".json":
+        out.mkdir(parents=True, exist_ok=True)
+        out = out / "tokenizer.json"
+    else:
+        out.parent.mkdir(parents=True, exist_ok=True)
+    tok.save(str(out))
+    return out
+
+
+def iter_corpus_texts(inp) -> Iterator[str]:
+    """Yield document texts from `inp`: a directory (each source file = one doc) or a single
+    file (whole-file = one doc). Offline, stdlib-only."""
+    p = Path(inp)
+    if p.is_dir():
+        for f in sorted(p.rglob("*")):
+            if f.is_file() and f.suffix in _SOURCE_SUFFIXES:
+                yield f.read_text(encoding="utf-8", errors="replace")
+    else:
+        yield p.read_text(encoding="utf-8", errors="replace")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--in", dest="inp", type=Path, required=True,
+                    help="a directory of source files, or a single file")
+    ap.add_argument("--out", type=Path, required=True,
+                    help="output dir (-> out/tokenizer.json) or a .json path")
+    ap.add_argument("--vocab-size", type=int, default=DEFAULT_VOCAB_SIZE)
+    args = ap.parse_args()
+
+    tok = train_code_bpe(iter_corpus_texts(args.inp), vocab_size=args.vocab_size)
+    out = save_tokenizer(tok, args.out)
+    print(f"trained {tok.get_vocab_size()} BPE ({len(SPECIAL_TOKENS)} special) -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -52,6 +52,7 @@ PORTABLE_MODULES = [
     "src.data.pack",
     "src.data.split",
     "src.data.download",
+    "src.data.tokenizer_train",
     "src.data.instruct_format",
     "src.data.chat_template",
     "src.data.instruct_sft",

--- a/tests/test_tokenizer_train.py
+++ b/tests/test_tokenizer_train.py
@@ -1,0 +1,84 @@
+"""Unit tests for the shared code BPE trainer + loader (#191)."""
+
+import pytest
+
+tokenizers = pytest.importorskip("tokenizers")
+
+import numpy as np
+
+from src.data.tokenizer_train import (
+    train_code_bpe, save_tokenizer, SPECIAL_TOKENS, DEFAULT_VOCAB_SIZE)
+from src.data.tokenize import (
+    load_code_tokenizer, CodeTokenizer, tokenize_texts, _capped)
+from src.data.pack import pack_ids, open_packed, packing_dtype_for
+
+SAMPLE = [
+    "function add(a: number, b: number): number { return a + b; }",
+    "const greet = (name: string): string => `hello ${name}`;",
+    "interface Point { x: number; y: number; }",
+    "export class Vec { constructor(public x: number, public y: number) {} }",
+] * 50   # repeat so BPE has merges to learn
+
+
+def test_train_vocab_and_specials():
+    tok = train_code_bpe(SAMPLE, vocab_size=2000)
+    assert tok.get_vocab_size() <= 2000
+    for t in SPECIAL_TOKENS:
+        assert tok.token_to_id(t) is not None
+    assert tok.token_to_id("<mask>") is not None
+    assert tok.token_to_id("<|fim_prefix|>") is not None
+
+
+def test_vocab_cap_16k():
+    tok = train_code_bpe(SAMPLE)  # default vocab_size
+    assert tok.get_vocab_size() <= DEFAULT_VOCAB_SIZE
+
+
+def test_roundtrip_encode_decode():
+    tok = train_code_bpe(SAMPLE, vocab_size=2000)
+    s = "const x = 'π≈3.14'; // 数字"
+    ids = tok.encode(s).ids
+    assert tok.decode(ids) == s
+
+
+def test_special_tokens_ids_stable():
+    tok = train_code_bpe(SAMPLE, vocab_size=2000)
+    assert tok.token_to_id("<|endoftext|>") == 0
+
+
+def test_save_and_load_code_tokenizer(tmp_path):
+    tok = train_code_bpe(SAMPLE, vocab_size=2000)
+    save_tokenizer(tok, tmp_path)
+    ct = load_code_tokenizer(tmp_path)
+    assert isinstance(ct, CodeTokenizer)
+    assert ct.vocab_size == tok.get_vocab_size()
+    assert ct.eos_token_id == 0
+    s = "const x = 'π≈3.14'; // 数字"
+    assert ct.decode(ct.encode(s)) == s
+
+    # Also test loading via the explicit tokenizer.json path.
+    ct2 = load_code_tokenizer(tmp_path / "tokenizer.json")
+    assert ct2.vocab_size == tok.get_vocab_size()
+
+
+def test_load_missing_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_code_tokenizer(tmp_path / "nope")
+
+
+def test_uint16_pack_roundtrip(tmp_path):
+    tok = train_code_bpe(SAMPLE, vocab_size=2000)
+    save_tokenizer(tok, tmp_path)
+    ct = load_code_tokenizer(tmp_path)
+
+    texts = ["function f(x: number) { return x + 1; }", "const y = f(2);"]
+    dtype = packing_dtype_for(ct.vocab_size)
+    assert dtype == np.uint16
+
+    out = tmp_path / "packed.bin"
+    stream = _capped(tokenize_texts(texts, ct), None)
+    n = pack_ids(stream, out, dtype=dtype)
+    assert n > 0
+    packed = np.asarray(open_packed(out))
+    assert packed.dtype == np.uint16
+    assert packed.size == n


### PR DESCRIPTION
Refs #191

## Summary
- New `src/data/tokenizer_train.py` — portable (no mlx/torch, `tokenizers` imported lazily) 16k byte-level BPE trainer, offline-runnable on a sample corpus via `train_from_iterator`. Reserves FIM sentinels (`<|fim_prefix|>` / `<|fim_middle|>` / `<|fim_suffix|>` / `<|fim_pad|>`) + `<|endoftext|>` + `<mask>` as special tokens (ids 0..5) so one tokenizer serves both the AR arm (FIM, #215) and the diffusion arm (`<mask>`, M13 WS5b) with no retrain. Byte-level pre-tokenizer + full 256-byte `initial_alphabet` + `unk_token=None` gives a lossless round-trip on arbitrary UTF-8.
- `src/data/tokenize.py` — new `CodeTokenizer` wrapper (mirrors `ByteTokenizer`'s shape: `vocab_size`/`encode`/`decode`/`eos_token_id`) + `load_code_tokenizer(path)`, which loads a locally-trained `tokenizers` JSON artifact from a filesystem path (not `AutoTokenizer.from_pretrained`). CLI gets `"code"` in `--tokenizer` choices, a `--tokenizer-path` arg, and `_loaders` wiring.
- `tests/test_import_guard.py` — registers `src.data.tokenizer_train` in `PORTABLE_MODULES` (seam guard).
- `pyproject.toml` — declares `tokenizers>=0.20` explicitly in the `data` extra (previously only transitive).
- `tests/test_tokenizer_train.py` (new) — 7 unit tests: vocab cap + specials, 16k default cap, unicode round-trip, stable special-token ids, save/load round-trip, missing-artifact error, and the uint16-pack acceptance path through `pack_ids`/`open_packed`.

This issue builds the tokenizer trainer + loader **machinery** and proves it offline on a sample corpus, per the plan. The real training run over the final corpus mixture is `#193`-gated (later), tracked separately under `#188`.

## Testing
- [x] Tests added (`tests/test_tokenizer_train.py`, 7 tests, all passing)
- [x] Full suite green: `.venv/bin/python -m pytest -q` → 835 passed, 6 skipped
- [x] Import guard passes: `.venv/bin/python -m pytest tests/test_import_guard.py -q`
- [x] Manual offline CLI smoke: `tokenizer_train` → `tokenize --tokenizer code` → uint16 `.bin` + `.meta.json`, verified end-to-end