### PR TITLE
feat: [M12] Optimizer: hybrid Muon + AdamW at the make_optimizer seam

### DIFF
--- a/config/toy-muon.yaml
+++ b/config/toy-muon.yaml
@@ -1,0 +1,32 @@
+# Toy config for the milestone-1..4 smoke test, hybrid Muon + AdamW optimizer (#237).
+# Same tiny/fp32 shape as toy.yaml (exact-resume) but exercises `optimizer: muon` — CUDA
+# backend only; the CUDA backend runs on CPU on the Mac dev box (fused=False fallback),
+# so this is fully validatable locally via `scripts/smoke_test.py --backend cuda`.
+d_model: 64
+n_layers: 2
+d_state: 16            # SSM state width N (per head)
+expand: 2              # d_inner = 128
+d_conv: 4
+head_dim: 16           # Mamba-2/SSD: 128/16 = 8 heads (scalar A per head)
+dt_rank: auto
+
+vocab_size: 256        # byte fallback tokenizer for offline smoke testing
+seq_len: 128
+tie_embeddings: true
+
+precision: fp32        # correctness first; also keeps Newton-Schulz's fp32 path exact
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false # tiny model -> not needed; keep smoke exact-resume cheap
+
+# --- optimizer (#237) ---
+optimizer: muon
+# muon_lr omitted on purpose: derives to base_lr at optimizer-build time (lr_scale ==
+# 1.0), the simplest/most-deterministic path for the smoke gate. NOT a tuned value —
+# published Muon runs typically use 10-50x the Adam LR.
+muon_momentum: 0.95
+muon_ns_steps: 5
+
+# dt-projection bias init (load-bearing)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -128,15 +128,25 @@ def _mlx_backend() -> Backend:
         from .mlx_distill import make_distill_train_step
         return make_distill_train_step(*args, **kwargs)
 
