### PR TITLE
feat: torch.compile enabled-by-default for real (CUDA) runs

### DIFF
--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -36,6 +36,10 @@ def main() -> None:
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--out", type=Path, default=Path("runs/smoke"))
     ap.add_argument("--atol", type=float, default=1e-4)
+    ap.add_argument("--compile", action="store_true",
+                    help="also run ONE torch.compile'd training step (CUDA + .[cuda-fast] "
+                         "pod) and assert it does not hard-error; the main resume-exactness "
+                         "run stays eager. Verifies the Triton graph-break path on hardware.")
     args = ap.parse_args()
 
     # Backend selection stays behind the seam factory; only portable modules are
@@ -127,6 +131,28 @@ def main() -> None:
                               args.batch_size, shuffle=False, drop_last=False)
     val = evaluate(model_b, val_loader, max_batches=4, to_numpy=np_to)
     print(f"[eval] val_loss={val['val_loss']:.4f}  val_perplexity={val['val_perplexity']:.4f}")
+
+    # --- 5) optional: one torch.compile'd step (#239) ---------------------------
+    # Isolated from the resume math above (fresh model, own optimizer/step_fn) so
+    # --compile can never perturb the gated eager comparison; this only asserts the
+    # compiled Triton graph-break path runs without a hard error on real hardware.
+    if args.compile:
+        if backend.name != "cuda":
+            print("[compile] skipped (only meaningful on the CUDA backend)")
+        else:
+            import dataclasses
+            import math as _math
+
+            ccfg = dataclasses.replace(cfg, torch_compile=True)
+            backend.seed(args.seed)
+            cmodel = backend.model_cls(ccfg)
+            copt = backend.make_optimizer(cmodel, sched.base_lr)
+            cstep = backend.make_train_step(cmodel, copt, grad_clip=1.0)
+            inp, tgt = batches[0]
+            out_c = cstep(cmodel, [(inp, tgt)], sched.lr_at(0))
+            assert _math.isfinite(float(out_c["loss"])), \
+                f"compiled step loss not finite: {out_c['loss']}"
+            print(f"[compile] one compiled step OK  loss={float(out_c['loss']):.5f}")
 
     print("\nSMOKE TEST PASSED ✅  resume is exact and eval runs.")
 

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -90,12 +90,17 @@ class MambaConfig:
     # 32GB and swaps). Off for toy/smoke (tiny; keep exact-resume cheap).
     grad_checkpoint: bool = False
 
-    # CUDA-only (#145): compile the student forward with torch.compile (inductor) to fuse
-    # the SSD scan + hybrid forward's many small ops (~1.3-2x on GPU). Opt-in and default
-    # OFF so every parity/conformance/smoke path runs the eager code unchanged. A no-op on
-    # MLX (the MLX backend never reads it) and on the eager torch path. The optional
-    # mamba-ssm/causal-conv1d kernels (#40) graph-break inductor around them (safe).
-    torch_compile: bool = False
+    # CUDA-only (#145, #239): compile the student forward with torch.compile (inductor) to
+    # fuse the SSD scan + hybrid forward's many small ops (~1.3-2x on GPU). Tri-state:
+    #   None  (default) = AUTO — the CUDA backend compiles iff it is built on a real CUDA
+    #     device and torch >= 2.1; eager everywhere else (CPU parity, MLX). This makes
+    #     compile the default for real (CUDA) runs without touching the CPU parity surface.
+    #   True  = force compile on whatever device the model is built on (used by the parity
+    #     tests below, which build on CPU).
+    #   False = force eager.
+    # A no-op on MLX (the MLX backend never reads it). The optional mamba-ssm/causal-conv1d
+    # kernels (#40) graph-break inductor around them (safe).
+    torch_compile: Optional[bool] = None
 
     # --- hybrid attention (#67) ---
     # Make the model a Mamba-2 HYBRID: every Nth block is a causal multi-head
@@ -296,6 +301,8 @@ class MambaConfig:
             raise ValueError(f"unknown precision {self.precision!r}")
         if self.optimizer not in ("adamw", "muon"):
             raise ValueError(f"unknown optimizer {self.optimizer!r}")
+        if self.torch_compile not in (None, True, False):
+            raise ValueError("torch_compile must be None (auto), True, or False")
         if not (0.0 <= self.muon_momentum < 1.0):
             raise ValueError(f"muon_momentum={self.muon_momentum} must be in [0, 1)")
         if self.muon_ns_steps < 1:

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -563,6 +563,13 @@ class AttentionBlock(nn.Module):
         return x + _linear(self.o_proj, _cast(out, cd), cd), (k_cache, v_cache)
 
 
+def _torch_ge_21() -> bool:
+    # "2.3.1+cu121" -> (2, 3); robust to the +cuXXX / +cpu local suffix.
+    parts = torch.__version__.split("+")[0].split(".")
+    major, minor = int(parts[0]), int(parts[1])
+    return (major, minor) >= (2, 1)
+
+
 # --------------------------------------------------------------------------- #
 # Top-level model implementing the seam
 # --------------------------------------------------------------------------- #
@@ -594,11 +601,22 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         self._state = None
         self.to(self._device)
         _report_fast_path_once(self._device)
