### PR TITLE
feat: [M12] MoE load balancing (portable aux-loss-free policy + MLX router)

### DIFF
--- a/config/toy-moe.yaml
+++ b/config/toy-moe.yaml
@@ -14,6 +14,12 @@ moe_every: 2           # layers 1 and 3 (0-indexed (i+1)%2==0) are MoE
 n_experts: 4           # route each token to top_k of these
 top_k: 2               # 2/4 experts active per token (sparse)
 moe_d_ff: null         # expert hidden width (null -> d_inner = 128)
+# Loss-Free-Balancing (#213) bias-update rate, in logit units. null = OFF (the default
+# here) — the router takes the pre-#213 probs-ranked path verbatim, so this config's
+# existing parity/sizing tests stay byte-identical. Set a small positive rate (e.g. 1e-3;
+# tests/test_moe_balance_mlx.py uses 0.05 on a deliberately collapse-prone 8-expert toy)
+# to steer top-k SELECTION toward under-used experts. See src/train/moe_balance.py.
+moe_balance_rate: null
 
 vocab_size: 256        # byte-fallback tokenizer for offline tests
 seq_len: 64

--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -10,15 +10,19 @@ from-scratch code model, described below.
 
 ## What this is
 
-> **Read this section as the target design, not as shipped state.** As of 2026-07-25 the only
-> MHM component that is **built** is the tokenizer (MHM-P1b, #191/#245). `MambaConfig` carries the
-> MoE and hybrid-attention knobs (`moe_every`, `n_experts`, `top_k`, `attn_every`, `fp8_experts`)
-> and the MLX backend has a **toy** `MoEBlock` — a plain softmax top-k router with **no shared
-> expert and no load balancing**, which collapses at the target 64×top-6 shape. The CUDA backend
-> still raises `NotImplementedError` for MoE (#214). The shared expert, aux-loss-free balancing,
-> FIM, the Essential-Web + Stack-v2 mixture, and repo-context packing described below are **designed,
-> not implemented**. Per-item status is in the MHM-P# list that follows; when the two disagree,
-> the P# list wins.
+> **Read this section as the target design, not as shipped state.** As of 2026-08-03 the MHM
+> components that are **built** are the tokenizer (MHM-P1b, #191/#245) and aux-loss-free load
+> balancing on MLX (MHM-P2-T0, #213). `MambaConfig` carries the MoE and hybrid-attention knobs
+> (`moe_every`, `n_experts`, `top_k`, `attn_every`, `fp8_experts`, `moe_balance_rate`) and the MLX
+> backend's `MoEBlock` now has a DeepSeek-V3 Loss-Free-Balancing router: a per-expert bias steers
+> top-k **selection** only, updated outside the gradient from per-expert load counts, with no aux
+> loss on the objective (portable policy in `src/train/moe_balance.py`; `moe_balance_rate: null`
+> keeps the pre-#213 router byte-identical). It still has **no shared expert**, and it densely
+> evaluates every expert (sparse *combination*, not sparse compute) — a capacity experiment, not a
+> production kernel. The CUDA backend still raises `NotImplementedError` for MoE (#214), which will
+> reuse `src/train/moe_balance.py` unchanged. The shared expert, FIM, the Essential-Web + Stack-v2
+> mixture, and repo-context packing described below are **designed, not implemented**. Per-item
+> status is in the MHM-P# list that follows; when the two disagree, the P# list wins.
 
 A from-scratch, **TypeScript-first Mamba-2 hybrid Mixture-of-Experts (MoE) code model**. The
 backbone is mostly Mamba-2/SSD state-space layers with a **minority (~12.5%) of full-attention
@@ -73,7 +77,9 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
   written `compression="snappy"` (`src/data/corpus.py --compression snappy`) for the Swift
   packer to read them.
 - **MHM-P2 — Architecture & harness build** (the large net-new engineering): aux-loss-free
-  balancing router (#213, *land first*) → CUDA MoE backend (#214: dropless routing, shared expert,
+  balancing router (#213, **done on MLX** — portable `MoEBalancer` policy above the seam +
+  selection-only route bias in `MoEBlock`; the bias rides in the portable safetensors so a served
+  or ported checkpoint routes as trained) → CUDA MoE backend (#214: dropless routing, shared expert,
   FSDP, sparse-upcycle init) → FIM collator (#215 — consumes the Swift-packed shards; the FIM
   insertion transform may live in the Swift `pack` path), length curriculum + dataloader-state resume
   (#216), routing instrumentation (#217), pure-PyTorch Mamba-2 reference for laptop parity (#218).

--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -69,6 +69,7 @@ def main() -> None:
     from src.model.blocks import load_config
     from src.data.dpo_loader import DPOLoader
     from src.train.loss_scale import scaler_for_precision
+    from src.train.moe_balance import attach_balancer, balancer_for_config
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
     from src.train.checkpoint import CheckpointStore
@@ -93,8 +94,13 @@ def main() -> None:
     ref.load(str(args.init))                             # frozen reference (never updated)
     opt = backend.make_optimizer(policy, args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
+    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch and why the
+    # kwarg is conditional (CUDA's make_dpo_train_step has no balancer param).
+    balancer = balancer_for_config(cfg)
+    balancer_kwargs = {"balancer": balancer} if balancer is not None else {}
     train_step = backend.make_dpo_train_step(policy, ref, opt, beta=args.beta,
-                                             grad_clip=args.grad_clip, scaler=scaler)
+                                             grad_clip=args.grad_clip, scaler=scaler,
+                                             **balancer_kwargs)
 
     np_to = backend.to_numpy
     max_b = args.eval_batches or None
@@ -120,6 +126,10 @@ def main() -> None:
     else:
         policy.load(str(args.init))                      # init policy from SFT weights
         print(f"[init] policy + reference from {args.init}")
+    # Loss-Free-Balancing (#213): adopt the bias that came in with the policy weights
+    # (D3), push it into the routers, enable load counting. The frozen reference is left
+    # alone — it never trains, so it keeps whatever bias its checkpoint carried.
+    attach_balancer(balancer, policy)
 
     logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 

--- a/scripts/rlvr.py
+++ b/scripts/rlvr.py
@@ -80,6 +80,7 @@ def main() -> None:
     from src.serve.sessions import SessionStore
     from src.serve.sampling import sample
     from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
+    from src.train.moe_balance import attach_balancer, balancer_for_config
 
     backend = get_backend()
     cfg = load_config(str(args.config))
@@ -90,7 +91,14 @@ def main() -> None:
     store = SessionStore(model)
     np_to = backend.to_numpy
     opt = backend.make_optimizer(model, args.lr)
-    grpo_step = backend.make_grpo_train_step(model, opt)
+    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch and why the
+    # kwarg is conditional (CUDA's make_grpo_train_step has no balancer param). The bias
+    # arrives with `--init`'s portable weights (D3); attach_balancer adopts it, pushes it
+    # into the routers, and enables load counting. No-op when balancing is off.
+    balancer = balancer_for_config(cfg)
+    grpo_step = backend.make_grpo_train_step(
+        model, opt, **({"balancer": balancer} if balancer is not None else {}))
+    attach_balancer(balancer, model)
     reward_fn = math_reward if args.reward == "math" else exact_match_reward
 
     problems = [json.loads(ln) for ln in args.problems.read_text(encoding="utf-8").splitlines()

--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -70,6 +70,7 @@ def main() -> None:
     from src.model.blocks import load_config
     from src.data.sft_loader import SFTLoader
     from src.train.loss_scale import scaler_for_precision
+    from src.train.moe_balance import attach_balancer, balancer_for_config
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
     from src.train.checkpoint import CheckpointStore
@@ -93,8 +94,12 @@ def main() -> None:
     model = backend.model_cls(cfg)
     opt = backend.make_optimizer(model, args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
+    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch and why the
+    # kwarg is conditional (CUDA's make_sft_train_step has no balancer param).
+    balancer = balancer_for_config(cfg)
+    balancer_kwargs = {"balancer": balancer} if balancer is not None else {}
     train_step = backend.make_sft_train_step(model, opt, grad_clip=args.grad_clip,
-                                             scaler=scaler)
+                                             scaler=scaler, **balancer_kwargs)
 
     np_to = backend.to_numpy
     max_b = args.eval_batches or None
@@ -119,6 +124,9 @@ def main() -> None:
     else:
         model.load(str(args.init))                       # initialize from pretrained base
         print(f"[init] from pretrained base {args.init}")
+    # Loss-Free-Balancing (#213): adopt the bias that came in with the weights (D3), push
+    # it into the routers, enable load counting. No-op when balancing is off.
+    attach_balancer(balancer, model)
 
     logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -76,6 +76,7 @@ def main() -> None:
     from src.model.blocks import load_config
     from src.data.loader import PackedLoader
     from src.train.loss_scale import scaler_for_precision
+    from src.train.moe_balance import attach_balancer, balancer_for_config
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
     from src.train.checkpoint import CheckpointStore
@@ -98,7 +99,15 @@ def main() -> None:
     if scaler is None and cfg.precision != "fp32":
         print(f"[info] precision={cfg.precision!r}: training unscaled "
               "(loss scaling is fp16-only; expected for bf16)")
-    train_step = backend.make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler)
+    # Loss-Free-Balancing (#213): None for dense/hybrid configs and for MoE configs with
+    # moe_balance_rate unset (the default) — balancer_for_config is the single source of
+    # truth for the off-switch. Passed as a kwarg only when set, so the CUDA backend's
+    # make_train_step (which has no balancer param; CUDA rejects MoE entirely, #214) is
+    # untouched.
+    balancer = balancer_for_config(cfg)
+    balancer_kwargs = {"balancer": balancer} if balancer is not None else {}
+    train_step = backend.make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler,
+                                         **balancer_kwargs)
 
     # --- data ------------------------------------------------------------------
     train_loader = PackedLoader(args.data / "train.bin", cfg.seq_len,
@@ -125,6 +134,11 @@ def main() -> None:
         if scaler is not None:
             scaler.load_state_dict(meta.get("loss_scale_state") or {})
         print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})")
+    # Loss-Free-Balancing (#213): seed the policy from the just-loaded weights (the bias
+    # rides in the portable safetensors, D3), push it into the routers, and enable load
+    # counting. No-op when balancing is off. `CheckpointStore.save` is unchanged — there
+    # is deliberately no second copy of the bias in the resume bundle.
+    attach_balancer(balancer, model)
 
     logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -125,6 +125,14 @@ class MambaConfig:
     top_k: int = 2              # experts routed per token (1 <= top_k <= n_experts)
     # Expert FFN hidden width. None => d_inner (the Mamba inner width), a natural scale.
     moe_d_ff: Optional[int] = None
+    # Loss-Free-Balancing (#213, DeepSeek-V3 style) bias-update rate, in LOGIT units.
+    # None = balancing OFF and the router is byte-identical to pre-#213 behavior (every
+    # config in the tree today, including the smoke gate's dense toy.yaml). When set, a
+    # per-expert bias — updated OUTSIDE the gradient from per-expert load counts, never
+    # an aux loss on the objective — steers the router's top-k SELECTION only; the gate
+    # weights stay the unbiased softmax. See `src/train/moe_balance.py` (the portable
+    # policy) and `MoEBlock._moe` (src/model/mlx_backend.py) for the mechanism.
+    moe_balance_rate: Optional[float] = None
     # fp8 expert GEMMs via NVIDIA Transformer Engine (#240), CUDA/Hopper-only. A separate
     # bool rather than a `precision` value: fp8 applies ONLY to the three expert linears
     # (gate/up/down), not the whole model — everything else stays at `precision`. A no-op
@@ -356,6 +364,10 @@ class MambaConfig:
                 raise ValueError(
                     f"moe_every={self.moe_every} selects no layer at n_layers="
                     f"{self.n_layers} (after attention precedence)."
+                )
+            if self.moe_balance_rate is not None and self.moe_balance_rate <= 0:
+                raise ValueError(
+                    f"moe_balance_rate={self.moe_balance_rate} must be > 0, or None (off)."
                 )
         if self.fp8_experts:
             # n_moe_layers==0 also catches moe_every=None (fp8 applies to expert GEMMs

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -612,20 +612,100 @@ class MoEBlock(nn.Module):
         self.router = nn.Linear(config.d_model, config.n_experts, bias=False)
         d_ff = config.moe_d_ff_resolved
         self.experts = [_Expert(config.d_model, d_ff) for _ in range(config.n_experts)]
+        # Loss-Free-Balancing (#213 D1): a per-expert route BIAS and a per-expert LOAD-COUNT
+        # accumulator. Both names start with an underscore ON PURPOSE — DO NOT "clean this
+        # up". `nn.Module.valid_parameter_filter` is
+        #     isinstance(value, (dict, list, mx.array)) and not key.startswith("_")
+        # so a leading-underscore attribute holding an mx.array is EXCLUDED from
+        # `parameters()`/`trainable_parameters()`. That is the whole method: the bias must
+        # live outside the gradient, so `nn.value_and_grad` never differentiates it and
+        # `optimizer.update` never steps it. Renaming these without the underscore would
+        # silently turn the bias into a trained parameter and void Loss-Free-Balancing.
+        # (Asserted in tests/test_moe_balance_mlx.py, not merely assumed.)
+        #
+        # `_bias_active` starts False: until `set_route_bias` is called at least once,
+        # `_moe` takes the ORIGINAL pre-#213 ranking path verbatim — byte-identical when
+        # balancing is off, which is every config in the tree today.
+        self._route_bias = mx.zeros((config.n_experts,))
+        self._bias_active = False
+        # `_count_loads` gates the accumulation (#213 D4): without the gate the lazy MLX
+        # graph behind `_load_counts` would grow for an entire un-balanced MoE run (nothing
+        # ever pops it), pinning every step's routing mask alive — a slow memory leak. The
+        # training wiring flips this on exactly when a balancer exists.
+        self._count_loads = False
+        self._load_counts = mx.zeros((config.n_experts,))
+
+    def set_route_bias(self, vec) -> None:
+        """Set the per-expert selection bias (Loss-Free-Balancing, #213) — `vec` a
+        `list[float]` of length `n_experts` (one `MoEBalancer.biases()` layer entry).
+        Switches `_moe` onto the biased-ranking path."""
+        self._route_bias = mx.array(vec, dtype=mx.float32)
+        self._bias_active = True
+
+    def route_bias(self) -> list:
+        """This block's current bias as host floats (`[]` when it was never activated) —
+        the read-back the portable state dict and the drivers' resume seeding use."""
+        return [float(b) for b in self._route_bias.tolist()] if self._bias_active else []
+
+    def set_load_counting(self, flag: bool) -> None:
+        """Enable/disable per-expert load counting in `_moe` (see `_count_loads`)."""
+        self._count_loads = bool(flag)
+
+    def pop_load(self) -> list:
+        """Return this block's accumulated per-expert token counts since the last pop
+        (host `list[float]` — the portable `MoEBalancer` never touches MLX arrays), then
+        reset the accumulator. Reading forces the eval, so the lazy graph never outlives
+        one step."""
+        counts = self._load_counts
+        self._load_counts = mx.zeros_like(counts)
+        return [float(c) for c in counts.tolist()]
 
     def _moe(self, xn: Array) -> Array:
         cd = _DTYPES[self.config.precision]
         E, k = self.config.n_experts, self.config.top_k
         logits = _f32(_linear(self.router, xn, cd))          # (..., E) — route in fp32
-        probs = mx.softmax(logits, axis=-1)
+        probs = mx.softmax(logits, axis=-1)                  # UNBIASED — always the gate weight
         if k < E:                                            # keep EXACTLY top_k per token
-            # Rank each expert by descending prob (double argsort), keep ranks < k. A plain
-            # `probs >= kth` threshold would keep MORE than k experts on ties (e.g. uniform
-            # routing early in training), breaking the top_k contract and the active-FLOP
-            # count; ranking breaks ties by index so exactly k survive.
-            ranks = mx.argsort(mx.argsort(-probs, axis=-1), axis=-1)
-            gate = mx.where(ranks < k, probs, mx.zeros_like(probs))
+            # Loss-Free-Balancing (#213 D2): when active, rank by the BIASED selection
+            # score `logits + route_bias`; the gate weight below stays `probs` (unbiased).
+            # The bias steers ROUTING only, never the combination weight — biasing the gate
+            # would be a different (and wrong) algorithm. Bias is added in LOGIT space, and
+            # ranking by logits is order-identical to ranking by probs (softmax is monotone
+            # per row and preserves ties), so a zero bias does not perturb routing.
+            if self._bias_active:
+                sel = logits + self._route_bias
+                ranks = mx.argsort(mx.argsort(-sel, axis=-1), axis=-1)
+            else:
+                # Rank each expert by descending prob (double argsort), keep ranks < k. A
+                # plain `probs >= kth` threshold would keep MORE than k experts on ties
+                # (e.g. uniform routing early in training), breaking the top_k contract and
+                # the active-FLOP count; ranking breaks ties by index so exactly k survive.
+                # (The biased branch above uses the same double argsort for the same
+                # reason.)
+                ranks = mx.argsort(mx.argsort(-probs, axis=-1), axis=-1)
+            mask = ranks < k
+            gate = mx.where(mask, probs, mx.zeros_like(probs))
             gate = gate / mx.sum(gate, axis=-1, keepdims=True)   # renormalize the kept gates
+            if self._count_loads:
+                # Per-expert load bookkeeping for the balancer: how many tokens (summed
+                # over every non-expert axis) this forward routed to each expert, detached
+                # from the graph (`stop_gradient` — the count must never become a training
+                # signal) and accumulated; `pop_load()` reads + resets it after the step.
+                # Counted only here, in the `k < E` branch: with `k == E` every expert takes
+                # every token and balancing is vacuous (no mask exists).
+                # Two known, benign inexactnesses:
+                #  * With `grad_checkpoint: true` each layer's forward is RECOMPUTED in
+                #    backward, so every count doubles (#213 D5). Both consumers are
+                #    invariant to a uniform positive scale — `update` uses
+                #    `sign(mean - load_i)` and `utilization_variance` normalizes to
+                #    fractions — and the recompute uses the same inputs and the same bias,
+                #    so the factor is exactly 2 for every expert of every MoE layer.
+                #  * On an fp16 overflow-skipped step `_accumulate_and_step` returns before
+                #    popping, so those counts carry into the next pop. Harmless: the update
+                #    is sign-based and the routing really did happen.
+                axes = tuple(range(mask.ndim - 1))
+                self._load_counts = self._load_counts + mx.stop_gradient(
+                    mx.sum(mask.astype(mx.float32), axis=axes))
         else:
             gate = probs                                          # softmax already sums to 1
         outs = mx.stack([e(xn, cd) for e in self.experts], axis=-2)   # (..., E, d_model)
@@ -787,6 +867,37 @@ class MLXMambaModel(ModelInterface, nn.Module):
             h = layer_fn(h)
         return out
 
+    # --- Loss-Free-Balancing accessors (#213) ---------------------------------
+    def moe_blocks(self) -> List["MoEBlock"]:
+        """This model's MoE layers, in layer order — the accessor the balancer wiring
+        (`src/model/mlx_train_step.py`, the training drivers) uses."""
+        return [l for l in self.layers if isinstance(l, MoEBlock)]
+
+    def set_moe_biases(self, biases: List[List[float]]) -> None:
+        """Push per-layer route-bias vectors (`MoEBalancer.biases()`) into each MoE
+        block, in layer order."""
+        for block, vec in zip(self.moe_blocks(), biases):
+            block.set_route_bias(vec)
+
+    def moe_biases(self) -> List[List[float]]:
+        """Per-MoE-layer route biases as host floats, in layer order (an inactive block
+        reports `[]`). The read-back the drivers use to re-seed the portable `MoEBalancer`
+        from just-loaded weights after a resume (#213 D3) — one copy of the numbers, in
+        the model, with no second checkpoint field to drift from it."""
+        return [block.route_bias() for block in self.moe_blocks()]
+
+    def set_moe_load_counting(self, flag: bool) -> None:
+        """Enable/disable per-expert load counting on every MoE block (#213 D4). Off by
+        default; the training wiring turns it on exactly when a balancer is present."""
+        for block in self.moe_blocks():
+            block.set_load_counting(flag)
+
+    def pop_moe_load(self) -> List[List[float]]:
+        """Per-MoE-layer accumulated expert-load counts since the last pop (in layer
+        order), resetting each block's accumulator. `[]` when the model has no MoE
+        layers (dense / hybrid-only models)."""
+        return [block.pop_load() for block in self.moe_blocks()]
+
     def init_state(self, batch_size: int) -> State:
         c = self.config
         di, k = c.d_inner, c.d_conv
@@ -823,12 +934,41 @@ class MLXMambaModel(ModelInterface, nn.Module):
         from ..train.checkpoint import load_weights
         load_weights(self, path)
 
+    # `moe_route_bias.{layer_index}` — the MoE route bias's key prefix in the portable
+    # weights (#213 D3). Not a parameter (see MoEBlock.__init__), so it is added/popped
+    # explicitly around the `tree_flatten(self.parameters())` path rather than riding it.
+    _MOE_BIAS_PREFIX = "moe_route_bias."
+
     def _portable_state_dict(self) -> dict:
         # Flatten MLX params to {name: numpy array} for safetensors. With tied
         # embeddings there is no separate head param, so nothing to drop.
-        return {k: np.array(v) for k, v in tree_flatten(self.parameters())}
+        out = {k: np.array(v) for k, v in tree_flatten(self.parameters())}
+        # Loss-Free-Balancing bias (#213 D3): it rides in the PORTABLE weights, not the
+        # resume bundle. It is routing state that changes the model's function at
+        # inference — a model served or evaluated from weights.safetensors must route the
+        # way it was trained, and #214 must be able to load an MLX-trained MoE checkpoint
+        # into CUDA and route identically. `src/train/checkpoint.py`'s split is explicit:
+        # weights port across backends, optimizer state does not need to.
+        # The key is emitted ONLY for a block whose bias is active — an unconditional key
+        # would break `sum(v.size) == cfg.num_parameters()` (tests/test_moe.py,
+        # tests/test_sizing_mlx.py), and the bias genuinely is not a parameter, so it does
+        # not belong in num_parameters() either way.
+        for i, layer in enumerate(self.layers):
+            if isinstance(layer, MoEBlock) and layer._bias_active:
+                out[f"{self._MOE_BIAS_PREFIX}{i}"] = np.array(layer._route_bias)
+        return out
 
     def _load_portable(self, weights: dict) -> None:
-        params = [(k, mx.array(v)) for k, v in weights.items()]
+        # Pop the non-parameter route-bias keys first — they must never reach
+        # `Module.update`, which only knows about the parameter tree. Absent keys (an old
+        # checkpoint, balancing off, a dense model) simply leave every block inactive.
+        biases, params = {}, []
+        for k, v in weights.items():
+            if k.startswith(self._MOE_BIAS_PREFIX):
+                biases[int(k[len(self._MOE_BIAS_PREFIX):])] = v
+            else:
+                params.append((k, mx.array(v)))
         self.update(tree_unflatten(params))
+        for i, vec in biases.items():
+            self.layers[i].set_route_bias(np.asarray(vec).reshape(-1).tolist())
         mx.eval(self.parameters())

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -638,7 +638,15 @@ class MoEBlock(nn.Module):
     def set_route_bias(self, vec) -> None:
         """Set the per-expert selection bias (Loss-Free-Balancing, #213) — `vec` a
         `list[float]` of length `n_experts` (one `MoEBalancer.biases()` layer entry).
-        Switches `_moe` onto the biased-ranking path."""
+        Switches `_moe` onto the biased-ranking path.
+
+        A wrong-length `vec` raises here rather than broadcasting into a silently wrong
+        ranking downstream (`logits + bias` would broadcast a length-1 vector happily)."""
+        if len(vec) != self.config.n_experts:
+            raise ValueError(
+                f"route bias has {len(vec)} entries, expected "
+                f"n_experts={self.config.n_experts}."
+            )
         self._route_bias = mx.array(vec, dtype=mx.float32)
         self._bias_active = True
 
@@ -880,8 +888,18 @@ class MLXMambaModel(ModelInterface, nn.Module):
 
     def set_moe_biases(self, biases: List[List[float]]) -> None:
         """Push per-layer route-bias vectors (`MoEBalancer.biases()`) into each MoE
-        block, in layer order."""
-        for block, vec in zip(self.moe_blocks(), biases):
+        block, in layer order.
+
+        A layer-count mismatch raises rather than `zip`-truncating: leaving some routers
+        on the old bias while others take the new one is a partially-activated routing
+        state that would be very hard to notice mid-run. Per-vector length is checked by
+        `MoEBlock.set_route_bias`."""
+        blocks = self.moe_blocks()
+        if len(biases) != len(blocks):
+            raise ValueError(
+                f"got {len(biases)} bias vectors for {len(blocks)} MoE layers."
+            )
+        for block, vec in zip(blocks, biases):
             block.set_route_bias(vec)
 
     def moe_biases(self) -> List[List[float]]:
@@ -975,5 +993,15 @@ class MLXMambaModel(ModelInterface, nn.Module):
                 params.append((k, mx.array(v)))
         self.update(tree_unflatten(params))
         for i, vec in biases.items():
+            # Check the key names a real MoE layer before indexing: a balanced checkpoint
+            # loaded into a dense or differently-interleaved config would otherwise die on
+            # an IndexError / AttributeError deep in the load, with nothing pointing at the
+            # actual mismatch. (Per-vector length is checked by `set_route_bias`.)
+            if not (0 <= i < len(self.layers)) or not isinstance(self.layers[i], MoEBlock):
+                raise ValueError(
+                    f"checkpoint has {self._MOE_BIAS_PREFIX}{i}, but layer {i} of this "
+                    "config is not an MoE layer — the weights and the config disagree "
+                    "about the MoE interleave."
+                )
             self.layers[i].set_route_bias(np.asarray(vec).reshape(-1).tolist())
         mx.eval(self.parameters())

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -644,7 +644,12 @@ class MoEBlock(nn.Module):
 
     def route_bias(self) -> list:
         """This block's current bias as host floats (`[]` when it was never activated) —
-        the read-back the portable state dict and the drivers' resume seeding use."""
+        the read-back the portable state dict and the drivers' resume seeding use.
+
+        The router holds the bias in fp32, so a policy -> model -> policy round-trip
+        (what a resume does, D3) quantizes it to fp32. Immaterial: the bias is a coarse
+        steering signal accumulated in units of `rate`, and fp32 resolves that ~7 decimal
+        digits deep."""
         return [float(b) for b in self._route_bias.tolist()] if self._bias_active else []
 
     def set_load_counting(self, flag: bool) -> None:

--- a/src/model/mlx_train_step.py
+++ b/src/model/mlx_train_step.py
@@ -15,6 +15,8 @@ import mlx.nn as nn
 import mlx.optimizers as optim
 from mlx.utils import tree_flatten, tree_unflatten
 
+from ..train.moe_balance import MoEBalancer
+
 
 def _global_grad_norm(grads) -> mx.array:
     leaves = [v for _, v in tree_flatten(grads)]
@@ -23,7 +25,7 @@ def _global_grad_norm(grads) -> mx.array:
 
 
 def _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches, lr,
-                         grad_clip, scaler) -> dict:
+                         grad_clip, scaler, balancer=None) -> dict:
     """Shared accumulate -> (unscale) -> clip -> optimizer-step tail.
 
     `loss_and_grad(model, micro_batch) -> (loss, grads)` is the only objective-specific
@@ -32,6 +34,14 @@ def _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches, lr,
     pretraining, SFT, and DPO, so they all funnel through here. Grads are averaged over
     the micro-batches so an effective batch can exceed what fits in memory (one
     micro-batch is live at a time).
+
+    `balancer` (a `MoEBalancer`, #213) is the Loss-Free-Balancing policy: on a successful
+    (non-skipped) step it reads this step's per-expert load counts off the model
+    (`pop_moe_load`), nudges the bias OUTSIDE the gradient (`update` — no aux loss ever
+    touches the objective above), and pushes the new biases back into the model's MoE
+    blocks (`set_moe_biases`) for the next forward. `None` (dense/hybrid models, or MoE
+    without balancing) is a no-op — the default, so every non-MoE-balanced train step is
+    unaffected.
     """
     n = len(micro_batches)
     acc_grads = None
@@ -68,17 +78,28 @@ def _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches, lr,
     if scaler:
         out["loss_scale"] = scaler.scale
         out["skipped"] = False
+    if balancer is not None:
+        # Loss-Free-Balancing (#213): update the bias from this step's routed-token
+        # counts, OUTSIDE the gradient, then push the new biases back into the model for
+        # the next forward. `pop_moe_load` returns `[]` for a model with no MoE layers.
+        loads = model.pop_moe_load()
+        if loads:
+            balancer.update(loads)
+            model.set_moe_biases(balancer.biases())
+            out["moe_util_var"] = max(MoEBalancer.utilization_variance(loads))
     return out
 
 
 def make_train_step(model, optimizer, *, grad_clip: float = 1.0,
-                    scaler=None) -> Callable:
+                    scaler=None, balancer=None) -> Callable:
     """Build a `train_step(model, micro_batches, lr) -> dict` (pretraining CE).
 
     `micro_batches` is a list of `(inputs, targets)`. `scaler` (a `DynamicLossScaler`,
     fp16 path) scales the loss before backprop and unscales grads after; on a non-finite
     gradient the optimizer step is SKIPPED and the scale is backed off (see
-    `_accumulate_and_step`). Pass None for fp32 (toy/smoke).
+    `_accumulate_and_step`). Pass None for fp32 (toy/smoke). `balancer` (a `MoEBalancer`,
+    #213) is the Loss-Free-Balancing policy; None (the default) for dense/hybrid models
+    and for MoE configs with `moe_balance_rate` unset.
     """
     def loss_fn(model, inputs, targets):
         logits = model.forward(inputs)                      # (B, L, V)
@@ -99,20 +120,20 @@ def make_train_step(model, optimizer, *, grad_clip: float = 1.0,
 
     def train_step(model, micro_batches, lr: float) -> dict:
         return _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches,
-                                    lr, grad_clip, scaler)
+                                    lr, grad_clip, scaler, balancer)
 
     return train_step
 
 
 def make_sft_train_step(model, optimizer, *, grad_clip: float = 1.0,
-                        scaler=None) -> Callable:
+                        scaler=None, balancer=None) -> Callable:
     """Build an SFT `train_step(model, micro_batches, lr) -> dict` (masked CE).
 
     `micro_batches` is a list of `(inputs, targets, mask)` (the `SFTLoader` 3-tuple). The
     loss is the per-token cross-entropy averaged over the *response* tokens only:
     `sum(mask * CE) / sum(mask)`, so prompt/padding positions (mask 0) never contribute.
     Accumulation, fp16 scaling/overflow-skip, clipping, and the optimizer step are shared
-    with pretraining via `_accumulate_and_step`.
+    with pretraining via `_accumulate_and_step`. `balancer` (#213) as in `make_train_step`.
     """
     def loss_fn(model, inputs, targets, mask):
         logits = model.forward(inputs)                      # (B, L, V)
@@ -132,7 +153,7 @@ def make_sft_train_step(model, optimizer, *, grad_clip: float = 1.0,
 
     def train_step(model, micro_batches, lr: float) -> dict:
         return _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches,
-                                    lr, grad_clip, scaler)
+                                    lr, grad_clip, scaler, balancer)
 
     return train_step
 
@@ -161,7 +182,7 @@ def _log_sigmoid(x: mx.array) -> mx.array:
 
 
 def make_dpo_train_step(policy_model, ref_model, optimizer, *, beta: float = 0.1,
-                        grad_clip: float = 1.0, scaler=None) -> Callable:
+                        grad_clip: float = 1.0, scaler=None, balancer=None) -> Callable:
     """Build a DPO `train_step(model, micro_batches, lr) -> dict`.
 
     `micro_batches` is a list of the `DPOLoader` 6-tuple `(c_in, c_tgt, c_mask, r_in,
@@ -171,7 +192,7 @@ def make_dpo_train_step(policy_model, ref_model, optimizer, *, beta: float = 0.1
     updates the policy, and the reference forward is wrapped in `mx.stop_gradient` (and
     `ref_model` is a distinct object never handed to the optimizer), so the reference
     stays frozen. Accumulation / fp16 scaling / clipping are shared via
-    `_accumulate_and_step`.
+    `_accumulate_and_step`. `balancer` (#213) as in `make_train_step`.
     """
     def loss_fn(policy, c_in, c_tgt, c_mask, r_in, r_tgt, r_mask):
         lp_c = _masked_seq_logprob(policy, c_in, c_tgt, c_mask)
@@ -189,13 +210,13 @@ def make_dpo_train_step(policy_model, ref_model, optimizer, *, beta: float = 0.1
 
     def train_step(model, micro_batches, lr: float) -> dict:
         return _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches,
-                                    lr, grad_clip, scaler)
+                                    lr, grad_clip, scaler, balancer)
 
     return train_step
 
 
 def make_grpo_train_step(model, optimizer, *, grad_clip: float = 1.0,
-                         scaler=None) -> Callable:
+                         scaler=None, balancer=None) -> Callable:
     """Build a GRPO `train_step(model, micro_batches, lr) -> dict`.
 
     `micro_batches` is a list of `(inputs, targets, mask, advantages)`: a batch of sampled
@@ -203,7 +224,8 @@ def make_grpo_train_step(model, optimizer, *, grad_clip: float = 1.0,
     advantages (one per sequence, precomputed in the driver via `train.grpo.group_advantages`
     from verifier rewards). The loss is `-mean(advantage * logpθ(completion))` — REINFORCE
     with the GRPO group baseline; gradients flow through the policy only. Accumulation /
-    fp16 scaling / clipping are shared via `_accumulate_and_step`.
+    fp16 scaling / clipping are shared via `_accumulate_and_step`. `balancer` (#213) as in
+    `make_train_step`.
     """
     def loss_fn(model, inputs, targets, mask, advantages):
         logp = _masked_seq_logprob(model, inputs, targets, mask)     # (B,)
@@ -218,7 +240,7 @@ def make_grpo_train_step(model, optimizer, *, grad_clip: float = 1.0,
 
     def train_step(model, micro_batches, lr: float) -> dict:
         return _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches,
-                                    lr, grad_clip, scaler)
+                                    lr, grad_clip, scaler, balancer)
 
     return train_step
 

--- a/src/train/moe_balance.py
+++ b/src/train/moe_balance.py
@@ -1,0 +1,148 @@
+"""Loss-Free-Balancing policy for MoE routers (portable — never imports a backend).
+
+DeepSeek-V3-style Loss-Free-Balancing (Wang et al., 2024): instead of an auxiliary
+load-balancing loss added to the training objective (which fights the primary loss and
+needs a hand-tuned weight), a per-expert BIAS is added to the router's *selection*
+score only — the gate weight used to combine expert outputs stays the UNBIASED softmax
+probability. The bias is nudged after every optimizer step from that step's per-expert
+token counts, entirely OUTSIDE the gradient:
+
+    s_i = logit_i + b_i            # selection score (ranks the top-k)
+    gate_i = softmax(logit)_i      # UNBIASED — bias never touches the combination weight
+    b_i += rate * sign(mean(load) - load_i)     # after the step, from routed-token counts
+
+Under-used experts (load below the layer mean) gain bias and route more; over-used
+experts lose bias and route less. No aux loss touches the objective.
+
+One policy object manages ALL MoE layers (`bias` is `[n_layers][n_experts]`), mirroring
+the single-object `DynamicLossScaler` precedent (`src/train/loss_scale.py`) and giving a
+single place for the numbers to live. This module holds ONLY the number policy — the
+backend computes hardware-dependent per-expert load counts (from its own router forward)
+and calls `update(loads)` here; keeping the policy above the seam makes it unit-testable
+without MLX and ready for a future CUDA MoE router (#214) to reuse unchanged.
+
+Persistence note (#213 D3): the bias itself is NOT checkpointed here. It rides in the
+PORTABLE weights (`MLXMambaModel._portable_state_dict`'s `moe_route_bias.*` keys) because
+it is routing state that changes the model's function at inference — a model served or
+evaluated from `weights.safetensors` must route the way it was trained. The drivers
+re-seed this object from the model after a resume (`load_state_dict({"bias":
+model.moe_biases()})`), so there is exactly one copy of the numbers. `rate` is a
+hyperparameter read from config, not state, so the bias vector is this policy's entire
+state.
+"""
+
+from __future__ import annotations
+
+
+class MoEBalancer:
+    def __init__(self, n_layers: int, n_experts: int, rate: float = 1e-3):
+        self.n_layers = int(n_layers)
+        self.n_experts = int(n_experts)
+        self.rate = float(rate)
+        self.bias: list = [[0.0] * self.n_experts for _ in range(self.n_layers)]
+
+    def update(self, loads: list) -> None:
+        """Nudge each layer's per-expert bias from that layer's per-expert token counts.
+
+        `loads` is `[n_layers][n_experts]` (this step's routed-token counts, per MoE
+        layer in layer order). Under-used experts (count below the layer mean) gain
+        bias; over-used experts lose it — a unit step in `sign(mean - count)`, scaled by
+        `rate`. Pure Python; no numpy/backend.
+
+        Invariant to a uniform positive scale on `loads` (only the sign of the deviation
+        matters), which is what makes the `grad_checkpoint` double-count harmless — see
+        `MoEBlock._moe`'s counting comment (#213 D5).
+        """
+        for layer_bias, layer_loads in zip(self.bias, loads):
+            if not layer_loads:
+                continue
+            mean = sum(layer_loads) / len(layer_loads)
+            for i, load in enumerate(layer_loads):
+                diff = mean - load
+                sign = (diff > 0) - (diff < 0)   # -1, 0, or +1 (no numpy dependency)
+                layer_bias[i] += self.rate * sign
+
+    def biases(self) -> list:
+        """Current per-layer bias vectors, for the backend to push into its routers."""
+        return [list(b) for b in self.bias]
+
+    @staticmethod
+    def utilization_variance(loads: list) -> list:
+        """Per-layer variance of the load distribution, normalized to fractions of that
+        layer's total routed tokens — the de-collapse metric (lower = more even
+        utilization across experts). A layer with zero total load reports 0.0 (no
+        signal yet, not "perfectly balanced")."""
+        out = []
+        for layer_loads in loads:
+            total = sum(layer_loads)
+            if total <= 0 or not layer_loads:
+                out.append(0.0)
+                continue
+            fracs = [x / total for x in layer_loads]
+            n = len(fracs)
+            mean = sum(fracs) / n
+            out.append(sum((f - mean) ** 2 for f in fracs) / n)
+        return out
+
+    def state_dict(self) -> dict:
+        return {"bias": self.biases()}
+
+    def load_state_dict(self, state: dict) -> None:
+        """Seed the bias from a snapshot — either this object's own `state_dict()` or
+        `{"bias": model.moe_biases()}` read back off a just-resumed checkpoint (D3).
+
+        Defensive like `DynamicLossScaler.load_state_dict`: a missing/empty/None state,
+        or one whose `bias` key is absent or null, is a no-op rather than a `KeyError`
+        (an old checkpoint, or a resume into a config that only just turned balancing
+        on).
+        """
+        if not state:
+            return
+        rows = state.get("bias") or []
+        if not rows:
+            return
+        self.bias = [list(row) for row in rows]
+
+
+def balancer_for_config(cfg) -> "MoEBalancer | None":
+    """Map a `MambaConfig` to the `MoEBalancer` its training driver needs, or `None`.
+
+    `None` when MoE is off entirely (`moe_every` unset, or it selects no layer) OR when
+    `moe_balance_rate` is unset — the latter is the OFF switch: balancing stays off and
+    the router path stays byte-identical to pre-#213 behavior (see `MoEBlock._moe`).
+    Single source of truth for the config->balancer wiring, kept here (above the seam)
+    so it is unit-testable without a backend — parallels `scaler_for_precision`. See the
+    training drivers (`scripts/train.py` et al.) for how it is consumed.
+    """
+    if cfg.moe_every is None or cfg.n_moe_layers == 0:
+        return None
+    if cfg.moe_balance_rate is None:
+        return None
+    return MoEBalancer(cfg.n_moe_layers, cfg.n_experts, cfg.moe_balance_rate)
+
+
+def attach_balancer(balancer, model) -> None:
+    """Connect a `MoEBalancer` to a backend model before the first training step.
+
+    Three things, identical in every driver (`scripts/train.py`, `sft.py`, `dpo.py`,
+    `rlvr.py`), so they live here rather than being copied four times:
+
+      1. Adopt whatever bias arrived with the model's weights. After a resume (or an
+         SFT/DPO/RLVR init from a balanced checkpoint) the bias rides in the PORTABLE
+         weights (#213 D3), so the model — not a separate bundle field — is the single
+         source of truth; a fresh model reports empty vectors and keeps the zero init.
+      2. Push the resulting bias back into the routers, so the FIRST step already routes
+         with it instead of waiting for the first post-step push.
+      3. Turn on per-expert load counting (#213 D4), which is off by default.
+
+    A no-op when `balancer` is None (the off switch), so drivers can call it
+    unconditionally. `model` is duck-typed (`moe_biases` / `set_moe_biases` /
+    `set_moe_load_counting`) — this module still imports no backend.
+    """
+    if balancer is None:
+        return
+    loaded = model.moe_biases()
+    if loaded and all(row for row in loaded):     # every MoE layer carried a bias
+        balancer.load_state_dict({"bias": loaded})
+    model.set_moe_biases(balancer.biases())
+    model.set_moe_load_counting(True)

--- a/src/train/moe_balance.py
+++ b/src/train/moe_balance.py
@@ -52,7 +52,12 @@ class MoEBalancer:
         Invariant to a uniform positive scale on `loads` (only the sign of the deviation
         matters), which is what makes the `grad_checkpoint` double-count harmless — see
         `MoEBlock._moe`'s counting comment (#213 D5).
+
+        Raises on a shape mismatch rather than `zip`-truncating it: a short/long `loads`
+        means the model and the policy disagree about the MoE layout, and silently
+        skipping a layer would mis-steer routing for the rest of the run.
         """
+        self._check_shape(loads, "loads")
         for layer_bias, layer_loads in zip(self.bias, loads):
             if not layer_loads:
                 continue
@@ -61,6 +66,21 @@ class MoEBalancer:
                 diff = mean - load
                 sign = (diff > 0) - (diff < 0)   # -1, 0, or +1 (no numpy dependency)
                 layer_bias[i] += self.rate * sign
+
+    def _check_shape(self, rows: list, what: str) -> None:
+        """Assert `rows` is `[n_layers][n_experts]`, allowing an EMPTY row (a layer with
+        no signal yet, or a router that carries no bias). Shared by `update` and
+        `load_state_dict` so both fail loudly and identically."""
+        if len(rows) != self.n_layers:
+            raise ValueError(
+                f"{what} has {len(rows)} layers, expected n_layers={self.n_layers}."
+            )
+        for i, row in enumerate(rows):
+            if len(row) not in (0, self.n_experts):
+                raise ValueError(
+                    f"{what}[{i}] has {len(row)} entries, expected "
+                    f"n_experts={self.n_experts} (or 0 for no signal)."
+                )
 
     def biases(self) -> list:
         """Current per-layer bias vectors, for the backend to push into its routers."""
@@ -94,14 +114,17 @@ class MoEBalancer:
         Defensive like `DynamicLossScaler.load_state_dict`: a missing/empty/None state,
         or one whose `bias` key is absent or null, is a no-op rather than a `KeyError`
         (an old checkpoint, or a resume into a config that only just turned balancing
-        on).
+        on). A PRESENT but wrong-shaped bias is an error, not a no-op — it means the
+        checkpoint was trained under a different MoE layout, and adopting it would
+        mis-steer every router.
         """
         if not state:
             return
         rows = state.get("bias") or []
         if not rows:
             return
-        self.bias = [list(row) for row in rows]
+        self._check_shape(rows, "bias")
+        self.bias = [list(row) if row else [0.0] * self.n_experts for row in rows]
 
 
 def balancer_for_config(cfg) -> "MoEBalancer | None":

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -68,6 +68,7 @@ PORTABLE_MODULES = [
     "src.train.schedule",
     "src.train.checkpoint",
     "src.train.loss_scale",
+    "src.train.moe_balance",
     "src.train.loop",
     "src.train.logging",
     "src.eval.val_loss",

--- a/tests/test_moe_balance.py
+++ b/tests/test_moe_balance.py
@@ -89,6 +89,36 @@ def test_update_ignores_empty_layer_loads():
     assert b.biases()[1][0] < 0.0
 
 
+def test_update_raises_on_a_shape_mismatch():
+    """A short/long `loads` means the model and the policy disagree about the MoE
+    layout; `zip`-truncating it would silently stop steering some layer."""
+    import pytest
+    b = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    with pytest.raises(ValueError, match="loads has 1 layers"):
+        b.update([[1.0, 2.0, 3.0]])
+    with pytest.raises(ValueError, match=r"loads\[1\] has 2 entries"):
+        b.update([[1.0, 2.0, 3.0], [1.0, 2.0]])
+    assert b.biases() == [[0.0] * 3, [0.0] * 3]        # nothing partially applied
+
+
+def test_load_state_dict_raises_on_a_wrong_shaped_bias():
+    """A PRESENT but wrong-shaped bias is a mismatched checkpoint, not a no-op."""
+    import pytest
+    b = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    with pytest.raises(ValueError, match="bias has 1 layers"):
+        b.load_state_dict({"bias": [[0.1, 0.2, 0.3]]})
+    with pytest.raises(ValueError, match=r"bias\[0\] has 4 entries"):
+        b.load_state_dict({"bias": [[0.1, 0.2, 0.3, 0.4], [0.0, 0.0, 0.0]]})
+
+
+def test_load_state_dict_fills_an_empty_row_with_zeros():
+    """An inactive router reads back as `[]`; adopting it must still leave a usable
+    `[n_layers][n_experts]` bias rather than a ragged one."""
+    b = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    b.load_state_dict({"bias": [[0.1, 0.2, 0.3], []]})
+    assert b.biases() == [[0.1, 0.2, 0.3], [0.0, 0.0, 0.0]]
+
+
 def test_repeated_update_reduces_utilization_variance():
     """A toy closed-loop sanity check of the intended dynamics: if routing load shifts
     toward whichever expert currently holds the larger bias (the effect the router's

--- a/tests/test_moe_balance.py
+++ b/tests/test_moe_balance.py
@@ -1,0 +1,252 @@
+"""MoEBalancer policy — portable (no backend); Loss-Free-Balancing (#213) number machine."""
+
+from src.model.blocks import MambaConfig
+from src.train.moe_balance import MoEBalancer, attach_balancer, balancer_for_config
+
+
+def _cfg(**over):
+    base = dict(d_model=64, n_layers=4, head_dim=16, d_state=16, vocab_size=256,
+                seq_len=32, precision="fp32")
+    base.update(over)
+    return MambaConfig(**base)
+
+
+# --------------------------------------------------------------------------- #
+# utilization_variance
+# --------------------------------------------------------------------------- #
+def test_utilization_variance_zero_for_perfectly_uniform_load():
+    loads = [[10.0, 10.0, 10.0, 10.0]]
+    assert MoEBalancer.utilization_variance(loads) == [0.0]
+
+
+def test_utilization_variance_positive_for_collapsed_load():
+    loads = [[40.0, 0.0, 0.0, 0.0]]
+    var = MoEBalancer.utilization_variance(loads)[0]
+    assert var > 0.0
+
+
+def test_utilization_variance_zero_total_reports_zero_not_nan():
+    loads = [[0.0, 0.0, 0.0, 0.0]]
+    assert MoEBalancer.utilization_variance(loads) == [0.0]
+
+
+def test_utilization_variance_per_layer():
+    loads = [[10.0, 10.0], [40.0, 0.0]]
+    var_uniform, var_collapsed = MoEBalancer.utilization_variance(loads)
+    assert var_uniform == 0.0
+    assert var_collapsed > var_uniform
+
+
+def test_utilization_variance_invariant_to_uniform_scale():
+    """The property that makes the `grad_checkpoint` double-count harmless (#213 D5):
+    the metric reads load FRACTIONS, so scaling every count by 2 changes nothing."""
+    loads = [[4.0, 13.0, 12.0, 3.0]]
+    doubled = [[2 * x for x in loads[0]]]
+    assert MoEBalancer.utilization_variance(loads) == MoEBalancer.utilization_variance(doubled)
+
+
+# --------------------------------------------------------------------------- #
+# update() — bias moves toward starved experts, away from overloaded ones
+# --------------------------------------------------------------------------- #
+def test_skewed_load_moves_bias_toward_starved_experts():
+    b = MoEBalancer(n_layers=1, n_experts=2, rate=0.1)
+    b.update([[10.0, 0.0]])          # expert 0 overloaded, expert 1 starved
+    bias0, bias1 = b.biases()[0]
+    assert bias1 > 0.0                # starved expert gains bias
+    assert bias0 < 0.0                # overloaded expert loses bias
+    assert bias1 == -bias0            # symmetric two-expert case, rate=0.1 either side
+
+
+def test_update_is_a_noop_on_perfectly_balanced_load():
+    b = MoEBalancer(n_layers=1, n_experts=3, rate=0.1)
+    b.update([[5.0, 5.0, 5.0]])       # every expert exactly at the mean -> sign(0) == 0
+    assert b.biases() == [[0.0, 0.0, 0.0]]
+
+
+def test_update_covers_every_layer_independently():
+    b = MoEBalancer(n_layers=2, n_experts=2, rate=0.1)
+    b.update([[10.0, 0.0], [0.0, 10.0]])   # layer 0 and layer 1 skewed opposite ways
+    (l0_0, l0_1), (l1_0, l1_1) = b.biases()
+    assert l0_1 > 0.0 and l0_0 < 0.0
+    assert l1_0 > 0.0 and l1_1 < 0.0
+
+
+def test_update_is_invariant_to_uniform_scale_on_loads():
+    """The other half of #213 D5: `update` reads only `sign(mean - load_i)`, so a
+    doubled count vector (grad_checkpoint's recompute) produces the identical bias."""
+    a = MoEBalancer(n_layers=1, n_experts=4, rate=0.1)
+    b = MoEBalancer(n_layers=1, n_experts=4, rate=0.1)
+    loads = [[4.0, 13.0, 12.0, 3.0]]
+    a.update(loads)
+    b.update([[2 * x for x in loads[0]]])
+    assert a.biases() == b.biases()
+
+
+def test_update_ignores_empty_layer_loads():
+    b = MoEBalancer(n_layers=2, n_experts=2, rate=0.1)
+    b.update([[], [10.0, 0.0]])
+    assert b.biases()[0] == [0.0, 0.0]
+    assert b.biases()[1][0] < 0.0
+
+
+def test_repeated_update_reduces_utilization_variance():
+    """A toy closed-loop sanity check of the intended dynamics: if routing load shifts
+    toward whichever expert currently holds the larger bias (the effect the router's
+    biased-selection path is meant to produce), repeated `update()` calls converge the
+    load distribution toward uniform — the de-collapse the real MLX router exercises."""
+    n_experts = 4
+    balancer = MoEBalancer(n_layers=1, n_experts=n_experts, rate=0.1)
+    loads = [[100.0, 0.0, 0.0, 0.0]]   # fully collapsed onto expert 0
+    first_var = MoEBalancer.utilization_variance(loads)[0]
+
+    for _ in range(200):
+        balancer.update(loads)
+        bias = balancer.biases()[0]
+        total = sum(loads[0])
+        # Toy feedback: route mass proportional to (1 + bias), clipped nonnegative.
+        weights = [max(0.0, 1.0 + bias[i]) for i in range(n_experts)]
+        s = sum(weights) or 1.0
+        loads = [[total * w / s for w in weights]]
+
+    final_var = MoEBalancer.utilization_variance(loads)[0]
+    assert final_var < first_var
+    assert final_var < 0.01           # converges close to uniform
+
+
+# --------------------------------------------------------------------------- #
+# state_dict round trip / resume-safety
+# --------------------------------------------------------------------------- #
+def test_state_dict_round_trip():
+    b = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    b.update([[10.0, 0.0, 0.0], [0.0, 0.0, 10.0]])
+    snap = b.state_dict()
+
+    restored = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    restored.load_state_dict(snap)
+    assert restored.biases() == b.biases()
+    # And it keeps evolving identically from there.
+    b.update([[5.0, 5.0, 0.0], [0.0, 5.0, 5.0]])
+    restored.update([[5.0, 5.0, 0.0], [0.0, 5.0, 5.0]])
+    assert restored.biases() == b.biases()
+
+
+def test_load_state_dict_seeds_from_a_model_read_back():
+    """The D3 resume path: the bias rides in the portable weights, so the driver seeds
+    the policy with `{"bias": model.moe_biases()}` rather than a checkpoint bundle."""
+    b = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    from_model = [[0.1, -0.2, 0.3], [-0.4, 0.5, 0.0]]
+    b.load_state_dict({"bias": from_model})
+    assert b.biases() == from_model
+    b.biases()[0][0] = 99.0                       # biases() hands back copies
+    assert b.biases() == from_model
+
+
+def test_load_empty_state_is_noop():
+    b = MoEBalancer(n_layers=1, n_experts=2, rate=0.1)
+    b.update([[10.0, 0.0]])
+    before = b.biases()
+    b.load_state_dict({})
+    assert b.biases() == before
+    b.load_state_dict(None)            # resume with no balancer bundle
+    assert b.biases() == before
+    b.load_state_dict({"bias": None})  # bundle present, key nulled
+    assert b.biases() == before
+    b.load_state_dict({"bias": []})    # a dense/never-balanced model read back
+    assert b.biases() == before
+
+
+# --------------------------------------------------------------------------- #
+# balancer_for_config — the single source of truth for config->balancer wiring
+# --------------------------------------------------------------------------- #
+def test_balancer_for_config_none_for_dense_config():
+    cfg = _cfg()                       # moe_every is None
+    assert balancer_for_config(cfg) is None
+
+
+def test_balancer_for_config_none_when_balance_rate_unset():
+    # MoE is on, but moe_balance_rate is the None default -> balancing OFF.
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    assert cfg.moe_balance_rate is None
+    assert balancer_for_config(cfg) is None
+
+
+def test_balancer_for_config_sized_balancer_when_rate_set():
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2, moe_balance_rate=1e-3)
+    b = balancer_for_config(cfg)
+    assert isinstance(b, MoEBalancer)
+    assert b.n_layers == cfg.n_moe_layers == 2
+    assert b.n_experts == cfg.n_experts == 4
+    assert b.rate == 1e-3
+    assert b.biases() == [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+
+
+def test_toy_moe_config_ships_with_balancing_off():
+    """config/toy-moe.yaml must keep balancing OFF so every pre-#213 MoE test stays
+    byte-identical."""
+    from src.model.blocks import load_config
+    cfg = load_config("config/toy-moe.yaml")
+    assert cfg.moe_balance_rate is None
+    assert balancer_for_config(cfg) is None
+
+
+def test_validate_rejects_non_positive_balance_rate():
+    import pytest
+    for bad in (0.0, -1e-3):
+        with pytest.raises(ValueError, match="moe_balance_rate"):
+            _cfg(moe_every=2, n_experts=4, top_k=2, moe_balance_rate=bad).validate()
+    _cfg(moe_every=2, n_experts=4, top_k=2, moe_balance_rate=1e-3).validate()   # no raise
+
+
+# --------------------------------------------------------------------------- #
+# attach_balancer — driver wiring, duck-typed so it needs no backend
+# --------------------------------------------------------------------------- #
+class _FakeModel:
+    """The three-method slice of the backend model `attach_balancer` touches."""
+
+    def __init__(self, biases):
+        self._biases = biases
+        self.pushed = None
+        self.counting = False
+
+    def moe_biases(self):
+        return [list(b) for b in self._biases]
+
+    def set_moe_biases(self, biases):
+        self.pushed = [list(b) for b in biases]
+
+    def set_moe_load_counting(self, flag):
+        self.counting = bool(flag)
+
+
+def test_attach_balancer_is_a_noop_when_balancing_off():
+    m = _FakeModel([[], []])
+    attach_balancer(None, m)
+    assert m.pushed is None and m.counting is False
+
+
+def test_attach_balancer_pushes_zero_bias_and_enables_counting_on_a_fresh_model():
+    m = _FakeModel([[], []])                       # no bias in the weights yet
+    b = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    attach_balancer(b, m)
+    assert b.biases() == [[0.0] * 3, [0.0] * 3]    # empty read-back left the init alone
+    assert m.pushed == [[0.0] * 3, [0.0] * 3]      # pushed before the first step
+    assert m.counting is True
+
+
+def test_attach_balancer_adopts_the_bias_that_came_with_the_weights():
+    loaded = [[0.1, -0.2, 0.3], [-0.4, 0.5, 0.0]]
+    m = _FakeModel(loaded)
+    b = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    attach_balancer(b, m)
+    assert b.biases() == loaded                    # policy seeded FROM the model (D3)
+    assert m.pushed == loaded
+    assert m.counting is True
+
+
+def test_attach_balancer_ignores_a_partially_biased_read_back():
+    """A model where only some MoE blocks carry a bias is not a usable seed (shape
+    mismatch); keep the zero init rather than truncating the policy."""
+    m = _FakeModel([[0.1, -0.2, 0.3], []])
+    b = MoEBalancer(n_layers=2, n_experts=3, rate=0.1)
+    attach_balancer(b, m)
+    assert b.biases() == [[0.0] * 3, [0.0] * 3]

--- a/tests/test_moe_balance_mlx.py
+++ b/tests/test_moe_balance_mlx.py
@@ -328,6 +328,45 @@ def test_set_moe_biases_and_pop_moe_load_round_trip():
 
 
 @requires_mlx
+def test_set_moe_biases_raises_on_a_shape_mismatch():
+    """Driver-facing API: a wrong layer count or expert count must fail loudly, not
+    leave the model in a partially-activated routing state."""
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = _cfg(moe_balance_rate=0.05)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    with pytest.raises(ValueError, match="1 bias vectors for 2 MoE layers"):
+        model.set_moe_biases([[0.0] * 8])
+    with pytest.raises(ValueError, match="route bias has 3 entries"):
+        model.set_moe_biases([[0.0] * 3, [0.0] * 3])
+    assert all(not b._bias_active for b in model.moe_blocks())
+
+
+@requires_mlx
+def test_loading_a_bias_for_a_non_moe_layer_raises_clearly(tmp_path):
+    """A balanced checkpoint loaded into a config with a different MoE interleave must
+    name the mismatch, not die on an IndexError deep in the load."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.train.checkpoint import load_weights_dict, save_weights
+    cfg = _cfg(moe_balance_rate=0.05)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    model.set_moe_biases([[0.1] * 8, [0.2] * 8])
+    path = str(tmp_path / "weights.safetensors")
+    model.save(path)
+
+    weights = load_weights_dict(path)
+    weights["moe_route_bias.7"] = weights.pop("moe_route_bias.1")   # no layer 7 here
+    bad = str(tmp_path / "bad.safetensors")
+    save_weights(weights, bad, config=cfg)
+
+    mx.random.seed(1)
+    fresh = MLXMambaModel(cfg)
+    with pytest.raises(ValueError, match="layer 7 of this config is not an MoE layer"):
+        fresh.load(bad)
+
+
+@requires_mlx
 def test_pop_moe_load_is_empty_for_a_dense_model():
     from src.model.mlx_backend import MLXMambaModel
     mx.random.seed(0)

--- a/tests/test_moe_balance_mlx.py
+++ b/tests/test_moe_balance_mlx.py
@@ -1,0 +1,438 @@
+"""MLX router tests for Loss-Free-Balancing (#213): the real router de-collapses.
+
+`tests/test_moe_balance.py` unit-tests the portable `MoEBalancer` policy in isolation
+(no backend). This file is the end-to-end proof: train a small many-expert MoE with and
+without the balancer wired through the real `make_train_step` -> `_accumulate_and_step`
+-> `MoEBlock` path and confirm the balanced run's expert-utilization variance is
+materially lower (the acceptance criterion), plus the load-bearing invariants —
+
+  D1  the bias is NOT in the parameter tree, so no optimizer ever steps it;
+  D2  the bias steers top-k SELECTION only; gates stay the unbiased softmax probs;
+  D3  the bias round-trips through the PORTABLE safetensors, not the resume bundle;
+  D4  load counting is gated off by default;
+  D5  `grad_checkpoint` double-counts by exactly 2x, which both consumers ignore;
+
+and the off-path invariant that `moe_balance_rate: null` leaves the router untouched.
+"""
+
+import numpy as np
+import pytest
+
+from src.model.blocks import MambaConfig
+from src.train.moe_balance import MoEBalancer, attach_balancer, balancer_for_config
+
+# Per-test skip marker, NOT a module-level `importorskip`: the latter runs at import
+# time and would skip the whole module on a non-Mac host (matches tests/test_moe.py).
+try:
+    import mlx.core as mx
+    import mlx.optimizers as optim
+    from mlx.utils import tree_flatten
+    HAVE_MLX = True
+except ImportError:
+    HAVE_MLX = False
+requires_mlx = pytest.mark.skipif(not HAVE_MLX, reason="requires mlx (Apple Silicon)")
+
+
+def _cfg(**over):
+    base = dict(d_model=32, n_layers=2, head_dim=8, d_state=8, vocab_size=32,
+                seq_len=16, precision="fp32", moe_every=1, n_experts=8, top_k=2,
+                moe_d_ff=32)
+    base.update(over)
+    return MambaConfig(**base)
+
+
+def _train_and_probe(cfg, seed=0, steps=400, lr=2e-3, batch=4):
+    """Train `cfg`'s model for `steps` real train_steps on fresh random toy batches each
+    step (sustained gradient signal — a single memorized batch saturates the loss too
+    fast for the rich-get-richer collapse dynamic to show up), wiring the balancer
+    exactly as `scripts/train.py` does. Returns the per-MoE-layer `utilization_variance`
+    from a FRESH, fixed probe evaluation (independent of the training seed) — an
+    apples-to-apples snapshot of the post-training routing distribution."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+
+    mx.random.seed(seed)
+    model = MLXMambaModel(cfg)
+    opt = optim.AdamW(learning_rate=lr)
+    balancer = balancer_for_config(cfg)
+    train_step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=balancer)
+    attach_balancer(balancer, model)
+
+    rng = np.random.default_rng(seed)
+    last_metrics = None
+    for _ in range(steps):
+        tokens = rng.integers(0, cfg.vocab_size, size=(batch, cfg.seq_len + 1))
+        inputs, targets = tokens[:, :-1], tokens[:, 1:]
+        last_metrics = train_step(model, [(inputs, targets)], lr)
+
+    # Fair snapshot: turn counting ON for the probe (the unbalanced run never enabled it)
+    # and clear whatever accumulated during training, then aggregate many FRESH probe
+    # batches (fixed seed, independent of `seed`) to average out per-batch sampling noise
+    # before reading the final distribution.
+    model.set_moe_load_counting(True)
+    model.pop_moe_load()
+    probe_rng = np.random.default_rng(1234)
+    for _ in range(30):
+        probe = probe_rng.integers(0, cfg.vocab_size, size=(8, cfg.seq_len))
+        model.forward(mx.array(probe))
+    loads = model.pop_moe_load()
+    return MoEBalancer.utilization_variance(loads), last_metrics, model
+
+
+# --------------------------------------------------------------------------- #
+# Acceptance: the router de-collapses
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_balancing_reduces_expert_utilization_variance(capsys):
+    """The acceptance criterion: expert-utilization variance de-collapses on a toy MoE
+    run. Same seed / data / hyperparameters for both conditions — `moe_balance_rate` is
+    the only difference. Run with `-s` to read the before/after numbers."""
+    var_off, metrics_off, _ = _train_and_probe(_cfg(moe_balance_rate=None), seed=0)
+    var_on, metrics_on, _ = _train_and_probe(_cfg(moe_balance_rate=0.05), seed=0)
+
+    with capsys.disabled():
+        print(f"\n[#213 de-collapse] utilization_variance per MoE layer")
+        print(f"  unbalanced (moe_balance_rate=None): {var_off}  max={max(var_off):.6f}")
+        print(f"  balanced   (moe_balance_rate=0.05): {var_on}  max={max(var_on):.6f}")
+        print(f"  reduction: {max(var_off) / max(max(var_on), 1e-12):.1f}x")
+
+    assert "moe_util_var" not in metrics_off       # balancer off -> no balancer metric
+    assert "moe_util_var" in metrics_on            # balancer on -> reported every step
+
+    # Materially lower, not just numerically lower: a >=3x margin comfortably clears the
+    # reduction observed across several seeds while training this toy setup.
+    assert max(var_on) * 3 < max(var_off), (
+        f"balanced variance {var_on} not materially below unbalanced {var_off}")
+
+
+# --------------------------------------------------------------------------- #
+# D1 — the bias is NOT a trained parameter
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_route_bias_and_load_counts_are_not_in_the_parameter_tree():
+    """The whole method depends on this: `nn.Module.valid_parameter_filter` excludes
+    leading-underscore keys, so `nn.value_and_grad` cannot differentiate the bias and
+    `optimizer.update` cannot step it. Verified, not assumed."""
+    from src.model.mlx_backend import MLXMambaModel
+    mx.random.seed(0)
+    model = MLXMambaModel(_cfg(moe_balance_rate=0.05))
+    model.set_moe_biases([[0.5] * 8, [-0.5] * 8])       # active, non-zero
+
+    for tree in (model.parameters(), model.trainable_parameters()):
+        keys = [k for k, _ in tree_flatten(tree)]
+        assert not any("_route_bias" in k for k in keys), keys
+        assert not any("_load_counts" in k for k in keys), keys
+    # ...and it does not sneak into the portable dict through its `tree_flatten(
+    # self.parameters())` path either: the only bias keys there are the two D3 adds
+    # explicitly, never a `layers.N._route_bias` module-attribute leak.
+    sd = list(model._portable_state_dict())
+    assert [k for k in sd if "route_bias" in k] == ["moe_route_bias.0", "moe_route_bias.1"], sd
+    assert not any("_load_counts" in k for k in sd), sd
+
+
+@requires_mlx
+def test_optimizer_step_leaves_the_bias_bit_identical():
+    """A full train step (forward + backward + AdamW update) with an ACTIVE bias and no
+    balancer must leave the bias exactly as set — only the policy may move it."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    mx.random.seed(0)
+    model = MLXMambaModel(_cfg(moe_balance_rate=0.05))
+    model.set_moe_biases([[0.1 * i for i in range(8)], [-0.1 * i for i in range(8)]])
+    # Baseline read AFTER the push: the router stores the bias in fp32, so this is the
+    # exact vector the model holds. Bit-identity is then a real claim about the optimizer.
+    before = model.moe_biases()
+    opt = optim.AdamW(learning_rate=1e-2)
+    step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=None)
+
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, 32, size=(4, 17))
+    for _ in range(3):
+        step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-2)
+    assert model.moe_biases() == before                  # not a float apart
+
+
+@requires_mlx
+def test_balancer_moves_the_bias_by_exactly_rate_per_step():
+    """With the balancer wired, the bias moves by `rate * sign(mean - load)` and nothing
+    else — an exact-arithmetic check that the policy is the sole author of the bias."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    cfg = _cfg(moe_balance_rate=0.25)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    opt = optim.AdamW(learning_rate=1e-3)
+    balancer = balancer_for_config(cfg)
+    step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=balancer)
+    attach_balancer(balancer, model)
+
+    # Shadow the policy by hand: pull the loads the step will see, apply the same rule.
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, 32, size=(4, 17))
+    step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+    got = model.moe_biases()
+    for layer_bias in got:
+        # rate=0.25, one step from zero -> every entry is exactly -0.25, 0.0 or +0.25.
+        assert set(layer_bias) <= {-0.25, 0.0, 0.25}, layer_bias
+    assert got == balancer.biases()
+
+
+# --------------------------------------------------------------------------- #
+# D2 — the bias steers SELECTION only; gates stay the unbiased softmax
+# --------------------------------------------------------------------------- #
+def _reference_moe(block, xn, bias=None):
+    """Independent re-implementation of the intended routing, for `_moe` to match."""
+    logits = np.array(block.router(xn).astype(mx.float32))
+    probs = np.exp(logits - logits.max(-1, keepdims=True))
+    probs /= probs.sum(-1, keepdims=True)
+    k = block.config.top_k
+    sel = logits + np.asarray(bias) if bias is not None else probs
+    keep = np.argsort(np.argsort(-sel, axis=-1), axis=-1) < k
+    gate = np.where(keep, probs, 0.0)                    # UNBIASED gate values
+    gate = gate / gate.sum(-1, keepdims=True)            # renormalized over the kept set
+    return keep, gate
+
+
+@requires_mlx
+def test_bias_changes_selection_but_not_gate_values():
+    """D2 pinned: with a large hand-set bias the KEPT SET changes, while each surviving
+    expert's gate is still its unbiased softmax prob (renormalized over the new kept
+    set) — and the block's output equals the reference combination built from those
+    unbiased gates."""
+    from src.model.mlx_backend import MoEBlock
+    cfg = _cfg(moe_balance_rate=0.05)
+    mx.random.seed(0)
+    block = MoEBlock(cfg)
+    xn = mx.random.normal((3, cfg.seq_len, cfg.d_model))
+
+    keep_off, gate_off = _reference_moe(block, xn)
+    y_off = np.array(block._moe(xn))
+
+    # A bias big enough to force expert 7 in and expert 0 out, whatever the logits say.
+    bias = [-50.0] + [0.0] * 6 + [50.0]
+    block.set_route_bias(bias)
+    keep_on, gate_on = _reference_moe(block, xn, bias)
+    y_on = np.array(block._moe(xn))
+
+    # The SELECTION moved: expert 7 is always kept, expert 0 never is.
+    assert keep_on[..., 7].all() and not keep_on[..., 0].any()
+    assert not np.array_equal(keep_off, keep_on)
+
+    # The GATE VALUES did not become biased: each kept expert's gate is still its
+    # unbiased softmax prob, and the ratio between two co-kept experts is unchanged by
+    # the bias (it would shift by exp(b_i - b_j) if the bias touched the gate).
+    both = keep_off & keep_on
+    ratio_off = np.where(both, gate_off, np.nan)
+    ratio_on = np.where(both, gate_on, np.nan)
+    scale = np.nansum(ratio_on, -1, keepdims=True) / np.nansum(ratio_off, -1, keepdims=True)
+    assert np.allclose(ratio_on[both], (ratio_off * scale)[both], atol=1e-5)
+
+    # And the block reproduces the reference combination in both conditions.
+    assert np.allclose(y_off, _combine(block, xn, gate_off), atol=1e-4)
+    assert np.allclose(y_on, _combine(block, xn, gate_on), atol=1e-4)
+
+
+def _combine(block, xn, gate):
+    cd = mx.float32
+    outs = np.stack([np.array(e(xn, cd)) for e in block.experts], axis=-2)
+    return (np.asarray(gate)[..., None] * outs).sum(-2)
+
+
+@requires_mlx
+def test_zero_bias_does_not_perturb_routing():
+    """Bias lives in LOGIT space while the off-path ranks by probs; softmax is monotone
+    per row and preserves ties, so activating with an all-zero bias is a no-op."""
+    from src.model.mlx_backend import MoEBlock
+    mx.random.seed(0)
+    block = MoEBlock(_cfg(moe_balance_rate=0.05))
+    xn = mx.random.normal((2, 16, 32))
+    y_unbiased = np.array(block._moe(xn))
+    block.set_route_bias([0.0] * 8)
+    assert block._bias_active
+    assert np.array_equal(y_unbiased, np.array(block._moe(xn)))
+
+
+@requires_mlx
+def test_exactly_top_k_experts_survive_on_a_tie_under_bias():
+    """The double-argsort tie-break must hold on the BIASED path too: a router that
+    scores every expert identically (zero weights -> uniform probs, zero bias) still
+    keeps exactly top_k, not all E."""
+    from src.model.mlx_backend import MoEBlock
+    cfg = _cfg(moe_balance_rate=0.05)
+    mx.random.seed(0)
+    block = MoEBlock(cfg)
+    block.router.weight = mx.zeros_like(block.router.weight)   # perfectly tied logits
+    block.set_route_bias([0.0] * cfg.n_experts)
+    block.set_load_counting(True)
+    xn = mx.random.normal((2, cfg.seq_len, cfg.d_model))
+    block._moe(xn)
+    assert sum(block.pop_load()) == 2 * cfg.seq_len * cfg.top_k
+
+
+# --------------------------------------------------------------------------- #
+# Off-path invariant — moe_balance_rate: null is byte-identical to pre-#213
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_bias_inactive_and_router_unaffected_when_balancing_off():
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_balance_rate=None)
+    assert balancer_for_config(cfg) is None
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    blocks = model.moe_blocks()
+    assert len(blocks) == cfg.n_moe_layers > 0
+    assert all(isinstance(b, MoEBlock) and not b._bias_active for b in blocks)
+    assert all(not b._count_loads for b in blocks)      # D4: counting off by default
+
+    tokens = mx.array(np.arange(2 * cfg.seq_len).reshape(2, cfg.seq_len) % cfg.vocab_size)
+    y1 = np.array(model.forward(tokens))
+    y2 = np.array(model.forward(tokens))
+    assert np.array_equal(y1, y2)                      # deterministic, no bias touched
+    assert all(not b._bias_active for b in blocks)     # still untouched after forwards
+    # D4: with counting off the accumulator never grew, so a pop reads all-zero.
+    assert model.pop_moe_load() == [[0.0] * cfg.n_experts for _ in blocks]
+
+
+# --------------------------------------------------------------------------- #
+# Plumbing — the accessors the drivers use
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_set_moe_biases_and_pop_moe_load_round_trip():
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = _cfg(moe_balance_rate=1e-3)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    blocks = model.moe_blocks()
+    assert all(not b._bias_active for b in blocks)     # zero bias, never pushed yet
+    model.set_moe_load_counting(True)
+
+    n_tokens = 3 * cfg.seq_len
+    tokens = mx.array(np.arange(n_tokens).reshape(3, cfg.seq_len) % cfg.vocab_size)
+    model.forward(tokens)
+    loads = model.pop_moe_load()
+    assert len(loads) == cfg.n_moe_layers
+    for layer_loads in loads:
+        assert len(layer_loads) == cfg.n_experts
+        assert sum(layer_loads) == n_tokens * cfg.top_k   # every token picks top_k experts
+
+    # A second pop (no forward in between) returns all-zero — the accumulator was reset.
+    assert model.pop_moe_load() == [[0.0] * cfg.n_experts for _ in range(cfg.n_moe_layers)]
+
+    balancer = MoEBalancer(cfg.n_moe_layers, cfg.n_experts, rate=0.1)
+    balancer.update(loads)
+    model.set_moe_biases(balancer.biases())
+    assert all(b._bias_active for b in blocks)
+    # fp32 in the router (MLX's compute dtype), float in the policy — compare at fp32.
+    assert np.allclose(np.array(model.moe_biases()), np.array(balancer.biases()),
+                       atol=1e-6)
+
+
+@requires_mlx
+def test_pop_moe_load_is_empty_for_a_dense_model():
+    from src.model.mlx_backend import MLXMambaModel
+    mx.random.seed(0)
+    model = MLXMambaModel(_cfg(moe_every=None, n_experts=0, moe_d_ff=None))
+    assert model.moe_blocks() == []
+    assert model.pop_moe_load() == []
+    assert model.moe_biases() == []
+
+
+# --------------------------------------------------------------------------- #
+# D3 — the bias round-trips in the PORTABLE safetensors
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_route_bias_round_trips_through_portable_weights(tmp_path):
+    """A model served or evaluated from weights.safetensors must route the way it was
+    trained, so the bias rides with the weights — not the resume bundle."""
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = _cfg(moe_balance_rate=0.05)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    bias = [[0.1 * i for i in range(8)], [-0.05 * i for i in range(8)]]
+    model.set_moe_biases(bias)
+
+    path = str(tmp_path / "weights.safetensors")
+    keys = model._portable_state_dict()
+    assert sorted(k for k in keys if k.startswith("moe_route_bias.")) == \
+        ["moe_route_bias.0", "moe_route_bias.1"]
+    model.save(path)
+
+    mx.random.seed(1)                                  # different init on purpose
+    fresh = MLXMambaModel(cfg)
+    assert fresh.moe_biases() == [[], []]              # inactive before the load
+    fresh.load(path)
+    assert fresh.moe_biases() == model.moe_biases()      # fp32 round-trip, exact
+    assert np.allclose(np.array(fresh.moe_biases()), np.array(bias), atol=1e-6)
+    assert all(b._bias_active for b in fresh.moe_blocks())
+
+    tokens = mx.array(np.arange(2 * cfg.seq_len).reshape(2, cfg.seq_len) % cfg.vocab_size)
+    assert np.allclose(np.array(model.forward(tokens)), np.array(fresh.forward(tokens)))
+
+
+@requires_mlx
+def test_portable_key_set_unchanged_when_the_bias_is_inactive():
+    """Guards tests/test_moe.py's and tests/test_sizing_mlx.py's
+    `sum(v.size) == num_parameters()`: no bias key may appear when balancing is off."""
+    from src.model.mlx_backend import MLXMambaModel
+    for cfg in (_cfg(moe_balance_rate=None), _cfg(moe_balance_rate=0.05)):
+        mx.random.seed(0)
+        model = MLXMambaModel(cfg)                     # constructed, never activated
+        sd = model._portable_state_dict()
+        assert not any(k.startswith("moe_route_bias.") for k in sd), list(sd)
+        assert sum(int(v.size) for v in sd.values()) == cfg.num_parameters()
+
+
+@requires_mlx
+def test_loading_a_pre_213_checkpoint_leaves_the_bias_inactive(tmp_path):
+    """Old checkpoints carry no `moe_route_bias.*` keys; loading one must not raise and
+    must leave the router on the unbiased path."""
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = _cfg(moe_balance_rate=0.05)
+    mx.random.seed(0)
+    old = MLXMambaModel(cfg)                           # bias never activated
+    path = str(tmp_path / "weights.safetensors")
+    old.save(path)
+
+    mx.random.seed(1)
+    fresh = MLXMambaModel(cfg)
+    fresh.load(path)
+    assert all(not b._bias_active for b in fresh.moe_blocks())
+    assert fresh.moe_biases() == [[], []]
+
+
+# --------------------------------------------------------------------------- #
+# D5 — grad_checkpoint double-counts by exactly 2x, harmlessly
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_grad_checkpoint_doubles_the_counts_and_changes_nothing_else():
+    """With `grad_checkpoint: true` each layer's forward is recomputed in backward, so
+    `_moe` runs twice per micro-batch. Measured: the counter assignment inside the
+    grad-traced, `mx.checkpoint`-wrapped call does not raise, and every expert of every
+    MoE layer counts exactly 2x. Both consumers are invariant to a uniform positive
+    scale (`update` is sign-based, `utilization_variance` normalizes to fractions), so
+    the balancing behaviour is identical."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+
+    def counts(grad_checkpoint):
+        cfg = _cfg(moe_balance_rate=0.05, grad_checkpoint=grad_checkpoint)
+        mx.random.seed(0)
+        model = MLXMambaModel(cfg)
+        opt = optim.AdamW(learning_rate=1e-3)
+        step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=None)
+        model.set_moe_load_counting(True)
+        rng = np.random.default_rng(0)
+        tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
+        step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+        return model.pop_moe_load()
+
+    plain, checkpointed = counts(False), counts(True)
+    assert checkpointed == [[2 * c for c in layer] for layer in plain]
+    assert MoEBalancer.utilization_variance(plain) == \
+        MoEBalancer.utilization_variance(checkpointed)
+
+    b_plain = MoEBalancer(2, 8, rate=0.05)
+    b_ckpt = MoEBalancer(2, 8, rate=0.05)
+    b_plain.update(plain)
+    b_ckpt.update(checkpointed)
+    assert b_plain.biases() == b_ckpt.biases()


### PR DESCRIPTION
Closes #213

## Summary

DeepSeek-V3 **Loss-Free-Balancing** for the MLX MoE router: a per-expert bias steers the
router's top-k **selection** only, updated **outside the gradient** from per-expert load
counts (`b_i += rate * sign(mean_count - count_i)`). **No aux loss is added to the
objective.**

- **`src/train/moe_balance.py`** (new, portable — stdlib only, in `PORTABLE_MODULES`):
  the `MoEBalancer` policy (`update` / `biases` / `utilization_variance` /
  `state_dict` / `load_state_dict`), the `balancer_for_config` off-switch, and
  `attach_balancer` for the driver wiring. Mirrors the `DynamicLossScaler` precedent.
- **`src/model/blocks.py`**: `moe_balance_rate` (logit units; `None` = OFF) + validation
  (`> 0`, or `None`).
- **`src/model/mlx_backend.py`**: `MoEBlock` gains `_route_bias` / `_load_counts` /
  `_bias_active` / `_count_loads`; `_moe` ranks on the biased selection score when
  active and takes the pre-#213 `probs`-ranked branch verbatim otherwise. The
  **double-argsort tie-break is preserved on both paths** (a plain threshold keeps more
  than `top_k` on ties during early uniform routing). `MLXMambaModel` gains
  `moe_blocks` / `set_moe_biases` / `moe_biases` / `set_moe_load_counting` /
  `pop_moe_load`, plus the portable state-dict round-trip.
- **`src/model/mlx_train_step.py`**: `balancer=None` threaded through
  `_accumulate_and_step` and all four `make_*_train_step` factories; after a successful
  step it pops loads, updates the policy, pushes the new biases, and reports
  `moe_util_var`.
- **`scripts/{train,sft,dpo,rlvr}.py`**: driver wiring. The `balancer` kwarg is passed
  **conditionally**, so the CUDA factories (no such parameter) are untouched.
- **`config/toy-moe.yaml`**: `moe_balance_rate: null` with the decision comment.

## Acceptance — the de-collapse numbers

```
.venv/bin/python -m pytest -q -s \
  tests/test_moe_balance_mlx.py::test_balancing_reduces_expert_utilization_variance
```

Two runs of the same tiny 8-expert / top-2 MoE (`d_model 32`, 2 layers, `moe_every 1`,
fp32), identical seed, data, and hyperparameters — `moe_balance_rate` is the **only**
difference — 400 steps on fresh random batches, then probed with the same fixed-seed
batches:

```
[#213 de-collapse] utilization_variance per MoE layer
  unbalanced (moe_balance_rate=None): [0.011885354783799915, 0.00811492919921875]  max=0.011885
  balanced   (moe_balance_rate=0.05): [0.0006788041856553819, 7.362789577907981e-05]  max=0.000679
  reduction: 17.5x
```

The test asserts a >=3x margin (the flake-proof floor), and that `moe_util_var` is
present in the balanced run's metrics and absent from the unbalanced one.

## Design decisions

**D1 — the bias is NOT a trained parameter.** It is stored as `self._route_bias`; MLX's
`nn.Module.valid_parameter_filter` excludes leading-underscore keys, so
`nn.value_and_grad` cannot differentiate it and `optimizer.update` cannot step it. If
the optimizer trained this bias the whole method would be void, so this is **verified,
not assumed**: a test asserts `_route_bias` / `_load_counts` appear in no key of
`tree_flatten(model.parameters())` or `trainable_parameters()`, that they do not leak
through `_portable_state_dict`'s `tree_flatten(self.parameters())` path, and that three
full AdamW steps with an active bias leave it **bit-identical**.

**D2 — the bias shifts SELECTION only.** `sel_i = logits_i + b_i` ranks the top-k;
`gate_i = softmax(logits)_i` (**unbiased**) is the combination weight, renormalized over
the kept set. Biasing the gate would be a different algorithm. Pinned by a test that
sets a large bias, confirms the kept set changes, and checks the block's output against
an independent reference implementation built from unbiased gates — plus that the gate
ratio between two co-kept experts is unchanged by the bias (it would shift by
`exp(b_i - b_j)` if the bias touched the gate). Bias is added in logit space, and
ranking by logits is order-identical to ranking by probs (softmax is monotone per row
and preserves ties), so activating with a zero bias does not perturb routing — also
tested.

**D3 — the bias persists in the PORTABLE safetensors, not the resume bundle.** It is
routing state that changes the model's function at inference, not optimizer state: a
model served or evaluated from `weights.safetensors` must route the way it was trained,
and #214 must be able to load an MLX-trained MoE checkpoint into CUDA and route
identically. `src/train/checkpoint.py`'s split is explicit — weights port across
backends, optimizer state does not need to. `_portable_state_dict` emits
`moe_route_bias.{layer}` **only for an active block** (an unconditional key would break
the `sum(v.size) == num_parameters()` assertions in `tests/test_moe.py` and
`tests/test_sizing_mlx.py`, and the bias genuinely is not a parameter); `_load_portable`
pops those keys before `tree_unflatten`/`update` and calls `set_route_bias`. The drivers
re-seed the policy from the model after resume, so there is exactly one copy of the
numbers and **`CheckpointStore.save` is unchanged**. Proven by a save/load round-trip
test asserting both the biases and a full `forward` match, plus tests that a pre-#213
checkpoint loads clean and that the inactive key set is unchanged.

**D4 — load counting is gated.** `_count_loads` (default `False`) gates the
accumulation. Without it the lazy MLX graph behind `_load_counts` would grow for an
entire un-balanced MoE run (nothing ever pops it), pinning every step's routing mask
alive — a slow memory leak. `MLXMambaModel.set_moe_load_counting(True)` flips it on
exactly when a balancer is present. Counting happens only in the `k < E` branch (with
`k == E` balancing is vacuous). On an fp16 overflow-skipped step the counts carry into
the next pop — harmless, the update is sign-based and the routing did happen.

**D5 — `grad_checkpoint` double-counts, harmlessly — measured, not asserted.** With
`grad_checkpoint: true` each layer's forward recomputes in backward, so `_moe` runs
twice and every count doubles. The experiment: it does **not** raise (the counter
assignment inside the `mx.checkpoint`-wrapped, grad-traced call is tolerated), and the
counts are **exactly 2x** for every expert of every MoE layer. Both consumers are
invariant to a uniform positive scale (`update` is sign-based;
`utilization_variance` normalizes to fractions), so the balancing decisions are
identical. That outcome is now a test, so no `validate()` rejection was needed.

## CUDA is untouched

Nothing in this PR touches `src/model/cuda_backend.py` or `cuda_train_step.py` — CUDA
still raises on MoE (#214). `#214` will reuse `src/train/moe_balance.py` **unchanged**;
the policy is above the seam and imports no backend.

## Testing

- [x] Tests added/updated — `tests/test_moe_balance.py` (23 portable cases) and
      `tests/test_moe_balance_mlx.py` (14 MLX cases, per-test `skipif`)
- [x] All tests passing — `.venv/bin/python -m pytest -q -rs`: **804 passed, 13 skipped**
      (skips all pre-existing: no CUDA device, no prettier toolchain, `#214`-blocked fp8)
- [x] Manual testing completed — smoke gate green on a freshly built toy split:
      `scripts/smoke_test.py --backend mlx` → resume exact (`max|loss diff| = 2.384e-07`),
      prefill/decode parity, `SMOKE TEST PASSED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrGJ9PEaQSRE5MfvxQiwrB