+    def _make_optimizer(model, base_lr):
+        # MLX AdamW holds no parameter refs at construction (params arrive at update);
+        # `model` is read only for `.config.optimizer` (a uniform signature otherwise).
+        # Muon (#237) is CUDA-only for now — raise loudly rather than silently falling
+        # back to AdamW on a config that asked for Muon.
+        if model.config.optimizer == "muon":
+            raise NotImplementedError(
+                "Muon is CUDA-only (#237); the MLX Newton-Schulz port is a scoped "
+                "follow-up."
+            )
+        return optim.AdamW(learning_rate=base_lr)
+
     return Backend(
         name="mlx",
         model_cls=MLXMambaModel,
         make_train_step=make_train_step,
         save_optimizer=save_optimizer,
         load_optimizer=load_optimizer,
-        # MLX AdamW holds no parameter refs at construction (params arrive at update);
-        # `model` is accepted for a uniform signature and ignored.
-        make_optimizer=lambda model, base_lr: optim.AdamW(learning_rate=base_lr),
+        make_optimizer=_make_optimizer,
         seed=lambda value: mx.random.seed(value),
         to_numpy=lambda a: np.array(a),
         make_sft_train_step=make_sft_train_step,
@@ -227,7 +237,25 @@ def _cuda_backend() -> Backend:
         # on H100 (fewer kernel launches), no numerical change. It requires all params on a
         # CUDA device, so gate on it; on CPU (torch-CPU parity runs) fall back to the default.
         fused = _dev.startswith("cuda")
-        return torch.optim.AdamW(model.parameters(), lr=base_lr, fused=fused)
+        cfg = model.config
+        if cfg.optimizer == "adamw":
+            return torch.optim.AdamW(model.parameters(), lr=base_lr, fused=fused)
+        if cfg.optimizer == "muon":
+            # Hybrid optimizer (#237): 2D hidden weight matrices go through Newton-Schulz
+            # orthogonalization (Muon); everything else stays on AdamW. `is_muon_param` is
+            # portable (src.model.blocks); the Muon/HybridOptimizer classes are torch-only
+            # and stay lazily imported here, matching this module's lazy-import style.
+            from .blocks import is_muon_param
+            from .cuda_muon import Muon, HybridOptimizer
+            muon_params, adam_params = [], []
+            for name, p in model.named_parameters():
+                (muon_params if is_muon_param(name, p.ndim) else adam_params).append(p)
+            muon_lr = cfg.muon_lr if cfg.muon_lr is not None else base_lr
+            adam = torch.optim.AdamW(adam_params, lr=base_lr, fused=fused) if adam_params else None
+            muon = Muon(muon_params, lr=base_lr, lr_scale=muon_lr / base_lr,
+                       momentum=cfg.muon_momentum, ns_steps=cfg.muon_ns_steps) if muon_params else None
+            return HybridOptimizer(adam, muon)
+        raise ValueError(f"unknown optimizer {cfg.optimizer!r}")
 
     return Backend(
         name="cuda",

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -66,6 +66,19 @@ class MambaConfig:
     # fp16 + loss scaling is the likely Metal-friendly choice).
     precision: str = "fp32"
 
+    # --- optimizer (#237) ---
+    # "adamw" (default) or "muon". Muon (MomentUm Orthogonalized by Newton-schulz) applies
+    # Newton-Schulz orthogonalization to 2D hidden weight matrices (see `is_muon_param`
+    # below); everything else (embeddings, norms, biases, 1D/3D params) stays on AdamW in
+    # a hybrid optimizer. CUDA-only for now (see `backend.py`); MLX raises NotImplementedError.
+    optimizer: str = "adamw"
+    # Matrix-group LR for Muon params. None => derived at optimizer-build time as `base_lr`
+    # (lr_scale 1.0) — a conservative starting point, NOT a tuned value. Published Muon runs
+    # typically use 10-50x the Adam LR; tune `muon_lr` explicitly for a real run.
+    muon_lr: Optional[float] = None
+    muon_momentum: float = 0.95
+    muon_ns_steps: int = 5
+
     # SSD chunk length Q. None => the backend default (64). The chunked-matmul scan
     # processes the sequence in chunks of Q; the sequence is padded up to a multiple
     # of Q (padded steps carry zero input, trimmed from the output).
@@ -281,6 +294,14 @@ class MambaConfig:
             )
         if self.precision not in ("fp32", "fp16", "bf16"):
             raise ValueError(f"unknown precision {self.precision!r}")
+        if self.optimizer not in ("adamw", "muon"):
+            raise ValueError(f"unknown optimizer {self.optimizer!r}")
+        if not (0.0 <= self.muon_momentum < 1.0):
+            raise ValueError(f"muon_momentum={self.muon_momentum} must be in [0, 1)")
+        if self.muon_ns_steps < 1:
+            raise ValueError("muon_ns_steps must be >= 1")
+        if self.muon_lr is not None and self.muon_lr <= 0:
+            raise ValueError("muon_lr must be positive or None")
         if self.chunk_size is not None and self.chunk_size <= 0:
             raise ValueError("chunk_size must be positive or None")
         if self.long_ctx_factor < 1.0:
@@ -332,3 +353,28 @@ def load_config(path: Union[str, Path]) -> MambaConfig:
     cfg = MambaConfig(**raw)
     cfg.validate()
     return cfg
+
+
+# --- Muon optimizer parameter taxonomy (#237) ---
+# Which named params route to Muon vs AdamW in the hybrid optimizer (`cuda_muon.py`).
+# Pure str/int logic, no backend import, so it lives above the seam and is shared by
+# the (below-seam) CUDA optimizer construction and the portable taxonomy test.
+_MUON_EXCLUDE_EXACT = {"embedding.weight", "lm_head.weight"}
+_MUON_EXCLUDE_SUFFIX = (".router.weight", ".dt_proj.weight")
+
+
+def is_muon_param(name: str, ndim: int) -> bool:
+    """True if the named parameter (given its `named_parameters()` dotted name and
+    `.ndim`) is a Muon candidate: 2D hidden weight matrices (Mamba in/out/x_proj,
+    attention qkv/o_proj, MoE expert gate/up/down), EXCLUDING the embedding, LM head,
+    router, and dt_proj (the dt-bias init is load-bearing — see `dt_min`/`dt_max`
+    above). Everything else (1D norms/biases/A_log/D, 3D conv weights, and the
+    excluded 2D matrices) stays on AdamW.
+    """
+    if ndim != 2:
+        return False
+    if name in _MUON_EXCLUDE_EXACT:
+        return False
+    if name.endswith(_MUON_EXCLUDE_SUFFIX):
+        return False
+    return True

--- a/src/model/cuda_muon.py
+++ b/src/model/cuda_muon.py
@@ -1,0 +1,133 @@
+"""Muon optimizer + hybrid Muon/AdamW container (#237). Below the seam — imports torch.
+
+Muon (MomentUm Orthogonalized by Newton-Schulz) orthogonalizes the momentum-accumulated
+gradient of 2D hidden weight matrices via a 5-iteration quintic Newton-Schulz iteration
+before applying the update, reaching target loss in fewer steps than AdamW on those params.
+Everything else (embeddings, LM head, router, dt_proj, norms, biases, conv weights — see
+`is_muon_param` in `src.model.blocks`) stays on AdamW. `HybridOptimizer` wraps one of each
+so `cuda_train_step._accumulate_and_step` can drive them through the single
+`optimizer.{param_groups,zero_grad,step,state_dict,load_state_dict}` surface it already uses.
+
+The two-LR hazard: `_accumulate_and_step` writes `group["lr"] = lr` on EVERY param group
+every step (a schedule value), so Muon cannot store its own learning rate in `group["lr"]`
+— it would be clobbered. Instead Muon stores a constant `lr_scale = muon_lr / base_lr` in
+its defaults and computes `group["lr"] * lr_scale` fresh inside `step()`.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def _newton_schulz5(G: torch.Tensor, steps: int) -> torch.Tensor:
+    """Orthogonalize `G` (2D) via `steps` quintic Newton-Schulz iterations.
+
+    Runs in fp32 regardless of the param dtype so it stays deterministic under fp16/bf16
+    training configs — required for the smoke gate's bit-exact resume assertion (the
+    orthogonalized update must reproduce identically from a restored momentum buffer).
+    """
+    assert G.ndim == 2
+    a, b, c = 3.4445, -4.7750, 2.0315
+    X = G.float()
+    X = X / (X.norm() + 1e-7)
+    transposed = X.shape[0] > X.shape[1]
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.T
+    return X.to(G.dtype)
+
+
+class Muon(torch.optim.Optimizer):
+    """SGD-momentum + Newton-Schulz orthogonalization, for 2D hidden weight matrices only.
+
+    `lr` seeds `group["lr"]` (so it starts sane before the first scheduled write); the
+    effective per-step learning rate is always `group["lr"] * lr_scale` — see the module
+    docstring for why the scale (not the raw lr) is what Muon owns.
+    """
+
+    def __init__(self, params, lr: float, lr_scale: float,
+                momentum: float = 0.95, ns_steps: int = 5):
+        defaults = dict(lr=lr, lr_scale=lr_scale, momentum=momentum, ns_steps=ns_steps)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = closure() if closure is not None else None
+        for group in self.param_groups:
+            eff_lr = group["lr"] * group["lr_scale"]
+            momentum = group["momentum"]
+            ns_steps = group["ns_steps"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(p)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(p.grad)
+                update = _newton_schulz5(buf, ns_steps)
+                # Non-square rescale (standard Muon): keeps the update norm comparable
+                # across matrix aspect ratios.
+                scale = max(1.0, p.shape[0] / p.shape[1]) ** 0.5
+                p.add_(update, alpha=-eff_lr * scale)
+        return loss
+
+
+class HybridOptimizer:
+    """Wraps an AdamW sub-optimizer (everything else) and a Muon sub-optimizer (2D hidden
+    weight matrices), exposing the subset of `torch.optim.Optimizer`'s surface that
+    `cuda_train_step.py` and `checkpoint.py` use: `param_groups`, `zero_grad`, `step`,
+    `state_dict`, `load_state_dict`. Deliberately does NOT subclass `torch.optim.Optimizer`
+    — that base class's `__init__` expects a single flat param-group list, which doesn't fit
+    a container of two independent optimizers.
+
+    Either sub-optimizer may be `None` (empty partition — e.g. a config with no 2D
+    non-excluded param, not the real case but cheap to guard); its methods then no-op.
+    """
+
+    def __init__(self, adam, muon):
+        self.adam = adam
+        self.muon = muon
+
+    @property
+    def param_groups(self):
+        # MUST return the sub-optimizers' live group dicts (not copies): this is a fresh
+        # list each call, but its elements are the real dicts, so the scheduler's
+        # `group["lr"] = lr` write (see `_accumulate_and_step`) reaches both real
+        # optimizers — Muon then re-derives its effective lr via `lr_scale` in `step()`.
+        groups = []
+        if self.adam is not None:
+            groups += self.adam.param_groups
+        if self.muon is not None:
+            groups += self.muon.param_groups
+        return groups
+
+    def zero_grad(self, set_to_none: bool = True):
+        if self.adam is not None:
+            self.adam.zero_grad(set_to_none=set_to_none)
+        if self.muon is not None:
+            self.muon.zero_grad(set_to_none=set_to_none)
+
+    def step(self, closure=None):
+        if self.adam is not None:
+            self.adam.step()
+        if self.muon is not None:
+            self.muon.step()
+        return closure() if closure is not None else None
+
+    def state_dict(self):
+        return {
+            "adam": self.adam.state_dict() if self.adam is not None else None,
+            "muon": self.muon.state_dict() if self.muon is not None else None,
+        }
+
+    def load_state_dict(self, sd):
+        if self.adam is not None and sd.get("adam") is not None:
+            self.adam.load_state_dict(sd["adam"])
+        if self.muon is not None and sd.get("muon") is not None:
+            self.muon.load_state_dict(sd["muon"])

--- a/tests/test_cuda_muon.py
+++ b/tests/test_cuda_muon.py
@@ -1,0 +1,197 @@
+"""CUDA/PyTorch Muon + hybrid optimizer (#237). Runs on CPU — no GPU needed.
+
+Covers: Newton-Schulz orthogonality, the Adam sub-group bit-matching a stock AdamW,
+optimizer-state resume through `HybridOptimizer`'s state_dict round-trip, and the
+two-LR wiring (`group["lr"] * lr_scale`) that survives the scheduler clobbering
+`group["lr"]` every step (see `_accumulate_and_step` in `cuda_train_step.py`).
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import is_muon_param, load_config
+from src.model.backend import get_backend
+from src.model.cuda_backend import CUDAMambaModel
+from src.model.cuda_muon import HybridOptimizer, Muon, _newton_schulz5
+
+TOY_MUON_CFG = "config/toy-muon.yaml"
+
+
+def _orthogonality_check(G):
+    # The standard Muon quintic coefficients (3.4445, -4.7750, 2.0315) do not converge
+    # singular values exactly to 1 in 5 steps — by design they push them into a tight
+    # band (empirically ~[0.68, 1.13] here), which is sufficient orthogonalization for
+    # the optimizer's purpose. Assert the band, not exact unit singular values.
+    X = _newton_schulz5(G, steps=5)
+    sv = torch.linalg.svdvals(X)
+    assert sv.min() > 0.5 and sv.max() < 1.25, sv
+
+
+def test_newton_schulz5_orthogonal_tall():
+    torch.manual_seed(0)
+    _orthogonality_check(torch.randn(40, 10))
+
+
+def test_newton_schulz5_orthogonal_wide():
+    torch.manual_seed(0)
+    _orthogonality_check(torch.randn(10, 40))
+
+
+def test_newton_schulz5_runs_in_fp32_regardless_of_input_dtype():
+    torch.manual_seed(0)
+    G = torch.randn(20, 6, dtype=torch.float16)
+    X = _newton_schulz5(G, steps=5)
+    assert X.dtype == torch.float16                # returned in the param dtype
+    sv = torch.linalg.svdvals(X.float())
+    assert sv.min() > 0.5 and sv.max() < 1.25, sv
+
+
+def test_adam_subgroup_bitmatches_stock_adamw():
+    """The AdamW half of HybridOptimizer, driven through the scheduler-write pattern
+    (`group["lr"] = lr` every step), must reproduce a stock AdamW exactly."""
+    torch.manual_seed(0)
+    p1 = torch.nn.Parameter(torch.randn(8))
+    p2 = torch.nn.Parameter(torch.randn(4, 4))
+    ref1 = torch.nn.Parameter(p1.detach().clone())
+    ref2 = torch.nn.Parameter(p2.detach().clone())
+
+    hybrid = HybridOptimizer(torch.optim.AdamW([p1, p2], lr=1e-3), None)
+    ref_opt = torch.optim.AdamW([ref1, ref2], lr=1e-3)
+
+    for _ in range(5):
+        for g in hybrid.param_groups:
+            g["lr"] = 1e-3
+        p1.grad = torch.full_like(p1, 0.1)
+        p2.grad = torch.full_like(p2, 0.1)
+        hybrid.step()
+        hybrid.zero_grad()
+
+        ref1.grad = torch.full_like(ref1, 0.1)
+        ref2.grad = torch.full_like(ref2, 0.1)
+        ref_opt.step()
+        ref_opt.zero_grad()
+
+    assert torch.equal(p1, ref1)
+    assert torch.equal(p2, ref2)
+
+
+def test_hybrid_state_dict_round_trip_resumes_exactly():
+    """Save mid-run, rebuild fresh sub-optimizers, load_state_dict, and continue —
+    the post-resume trajectory must match the uninterrupted reference exactly (fp32,
+    fixed grads — mirrors the smoke gate's save/kill/resume protocol)."""
+    torch.manual_seed(0)
+
+    def fresh_params():
+        torch.manual_seed(0)
+        return (torch.nn.Parameter(torch.randn(8)),        # AdamW
+                torch.nn.Parameter(torch.randn(6, 3)))      # Muon
+
+    def make_hybrid(p_adam, p_muon):
+        adam = torch.optim.AdamW([p_adam], lr=1e-2)
+        muon = Muon([p_muon], lr=1e-2, lr_scale=2.0, momentum=0.9, ns_steps=5)
+        return HybridOptimizer(adam, muon)
+
+    def grads_for(step, p_adam, p_muon):
+        g = torch.Generator().manual_seed(step)
+        return (torch.randn(p_adam.shape, generator=g),
+               torch.randn(p_muon.shape, generator=g))
+
+    def run(p_adam, p_muon, hybrid, lo, hi):
+        for s in range(lo, hi):
+            ga, gm = grads_for(s, p_adam, p_muon)
+            p_adam.grad, p_muon.grad = ga, gm
+            for g in hybrid.param_groups:
+                g["lr"] = 1e-2
+            hybrid.step()
+            hybrid.zero_grad()
+
+    # Uninterrupted reference.
+    ref_adam, ref_muon = fresh_params()
+    ref_hybrid = make_hybrid(ref_adam, ref_muon)
+    run(ref_adam, ref_muon, ref_hybrid, 0, 8)
+
+    # Save/kill/resume at step 4.
+    a_p, m_p = fresh_params()
+    hybrid = make_hybrid(a_p, m_p)
+    run(a_p, m_p, hybrid, 0, 4)
+    sd = hybrid.state_dict()
+
+    a_p2, m_p2 = torch.nn.Parameter(a_p.detach().clone()), torch.nn.Parameter(m_p.detach().clone())
+    hybrid2 = make_hybrid(a_p2, m_p2)
+    hybrid2.load_state_dict(sd)
+    run(a_p2, m_p2, hybrid2, 4, 8)
+
+    assert torch.allclose(a_p2, ref_adam, atol=1e-6)
+    assert torch.allclose(m_p2, ref_muon, atol=1e-6)
+
+
+def test_effective_lr_is_group_lr_times_lr_scale():
+    """Pins the two-LR wiring: the scheduler writes a plain `group["lr"]` every step
+    (see `_accumulate_and_step`), and Muon must derive its effective lr as
+    `group["lr"] * lr_scale`, never persisting `muon_lr` directly into the group."""
+    torch.manual_seed(0)
+    p = torch.nn.Parameter(torch.randn(6, 3))
+    grad = torch.randn(6, 3)
+    p.grad = grad.clone()
+
+    muon = Muon([p], lr=1.0, lr_scale=2.5, momentum=0.9, ns_steps=5)
+    hybrid = HybridOptimizer(None, muon)
+
+    scheduled_lr = 0.02
+    for g in hybrid.param_groups:
+        g["lr"] = scheduled_lr
+    before = p.detach().clone()
+    hybrid.step()
+
+    # Momentum buffer starts at zero, so after one step buf == grad exactly.
+    ns = _newton_schulz5(grad, steps=5)
+    scale = max(1.0, p.shape[0] / p.shape[1]) ** 0.5
+    expected = before - (scheduled_lr * 2.5) * scale * ns
+    assert torch.allclose(p, expected, atol=1e-6)
+
+
+def test_hybrid_optimizer_tolerates_empty_side():
+    """An all-AdamW or all-Muon partition (one side empty) must not crash step/zero_grad/
+    state_dict/load_state_dict."""
+    torch.manual_seed(0)
+    p = torch.nn.Parameter(torch.randn(4, 4))
+    p.grad = torch.ones_like(p)
+    hybrid = HybridOptimizer(torch.optim.AdamW([p], lr=1e-3), None)
+    hybrid.step()
+    hybrid.zero_grad()
+    sd = hybrid.state_dict()
+    assert sd["muon"] is None
+    hybrid.load_state_dict(sd)                       # no-op on the muon side, must not raise
+
+
+def test_backend_partitions_real_model_params_via_is_muon_param():
+    """End-to-end: `get_backend("cuda").make_optimizer` on a `optimizer: muon` config
+    partitions the real CUDA model's named_parameters() exactly per `is_muon_param`."""
+    cfg = load_config(TOY_MUON_CFG)
+    assert cfg.optimizer == "muon"
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    backend = get_backend("cuda")
+    opt = backend.make_optimizer(model, 1e-3)
+    assert isinstance(opt, HybridOptimizer)
+
+    muon_ids = {id(p) for g in opt.muon.param_groups for p in g["params"]}
+    adam_ids = {id(p) for g in opt.adam.param_groups for p in g["params"]}
+    for name, p in model.named_parameters():
+        expected_muon = is_muon_param(name, p.ndim)
+        assert (id(p) in muon_ids) == expected_muon, name
+        assert (id(p) in adam_ids) == (not expected_muon), name
+
+    # Sanity: a hybrid model has both attention and Mamba 2D matrices, so neither side
+    # of the real partition is empty.
+    assert muon_ids and adam_ids
+
+
+def test_mlx_backend_raises_on_muon_config():
+    pytest.importorskip("mlx")
+    cfg = load_config(TOY_MUON_CFG)
+    backend = get_backend("mlx")
+    model = backend.model_cls(cfg)
+    with pytest.raises(NotImplementedError):
+        backend.make_optimizer(model, 1e-3)

--- a/tests/test_muon_taxonomy.py
+++ b/tests/test_muon_taxonomy.py
@@ -1,0 +1,93 @@
+"""Portable taxonomy test for `is_muon_param` (#237) — no backend import required.
+
+Pins the exact routing table from the plan/issue: 2D hidden weight matrices (Mamba
+in/out/x_proj, attention qkv/o_proj, MoE expert gate/up/down) go to Muon; everything else
+(embedding, LM head, router, dt_proj, and all 1D/3D params) stays on AdamW.
+
+Belt-and-suspenders: when mlx is importable, also build the real toy-hybrid + toy-moe MLX
+models and assert their actual flattened param names classify identically, guarding against
+name drift between this hardcoded table and the real modules.
+"""
+
+import pytest
+
+from src.model.blocks import is_muon_param
+
+MUON_TRUE = [
+    ("layers.0.in_proj.weight", 2),
+    ("layers.0.out_proj.weight", 2),
+    ("layers.0.x_proj.weight", 2),
+    ("layers.1.qkv_proj.weight", 2),
+    ("layers.1.o_proj.weight", 2),
+    ("layers.1.experts.0.gate.weight", 2),
+    ("layers.1.experts.0.up.weight", 2),
+    ("layers.1.experts.0.down.weight", 2),
+]
+
+MUON_FALSE = [
+    ("embedding.weight", 2),
+    ("lm_head.weight", 2),
+    ("layers.1.router.weight", 2),
+    ("layers.0.dt_proj.weight", 2),
+    ("layers.0.dt_proj.bias", 1),
+    ("layers.0.A_log", 1),
+    ("layers.0.D", 1),
+    ("layers.0.norm.weight", 1),
+    ("norm_f.weight", 1),
+    ("layers.0.conv.weight", 3),
+    ("layers.0.conv.bias", 1),
+    ("layers.0.in_proj.bias", 1),
+    ("layers.1.qkv_proj.bias", 1),
+]
+
+
+@pytest.mark.parametrize("name,ndim", MUON_TRUE)
+def test_muon_routes_hidden_matrices(name, ndim):
+    assert is_muon_param(name, ndim) is True
+
+
+@pytest.mark.parametrize("name,ndim", MUON_FALSE)
+def test_adamw_routes_everything_else(name, ndim):
+    assert is_muon_param(name, ndim) is False
+
+
+def test_ndim_gate_alone_excludes_non_2d():
+    # Even a name that would otherwise pass (no exact/suffix exclusion) must be ndim==2.
+    assert is_muon_param("layers.0.in_proj.weight", 1) is False
+    assert is_muon_param("layers.0.in_proj.weight", 3) is False
+
+
+def test_real_mlx_models_classify_identically():
+    """Guard against name drift: build the real toy-hybrid + toy-moe MLX models and check
+    every flattened param name against the hardcoded table's exclusion rules directly
+    (rather than re-deriving the table), i.e. re-run `is_muon_param` and sanity-check the
+    counts are non-trivial on both sides of the partition."""
+    pytest.importorskip("mlx")
+    from mlx.utils import tree_flatten
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+
+    for cfg_path in ("config/toy-hybrid.yaml", "config/toy-moe.yaml"):
+        cfg = load_config(cfg_path)
+        model = MLXMambaModel(cfg)
+        leaves = tree_flatten(model.parameters())
+        assert leaves, f"{cfg_path} produced no parameters"
+
+        muon_names = [name for name, v in leaves if is_muon_param(name, v.ndim)]
+        adam_names = [name for name, v in leaves if not is_muon_param(name, v.ndim)]
+
+        assert muon_names, f"{cfg_path}: expected at least one Muon-routed param"
+        assert adam_names, f"{cfg_path}: expected at least one AdamW-routed param"
+        # Excluded-by-name params must never appear in the Muon set.
+        for name in muon_names:
+            assert not name.endswith((".router.weight", ".dt_proj.weight"))
+            assert name not in ("embedding.weight", "lm_head.weight")
+        # Every param actually excluded by ndim must be 1D or 3D+, never 2D.
+        for name, v in leaves:
+            if name in adam_names and (
+                name.endswith((".router.weight", ".dt_proj.weight"))
+                or name in ("embedding.weight", "lm_head.weight")
+            ):
+                continue
+            if name in adam_names:
+                assert v.ndim != 2, f"{cfg_path}: {name} is 2D but routed to AdamW unexpectedly"


### PR DESCRIPTION
Closes #237

## Summary
- `is_muon_param(name, ndim)` predicate + 4 config fields (`optimizer`, `muon_lr`,
  `muon_momentum`, `muon_ns_steps`) + `validate()` checks in `src/model/blocks.py`
  (portable, no backend import).
- New below-seam `src/model/cuda_muon.py`: `Muon(torch.optim.Optimizer)` (SGD-momentum
  + 5-step Newton-Schulz orthogonalization, fp32 for deterministic resume) +
  `HybridOptimizer` container exposing `param_groups`/`zero_grad`/`step`/`state_dict`/
  `load_state_dict`. Muon derives its effective lr as `group["lr"] * lr_scale` each step
  (never persisting `muon_lr` into the group) because `_accumulate_and_step` overwrites
  `group["lr"]` every step — the two-LR hazard called out in the issue.
- `backend.py`: CUDA `_make_optimizer` partitions `named_parameters()` via
  `is_muon_param` into Muon (2D hidden weight matrices: Mamba `in_proj`/`out_proj`/
  `x_proj`, attention `qkv_proj`/`o_proj`, future MoE `experts.*.{gate,up,down}`) vs
  AdamW (embedding, lm_head, router, dt_proj, norms, biases, conv). MLX raises
  `NotImplementedError` for `optimizer=="muon"` — no silent AdamW fallback.
- `config/toy-muon.yaml` (fp32, cuda-smoke-able) exercising the default
  `lr_scale==1.0` path.
- `tests/test_muon_taxonomy.py` — portable predicate taxonomy, cross-checked against
  the real MLX `toy-hybrid`/`toy-moe` model param names.
- `tests/test_cuda_muon.py` (torch-CPU) — NS5 orthogonality band, Adam sub-group
  bit-matches a stock `AdamW`, `state_dict` save/load/step resume exactness, the
  two-LR wiring, the real CUDA model's partition matching `is_muon_param`, and the
  MLX `NotImplementedError` guard.

## Testing
- [x] Tests added/updated
- [x] All tests passing — full suite `910 passed, 8 skipped` (pre-existing skips)
- [x] `tests/test_import_guard.py` — `blocks` stays backend-free, `cuda_muon` did NOT
      leak into `PORTABLE_MODULES`
- [x] Smoke gate: `scripts/smoke_test.py --config config/toy-muon.yaml --backend cuda`
      (CPU torch, fp32) — exact resume through `HybridOptimizer`'s `state_dict`
      round-trip (`max|loss diff| = 0.000e+00`)