### PR TITLE
ci: stand up GitHub Actions — pytest + smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: CI
+
+# Standing CI for the portable test suite, the seam guard, and the M4 smoke gate
+# (resume-exactness + eval). See issue #249 for the design record and #246 for
+# the Swift toolchain job this workflow is structured to accept as a drop-in.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Job 1: portable suite + seam guard (Linux, no mlx, no torch) ──────────
+  # This is the one environment where test_import_guard.py's
+  # test_portable_modules_do_not_import_backends is unambiguous: mlx isn't
+  # installable on Linux, and torch is deliberately not installed in this job
+  # (it lives in smoke-linux instead), so any backend import above the seam
+  # fails loudly rather than being masked by a locally-present backend.
+  portable:
+    name: portable (pytest, no backend)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,data]"
+      - name: pytest
+        run: pytest -q -rs
+
+  # ── Job 2: smoke gate on Linux/CPU-torch (hardware-independent guarantee) ─
+  # Separate job from `portable`, not a step in it, so torch never enters
+  # portable's environment. Installs the CPU torch wheel first so the later
+  # editable install (which never requests the `cuda` extra) doesn't pull a
+  # different torch.
+  smoke-linux:
+    name: smoke gate (Linux, CPU torch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://download.pytorch.org/whl/cpu torch
+          pip install -e ".[dev,data]"
+      - name: Build a fresh toy split
+        # The gotcha this encodes: scripts/smoke_test.py needs a FRESHLY BUILT
+        # toy split, never data/split (which holds the real OLMo-vocab
+        # corpus). config/toy.yaml is vocab_size 256 (byte-fallback), so this
+        # needs no network, no HF token, and not even the `data` extra.
+        # Built under $RUNNER_TEMP so nothing lands in the checkout.
+        run: |
+          python -m src.data.download --dummy --out "$RUNNER_TEMP/toy/raw" --max-docs 2000
+          python -m src.data.tokenize --in "$RUNNER_TEMP/toy/raw/dummy.txt" \
+                 --out "$RUNNER_TEMP/toy/ids.npy" --byte-fallback
+          python -m src.data.pack  --in "$RUNNER_TEMP/toy/ids.npy" --out "$RUNNER_TEMP/toy/packed.bin"
+          python -m src.data.split --packed "$RUNNER_TEMP/toy/packed.bin" \
+                 --out "$RUNNER_TEMP/toy/split" --val-tokens 2000
+      - name: Smoke gate (CUDA backend, CPU device)
+        run: |
+          python scripts/smoke_test.py --backend cuda \
+                 --data "$RUNNER_TEMP/toy/split" --out "$RUNNER_TEMP/smoke"
+
+  # ── Job 3: full suite + smoke gate on macOS/MLX (arm64) ───────────────────
+  # macos-latest is arm64, so the mlx wheel installs and the ~19 mlx-gated
+  # test files actually run instead of skipping.
+  full-macos:
+    name: full suite + smoke gate (macOS, MLX)
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,data,mlx]"
+      - name: pytest
+        run: pytest -q -rs
+      - name: Build a fresh toy split
+        run: |
+          python -m src.data.download --dummy --out "$RUNNER_TEMP/toy/raw" --max-docs 2000
+          python -m src.data.tokenize --in "$RUNNER_TEMP/toy/raw/dummy.txt" \
+                 --out "$RUNNER_TEMP/toy/ids.npy" --byte-fallback
+          python -m src.data.pack  --in "$RUNNER_TEMP/toy/ids.npy" --out "$RUNNER_TEMP/toy/packed.bin"
+          python -m src.data.split --packed "$RUNNER_TEMP/toy/packed.bin" \
+                 --out "$RUNNER_TEMP/toy/split" --val-tokens 2000
+      - name: Smoke gate (MLX backend)
+        run: |
+          python scripts/smoke_test.py --backend mlx \
+                 --data "$RUNNER_TEMP/toy/split" --out "$RUNNER_TEMP/smoke"
+
+  # ── Swift toolchain (#246) drops in here ──────────────────────────────
+  # swift:
+  #   strategy: { matrix: { os: [macos-latest, ubuntu-latest] } }
+  #   runs-on: ${{ matrix.os }}
+  #   steps: ... cd swift && swift build && swift run monica-selfcheck
+  # Note: swift/Package.swift declares NO .testTarget and there is no Tests/ dir,
+  # so `swift test` finds nothing today — monica-selfcheck is the actual runner
+  # (dependency-free, no XCTest, exits non-zero on any failure).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
   # Separate job from `portable`, not a step in it, so torch never enters
   # portable's environment. Installs the CPU torch wheel first so the later
   # editable install (which never requests the `cuda` extra) doesn't pull a
-  # different torch.
+  # different torch. That editable install is bare (no `[dev,data]`): this
+  # job runs no pytest (dev/pytest unused) and the smoke path below has no
+  # module-level pyarrow/fsspec/datasets/transformers imports (data unused).
   smoke-linux:
     name: smoke gate (Linux, CPU torch)
     runs-on: ubuntu-latest
@@ -62,7 +64,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --index-url https://download.pytorch.org/whl/cpu torch
-          pip install -e ".[dev,data]"
+          pip install -e .
       - name: Build a fresh toy split
         # The gotcha this encodes: scripts/smoke_test.py needs a FRESHLY BUILT
         # toy split, never data/split (which holds the real OLMo-vocab

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,13 @@ python -m src.data.pack  --in data/ids.npy --out data/packed.bin
 python -m src.data.split --packed data/packed.bin --out data/split --val-tokens 2000
 ```
 
-There is no separate lint/format/build step — pytest is the gate. `mlx` is not
-installable on Linux; on a non-Mac host the MLX backend simply won't import (by
-design), and only the portable tests run.
+There is no separate lint/format/build step — pytest is the gate, and it now runs in CI
+(`.github/workflows/ci.yml`, #249): a Linux `portable` job (`pytest -q -rs`, no mlx/torch —
+where `test_import_guard.py` is unambiguous), a Linux `smoke-linux` job (CPU-torch,
+`scripts/smoke_test.py --backend cuda`), and a macOS `full-macos` job (mlx installed,
+`pytest -q -rs` + `scripts/smoke_test.py --backend mlx`). `mlx` is not installable on Linux;
+on a non-Mac host the MLX backend simply won't import (by design), and only the portable
+tests run.
 
 ## The seam — the most important architectural rule
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -45,8 +45,11 @@ to the loop, the SSD scan, mixed precision, checkpointing, or eval.
 `smoke-linux` job installs CPU-only torch and runs the same fresh-toy-split →
 `smoke_test.py --backend cuda` steps as above, under `$RUNNER_TEMP` instead of `data/`; and a
 macOS `full-macos` job runs the full `pytest -q -rs` plus `smoke_test.py --backend mlx`. The
-smoke-gate data build is offline (dummy corpus + byte fallback — no corpus, weights, or HF token
-needed), so all three jobs run on every PR.
+smoke-gate data build itself is fully offline (dummy corpus + byte fallback — no network, no HF
+token, no corpus or model weights ever fetched); CI as a whole does need network for dependency
+installs, and a few tests opportunistically fetch an HF tokenizer. Those degrade gracefully —
+`tests/test_chat_template.py` wraps the load in `except Exception: pytest.skip("OLMo tokenizer
+unavailable")`, so an HF outage produces a skip, not a red build.
 
 ---
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -44,8 +44,9 @@ to the loop, the SSD scan, mixed precision, checkpointing, or eval.
 `pytest -q -rs` with no mlx/torch installed (the unambiguous seam-guard environment); a Linux
 `smoke-linux` job installs CPU-only torch and runs the same fresh-toy-split →
 `smoke_test.py --backend cuda` steps as above, under `$RUNNER_TEMP` instead of `data/`; and a
-macOS `full-macos` job runs the full `pytest -q -rs` plus `smoke_test.py --backend mlx`. Nothing
-above requires network/HF/weights, so all three jobs run on every PR.
+macOS `full-macos` job runs the full `pytest -q -rs` plus `smoke_test.py --backend mlx`. The
+smoke-gate data build is offline (dummy corpus + byte fallback — no corpus, weights, or HF token
+needed), so all three jobs run on every PR.
 
 ---
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -42,10 +42,10 @@ to the loop, the SSD scan, mixed precision, checkpointing, or eval.
 
 **CI mirrors this recipe** (`.github/workflows/ci.yml`, #249): a Linux `portable` job runs
 `pytest -q -rs` with no mlx/torch installed (the unambiguous seam-guard environment); a Linux
-`smoke-linux` job installs CPU-only torch and runs the same fresh-toy-split → `smoke_test.py
---backend cuda` steps as above, under `$RUNNER_TEMP` instead of `data/`; and a macOS `full-macos`
-job runs the full `pytest -q -rs` plus `smoke_test.py --backend mlx`. Nothing above requires
-network/HF/weights, so all three jobs run on every PR.
+`smoke-linux` job installs CPU-only torch and runs the same fresh-toy-split →
+`smoke_test.py --backend cuda` steps as above, under `$RUNNER_TEMP` instead of `data/`; and a
+macOS `full-macos` job runs the full `pytest -q -rs` plus `smoke_test.py --backend mlx`. Nothing
+above requires network/HF/weights, so all three jobs run on every PR.
 
 ---
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -40,6 +40,13 @@ to the loop, the SSD scan, mixed precision, checkpointing, or eval.
 > The smoke gate must run on a **freshly built byte split**, not the real `data/split` (which is
 > the OLMo-vocab corpus) — `local_validate.sh` builds one for you.
 
+**CI mirrors this recipe** (`.github/workflows/ci.yml`, #249): a Linux `portable` job runs
+`pytest -q -rs` with no mlx/torch installed (the unambiguous seam-guard environment); a Linux
+`smoke-linux` job installs CPU-only torch and runs the same fresh-toy-split → `smoke_test.py
+--backend cuda` steps as above, under `$RUNNER_TEMP` instead of `data/`; and a macOS `full-macos`
+job runs the full `pytest -q -rs` plus `smoke_test.py --backend mlx`. Nothing above requires
+network/HF/weights, so all three jobs run on every PR.
+
 ---
 
 ## 2. Train test models locally


### PR DESCRIPTION
Closes #249

## Summary

The repo's first CI — there has never been a `.github/` directory on any ref, so the 704-test suite, the M4 resume-exactness smoke gate, and the seam-enforcing `tests/test_import_guard.py` were gated purely on someone remembering to run them locally.

`.github/workflows/ci.yml`, three jobs on Python 3.12 (`requires-python = ">=3.10"`; no matrix — broadest wheel coverage for pyarrow/mlx/torch):

- **`portable`** (ubuntu-latest) — `pip install -e ".[dev,data]"` + `pytest -q -rs`. Neither `mlx` nor `torch` is installed here, deliberately: this is the one environment where `test_import_guard.py`'s ungated `test_portable_modules_do_not_import_backends` is unambiguous rather than masked by a locally-present backend. ~500 of 704 test functions still run; `-rs` makes the skip reasons visible.
- **`smoke-linux`** (ubuntu-latest) — CPU-only torch wheel, then `scripts/smoke_test.py --backend cuda`. A separate job, not a step in `portable`, so torch never enters `portable`'s environment. Sound because `src/model/backend.py:167` selects `cpu` when `torch.cuda.is_available()` is false and `CUDAMambaModel.__init__` already defaults to `device="cpu"` — the same CPU path `tests/test_cuda_parity.py` builds on.
- **`full-macos`** (macos-latest, arm64) — `[dev,data,mlx]`, full `pytest -q -rs` + `scripts/smoke_test.py --backend mlx`.

Both smoke jobs build a **fresh toy split** into `$RUNNER_TEMP` via the CLAUDE.md offline recipe (`download --dummy` → `tokenize --byte-fallback` → `pack` → `split`) — never `data/split`, which holds the real OLMo-vocab corpus while `config/toy.yaml` is `vocab_size: 256`. That path needs no network, no HF token, and not even the `data` extra, and keeps the checkout clean.

The file ends with a commented drop-in slot for **#246**'s Swift job, which is now unblocked. (Note recorded there: `swift/Package.swift` declares no `.testTarget`, so `monica-selfcheck` — not `swift test` — is the actual runner.)

Docs: `CLAUDE.md`'s "there is no separate lint/format/build step" line and a new note in `docs/local-development.md` §1.

### Deliberately out of scope

- Anything needing CUDA hardware, R2 credentials, or network corpus access — real backend parity stays a manual rented-pod check (#224).
- The 7 node/tsc/prettier/opengrep-gated test files skip on both runners (no JS toolchain installed). A real coverage gap, worth its own issue.
- Running the 8 torch-gated `tests/test_cuda_*.py` files in `smoke-linux` — tempting since torch is already there, but unverified CPU-only.
- No lint/format/typecheck job; the repo configures no ruff/black/mypy.

## Testing

- [x] YAML parses (`yaml.safe_load`)
- [x] The four `python -m src.data.*` command lines rehearsed locally with the exact workflow flags against a temp dir, then `scripts/smoke_test.py` → `SMOKE TEST PASSED ✅ resume is exact and eval runs.`
- [x] `git status --short` clean after the rehearsal — nothing written into `data/` or `runs/`
- [ ] **The real test is this PR's own CI run.** Worth checking in the logs: `portable` shows `test_portable_modules_do_not_import_backends` as *passed*, not skipped; both smoke jobs reach the resume-exactness assertion; and `full-macos` actually runs the mlx-gated files, which is the one genuine unknown here — whether MLX/Metal is reachable inside GitHub's hosted macOS VM. If it isn't, the Linux smoke job still holds the resume-exactness criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjH2Bx6QGvLMBETLT36LoX