### PR TITLE
test: [M12] Pure-PyTorch Mamba-2 reference impl (laptop debug parity)

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -40,6 +40,40 @@ to the loop, the SSD scan, mixed precision, checkpointing, or eval.
 > The smoke gate must run on a **freshly built byte split**, not the real `data/split` (which is
 > the OLMo-vocab corpus) — `local_validate.sh` builds one for you.
 
+### Debug a forward pass on MPS (no pod)
+
+The torch/CUDA backend's SSD scan is pure PyTorch by default; the fused `mamba-ssm` scan and
+`causal-conv1d` only engage when `x.device.type == "cuda"`, and `torch.compile`'s AUTO mode stays
+eager off CUDA. So `CUDAMambaModel(cfg, device="mps")` runs the same math on Apple Silicon GPU as
+the CPU/no-`mamba-ssm` path — use it to catch a forward-pass typo or shape/logic bug locally
+instead of spinning up a pod (#218).
+
+```bash
+# forward/step parity on Apple Silicon GPU — the pure-PyTorch path, no CUDA:
+.venv/bin/python -m pytest tests/test_cuda_parity.py -q -rs
+```
+
+```python
+from src.model.blocks import load_config
+from src.model.cuda_backend import CUDAMambaModel
+from src.conformance.forward_step_parity import check_forward_step_parity
+
+cfg = load_config("config/toy.yaml")
+model = CUDAMambaModel(cfg, device="mps")
+model.eval()
+# ... build a (B, L) int token batch, then:
+check_forward_step_parity(model, tokens, to_numpy=lambda a: a.detach().cpu().numpy())
+```
+
+Measured (fp32, `rtol=1e-4, atol=1e-5`): `config/toy.yaml` → `max_abs_diff ≈ 2.3e-5`, `ok=True`;
+`config/toy-hybrid.yaml` (adds the attention block) → `≈ 3.1e-5`, `ok=True`.
+
+**Caveat:** this validates the *pure-PyTorch* path only. It does **not** validate the fused CUDA
+kernel — that's `tests/test_cuda_parity.py::test_fused_scan_matches_vanilla`, which needs a real
+GPU with `mamba-ssm` installed and skips everywhere else. MPS is for catching typos and
+shape/logic bugs, not for signing off kernel numerics or performance — for that, see
+[`docs/infrastructure.md`](infrastructure.md) for the pod path.
+
 **CI mirrors this recipe** (`.github/workflows/ci.yml`, #249): a Linux `portable` job runs
 `pytest -q -rs` with no mlx/torch installed (the unambiguous seam-guard environment); a Linux
 `smoke-linux` job installs CPU-only torch and runs the same fresh-toy-split →

--- a/src/conformance/backend_parity.py
+++ b/src/conformance/backend_parity.py
@@ -1,4 +1,4 @@
-"""Backend parity (write at the CUDA scale-up) — SKELETON.
+"""Backend parity (#38): MLX vs CUDA cross-backend agreement.
 
 Fixed seed, fixed weights, fixed input batch. Run `forward` through both the MLX
 and CUDA backends and assert agreement. Run the comparison in FP32 on BOTH sides:
@@ -6,8 +6,11 @@ bf16's machine epsilon (~8e-3) is larger than a meaningful tolerance, so compari
 low-precision paths yields false failures. In fp32 a tight tolerance (~1e-4
 relative) is meaningful: within = correct port, beyond = a real math bug.
 
-Requires both backends present, so this runs only where CUDA is available; until
-then it stays a stub the seam can point at.
+Requires both backends *installed*, not a GPU — the torch/CUDA backend runs on
+CPU, so MLX<->torch parity runs entirely on a Mac with both installed
+(`tests/test_backend_parity.py`), and skips cleanly wherever either backend is
+missing (no mlx on Linux, no CUDA on a Mac — `tests/test_cuda_parity.py::
+test_backend_parity_mlx_cuda`).
 """
 
 from __future__ import annotations

--- a/tests/test_cuda_parity.py
+++ b/tests/test_cuda_parity.py
@@ -145,6 +145,26 @@ def test_forward_step_parity_hybrid():
     assert result["ok"], result
 
 
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="no MPS device")
+def test_forward_step_parity_mps():
+    """forward/step parity on Apple Silicon GPU (#218): debug the pure-PyTorch scan
+    without a CUDA pod.
+
+    `CUDAMambaModel(cfg, device="mps")` exercises the same pure-torch chunked scan as
+    CPU/CUDA-without-mamba-ssm — the fused `mamba-ssm` kernel and `causal-conv1d` only
+    engage when `x.device.type == "cuda"`, and `torch.compile` AUTO mode stays eager off
+    CUDA, so this is a faithful check of the math, not the fused kernel."""
+    torch.manual_seed(0)
+    cfg = load_config("config/toy.yaml")
+    model = CUDAMambaModel(cfg, device="mps")
+    model.eval()
+    B, L = 2, 32
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(B, L)).astype(np.int32)
+    with torch.no_grad():
+        result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
+    assert result["ok"], result
+
+
 def test_fused_scan_matches_vanilla():
     """Fused mamba_chunk_scan_combined (#40) agrees with pure-PyTorch scan on CUDA.
 


### PR DESCRIPTION
Closes #218

## Summary

The pure-PyTorch Mamba-2 layer this issue asked for **already exists**: `src/model/cuda_backend.py`'s SSD scan is plain PyTorch and is the *default* path off CUDA — the fused `mamba-ssm` kernel (`SelectiveSSM.parallel`) and `causal-conv1d` (`_conv_seq`) are both gated behind `x.device.type == "cuda"`, and `torch.compile`'s AUTO mode stays eager off CUDA. `CUDAMambaModel(cfg, device=...)` already accepts an arbitrary device string, so `device="mps"` works today with no new layer needed. This PR is **test + docs only**, per the reviewed/approved plan:

- Added `test_forward_step_parity_mps` to `tests/test_cuda_parity.py` (skip-guarded on `torch.backends.mps.is_available()`), mirroring `test_forward_step_parity_toy` but constructing `CUDAMambaModel(cfg, device="mps")`, asserting via the existing `check_forward_step_parity` harness at `rtol=1e-4, atol=1e-5`.
- Rewrote the stale "SKELETON … stays a stub" header docstring in `src/conformance/backend_parity.py` to describe the module as implemented (it's fully exercised by `tests/test_backend_parity.py` and `test_cuda_parity.py::test_backend_parity_mlx_cuda`) — docstring only, no code change.
- Added a "Debug a forward pass on MPS (no pod)" subsection to `docs/local-development.md` (as a `###` under section 1, so the existing TOC/anchors/numbering stay intact), documenting the `device="mps"` workflow with the measured parity numbers.

**Acceptance nuance — please read:** the other half of #218's acceptance criterion, the fused-vs-vanilla kernel comparison (`tests/test_cuda_parity.py::test_fused_scan_matches_vanilla`), is already written in this file but is hardware-gated (`pytest.skip` unless real CUDA *and* `mamba-ssm` are present) and **has not been executed by this change** — it needs one CUDA pod run to actually validate the fused kernel against the vanilla path. This PR does not, and cannot, close that half. Per prior user decision, #218 still closes on merge; this note exists so nobody mistakes "closed" for "fused kernel verified."

## Testing

- [x] Tests added (`test_forward_step_parity_mps`)
- [x] `.venv/bin/python -m pytest tests/test_cuda_parity.py tests/test_backend_parity.py -q -rs` — 12 passed, 2 skipped (no CUDA — pre-existing, not a regression)
- [x] Confirmed via `-v -k mps` that `test_forward_step_parity_mps` actually **PASSED** on this machine (torch 2.12.0, MPS available), not silently skipped
- [x] Full suite: `.venv/bin/python -m pytest -q -rs` — 742 passed, 12 skipped (all pre-existing: torch.compile inductor toolchain unavailable on this host, CUDA MoE blocked on #214, prettier toolchain, opt-in CodeVerifier)
- [x] Read back the edited region of `docs/local-development.md` — TOC, anchors, and section numbering unaffected (new content is a `###` subsection, not a new `##`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)