### PR TITLE
feat: [M12] Training-loop: WSD (warmup-stable-decay) LR schedule

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -49,6 +49,9 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--base-lr", type=float, default=3e-4)
     ap.add_argument("--warmup-steps", type=int, default=None,
                     help="default: total_steps // 100 (min 1)")
+    ap.add_argument("--lr-schedule", choices=("cosine", "wsd"), default="cosine")
+    ap.add_argument("--decay-frac", type=float, default=0.2,
+                    help="WSD: fraction of total_steps spent decaying")
     ap.add_argument("--grad-clip", type=float, default=1.0)
     ap.add_argument("--log-every", type=int, default=10)
     ap.add_argument("--eval-every", type=int, default=200)
@@ -136,11 +139,13 @@ def main() -> None:
         grad_accum=args.grad_accum, grad_clip=args.grad_clip,
         log_every=args.log_every, eval_every=args.eval_every,
         ckpt_every=args.ckpt_every, out_dir=str(out), seed=args.seed,
+        lr_schedule=args.lr_schedule, decay_frac=args.decay_frac,
     )
 
     n_params = sum(int(np.asarray(v).size) for _, v in model._portable_state_dict().items())
     print(f"[run] params~{n_params/1e6:.1f}M  total_steps={total_steps}  warmup={warmup}  "
-          f"tokens/step={tokens_per_step}  precision={cfg.precision}")
+          f"tokens/step={tokens_per_step}  precision={cfg.precision}  "
+          f"schedule={args.lr_schedule}")
 
     train(model, train_loader, tcfg, train_step,
           val_eval=val_eval, logger=logger, on_checkpoint=on_checkpoint,

--- a/src/train/loop.py
+++ b/src/train/loop.py
@@ -7,7 +7,7 @@ Mac). This keeps the seam intact: the loop never imports MLX/CUDA.
 
 Required "robust run" features (wired on the Mac):
   * mixed precision (precision decided on MLX in M1; toy/smoke = fp32)
-  * warmup + cosine LR (schedule.CosineSchedule)
+  * warmup + cosine or WSD LR (schedule.make_schedule)
   * gradient accumulation
   * gradient clipping (proven necessary at toy scale)
   * checkpointing (portable weights + within-backend resume bundle)
@@ -23,7 +23,7 @@ from typing import Callable, Optional
 
 from ..model.interface import ModelInterface
 from ..data.loader import PackedLoader
-from .schedule import CosineSchedule
+from .schedule import make_schedule
 
 
 @dataclass
@@ -38,6 +38,8 @@ class TrainConfig:
     ckpt_every: int = 100
     out_dir: str = "runs/toy"
     seed: int = 0
+    lr_schedule: str = "cosine"
+    decay_frac: float = 0.2
 
 
 # A backend-provided step: (model, micro_batches, lr) -> dict(loss=, grad_norm=, ...).
