### PR TITLE
feat: fp8 MoE-expert linears (Transformer Engine, Hopper) — design-only

### DIFF
--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -35,6 +35,14 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
   balancing router (#213, *land first*) → CUDA MoE backend (#214: dropless routing, shared expert,
   FSDP, sparse-upcycle init) → FIM collator (#215), length curriculum + dataloader-state resume
   (#216), routing instrumentation (#217), pure-PyTorch Mamba-2 reference for laptop parity (#218).
+  **Training-efficiency levers** (folded 2026-07-20 from the efficiency-survey review): hybrid
+  Muon+AdamW optimizer at the `make_optimizer` seam (#237), WSD warmup-stable-decay LR schedule
+  (#238), and `torch.compile` default-on for real CUDA runs (#239) — all sequenced to land
+  *before* the #219 sweep so it and the #222/#223 runs carry them; plus fp8 MoE-expert linears
+  (Transformer Engine / Hopper, #240), *gated on #214* and ahead of the #223 large run. (The repo
+  is already mature on the survey's biggest axes — data dedup/filtering, fused AdamW, SDPA, the
+  mamba-ssm kernels, grad-checkpoint — so these four are the net-new levers; #216 is the
+  length-curriculum lever.)
 - **MHM-P2e — Evals** (build first): code eval suite (#221), BPB (#192, primary).
 - **MHM-P3 — Small-model ablation sweep** (#219, ~$80–120 each): attention ratio 8/12/16%,
   d_state 128 vs 256, Jamba vs Routing-Mamba.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,12 @@ cuda = ["torch>=2.0"]
 # Note: mamba-ssm 2.x top-level package requires a compatible transformers version;
 # the ops submodule used here (mamba_ssm.ops.triton) works independently.
 cuda-fast = ["torch>=2.0", "mamba-ssm>=2.0", "causal-conv1d>=1.0"]
+# fp8 MoE-expert linears via NVIDIA Transformer Engine (#240), separate from `cuda-fast`:
+# TE is Hopper-only (sm_90+) and a heavy dependency, and fp8 applies only to the expert
+# GEMMs (gate/up/down), not the whole model. Auto-detected at runtime by
+# `cuda_backend._te_linear_cls()` and degrades to bf16/fp16 `nn.Linear` when absent or
+# pre-Hopper. DESIGN-ONLY today (blocked on #214's CUDA MoE experts).
+cuda-fp8 = ["torch>=2.0", "transformer-engine>=1.0"]
 # Experiment logging.
 logging = ["wandb>=0.16"]
 # Tier-2 OLMES/lm-eval benchmark harness. A heavy optional dependency (some

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -125,6 +125,15 @@ class MambaConfig:
     top_k: int = 2              # experts routed per token (1 <= top_k <= n_experts)
     # Expert FFN hidden width. None => d_inner (the Mamba inner width), a natural scale.
     moe_d_ff: Optional[int] = None
+    # fp8 expert GEMMs via NVIDIA Transformer Engine (#240), CUDA/Hopper-only. A separate
+    # bool rather than a `precision` value: fp8 applies ONLY to the three expert linears
+    # (gate/up/down), not the whole model — everything else stays at `precision`. A no-op
+    # on MLX and on non-Hopper CUDA (the `cuda_backend._te_linear_cls()` probe falls back
+    # to a plain bf16/fp16 `nn.Linear` when TE is absent or the device is pre-sm_90).
+    # DESIGN-ONLY today: #240 is blocked on #214 (no CUDA MoE experts exist yet to attach
+    # fp8 to) — this field and its validate() rule land now so #214 can wire fp8 in
+    # mechanically. See `cuda_backend.py`'s `# BLOCKED-ON-#214` block.
+    fp8_experts: bool = False
 
     # --- training-free long-context extension (#54) ---
     # INFERENCE-TIME receptive-field enlargement (LongMamba). Divides the SSM
@@ -347,6 +356,20 @@ class MambaConfig:
                 raise ValueError(
                     f"moe_every={self.moe_every} selects no layer at n_layers="
                     f"{self.n_layers} (after attention precedence)."
+                )
+        if self.fp8_experts:
+            # n_moe_layers==0 also catches moe_every=None (fp8 applies to expert GEMMs
+            # only, so it needs an actual MoE model, not just moe_every set).
+            if self.n_moe_layers == 0:
+                raise ValueError(
+                    "fp8_experts requires an MoE model (set moe_every); fp8 applies "
+                    "only to the expert GEMMs."
+                )
+            if self.precision not in ("bf16", "fp16"):
+                raise ValueError(
+                    f"fp8_experts requires precision in (bf16, fp16), got "
+                    f"{self.precision!r} (bf16 recommended: no loss-scaler conflict "
+                    "with Transformer Engine's DelayedScaling)."
                 )
 
     def to_dict(self) -> dict:

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -109,6 +109,86 @@ def _report_fast_path_once(device: "torch.device") -> None:
             RuntimeWarning, stacklevel=2)
 
 
+# --------------------------------------------------------------------------- #
+# fp8 MoE-expert linears (#240, DESIGN-ONLY, blocked on #214): NVIDIA Transformer
+# Engine (TE) `te.Linear` on Hopper+ (sm_90) for the expert gate/up/down GEMMs only.
+# Mirrors the `_fused_scan()` / `_report_fast_path_once()` lazy-probe + warn-once
+# pattern above. TE is not wired to any expert module yet — #214 has not built the
+# CUDA MoE `_Expert`/`MoEBlock` (that lives only in `mlx_backend.py:499-560` today) —
+# so this probe is complete and tested, but has no live caller besides its own tests.
+# --------------------------------------------------------------------------- #
+_TE_LINEAR_CLS = None      # sentinel: None = untried, False = unavailable/pre-Hopper
+
+
+def _te_linear_cls():
+    """Return `transformer_engine.pytorch.Linear`, or None if TE is unavailable or the
+    device is pre-Hopper. Mirrors `_fused_scan()`. Hopper check uses
+    `get_device_capability()[0] >= 9`: TE also runs on Blackwell (sm_100+), so `>= 9`
+    is the correct forward-compatible lower bound, not an exact sm_90 match."""
+    global _TE_LINEAR_CLS
+    if _TE_LINEAR_CLS is None:
+        try:
+            if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9:
+                _TE_LINEAR_CLS = False
+                return None
+            from transformer_engine.pytorch import Linear as _TELinear
+            _TE_LINEAR_CLS = _TELinear
+        except Exception:
+            _TE_LINEAR_CLS = False
+    return _TE_LINEAR_CLS if _TE_LINEAR_CLS else None
+
+
+def fp8_status() -> bool:
+    """Is the fp8 expert-linear path (TE + Hopper) available? Mirrors `fast_path_status()`."""
+    return _te_linear_cls() is not None
+
+
+_FP8_STATUS_REPORTED = False
+
+
+def _report_fp8_status_once(device: "torch.device") -> None:
+    """On the first CUDA model built with `fp8_experts=True`, log whether TE fp8 is
+    active. Like `_report_fast_path_once`, a silent bf16 fallback on a GPU is a
+    throughput trap during a sweep — make it loud. Not called yet: no CUDA model
+    build path sets `fp8_experts` until #214 adds the CUDA MoE experts."""
+    global _FP8_STATUS_REPORTED
+    if _FP8_STATUS_REPORTED or device.type != "cuda":
+        return
+    _FP8_STATUS_REPORTED = True
+    if fp8_status():
+        print("[cuda] fp8 MoE experts ACTIVE (Transformer Engine, Hopper+).")
+    else:
+        import warnings
+        warnings.warn(
+            "[cuda] fp8_experts=True but Transformer Engine is unavailable or the "
+            "device is pre-Hopper — MoE experts fall back to bf16/fp16 nn.Linear. "
+            "Install the fp8 path with: pip install -e \".[dev,data,cuda-fp8]\" on a "
+            "Hopper+ (sm_90) GPU (#240).",
+            RuntimeWarning, stacklevel=2)
+
+
+# === BLOCKED-ON-#214: CUDA MoE experts do not exist yet ======================
+# When #214 adds the CUDA `_Expert`/`MoEBlock` (mirroring `mlx_backend.py:499-560`),
+# its three expert linears (gate/up/down) build via this helper: `te.Linear` when fp8
+# is available (TE keeps fp32 master weights and casts to fp8 at the GEMM, analogous
+# to `_linear`'s cast-at-matmul above), else a plain bf16/fp16 `nn.Linear`. This
+# function is DEFINED BUT NEVER CALLED until #214 lands — no CUDA `_Expert` exists to
+# call it. Un-dormanting is mechanical:
+#   _Expert.__init__: self.gate/up/down = _expert_linear(d_in, d_out, config, device)
+#   MoE grad-checkpoint wraps in `transformer_engine.pytorch.checkpoint`, NOT
+#     `torch.utils.checkpoint` — plain checkpoint double-updates the fp8 amax history
+#     on the recompute pass.
+#   model build calls `_report_fp8_status_once(device)` once fp8_experts is wired.
+# `te.Linear` graph-breaks `torch.compile` like `mamba-ssm` (safe/opaque, same as the
+# fused scan above).
+def _expert_linear(d_in: int, d_out: int, config: MambaConfig, device):
+    cls = _te_linear_cls() if getattr(config, "fp8_experts", False) else None
+    if cls is not None:
+        return cls(d_in, d_out, bias=False)        # TE fp8 GEMM, fp32 master weights
+    return nn.Linear(d_in, d_out, bias=False)       # bf16/fp16 fallback (no TE / pre-Hopper)
+# ===========================================================================
+
+
 def _silu(x: Array) -> Array:
     return F.silu(x)
 

--- a/tests/test_cuda_fp8.py
+++ b/tests/test_cuda_fp8.py
@@ -1,0 +1,94 @@
+"""fp8 MoE-expert linears via NVIDIA Transformer Engine (#240, DESIGN-ONLY).
+
+#240 is blocked on #214 (CUDA MoE backend — no `_Expert`/`MoEBlock` exists in
+`cuda_backend.py` yet), so only the pieces that don't need a CUDA MoE expert are
+tested live here: the `_te_linear_cls()` capability probe and the `fp8_experts`
+config-validation rules. The bf16-vs-fp8 forward-equivalence + finite-grad-under-
+checkpoint acceptance tests (the real #240 payoff) are recorded as skipped
+placeholders so the intent survives to the #214 landing, when they get un-skipped
+and filled in against the real CUDA `_Expert`.
+
+This whole module SKIPS its Hopper/TE-specific tests on the non-Hopper Mac/CI box
+(no CUDA, no `transformer_engine` installed) — only the probe/validate tests run
+there, and they must PASS everywhere (they assert graceful absence, not presence).
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import load_config
+from src.model.cuda_backend import _te_linear_cls, fp8_status
+
+
+@pytest.fixture(scope="module")
+def _hopper():
+    """Skip if there's no Hopper+ (sm_90) CUDA device — mirrors `_compile_works` in
+    test_cuda_compile.py. TE-specific acceptance tests build on this; the probe test
+    below does NOT use this fixture, since it must run (and pass) on the Mac box too."""
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("no Hopper+ (sm_90) CUDA device here")
+
+
+def test_te_linear_cls_returns_none_without_crashing():
+    """The probe never raises, and returns None when TE is absent or the device is
+    pre-Hopper — the expected state on the non-Hopper Mac/CI box. On a real Hopper+
+    box with `transformer-engine` installed (the `cuda-fp8` extra) this would instead
+    return the TE Linear class; that path is exercised by the (currently skipped)
+    acceptance tests below once #214 gives it something to build."""
+    cls = _te_linear_cls()
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9:
+        assert cls is None
+    assert fp8_status() == (cls is not None)
+
+
+def test_fp8_experts_requires_moe():
+    cfg = load_config("config/toy.yaml")           # no moe_every
+    cfg.fp8_experts = True
+    cfg.precision = "bf16"
+    with pytest.raises(ValueError, match="MoE"):
+        cfg.validate()
+
+
+def test_fp8_experts_requires_bf16_or_fp16_precision():
+    cfg = load_config("config/toy-moe.yaml")        # has moe_every/n_experts
+    cfg.fp8_experts = True
+    cfg.precision = "fp32"
+    with pytest.raises(ValueError, match="precision"):
+        cfg.validate()
+
+
+def test_fp8_experts_accepts_bf16_moe():
+    cfg = load_config("config/toy-moe.yaml")
+    cfg.fp8_experts = True
+    cfg.precision = "bf16"
+    cfg.validate()                                  # must not raise
+    assert cfg.fp8_experts is True
+
+
+def test_fp8_experts_default_off_is_unaffected():
+    """Sanity: fp8_experts=False (the default) never trips the new validate() rules,
+    even with fp32 + no MoE (the toy default)."""
+    cfg = load_config("config/toy.yaml")
+    assert cfg.fp8_experts is False
+    cfg.validate()
+
+
+@pytest.mark.skip(reason="BLOCKED-ON-#214: no CUDA MoE _Expert/MoEBlock to build fp8 "
+                          "linears against yet; un-skip once #214 lands.")
+def test_fp8_expert_forward_matches_bf16(_hopper):
+    """Acceptance (deferred): a fp8-expert MoE forward should match the bf16-expert
+    forward within an fp8-appropriate tolerance (NOT the 1e-4 fp32 parity bar — fp8
+    e4m3 has ~2 decimal digits; expect ~1e-1 rel or a loss-delta bound). Needs #214's
+    CUDA `_Expert`/`MoEBlock` to exist before this can build a model."""
+    raise NotImplementedError
+
+
+@pytest.mark.skip(reason="BLOCKED-ON-#214: no CUDA MoE _Expert/MoEBlock to build fp8 "
+                          "linears against yet; un-skip once #214 lands.")
+def test_fp8_expert_checkpoint_backward_finite_grads(_hopper):
+    """Acceptance (deferred): fp8 experts under grad-checkpoint (using
+    `transformer_engine.pytorch.checkpoint`, not `torch.utils.checkpoint` — see the
+    `# BLOCKED-ON-#214` note in cuda_backend.py) should backprop to finite grads.
+    Needs #214's CUDA `_Expert`/`MoEBlock` to exist before this can build a model."""
+    raise NotImplementedError


### PR DESCRIPTION
Refs #240 (design-only — see below). Tracker #198, MHM-P2.

## Summary

**This is a DESIGN-ONLY PR.** #240 is hard-blocked on #214 (CUDA MoE backend — OPEN,
no PRs). Today the CUDA backend has no MoE at all (`cuda_backend.py`'s
`NotImplementedError` guard on `n_moe_layers > 0` is untouched by this PR), so there
is no CUDA `_Expert`/`MoEBlock` to attach fp8 GEMMs to yet.

**Lands live + tested (no dependency on #214 symbols):**
- `fp8_experts: bool = False` config field in `src/model/blocks.py` (MoE field group)
  — a dedicated bool, not a `precision:"fp8"` value, since fp8 applies only to the
  expert `gate`/`up`/`down` GEMMs, not the whole model.
- `validate()` rules: `fp8_experts` requires an MoE model (`moe_every` set) and
  `precision in ("bf16", "fp16")`.
- `cuda-fp8` extra (`transformer-engine`) in `pyproject.toml`, separate from
  `cuda-fast` (TE is Hopper-only and heavy).
- Lazy `_te_linear_cls()` capability probe in `src/model/cuda_backend.py` (local TE
  import + `torch.cuda.get_device_capability()[0] >= 9`), `fp8_status()`, and a
  warn-once `_report_fp8_status_once()` — mirrors the existing `_fused_scan()` /
  `_report_fast_path_once()` pattern. Never crashes on absence.
- `tests/test_cuda_fp8.py`: the probe + validate-rule tests run and pass on the
  non-Hopper Mac box.

**Dormant / design (references #214's not-yet-existing symbols, never executed):**
- `_expert_linear()` helper in `cuda_backend.py`, under a `# BLOCKED-ON-#214` block —
  defined but never called (no CUDA `_Expert` exists to call it). Precise enough that
  un-dormanting when #214 lands is mechanical: swap `_Expert.__init__`'s three
  `nn.Linear(...)` for `_expert_linear(...)`, wrap the MoE grad-checkpoint in
  `transformer_engine.pytorch.checkpoint` (not `torch.utils.checkpoint` — avoids
  double-updating the fp8 amax on the recompute pass), and call
  `_report_fp8_status_once()` at model build.
- Two acceptance tests (bf16-vs-fp8 forward equivalence, finite grads under
  checkpoint) recorded as `@pytest.mark.skip(reason="BLOCKED-ON-#214: ...")`
  placeholders so the intent survives to the #214 landing.

**Why not `Closes #240`:** #240's acceptance criteria include the bf16-vs-fp8
forward-equivalence and finite-grad-under-checkpoint tests, which need #214's CUDA
MoE experts to exist and are deferred here. Leaving #240 open; the dormant wiring and
skipped tests land for real once #214 merges.

## Testing
- [x] `.venv/bin/python -c "import src.model.blocks; import src.model.cuda_backend"` — imports clean
- [x] `.venv/bin/python -m pytest tests/test_cuda_fp8.py -q -rs` — 5 passed, 2 skipped (BLOCKED-ON-#214)
- [x] `.venv/bin/python -m pytest tests/test_import_guard.py -q` — green (`blocks.py` stays backend-free)
- [x] `.venv/bin/python -m pytest -q` — full suite green (922 passed, 12 pre-existing skips)
- [x] `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"` — TOML parses
- [x] `.venv/bin/python scripts/smoke_test.py --data data/split` — PASSED, fp32/dense untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRoRJxdHnmsRFN8AGNbMAu