### PR TITLE
ci: run swift test / monica-selfcheck on macOS + Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
-# Standing CI for the portable test suite, the seam guard, and the M4 smoke gate
-# (resume-exactness + eval). See issue #249 for the design record and #246 for
-# the Swift toolchain job this workflow is structured to accept as a drop-in.
+# Standing CI for the portable test suite, the seam guard, the M4 smoke gate
+# (resume-exactness + eval), and the native Swift tokenizer's cross-platform
+# parity gate. See issue #249 for the Python design record and #246 for the
+# Swift jobs.
 
 on:
   pull_request:
@@ -116,11 +117,100 @@ jobs:
           python scripts/smoke_test.py --backend mlx \
                  --data "$RUNNER_TEMP/toy/split" --out "$RUNNER_TEMP/smoke"
 
-  # ── Swift toolchain (#246) drops in here ──────────────────────────────
-  # swift:
-  #   strategy: { matrix: { os: [macos-latest, ubuntu-latest] } }
-  #   runs-on: ${{ matrix.os }}
-  #   steps: ... cd swift && swift build && swift run monica-selfcheck
-  # Note: swift/Package.swift declares NO .testTarget and there is no Tests/ dir,
-  # so `swift test` finds nothing today — monica-selfcheck is the actual runner
-  # (dependency-free, no XCTest, exits non-zero on any failure).
+  # ── Job 4: native Swift toolchain, macOS (#246) ───────────────────────────
+  # swift/Package.swift declares NO .testTarget and there is no Tests/ dir, so
+  # `swift test` finds nothing — monica-selfcheck is the actual runner
+  # (dependency-free, no XCTest, exits non-zero on any failure). Swift ships
+  # with Xcode on macos-latest, so there is no toolchain install step.
+  swift-macos:
+    name: swift selfcheck (macOS)
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Toolchain
+        run: swift --version
+      - name: Build
+        working-directory: swift
+        run: swift build
+      - name: Self-check
+        working-directory: swift
+        run: swift run monica-selfcheck
+      - name: Train the parity corpus
+        # Fixed corpus in, tokenizer.json out — compared byte-for-byte against
+        # the Linux job's copy in swift-parity below. TokenizerFormat.save uses
+        # JSONEncoder [.prettyPrinted, .sortedKeys] over Int/String-only fields,
+        # so identical merges must serialize to identical bytes.
+        working-directory: swift
+        run: |
+          swift run monica-tokenize train \
+            --in Fixtures/parity-corpus.jsonl \
+            --out "$RUNNER_TEMP/tokenizer.json" --vocab-size 2000
+          shasum -a 256 "$RUNNER_TEMP/tokenizer.json"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tokenizer-macos
+          path: ${{ runner.temp }}/tokenizer.json
+          retention-days: 7
+
+  # ── Job 5: native Swift toolchain, Linux (#246) ───────────────────────────
+  # The official swift image (Ubuntu 24.04, glibc 2.39) — the same toolchain the
+  # CUDA host would use. Zero external package dependencies, and the image
+  # already carries git/tar, so no apt step is needed.
+  swift-linux:
+    name: swift selfcheck (Linux, swift:latest)
+    runs-on: ubuntu-latest
+    container:
+      image: swift:latest
+    timeout-minutes: 20
+    steps:
+      # checkout runs as root inside the container; pre-trusting the workspace
+      # keeps git's dubious-ownership check from tripping the build.
+      - name: Trust the workspace
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: actions/checkout@v4
+      - name: Toolchain
+        run: swift --version
+      - name: Build
+        working-directory: swift
+        run: swift build
+      - name: Self-check
+        working-directory: swift
+        run: swift run monica-selfcheck
+      - name: Train the parity corpus
+        working-directory: swift
+        run: |
+          swift run monica-tokenize train \
+            --in Fixtures/parity-corpus.jsonl \
+            --out "$RUNNER_TEMP/tokenizer.json" --vocab-size 2000
+          sha256sum "$RUNNER_TEMP/tokenizer.json"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tokenizer-linux
+          path: ${{ runner.temp }}/tokenizer.json
+          retention-days: 7
+
+  # ── Job 6: the bit-identical guarantee itself (#246) ──────────────────────
+  # #191/#245's whole premise is that the Swift tokenizer produces identical
+  # vocab/ids on the Mac dev box and the Linux/CUDA host. This job is what
+  # makes that claim a gate rather than a comment.
+  swift-parity:
+    name: tokenizer bit-identity (macOS vs Linux)
+    runs-on: ubuntu-latest
+    needs: [swift-macos, swift-linux]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: tokenizer-macos
+          path: macos
+      - uses: actions/download-artifact@v4
+        with:
+          name: tokenizer-linux
+          path: linux
+      - name: Diff the two tokenizer.json
+        # cmp reports the first differing byte/line, which is far more useful
+        # than a bare hash mismatch when this ever does fail.
+        run: |
+          sha256sum macos/tokenizer.json linux/tokenizer.json
+          cmp macos/tokenizer.json linux/tokenizer.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,12 @@ where `test_import_guard.py` is unambiguous), a Linux `smoke-linux` job (CPU-tor
 `scripts/smoke_test.py --backend cuda`), and a macOS `full-macos` job (mlx installed,
 `pytest -q -rs` + `scripts/smoke_test.py --backend mlx`). `mlx` is not installable on Linux;
 on a non-Mac host the MLX backend simply won't import (by design), and only the portable