-        # torch.compile (#145): fuse the pure-tensor forward (layer loop + head) via inductor.
-        # Opt-in (default off) so the eager path — and every parity/conformance run — is
-        # untouched. We compile the inner `_forward_compute` rather than `forward`, which
-        # opens with a numpy->tensor boundary that isn't cleanly traceable. A no-op when off.
-        if config.torch_compile:
+        # torch.compile (#145, #239): fuse the pure-tensor forward (layer loop + head) via
+        # inductor. Tri-state config.torch_compile: None = AUTO (compile only on a real CUDA
+        # device with torch>=2.1 — the real-run path), True/False = explicit override honored
+        # on any device. NEVER auto-compile on CPU: CPU is the fp32 parity/conformance surface
+        # (tests/test_cuda_parity.py builds on CPU) and must stay eager. We compile the inner
+        # `_forward_compute` (not `forward`, which opens with an untraceable numpy->tensor
+        # boundary). Bare torch.compile — no max-autotune (long autotune + fragile capture);
+        # inductor's automatic dynamic-shape promotion handles varying (B, L). The optional
+        # mamba-ssm/causal-conv1d kernels graph-break inductor around them (safe).
+        # CUDA graphs: DEFERRED (out of scope) — follow-up is to profile launch-overhead at
+        # the small M12 rung and add mode="reduce-overhead" only if a stall shows.
+        if config.torch_compile is None:
+            self._compiled = self._device.type == "cuda" and _torch_ge_21()
+        else:
+            self._compiled = bool(config.torch_compile)
+        if self._compiled:
             self._forward_compute = torch.compile(self._forward_compute)
 
     def _head(self, h: Array) -> Array:

--- a/tests/test_cuda_compile.py
+++ b/tests/test_cuda_compile.py
@@ -79,3 +79,42 @@ def test_compiled_grad_checkpoint_backward_runs(_compile_works):
     grads = [p.grad for p in model.parameters() if p.grad is not None]
     assert grads, "no gradients populated"
     assert all(torch.isfinite(g).all() for g in grads), "non-finite gradient"
+
+
+def test_compiled_forward_matches_eager_pure_mamba(_compile_works):
+    """Compiled == eager at fp32 ~1e-4 for a PURE-Mamba config (no attention block)."""
+    torch.manual_seed(0)
+    cfg = load_config("config/toy.yaml")
+    eager = CUDAMambaModel(cfg)
+    eager.eval()
+
+    cfg_c = load_config("config/toy.yaml")
+    cfg_c.torch_compile = True
+    compiled = CUDAMambaModel(cfg_c)
+    compiled.load_state_dict(eager.state_dict())
+    compiled.eval()
+
+    B, L = 2, cfg.seq_len
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    with torch.no_grad():
+        y_eager = _np(eager.forward(tokens))
+        y_comp = _np(compiled.forward(tokens))
+    max_abs = float(np.max(np.abs(y_eager - y_comp)))
+    assert np.allclose(y_eager, y_comp, rtol=1e-4, atol=1e-5), f"max|diff|={max_abs:.3e}"
+
+
+def test_torch_compile_auto_resolves_eager_on_cpu():
+    """Default (None) => AUTO: a CPU-built model must NOT compile (CPU is the parity
+    surface). Asserted via the resolved `_compiled` decision flag."""
+    cfg = load_config("config/toy.yaml")
+    assert cfg.torch_compile is None          # tri-state default
+    model = CUDAMambaModel(cfg)               # device defaults to CPU
+    assert model._compiled is False
+
+
+def test_torch_compile_explicit_true_compiles_on_cpu(_compile_works):
+    """Explicit True is honored on ANY device (the parity tests rely on this)."""
+    cfg = load_config("config/toy.yaml")
+    cfg.torch_compile = True
+    model = CUDAMambaModel(cfg)
+    assert model._compiled is True


### PR DESCRIPTION
Closes #239

## Summary
- `MambaConfig.torch_compile` is now tri-state (`Optional[bool] = None`): `None` (default) = AUTO, compiling iff the CUDA backend is built on a real CUDA device with torch>=2.1; `True`/`False` force compile/eager on any device.
- `validate()` accepts `None`/`True`/`False` only.
- `CUDAMambaModel.__init__` resolves the tri-state and records the decision on `self._compiled`; CPU always stays eager under auto, so the fp32 parity/conformance surface is untouched.
- `scripts/smoke_test.py` gets an optional `--compile` flag that runs one isolated compiled step on the CUDA backend (skips on other backends); the default eager resume-exactness run is unperturbed.
- `tests/test_cuda_compile.py` gains a pure-Mamba compiled-vs-eager case plus two auto-resolution tests (CPU resolves to eager; explicit `True` still compiles on CPU).
- CUDA graphs remain explicitly deferred (comment only, follow-up noted).

## Testing
- [x] Tests added/updated
- [x] All tests passing (`pytest -q`: 917 passed, 10 skipped)
- [x] Manual testing completed (fresh toy split + `scripts/smoke_test.py` default run: bit-exact resume, `max|diff|=2.384e-07`; `--compile` cleanly skips on non-CUDA backend)