@@ -85,7 +87,7 @@ def train(
     `val_eval(model)` returns a metrics dict (e.g. {val_loss, val_perplexity}) that
     is merged into the logged payload.
     """
-    schedule = CosineSchedule(cfg.base_lr, cfg.warmup_steps, cfg.total_steps)
+    schedule = make_schedule(cfg)
     step = start_step
     log = logger or (lambda payload: print(payload))
     tokens_per_step = train_loader.batch_size * train_loader.seq_len * cfg.grad_accum

--- a/src/train/schedule.py
+++ b/src/train/schedule.py
@@ -1,13 +1,26 @@
-"""Learning-rate schedule: linear warmup + cosine decay to a floor.
+"""Learning-rate schedules: warmup + cosine decay, and warmup-stable-decay (WSD).
 
-Pure math, backend-free, fully testable in any environment. Decay stops at
-`min_lr_ratio * base_lr` (do NOT let LR hit zero).
+Pure math, backend-free, fully testable in any environment. Both schedules decay
+to `min_lr_ratio * base_lr` (do NOT let LR hit zero). `make_schedule(cfg)` selects
+between them from a duck-typed config (`lr_schedule`, `decay_frac`, ...).
+
+Note (#216 length curriculum): both schedules are expressed in absolute-step units
+over `total_steps`, and WSD's decay window is a *fraction* (`decay_frac`) of it — so
+if a future length curriculum makes `tokens_per_step` (and thus `total_steps`) vary
+per stage, passing each stage's own `total_steps` yields a correctly-scaled per-stage
+decay window for free; no code here depends on `total_steps` being fixed.
 """
 
 from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Schedule(Protocol):
+    def lr_at(self, step: int) -> float: ...
 
 
 @dataclass
@@ -44,3 +57,69 @@ class CosineSchedule:
         progress = min(1.0, (step - self.warmup_steps) / denom)
         cosine = 0.5 * (1.0 + math.cos(math.pi * progress))
         return floor + (self.base_lr - floor) * cosine
+
+
+@dataclass
+class WSDSchedule:
+    """Linear warmup -> constant base_lr plateau -> 1-sqrt decay to a floor.
+
+    `decay_steps` is the number of trailing steps (ending at `total_steps`) spent
+    decaying; the plateau fills the gap between warmup and the decay window. Fits
+    the dense-train / cheap-re-decay-per-branch pattern (a stable trunk checkpoint
+    can be re-decayed independently downstream, e.g. per sparse-upcycle branch).
+    """
+
+    base_lr: float
+    warmup_steps: int
+    total_steps: int
+    decay_steps: int
+    min_lr_ratio: float = 0.1  # floor as a fraction of base_lr; never 0
+
+    def __post_init__(self) -> None:
+        # Fail fast on misconfiguration that would yield negative/increasing LRs.
+        if self.base_lr <= 0:
+            raise ValueError("base_lr must be > 0")
+        if self.warmup_steps < 0:
+            raise ValueError("warmup_steps must be >= 0")
+        if self.total_steps <= 0:
+            raise ValueError("total_steps must be > 0")
+        if self.decay_steps < 0:
+            raise ValueError("decay_steps must be >= 0")
+        if self.warmup_steps + self.decay_steps > self.total_steps:
+            raise ValueError("warmup_steps + decay_steps must be <= total_steps")
+        if not 0 < self.min_lr_ratio <= 1:
+            raise ValueError("min_lr_ratio must be in (0, 1]")
+
+    def lr_at(self, step: int) -> float:
+        if step < 0:
+            raise ValueError("step must be >= 0")
+        floor = self.base_lr * self.min_lr_ratio
+
+        if self.warmup_steps > 0 and step < self.warmup_steps:
+            # Linear warmup from 0 up to base_lr (identical to CosineSchedule).
+            return self.base_lr * (step + 1) / self.warmup_steps
+
+        decay_start = self.total_steps - self.decay_steps
+        if step < decay_start:
+            # Stable plateau at base_lr, between warmup and the decay window.
+            return self.base_lr
+
+        # 1-sqrt decay from base_lr down to floor (WSD standard; cheap re-decay).
+        progress = min(1.0, (step - decay_start) / max(1, self.decay_steps))
+        factor = 1.0 - math.sqrt(progress)
+        return floor + (self.base_lr - floor) * factor
+
+
+def make_schedule(cfg) -> Schedule:
+    """Build a schedule from a duck-typed config (e.g. `TrainConfig`).
+
+    Reads only `lr_schedule`, `base_lr`, `warmup_steps`, `total_steps`, and (for
+    WSD) `decay_frac`; does not import `TrainConfig` to avoid a circular import
+    (`loop.py` imports from this module).
+    """
+    if cfg.lr_schedule == "cosine":
+        return CosineSchedule(cfg.base_lr, cfg.warmup_steps, cfg.total_steps)
+    if cfg.lr_schedule == "wsd":
+        decay_steps = max(1, int(round(cfg.decay_frac * cfg.total_steps)))
+        return WSDSchedule(cfg.base_lr, cfg.warmup_steps, cfg.total_steps, decay_steps)
+    raise ValueError(f"unknown lr_schedule {cfg.lr_schedule!r} (expected 'cosine' or 'wsd')")

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,8 +1,11 @@
-"""Unit tests for the warmup + cosine LR schedule (runs anywhere)."""
+"""Unit tests for the LR schedules (cosine + WSD) and the factory (runs anywhere)."""
 
 import math
+from types import SimpleNamespace
 
-from src.train.schedule import CosineSchedule
+import pytest
+
+from src.train.schedule import CosineSchedule, WSDSchedule, make_schedule
 
 
 def test_warmup_ramps_to_base():
@@ -22,3 +25,55 @@ def test_monotonic_decay_after_warmup():
     s = CosineSchedule(base_lr=1.0, warmup_steps=10, total_steps=100)
     post = [s.lr_at(t) for t in range(10, 101)]
     assert all(a >= b - 1e-12 for a, b in zip(post, post[1:]))
+
+
+def test_wsd_warmup_ends_at_base():
+    s = WSDSchedule(base_lr=1.0, warmup_steps=10, total_steps=100, decay_steps=20)
+    assert s.lr_at(0) == 0.1            # first step = base * 1/10
+    assert math.isclose(s.lr_at(9), 1.0)  # end of warmup hits base_lr
+
+
+def test_wsd_plateau_is_flat():
+    s = WSDSchedule(base_lr=1.0, warmup_steps=10, total_steps=100, decay_steps=20)
+    for t in range(10, 80):  # decay_start = 100 - 20 = 80
+        assert s.lr_at(t) == 1.0
+
+
+def test_wsd_decays_to_floor_at_total():
+    s = WSDSchedule(base_lr=1.0, warmup_steps=10, total_steps=100, decay_steps=20,
+                     min_lr_ratio=0.1)
+    end = s.lr_at(100)
+    assert math.isclose(end, 0.1, abs_tol=1e-6)   # floor, never 0
+    assert end > 0.0
+
+
+def test_wsd_monotonic_nonincreasing_in_decay():
+    s = WSDSchedule(base_lr=1.0, warmup_steps=10, total_steps=100, decay_steps=20)
+    decay = [s.lr_at(t) for t in range(80, 101)]  # decay_start = 80
+    assert all(a >= b - 1e-12 for a, b in zip(decay, decay[1:]))
+
+
+def test_wsd_validation():
+    with pytest.raises(ValueError):
+        WSDSchedule(base_lr=1.0, warmup_steps=10, total_steps=100, decay_steps=95)  # 10+95>100
+    with pytest.raises(ValueError):
+        WSDSchedule(base_lr=0.0, warmup_steps=10, total_steps=100, decay_steps=20)
+    with pytest.raises(ValueError):
+        WSDSchedule(base_lr=1.0, warmup_steps=10, total_steps=100, decay_steps=20,
+                    min_lr_ratio=0.0)
+
+
+def test_make_schedule_selects():
+    cfg_cosine = SimpleNamespace(lr_schedule="cosine", base_lr=1.0, warmup_steps=10,
+                                 total_steps=100, decay_frac=0.2)
+    cfg_wsd = SimpleNamespace(lr_schedule="wsd", base_lr=1.0, warmup_steps=10,
+                              total_steps=100, decay_frac=0.2)
+    cfg_bad = SimpleNamespace(lr_schedule="bogus", base_lr=1.0, warmup_steps=10,
+                              total_steps=100, decay_frac=0.2)
+
+    assert isinstance(make_schedule(cfg_cosine), CosineSchedule)
+    wsd = make_schedule(cfg_wsd)
+    assert isinstance(wsd, WSDSchedule)
+    assert wsd.decay_steps == round(cfg_wsd.decay_frac * cfg_wsd.total_steps)
+    with pytest.raises(ValueError):
+        make_schedule(cfg_bad)


### PR DESCRIPTION
Closes #238

## Summary
- Add `WSDSchedule` beside `CosineSchedule` in `src/train/schedule.py`: linear warmup -> constant `base_lr` plateau -> 1-sqrt decay to a `min_lr_ratio` floor over the final `decay_steps`, same fail-fast `__post_init__` style as the cosine schedule.
- Add a `Schedule` structural protocol and a `make_schedule(cfg)` factory that selects cosine or WSD from a duck-typed config (no ABC, no circular import).
- Rewire `src/train/loop.py:88` to build the schedule via `make_schedule(cfg)` instead of a hardcoded `CosineSchedule(...)`; add `lr_schedule: str = "cosine"` and `decay_frac: float = 0.2` to `TrainConfig` (default keeps existing cosine behavior unchanged).
- Surface `--lr-schedule {cosine,wsd}` / `--decay-frac` in `scripts/train.py`, threaded into `TrainConfig` and the run-log print.
- Extend `tests/test_schedule.py` with WSD phase-boundary, monotone-decay, validation, and `make_schedule`-selection tests (existing cosine tests unchanged).

Pure/stateless — a function of `step` only, so no resume impact.

## Testing
- [x] Tests added/updated (`tests/test_schedule.py`)
- [x] All tests passing (`.venv/bin/python -m pytest -q` — 916 passed, 8 skipped; `tests/test_import_guard.py` green — schedule/loop stay backend-free)
- [x] Manual testing completed (smoke gate: `scripts/smoke_test.py` against a freshly-built toy split — PASSED; manual `WSDSchedule` sanity check matches expected warmup/plateau/decay/floor values)