-tests run.
+tests run. Three more jobs (#246) gate the `swift/` native tokenizer, outside this Python
+suite entirely: `swift-macos` and `swift-linux` (the official `swift:latest` container) each
+build the package and run `monica-selfcheck` — `swift test` is still a no-op, there is no
+`.testTarget` — then train a fixed fixture corpus (`swift/Fixtures/parity-corpus.jsonl`) into
+a `tokenizer.json` artifact; `swift-parity` downloads both artifacts and `cmp`s them, turning
+#191/#245's bit-identical-output claim into an enforced gate rather than a comment.
 
 ## The seam — the most important architectural rule
 

--- a/docs/design/01-architecture-seam.md
+++ b/docs/design/01-architecture-seam.md
@@ -27,7 +27,10 @@ backend exists.
 **Outside this Python seam entirely:** the `swift/` native toolchain (the repo's first Swift
 package — the code tokenizer `MonicaTokenizer` + `monica-tokenize` CLI, #191/#245). It is neither
 above-seam Python nor a Python hardware backend; it builds and runs natively on macOS **and**
-Linux/CUDA with bit-identical output and is not covered by the import guard below. It emits the
+Linux/CUDA with bit-identical output and is not covered by the import guard below. The
+bit-identical claim is CI-enforced, not just asserted: `.github/workflows/ci.yml`'s
+`swift-macos`/`swift-linux`/`swift-parity` jobs (#246) build and self-check on both platforms,
+train a fixed fixture corpus on each, and `cmp` the resulting `tokenizer.json` files. It emits the
 same `src/data/shard.py` shard layout, so the Python data/training path consumes its output
 unchanged. This is the M13 "native, no-Python-runtime" engine direction (#163/#167).
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -85,6 +85,20 @@ installs, and a few tests opportunistically fetch an HF tokenizer. Those degrade
 `tests/test_chat_template.py` wraps the load in `except Exception: pytest.skip("OLMo tokenizer
 unavailable")`, so an HF outage produces a skip, not a red build.
 
+Three more jobs (#246) gate the `swift/` native tokenizer (outside this Python seam entirely —
+see [`01-architecture-seam.md`](design/01-architecture-seam.md)): `swift-macos` and `swift-linux`
+(the official `swift:latest` container) each build the package, run `monica-selfcheck`
+(`swift test` is still a no-op — there's no `.testTarget`), then train the fixed fixture corpus
+`swift/Fixtures/parity-corpus.jsonl` into a `tokenizer.json` artifact; `swift-parity` downloads
+both artifacts and `cmp`s them, so #191/#245's bit-identical-output claim is CI-enforced, not
+just asserted. Reproduce locally:
+
+```bash
+cd swift && swift build && swift run monica-selfcheck
+docker run --rm -v "$PWD/swift:/s" -w /s swift:latest \
+  bash -c 'swift build && swift run monica-selfcheck'
+```
+
 ---
 
 ## 2. Train test models locally

--- a/swift/Fixtures/parity-corpus.jsonl
+++ b/swift/Fixtures/parity-corpus.jsonl
@@ -1,0 +1,16 @@
+{"text": "export function add(a: number, b: number): number { return a + b; }"}
+{"text": "export const greet = (name: string): string => `hello ${name}`;"}
+{"text": "interface Point { x: number; y: number; label?: string; }"}
+{"text": "export class Vec2 { constructor(public x: number, public y: number) {} }"}
+{"text": "for (let i = 0; i < 1000; i++) { total += values[i]; }"}
+{"text": "const ids = [1, 22, 333, 4444, 55555, 666666, 1234567];"}
+{"text": "async function load(url: string): Promise<Response> { return await fetch(url); }"}
+{"text": "type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };"}
+{"text": "if (x) {\n\treturn 0;\n} else {\n\t\treturn 1;\n}"}
+{"text": "const ratio = 'π≈3.14'; // 数字とコメント — multi-byte UTF-8 on purpose"}
+{"text": "const emoji = '🚀🧪'; // surrogate-pair scalars, byte-level BPE must agree"}
+{"text": "def add(a: int, b: int) -> int:\n    return a + b\n"}
+{"text": "class Vec2:\n    def __init__(self, x: float, y: float) -> None:\n        self.x = x\n        self.y = y\n"}
+{"text": "public struct Point: Equatable { public var x: Int; public var y: Int }"}
+{"text": "let total = values.reduce(0) { $0 + $1 }"}
+{"text": "{\"name\": \"monica\", \"version\": \"1.0.0\", \"private\": true}"}


### PR DESCRIPTION
Closes #246

## Summary
- Add `swift-macos` and `swift-linux` CI jobs (build + `swift run monica-selfcheck`, since `swift test` is a no-op — no `.testTarget`, no `Tests/` dir).
- Add a `swift-parity` job that downloads both jobs' `tokenizer.json` artifacts (each produced by training a new fixed fixture corpus, `swift/Fixtures/parity-corpus.jsonl`, on that platform) and `cmp`s them, turning #191/#245's bit-identical macOS/Linux claim into a CI-enforced gate.
- `swift-linux` runs inside the official `swift:latest` container (Ubuntu 24.04) — no apt packages needed.
- Update `CLAUDE.md`, `docs/local-development.md`, and `docs/design/01-architecture-seam.md` to describe the six CI jobs (was three) and the now-enforced parity claim.

## Testing
- [x] `cd swift && swift build && swift run monica-selfcheck` locally (macOS arm64) — `OK — all checks passed`.
- [x] Trained the fixture on macOS: `591 tokens (329 merges, 6 special)`, sha256 `bcc193fab3391017751f9902cff207897616fd228ba5af827f437916c4281b78`.
- [x] Trained the fixture inside `swift:latest` via Docker (scratch copy, not the local `.build`) — identical build/self-check output and the **same sha256** as macOS.
- [x] `.venv/bin/python -m pytest -q -rs` — 742 passed, 12 skipped (pre-existing, environment-only skips).
- [x] `.venv/bin/python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses cleanly.