### PR TITLE
feat: [M11] Bits-per-byte (BPB) metric

### DIFF
--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -15,7 +15,7 @@ from typing import Iterator, Optional
 
 import numpy as np
 
-from .pack import open_packed
+from .pack import open_packed, packed_n_bytes
 
 
 class PackedLoader:
@@ -24,6 +24,8 @@ class PackedLoader:
                  vocab_size: Optional[int] = None):
         self.path = packed_path
         self.data = open_packed(packed_path)
+        self.n_tokens = int(self.data.shape[0])      # full packed token count (all tokens)
+        self.n_bytes = packed_n_bytes(packed_path)    # UTF-8 bytes if recorded, else None (#192)
         self.seq_len = seq_len
         self.batch_size = batch_size
         self.shuffle = shuffle

--- a/src/data/pack.py
+++ b/src/data/pack.py
@@ -43,12 +43,16 @@ def typecode_for(dtype) -> str:
 
 
 def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
-             chunk: int = 1 << 20, dtype=DTYPE) -> int:
+             chunk: int = 1 << 20, dtype=DTYPE, n_bytes: int | None = None) -> int:
     """Write a flat token file in `dtype` (uint16 or uint32). Returns the tokens written.
 
     Validates the ORIGINAL ids against `dtype`'s range before casting (casting first would
     silently wrap out-of-range / negative ids). The chosen dtype is recorded in the
-    `.meta.json` sidecar so `open_packed` reads the file back correctly."""
+    `.meta.json` sidecar so `open_packed` reads the file back correctly.
+
+    `n_bytes`, when given, is the UTF-8 byte count of the source text (#192, for the
+    tokenizer-invariant bits-per-byte metric) and is recorded in the sidecar too. Omitted
+    by default so legacy meta files stay byte-identical."""
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     dtype = np.dtype(dtype)
@@ -79,8 +83,11 @@ def pack_ids(ids: Iterable[int] | np.ndarray, out_path: Path,
                 np.asarray(buf, dtype=dtype).tofile(f)
                 n += len(buf)
 
+    meta = {"dtype": dtype.name, "n_tokens": int(n)}
+    if n_bytes is not None:
+        meta["n_bytes"] = int(n_bytes)
     with open(out_path.with_suffix(".meta.json"), "w") as f:
-        json.dump({"dtype": dtype.name, "n_tokens": int(n)}, f)
+        json.dump(meta, f)
     return n
 
 
@@ -90,6 +97,30 @@ def packed_dtype(path: Path) -> np.dtype:
     if meta_path.exists():
         return np.dtype(json.loads(meta_path.read_text()).get("dtype", "uint16"))
     return np.dtype(DTYPE)
+
+
+def packed_n_bytes(path: Path) -> int | None:
+    """UTF-8 byte count recorded in `<name>.meta.json`, or None if absent (legacy/np path)."""
+    meta_path = Path(path).with_suffix(".meta.json")
+    if meta_path.exists():
+        v = json.loads(meta_path.read_text()).get("n_bytes")
+        return int(v) if v is not None else None
+    return None
+
+
+def set_packed_n_bytes(path: Path, n_bytes: int) -> None:
+    """Patch the `n_bytes` field into `<name>.meta.json` after the fact (#192).
+
+    For streaming callers (tokenize.py's `.bin` path) the byte count is only known once
+    the token generator has been fully drained BY `pack_ids` — it can't be passed as a
+    `pack_ids(..., n_bytes=...)` kwarg, because Python evaluates call arguments (including
+    a `stats["n_bytes"]` lookup) before the function body runs and drains the generator,
+    which would capture 0. Call this only after the `pack_ids` call that wrote `path`
+    returns."""
+    meta_path = Path(path).with_suffix(".meta.json")
+    meta = json.loads(meta_path.read_text())
+    meta["n_bytes"] = int(n_bytes)
+    meta_path.write_text(json.dumps(meta))
 
 
 def open_packed(path: Path) -> np.memmap:

--- a/src/data/split.py
+++ b/src/data/split.py
@@ -14,7 +14,7 @@ from typing import Tuple
 
 import numpy as np
 
-from .pack import open_packed, packed_dtype
+from .pack import open_packed, packed_dtype, packed_n_bytes
 
 
 def split_packed(packed_path: Path, out_dir: Path, val_tokens: int,
@@ -27,6 +27,7 @@ def split_packed(packed_path: Path, out_dir: Path, val_tokens: int,
     out_dir.mkdir(parents=True, exist_ok=True)
     data = open_packed(packed_path)
     dtype = packed_dtype(packed_path)          # uint16 (POC) / uint32 (Qwen3) — preserved
+    src_bytes = packed_n_bytes(packed_path)     # UTF-8 byte count if recorded, else None (#192)
     n = data.shape[0]
     if val_tokens >= n:
         raise ValueError(f"val_tokens={val_tokens} >= total tokens={n}")
@@ -39,9 +40,19 @@ def split_packed(packed_path: Path, out_dir: Path, val_tokens: int,
     train_path, val_path = out_dir / "train.bin", out_dir / "val.bin"
     np.asarray(train, dtype=dtype).tofile(train_path)
     np.asarray(val, dtype=dtype).tofile(val_path)
-    for p, a in ((train_path, train), (val_path, val)):
+    # Propagate the corpus byte count proportionally to the token cut, preserving the
+    # uniform bytes/token ratio the bits-per-byte metric assumes (#192). None on legacy
+    # (no-n_bytes) packed files — val_bpb is simply omitted downstream.
+    val_bytes = train_bytes = None
+    if src_bytes is not None and n > 0:
+        val_bytes = round(src_bytes * (val_tokens / n))
+        train_bytes = src_bytes - val_bytes
+    for p, a, nb in ((train_path, train, train_bytes), (val_path, val, val_bytes)):
+        meta = {"dtype": dtype.name, "n_tokens": int(a.shape[0])}
+        if nb is not None:
+            meta["n_bytes"] = int(nb)
         with open(p.with_suffix(".meta.json"), "w") as f:
-            json.dump({"dtype": dtype.name, "n_tokens": int(a.shape[0])}, f)
+            json.dump(meta, f)
     return train_path, val_path
 
 
@@ -53,7 +64,12 @@ def split_shards(shard_dir: Path, out_dir: Path, val_tokens: int) -> Tuple[Path,
 
     Streams shard-by-shard (memmap -> file), so it is bounded in memory regardless of corpus size.
     Drops the `.bounds` sidecars — `PackedLoader` packs flat `seq_len` windows and ignores doc
-    boundaries (the #68 boundary-aware path is separate)."""
+    boundaries (the #68 boundary-aware path is separate).
+
+    Out of scope for #192: the shard manifest does not record UTF-8 byte counts, so the
+    outputs here carry no `n_bytes` and `val_bpb` is simply omitted downstream (graceful
+    degradation). Recording per-shard bytes in `shard.py`'s manifest is the follow-up needed
+    to light up BPB on this path (likely #193)."""
     from .shard import open_shard, read_manifest
 
     shard_dir = Path(shard_dir)

--- a/src/data/tokenize.py
+++ b/src/data/tokenize.py
@@ -130,10 +130,17 @@ def load_code_tokenizer(path):
     return CodeTokenizer(Tokenizer.from_file(str(p)))
 
 
-def tokenize_texts(texts: Iterable[str], tokenizer) -> Iterable[int]:
-    """Yield a flat stream of token ids across all documents (with EOS if available)."""
+def tokenize_texts(texts: Iterable[str], tokenizer, stats: dict | None = None) -> Iterable[int]:
+    """Yield a flat stream of token ids across all documents (with EOS if available).
+    When `stats` is given, accumulate the total UTF-8 byte count of the consumed docs
+    into stats['n_bytes'] (used for the tokenizer-invariant bits-per-byte metric, #192).
+    Counting happens per doc as it is pulled from this generator, so with `--max-tokens`
+    capping the stream mid-corpus only fully-started docs are counted (the final partial
+    doc may be slightly over-counted) — a coarse-cap corner, not special-cased."""
     eos = getattr(tokenizer, "eos_token_id", None)
     for text in texts:
+        if stats is not None:
+            stats["n_bytes"] += len(text.encode("utf-8"))
         for tid in tokenizer.encode(text):
             yield tid
         if eos is not None:
@@ -215,15 +222,22 @@ def main() -> None:
     dtype = packing_dtype_for(tok.vocab_size)   # uint16 (POC) / uint32 (Qwen3)
     # Input is either a one-doc-per-line text file or corpus Parquet shards (dir/.parquet).
     with _open_texts(args.inp) as texts:
-        stream = _capped(tokenize_texts(texts, tok), args.max_tokens)
+        stats = {"n_bytes": 0}
+        stream = _capped(tokenize_texts(texts, tok, stats=stats), args.max_tokens)
         if args.out.suffix == ".bin":
             # Stream straight into the packed format (chunked, bounded memory) — this
             # folds the `pack` stage in for the scale run and writes the .meta.json
             # sidecar, so `split` can consume the output directly.
-            from .pack import pack_ids
+            from .pack import pack_ids, set_packed_n_bytes
 
+            # n_bytes can't be passed as a pack_ids(..., n_bytes=...) kwarg here: `stats`
+            # is only fully populated once pack_ids's internal loop has drained `stream`
+            # (a lazy generator), which happens *after* call-time argument evaluation.
+            # Patch it into the sidecar once pack_ids returns instead (#192).
             n = pack_ids(stream, args.out, dtype=dtype)
-            print(f"tokenized+packed {n} ids ({dtype.name}, vocab {tok.vocab_size}) -> {args.out}")
+            set_packed_n_bytes(args.out, stats["n_bytes"])
+            print(f"tokenized+packed {n} ids ({dtype.name}, vocab {tok.vocab_size}, "
+                  f"{stats['n_bytes']} bytes) -> {args.out}")
         else:
             import numpy as np
 

--- a/src/eval/val_loss.py
+++ b/src/eval/val_loss.py
@@ -89,9 +89,18 @@ def perplexity(mean_ce_nats: float) -> float:
     return float(np.exp(mean_ce_nats))
 
 
+def bits_per_byte(total_ce_nats: float, n_bytes: float) -> float:
+    """Tokenizer-invariant bits-per-byte (#192): total cross-entropy (nats) over a token
+    span, converted to bits (÷ ln2) and normalized by the UTF-8 byte length of that span.
+    BPB = total_ce_nats / (ln2 * n_bytes)."""
+    return float(total_ce_nats / (np.log(2.0) * n_bytes))
+
+
 def evaluate(model: ModelInterface, loader: PackedLoader,
              max_batches: Optional[int] = None, to_numpy=np.asarray) -> dict:
-    """Run `forward` over held-out batches; return {val_loss, val_perplexity}.
+    """Run `forward` over held-out batches; return {val_loss, val_perplexity}, plus
+    `val_bpb` (#192, tokenizer-invariant) when `loader` exposes corpus byte/token totals
+    (`.n_bytes`/`.n_tokens`) — omitted otherwise (legacy artifacts, no byte count).
 
     `to_numpy` converts backend logits to numpy (identity by default; on MLX pass
     a converter). Backend-free otherwise.
@@ -111,7 +120,14 @@ def evaluate(model: ModelInterface, loader: PackedLoader,
         # masks a misconfigured eval (empty/missing val split, wrong path).
         raise ValueError("evaluate(): no tokens evaluated — val loader is empty")
     mean_ce = total_ce / total_tokens
-    return {"val_loss": mean_ce, "val_perplexity": perplexity(mean_ce)}
+    result = {"val_loss": mean_ce, "val_perplexity": perplexity(mean_ce)}
+    n_bytes = getattr(loader, "n_bytes", None)
+    n_tokens_total = getattr(loader, "n_tokens", None)
+    if n_bytes and n_tokens_total:                 # both present and non-zero
+        bytes_per_token = n_bytes / n_tokens_total
+        effective_bytes = total_tokens * bytes_per_token
+        result["val_bpb"] = bits_per_byte(total_ce, effective_bytes)
+    return result
 
 
 def evaluate_masked(model: ModelInterface, loader,
@@ -120,7 +136,9 @@ def evaluate_masked(model: ModelInterface, loader,
 
     `loader` yields `(inputs, targets, mask)` (an `SFTLoader`). Each batch's masked CE is
     weighted by its response-token count so partial final batches do not bias the mean.
-    Returns {val_loss, val_perplexity}.
+    Returns {val_loss, val_perplexity}, plus `val_bpb` (#192) when `loader` exposes
+    `.n_bytes`/`.n_tokens` — SFT loaders don't carry byte counts today, so this is the
+    common case (omitted); kept for the day a byte-aware loader is passed.
     """
     total_ce, total_tokens = 0.0, 0.0
     for i, (inputs, targets, mask) in enumerate(loader.epoch()):
@@ -137,4 +155,11 @@ def evaluate_masked(model: ModelInterface, loader,
         raise ValueError("evaluate_masked(): no response tokens evaluated — "
                          "val loader is empty or fully masked")
     mean_ce = total_ce / total_tokens
-    return {"val_loss": mean_ce, "val_perplexity": perplexity(mean_ce)}
+    result = {"val_loss": mean_ce, "val_perplexity": perplexity(mean_ce)}
+    n_bytes = getattr(loader, "n_bytes", None)
+    n_tokens_total = getattr(loader, "n_tokens", None)
+    if n_bytes and n_tokens_total:
+        bytes_per_token = n_bytes / n_tokens_total
+        effective_bytes = total_tokens * bytes_per_token
+        result["val_bpb"] = bits_per_byte(total_ce, effective_bytes)
+    return result

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -11,7 +11,7 @@ import sys
 import numpy as np
 
 from src.data.download import _normalize_doc
-from src.data.pack import pack_ids, open_packed
+from src.data.pack import pack_ids, open_packed, packed_n_bytes, set_packed_n_bytes
 from src.data.split import split_packed
 from src.data.loader import PackedLoader
 from src.data.tokenize import ByteTokenizer, tokenize_texts, _capped
@@ -58,6 +58,39 @@ def test_tokenize_streams_to_bin(tmp_path):
     assert n == len(expected)
     assert (tmp_path / "packed.meta.json").exists()
     assert np.array_equal(np.asarray(open_packed(out)), np.asarray(expected, np.uint16))
+
+
+def test_tokenize_counts_bytes(tmp_path):
+    # stats["n_bytes"] accumulates the UTF-8 byte length of each doc as it is consumed.
+    # It's only fully populated once the (lazy) generator has been drained by pack_ids,
+    # so n_bytes is patched into the sidecar afterward via set_packed_n_bytes (#192) --
+    # passing stats["n_bytes"] as a pack_ids(..., n_bytes=) kwarg would capture 0, since
+    # Python evaluates call arguments before pack_ids's body runs the generator.
+    tok = ByteTokenizer()
+    texts = ["abc", "de"]
+    out = tmp_path / "packed.bin"
+    stats = {"n_bytes": 0}
+    n = pack_ids(_capped(tokenize_texts(texts, tok, stats=stats), None), out)
+    set_packed_n_bytes(out, stats["n_bytes"])
+    assert stats["n_bytes"] == 5
+    assert n == 5
+    assert packed_n_bytes(out) == 5
+
+
+def test_split_propagates_n_bytes(tmp_path):
+    ids = np.arange(2000, dtype=np.uint16)
+    packed = tmp_path / "packed.bin"
+    pack_ids(ids, packed, n_bytes=4000)
+    train_p, val_p = split_packed(packed, tmp_path / "split", val_tokens=200)
+    assert packed_n_bytes(val_p) == round(4000 * 200 / 2000) == 400
+    assert packed_n_bytes(train_p) == 3600
+
+    # Legacy packed file (no n_bytes) -> both split metas carry no n_bytes either.
+    legacy = tmp_path / "legacy.bin"
+    pack_ids(ids, legacy)
+    train_p2, val_p2 = split_packed(legacy, tmp_path / "split_legacy", val_tokens=200)
+    assert packed_n_bytes(train_p2) is None
+    assert packed_n_bytes(val_p2) is None
 
 
 def test_capped_truncates_stream():

--- a/tests/test_packing_dtype.py
+++ b/tests/test_packing_dtype.py
@@ -7,8 +7,8 @@ import json
 import numpy as np
 import pytest
 
-from src.data.pack import (DTYPE, open_packed, pack_ids, packed_dtype, packing_dtype_for,
-                          typecode_for)
+from src.data.pack import (DTYPE, open_packed, pack_ids, packed_dtype, packed_n_bytes,
+                          packing_dtype_for, typecode_for)
 from src.data.loader import PackedLoader
 from src.data.shard import open_shard, pack_sequences
 from src.model.blocks import MambaConfig, load_config
@@ -78,6 +78,41 @@ def test_legacy_file_without_dtype_meta_defaults_uint16(tmp_path):
     (tmp_path / "legacy.meta.json").write_text(json.dumps({"n_tokens": 3}))
     assert packed_dtype(p) == np.dtype(np.uint16)
     assert list(open_packed(p)) == [1, 2, 3]
+
+
+# --- n_bytes (#192, bits-per-byte) ----------------------------------------------------
+def test_pack_ids_writes_n_bytes(tmp_path):
+    p = tmp_path / "bpb.bin"
+    pack_ids([1, 2, 3], p, n_bytes=17)
+    meta = json.loads((tmp_path / "bpb.meta.json").read_text())
+    assert meta["n_bytes"] == 17
+    assert packed_n_bytes(p) == 17
+
+
+def test_pack_ids_omits_n_bytes_by_default(tmp_path):
+    p = tmp_path / "no_bpb.bin"
+    pack_ids([1, 2, 3], p)
+    meta = json.loads((tmp_path / "no_bpb.meta.json").read_text())
+    assert "n_bytes" not in meta
+    assert packed_n_bytes(p) is None
+    # No regression: open_packed/packed_dtype still work with the key absent.
+    assert list(open_packed(p)) == [1, 2, 3]
+    assert packed_dtype(p) == np.dtype(np.uint16)
+
+
+def test_loader_exposes_n_bytes(tmp_path):
+    p_with = tmp_path / "with_bytes.bin"
+    ids = list(range(64))
+    pack_ids(ids, p_with, n_bytes=1000)
+    loader = PackedLoader(p_with, seq_len=4, batch_size=2, shuffle=False)
+    assert loader.n_bytes == 1000
+    assert loader.n_tokens == len(ids)
+
+    p_without = tmp_path / "without_bytes.bin"
+    pack_ids(ids, p_without)
+    loader2 = PackedLoader(p_without, seq_len=4, batch_size=2, shuffle=False)
+    assert loader2.n_bytes is None
+    assert loader2.n_tokens == len(ids)
 
 
 # --- shard path ----------------------------------------------------------------------

--- a/tests/test_val_loss.py
+++ b/tests/test_val_loss.py
@@ -3,7 +3,8 @@
 import numpy as np
 import pytest
 
-from src.eval.val_loss import cross_entropy, perplexity, evaluate
+from src.eval.val_loss import (bits_per_byte, cross_entropy, evaluate,
+                               evaluate_masked, perplexity)
 
 
 class _EmptyLoader:
@@ -16,6 +17,100 @@ def test_evaluate_empty_loader_raises_not_false_perfect():
     # score), which would silently mask a misconfigured eval path.
     with pytest.raises(ValueError, match="empty"):
         evaluate(model=None, loader=_EmptyLoader())
+
+
+class _FakeModel:
+    """Returns fixed uniform logits over V classes -> CE = log(V) per token, analytic."""
+
+    def __init__(self, vocab: int):
+        self.vocab = vocab
+
+    def forward(self, inputs):
+        b, t = np.asarray(inputs).shape
+        return np.zeros((b, t, self.vocab))
+
+
+class _FakeLoader:
+    """One fixed batch, with optional corpus byte/token totals (#192)."""
+
+    def __init__(self, batch_size=2, seq_len=4, n_bytes=None, n_tokens=None):
+        self.batch_size = batch_size
+        self.seq_len = seq_len
+        if n_bytes is not None:
+            self.n_bytes = n_bytes
+        if n_tokens is not None:
+            self.n_tokens = n_tokens
+        self._inputs = np.zeros((batch_size, seq_len), dtype=np.int64)
+        self._targets = np.zeros((batch_size, seq_len), dtype=np.int64)
+
+    def epoch(self, reseed=None, skip_batches=0):
+        yield self._inputs, self._targets
+
+
+class _FakeMaskedLoader:
+    """One fixed masked batch (all-ones mask), with optional byte/token totals."""
+
+    def __init__(self, batch_size=2, seq_len=4, n_bytes=None, n_tokens=None):
+        if n_bytes is not None:
+            self.n_bytes = n_bytes
+        if n_tokens is not None:
+            self.n_tokens = n_tokens
+        self._inputs = np.zeros((batch_size, seq_len), dtype=np.int64)
+        self._targets = np.zeros((batch_size, seq_len), dtype=np.int64)
+        self._mask = np.ones((batch_size, seq_len))
+
+    def epoch(self, reseed=None, skip_batches=0):
+        yield self._inputs, self._targets, self._mask
+
+
+def test_bits_per_byte_numeric():
+    total_ce = np.log(2) * 10
+    assert np.isclose(bits_per_byte(total_ce, 5), 2.0)
+
+
+def test_evaluate_returns_val_bpb():
+    V = 8
+    model = _FakeModel(V)
+    batch_size, seq_len = 2, 4
+    n_bytes, n_tokens = 400, 100
+    loader = _FakeLoader(batch_size=batch_size, seq_len=seq_len,
+                         n_bytes=n_bytes, n_tokens=n_tokens)
+    result = evaluate(model, loader)
+    assert "val_bpb" in result
+    total_tokens = batch_size * seq_len
+    total_ce = np.log(V) * total_tokens
+    effective_bytes = total_tokens * (n_bytes / n_tokens)
+    expected = bits_per_byte(total_ce, effective_bytes)
+    assert np.isclose(result["val_bpb"], expected)
+
+
+def test_evaluate_omits_val_bpb_when_no_bytes():
+    model = _FakeModel(8)
+    loader = _FakeLoader()  # no n_bytes/n_tokens attributes
+    result = evaluate(model, loader)
+    assert "val_loss" in result and "val_perplexity" in result
+    assert "val_bpb" not in result
+
+
+def test_evaluate_masked_val_bpb_present_and_absent():
+    V = 8
+    model = _FakeModel(V)
+    batch_size, seq_len = 2, 4
+    n_bytes, n_tokens = 200, 50
+    loader_with_bytes = _FakeMaskedLoader(batch_size=batch_size, seq_len=seq_len,
+                                          n_bytes=n_bytes, n_tokens=n_tokens)
+    result = evaluate_masked(model, loader_with_bytes)
+    assert "val_bpb" in result
+    total_tokens = batch_size * seq_len
+    total_ce = np.log(V) * total_tokens
+    effective_bytes = total_tokens * (n_bytes / n_tokens)
+    expected = bits_per_byte(total_ce, effective_bytes)
+    assert np.isclose(result["val_bpb"], expected)
+
+    loader_no_bytes = _FakeMaskedLoader(batch_size=batch_size, seq_len=seq_len)
+    result_no_bytes = evaluate_masked(model, loader_no_bytes)
+    assert "val_loss" in result_no_bytes and "val_perplexity" in result_no_bytes
+    assert "val_bpb" not in result_no_bytes
 
 
 def test_cross_entropy_uniform_logits():


### PR DESCRIPTION
#192

## Summary

Bits-per-byte is a tokenizer-invariant cross-run quality metric (vs. per-token perplexity, which breaks comparability across tokenizer changes like #191). Threads a UTF-8 byte count through the data pipeline into eval, `n_bytes` optional everywhere so nothing existing breaks:

- `src/data/tokenize.py` — `tokenize_texts` optionally accumulates UTF-8 byte count into a `stats` dict as docs are consumed; `main()` patches it into the `.bin` sidecar via the new `pack.set_packed_n_bytes` **after** the streaming generator is fully drained (passing it as a `pack_ids(..., n_bytes=)` kwarg would silently capture `0`, since Python evaluates call args before the generator runs — caught by a new test, fixed).
- `src/data/pack.py` — `pack_ids(..., n_bytes=None)` writes it to `.meta.json`; `packed_n_bytes()` reader; `set_packed_n_bytes()` patcher for the streaming case above.
- `src/data/split.py` — `split_packed` propagates `n_bytes` proportionally to the train/val token cut (preserves the corpus-wide bytes/token ratio).
- `src/data/loader.py` — `PackedLoader` exposes `.n_bytes` / `.n_tokens`.
- `src/eval/val_loss.py` — `bits_per_byte(total_ce_nats, n_bytes)`; `evaluate`/`evaluate_masked` add `val_bpb` to their result dict when the loader provides byte counts, omitted otherwise.
- Unit tests across `test_val_loss.py`, `test_packing_dtype.py`, `test_data_pipeline.py`.

**Follow-up flagged (likely #193):** the scale-corpus shard path (`split_shards`, driven by `shard.py`'s manifest) does not yet record per-shard byte counts, so `val_bpb` is omitted (gracefully) on that path. Only the single-file `tokenize → .bin → split_packed` path lights BPB up today.

## Testing
- [x] `.venv/bin/python -m pytest -q` — 844 passed, 6 skipped
- [x] `.venv/bin/python -m pytest tests/test_import_guard.py -q` — seam guard clean
- [x] Offline smoke: tokenized a small doc, confirmed `.meta.json` carries `n_bytes` (22, matching the byte-fallback text), confirmed `evaluate(...)` returns `val_bpb` via the new unit tests