### PR TITLE
feat: [M12] Re-derive the code-BPE vocab size before the corpus is packed (16k was sized for TS-only)

### DIFF
--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -44,17 +44,69 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
   tokenizer, not Python/MLX — see MHM-P1b), RunPod (CUDA) + M1 (MLX) dev. Carried decisions:
   D4 Jamba-vs-Routing-Mamba, D5 Large A vs Large B.
 
-  > **Vocab size — provisionally 16384, must be re-derived before the corpus is packed.**
-  > 16k is the Swift trainer's `DEFAULT_VOCAB_SIZE` and what #193/#200 assume, so it is decided in
-  > practice. But that number was chosen when #193 was scoped as *"TS LSP-clean pipeline (Stack v2
-  > **TS subset**)"* — 16k is reasonable for TypeScript alone. #198 then **rescoped the corpus to
-  > general multilingual Essential-Web + Stack-v2 and the vocab never moved.** On multilingual
-  > prose + multi-language code, 16k compresses poorly, and that costs twice: worse **BPB** (the
-  > program's primary metric) and fewer characters per token, which directly undercuts the
-  > context-length half of the local-hardware win. 32k still fits the uint16 ceiling with room.
-  > Re-derive by training candidate vocabs (16k/32k/48k) on a corpus sample and comparing
-  > bytes/token — hours of work with `monica-tokenize train --vocab-size`, and it must happen
-  > **before** the corpus is packed, since redoing it after is a full re-tokenize.
+  > **Vocab size — 49152, ratified 2026-08-04 (#251).** `DEFAULT_VOCAB_SIZE` was 16384, sized when
+  > #193 was scoped as *"TS LSP-clean pipeline (Stack v2 **TS subset**)"* — reasonable for
+  > TypeScript alone. #198 rescoped the corpus to general multilingual Essential-Web + Stack-v2 and
+  > the vocab never moved. Measured on the rescoped distribution, 16384 costs **7.6% of overall
+  > compression** and **11.4% on Markdown**; 49152 is the best of the three candidates swept and is
+  > under the 65536 uint16 packing cap.
+  >
+  > **bytes/token** (higher is better — more raw bytes carried per token):
+  >
+  > | Language | sample bytes | 16384 | 32768 | 49152 | Δ 32768 | Δ 49152 |
+  > |---|---:|---:|---:|---:|---:|---:|
+  > | cpp | 1.05 MB | 2.9998 | 3.2195 | 3.3177 | +7.33% | +10.60% |
+  > | en | 10.58 MB | 3.4368 | 3.7451 | 3.8893 | +8.97% | +13.17% |
+  > | go | 1.05 MB | 3.0427 | 3.2193 | 3.3134 | +5.80% | +8.90% |
+  > | java | 1.58 MB | 3.6480 | 3.9145 | 4.0703 | +7.31% | +11.58% |
+  > | javascript | 2.10 MB | 3.3452 | 3.5518 | 3.6518 | +6.18% | +9.17% |
+  > | markdown | 1.05 MB | 2.8511 | 3.1751 | 3.3509 | +11.37% | +17.53% |
+  > | python | 2.12 MB | 3.5047 | 3.7173 | 3.8233 | +6.07% | +9.09% |
+  > | rust | 1.06 MB | 3.5151 | 3.6811 | 3.7628 | +4.72% | +7.05% |
+  > | typescript | 4.26 MB | 3.5703 | 3.7943 | 3.9201 | +6.28% | +9.80% |
+  > | **overall** | 24.85 MB | 3.4029 | 3.6630 | 3.7920 | +7.64% | +11.43% |
+  >
+  > **Per-language rows are blend-independent** — a language's bytes/token is computed only over
+  > its own documents. **Only the "overall" row is blend-weighted**, so the decision does not
+  > silently depend on mixture weights nobody ratified.
+  >
+  > **Two limitations, so this is not read as better-founded than it is:**
+  > 1. **The tested range did not bracket the knee.** bytes/token is monotonic non-decreasing in
+  >    vocab size, and 32768→49152 was still yielding a lot (+3.5% overall, +5.25% Markdown).
+  >    Returns never flattened inside 16k–49k, so the rule returned the **largest candidate
+  >    tested** — which is not the same claim as "49152 is optimal". The honest statement is
+  >    **≥49152 on this evidence; the ceiling was not located.** The uint16 packing cap (65536)
+  >    bounds where it can be, leaving roughly **49k–64k unexplored**.
+  > 2. **The rule prices the benefit, not the cost.** Since bytes/token improves monotonically,
+  >    this metric alone has no interior optimum. The counterweight is the **tied-embedding
+  >    parameter cost** — at `d_model 768` each token costs 768 params in the embedding *and* the
+  >    output head, and 16384→49152 roughly triples that matrix (for scale: `config/poc.yaml`'s
+  >    tied embedding is ~38M of ~127M params, and M12-small is ~120M-active). The sweep measured
+  >    **compression only**; the parameter-cost side was **not** evaluated. Revisit if the small
+  >    rung turns out embedding-heavy.
+  >
+  > **Sample.** 24.85 MB / 5,420 docs, built by `src/data/vocab_sample.py`: 10.58 MB Essential-Web
+  > prose + 14.27 MB Stack-v2 code across 8 languages (TypeScript over-weighted at 4.26 MB — the
+  > program is TypeScript-first). Filters, applied to Stack-v2 *metadata columns before* any S3
+  > fetch: permissive license (`filters.is_permissive`; ~67% of rows carry an empty
+  > `detected_licenses`), not vendored, not generated, 1 KiB ≤ `length_bytes` ≤ 128 KiB. Carries
+  > **240,073 unique pre-tokens (122,111 appearing ≥2×)** — 4.9× / 2.5× the 49,152 merges
+  > requested, so the tail merges come from real repeated structure, not the exhaustion regime that
+  > caps an undersized sample. The run produced all 48,890 requested merges without exhausting.
+  >
+  > **Method.** One 49,152 train (2,035 s), with 32,768 / 16,384 derived by **truncating `merges`**
+  > — `Trainer.train` is greedy with no lookahead, so a k-vocab merge list is a strict prefix of
+  > any larger run's. That invariant is now guarded by `monica-selfcheck`, not assumed. `tokens`
+  > counts the EOS `pack` appends, so bytes/token is the real packed ratio. Reproduce with
+  > `scripts/vocab_sweep.py`.
+  >
+  > **Invariants that held:** FIM sentinel ids identical across all three sizes; pre-token counts
+  > identical (5,884,475 — the pre-tokenizer never sees the merges); `max_token_id` 49,151 < 65,536,
+  > and `monica-tokenize pack` confirmed the uint16 shard path.
+  >
+  > **BPB is unaffected by this choice.** BPB is byte-normalized, so a larger vocab does not
+  > "cheat" it the way it deflates raw perplexity — the table measures genuine compression, and
+  > BPB remains a fair primary metric across vocab sizes.
 - **MHM-P1 — Corpus** (#193): general multilingual Essential-Web + Stack-v2 mixture, repo-context
   packing, decontamination blocklist. (Rescopes the earlier FineWeb-Edu + Stack-v1 corpus.)
 - **MHM-P1b — Tokenizer** (#191, **done** — PR #245): own byte-level BPE, shipped as a **native

--- a/scripts/vocab_sweep.py
+++ b/scripts/vocab_sweep.py
@@ -3,7 +3,7 @@
 
     .venv/bin/python scripts/vocab_sweep.py [--work-dir ~/monica-data/vocab-sweep-251]
         [--vocab-sizes 16384,32768,49152] [--threads 64] [--mixture-scale 1.0]
-        [--rebuild-sample] [--no-truncate] [--sample-only] [--tokenize-bin PATH]
+        [--rebuild-sample] [--retrain] [--no-truncate] [--sample-only] [--tokenize-bin PATH]
 
 Flow: build (or reuse) the tagged sample -> train the BPE **once** at the largest size ->
 derive the smaller sizes by truncating `merges` -> `monica-tokenize stats` per size ->
@@ -15,8 +15,9 @@ base bytes) — verified empirically on a 2.46 MB corpus and now guarded by `mon
 Training once is ~2.5x cheaper than three independent runs on the dominant cost.
 `--no-truncate` trains each size independently and is kept as the audit path.
 
-The sample lives outside the repo (default `~/monica-data/vocab-sweep-251/`) and is cached:
-a re-run costs zero network time.
+The sample lives outside the repo (default `~/monica-data/vocab-sweep-251/`) and is cached, as
+are the trained tokenizers: a re-run costs zero network time and no retraining, so re-emitting
+the table is cheap. `--rebuild-sample` / `--retrain` force each half.
 """
 
 from __future__ import annotations
@@ -57,6 +58,21 @@ def resolve_tokenize_bin(explicit: str | None) -> Path:
     if not binary.exists():
         raise SystemExit(f"monica-tokenize not found at {binary}")
     return binary
+
+
+def tokenizer_is_usable(path: Path, vocab: int) -> bool:
+    """True when `path` is already a trained artifact of exactly `vocab` tokens.
+
+    Training at 49,152 on a ~50 MB sample is the long pole of the whole sweep, so a re-run
+    (after a `stats` fix, or to re-emit the table) must not pay for it twice. Rebuild with
+    `--retrain`.
+    """
+    if not path.exists():
+        return False
+    try:
+        return len(json.loads(path.read_text())["merges"]) == vocab - BASE_OFFSET
+    except (OSError, ValueError, KeyError):
+        return False
 
 
 def train_tokenizer(binary: Path, corpus: Path, out: Path, vocab: int) -> None:
@@ -196,16 +212,20 @@ def decide(stats: Dict[int, Dict], sizes: List[int]) -> Tuple[str, int]:
     pool = within or survivors or sizes
     winner = min(pool)
 
-    lines.append("**Rule 3 — TypeScript tie-break (>3% better on the TS row):**")
-    ts_best = max(stats[s]["by_lang"]["typescript"]["bytes_per_token"] for s in pool)
-    bumped = [s for s in pool if s > winner
-              and (ts_best - stats[winner]["by_lang"]["typescript"]["bytes_per_token"]) / ts_best > 0.03
-              and stats[s]["by_lang"]["typescript"]["bytes_per_token"] >= ts_best * 0.999]
-    if bumped:
-        lines.append(f"  {winner} is >3% off the best TS row -> promote to {min(bumped)}")
-        winner = min(bumped)
+    lines.append("**Rule 3 — TypeScript tie-break (a larger survivor >3% better on the TS row wins):**")
+    win_ts = stats[winner]["by_lang"]["typescript"]["bytes_per_token"]
+    better = [s for s in pool if s > winner
+              and (stats[s]["by_lang"]["typescript"]["bytes_per_token"] - win_ts) / win_ts > 0.03]
+    for s in pool:
+        if s == winner:
+            continue
+        gain = (stats[s]["by_lang"]["typescript"]["bytes_per_token"] - win_ts) / win_ts
+        lines.append(f"  {s} vs {winner} on TypeScript: {gain * 100:+.2f}%")
+    if better:
+        lines.append(f"  -> promote {winner} to {min(better)} (TypeScript-first program)")
+        winner = min(better)
     else:
-        lines.append(f"  no candidate is >3% better than {winner} on TypeScript -> no change")
+        lines.append(f"  -> no candidate is >3% better than {winner} on TypeScript; no change")
 
     lines.append(f"\n**WINNER: {winner}** "
                  f"(overall {stats[winner]['overall']['bytes_per_token']:.4f} bytes/token)")
@@ -221,6 +241,8 @@ def main() -> int:
     ap.add_argument("--mixture-scale", type=float, default=1.0,
                     help="scale every slice's byte target (keeps all languages)")
     ap.add_argument("--rebuild-sample", action="store_true")
+    ap.add_argument("--retrain", action="store_true",
+                    help="retrain even when a matching tokenizer artifact is cached")
     ap.add_argument("--no-truncate", action="store_true",
                     help="train each vocab size independently (audit path; much slower)")
     ap.add_argument("--sample-only", action="store_true",
@@ -246,12 +268,18 @@ def main() -> int:
     tok_dir.mkdir(parents=True, exist_ok=True)
     tokenizers: Dict[int, Path] = {s: tok_dir / f"vocab-{s}.json" for s in sizes}
 
+    def ensure_trained(size: int) -> None:
+        if not args.retrain and tokenizer_is_usable(tokenizers[size], size):
+            log(f"reusing cached tokenizer {tokenizers[size].name}")
+            return
+        train_tokenizer(binary, corpus, tokenizers[size], size)
+
     if args.no_truncate:
         for s in sizes:
-            train_tokenizer(binary, corpus, tokenizers[s], s)
+            ensure_trained(s)
     else:
         biggest = sizes[-1]
-        train_tokenizer(binary, corpus, tokenizers[biggest], biggest)
+        ensure_trained(biggest)
         for s in sizes[:-1]:
             truncate_tokenizer(tokenizers[biggest], tokenizers[s], s)
 

--- a/scripts/vocab_sweep.py
+++ b/scripts/vocab_sweep.py
@@ -119,7 +119,7 @@ def format_table(stats: Dict[int, Dict], sizes: List[int]) -> str:
     """Markdown bytes/token table: rows = languages then `overall`, columns = vocab sizes."""
     base = sizes[0]
     langs = sorted(stats[base]["by_lang"].keys())
-    cols = "".join(f" {s} |" for s in sizes) + "".join(f" Δ vs {base} |" for s in sizes[1:])
+    cols = "".join(f" {s} |" for s in sizes) + "".join(f" Δ {s} vs {base} |" for s in sizes[1:])
     lines = [f"| Language | bytes |{cols}",
              "|---|---:|" + "---:|" * (2 * len(sizes) - 1)]
 

--- a/scripts/vocab_sweep.py
+++ b/scripts/vocab_sweep.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Sweep the code-BPE vocab size on a multilingual sample and print the bytes/token table (#251).
+
+    .venv/bin/python scripts/vocab_sweep.py [--work-dir ~/monica-data/vocab-sweep-251]
+        [--vocab-sizes 16384,32768,49152] [--threads 64] [--mixture-scale 1.0]
+        [--rebuild-sample] [--no-truncate] [--sample-only] [--tokenize-bin PATH]
+
+Flow: build (or reuse) the tagged sample -> train the BPE **once** at the largest size ->
+derive the smaller sizes by truncating `merges` -> `monica-tokenize stats` per size ->
+bytes/token table (overall + per language) + the sanity checks.
+
+**Why one train and truncate.** `Trainer.train` is greedy with no lookahead, so a k-vocab
+run's merge list is exactly the first k-262 merges of any larger run (262 = 6 specials + 256
+base bytes) — verified empirically on a 2.46 MB corpus and now guarded by `monica-selfcheck`.
+Training once is ~2.5x cheaper than three independent runs on the dominant cost.
+`--no-truncate` trains each size independently and is kept as the audit path.
+
+The sample lives outside the repo (default `~/monica-data/vocab-sweep-251/`) and is cached:
+a re-run costs zero network time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.data.vocab_sample import (  # noqa: E402
+    DEFAULT_MIXTURE, build_sample, resolve_s3, scale_mixture)
+
+#: 6 special tokens + the 256 base bytes precede the merges in the id space.
+BASE_OFFSET = 262
+DEFAULT_WORK_DIR = Path.home() / "monica-data" / "vocab-sweep-251"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def log(msg: str) -> None:
+    print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def resolve_tokenize_bin(explicit: str | None) -> Path:
+    """The **release** binary — every timing this sweep is budgeted against was measured with
+    it, and the debug build is several times slower. Built on demand if absent."""
+    if explicit:
+        return Path(explicit)
+    swift_dir = REPO_ROOT / "swift"
+    binary = swift_dir / ".build" / "release" / "monica-tokenize"
+    if not binary.exists():
+        log("building monica-tokenize (release)...")
+        subprocess.run(["swift", "build", "-c", "release"], cwd=swift_dir, check=True)
+    if not binary.exists():
+        raise SystemExit(f"monica-tokenize not found at {binary}")
+    return binary
+
+
+def train_tokenizer(binary: Path, corpus: Path, out: Path, vocab: int) -> None:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    log(f"training vocab {vocab} on {corpus} ...")
+    t0 = time.time()
+    subprocess.run([str(binary), "train", "--in", str(corpus), "--out", str(out),
+                    "--vocab-size", str(vocab)], check=True)
+    log(f"  trained {vocab} in {time.time() - t0:.0f}s -> {out}")
+
+
+def truncate_tokenizer(src: Path, dst: Path, vocab: int) -> None:
+    """Derive a smaller tokenizer by keeping the first `vocab - 262` merges.
+
+    Fails loudly if the source run produced fewer merges than requested: that means the
+    trainer hit its `pairCounts.isEmpty` break because the sample had too few unique
+    pre-tokens, and the large-vocab number would be an artifact of sample size rather than a
+    measurement of compression.
+    """
+    fmt = json.loads(src.read_text())
+    want = vocab - BASE_OFFSET
+    have = len(fmt["merges"])
+    if have < want:
+        raise SystemExit(
+            f"cannot derive vocab {vocab}: {src.name} has only {have} merges "
+            f"({have + BASE_OFFSET} tokens), fewer than the {want} requested. The sample "
+            f"has too few unique pre-tokens — rebuild it larger rather than reporting this.")
+    fmt["merges"] = fmt["merges"][:want]
+    dst.write_text(json.dumps(fmt))
+    log(f"  truncated -> {dst.name} ({want} merges)")
+
+
+def run_stats(binary: Path, tokenizer: Path, corpus: Path) -> Dict:
+    log(f"stats: {tokenizer.name} ...")
+    t0 = time.time()
+    res = subprocess.run([str(binary), "stats", "--tokenizer", str(tokenizer),
+                          "--in", str(corpus), "--json"],
+                         check=True, capture_output=True, text=True)
+    log(f"  stats {tokenizer.name} in {time.time() - t0:.0f}s")
+    return json.loads(res.stdout)
+
+
+def format_table(stats: Dict[int, Dict], sizes: List[int]) -> str:
+    """Markdown bytes/token table: rows = languages then `overall`, columns = vocab sizes."""
+    base = sizes[0]
+    langs = sorted(stats[base]["by_lang"].keys())
+    cols = "".join(f" {s} |" for s in sizes) + "".join(f" Δ vs {base} |" for s in sizes[1:])
+    lines = [f"| Language | bytes |{cols}",
+             "|---|---:|" + "---:|" * (2 * len(sizes) - 1)]
+
+    def row(name: str, entries: Dict[int, Dict]) -> str:
+        b = entries[base]["bytes"]
+        cells = [f"{entries[s]['bytes_per_token']:.4f}" for s in sizes]
+        best = entries[base]["bytes_per_token"]
+        deltas = [f"{(entries[s]['bytes_per_token'] / best - 1) * 100:+.2f}%" for s in sizes[1:]]
+        return f"| {name} | {b / 1e6:.2f} MB | " + " | ".join(cells + deltas) + " |"
+
+    for lang in langs:
+        lines.append(row(lang, {s: stats[s]["by_lang"][lang] for s in sizes}))
+    lines.append(row("**overall**", {s: stats[s]["overall"] for s in sizes}))
+    return "\n".join(lines)
+
+
+def sanity_checks(stats: Dict[int, Dict], tokenizers: Dict[int, Path],
+                  sizes: List[int]) -> List[str]:
+    """The Step-8 invariants, reported as PASS/FAIL lines. A failure here means a real bug in
+    the truncation or in `stats`, not a surprising measurement."""
+    out: List[str] = []
+    base = sizes[0]
+
+    specials = {s: json.loads(tokenizers[s].read_text())["special_tokens"] for s in sizes}
+    ok = all(specials[s] == specials[base] for s in sizes)
+    out.append(f"{'PASS' if ok else 'FAIL'}: special-token layout identical across vocab sizes")
+
+    ok = all(stats[s]["overall"]["pretokens"] == stats[base]["overall"]["pretokens"]
+             for s in sizes)
+    ok = ok and all(stats[s]["by_lang"][lang]["pretokens"]
+                    == stats[base]["by_lang"][lang]["pretokens"]
+                    for s in sizes for lang in stats[base]["by_lang"])
+    out.append(f"{'PASS' if ok else 'FAIL'}: pre-token counts identical across vocab sizes "
+               f"({stats[base]['overall']['pretokens']} overall)")
+
+    worst = max(stats[s]["overall"]["max_token_id"] for s in sizes)
+    out.append(f"{'PASS' if worst < 65536 else 'FAIL'}: max token id {worst} < 65536 "
+               f"(uint16 packing)")
+
+    violations = []
+    for lang in list(stats[base]["by_lang"]) + ["__overall__"]:
+        def bpt(s: int) -> float:
+            d = stats[s]["overall"] if lang == "__overall__" else stats[s]["by_lang"][lang]
+            return d["bytes_per_token"]
+        for a, b in zip(sizes, sizes[1:]):
+            if bpt(b) < bpt(a) - 1e-9:
+                violations.append(f"{lang}: {a}->{b} {bpt(a):.4f}->{bpt(b):.4f}")
+    out.append(("PASS" if not violations else "FAIL") +
+               ": bytes/token is monotonic non-decreasing in vocab size"
+               + ("" if not violations else " — " + "; ".join(violations)))
+    return out
+
+
+def decide(stats: Dict[int, Dict], sizes: List[int]) -> Tuple[str, int]:
+    """Apply the pre-registered decision rule (written down before the numbers were read).
+
+    1. Reject a candidate more than 3% worse than the best on ANY single language.
+    2. Among survivors, take the SMALLEST vocab within 2% of the best overall bytes/token —
+       vocab is not free: with `d_model 768` and tied embeddings each extra token costs 768
+       params twice over (embedding + output head).
+    3. Tie-break on TypeScript (>3% better on the TS row wins) — the program is TS-first.
+    """
+    langs = list(stats[sizes[0]]["by_lang"])
+    lines = ["**Rule 1 — per-language anti-starvation (reject >3% worse than best on any language):**"]
+    survivors = []
+    for s in sizes:
+        worst_gap = 0.0
+        worst_lang = ""
+        for lang in langs:
+            best = max(stats[t]["by_lang"][lang]["bytes_per_token"] for t in sizes)
+            gap = (best - stats[s]["by_lang"][lang]["bytes_per_token"]) / best
+            if gap > worst_gap:
+                worst_gap, worst_lang = gap, lang
+        keep = worst_gap <= 0.03
+        if keep:
+            survivors.append(s)
+        lines.append(f"  {s}: worst per-language gap {worst_gap * 100:.2f}% "
+                     f"({worst_lang or 'n/a'}) -> {'keep' if keep else 'REJECT'}")
+
+    best_overall = max(stats[s]["overall"]["bytes_per_token"] for s in sizes)
+    lines.append("**Rule 2 — smallest survivor within 2% of the best overall bytes/token:**")
+    within = []
+    for s in survivors:
+        gap = (best_overall - stats[s]["overall"]["bytes_per_token"]) / best_overall
+        ok = gap <= 0.02
+        if ok:
+            within.append(s)
+        lines.append(f"  {s}: overall {stats[s]['overall']['bytes_per_token']:.4f} B/tok, "
+                     f"{gap * 100:.2f}% off best -> {'within 2%' if ok else 'outside 2%'}")
+    pool = within or survivors or sizes
+    winner = min(pool)
+
+    lines.append("**Rule 3 — TypeScript tie-break (>3% better on the TS row):**")
+    ts_best = max(stats[s]["by_lang"]["typescript"]["bytes_per_token"] for s in pool)
+    bumped = [s for s in pool if s > winner
+              and (ts_best - stats[winner]["by_lang"]["typescript"]["bytes_per_token"]) / ts_best > 0.03
+              and stats[s]["by_lang"]["typescript"]["bytes_per_token"] >= ts_best * 0.999]
+    if bumped:
+        lines.append(f"  {winner} is >3% off the best TS row -> promote to {min(bumped)}")
+        winner = min(bumped)
+    else:
+        lines.append(f"  no candidate is >3% better than {winner} on TypeScript -> no change")
+
+    lines.append(f"\n**WINNER: {winner}** "
+                 f"(overall {stats[winner]['overall']['bytes_per_token']:.4f} bytes/token)")
+    return "\n".join(lines), winner
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--work-dir", type=Path, default=DEFAULT_WORK_DIR)
+    ap.add_argument("--vocab-sizes", default="16384,32768,49152")
+    ap.add_argument("--threads", type=int, default=64)
+    ap.add_argument("--mixture-scale", type=float, default=1.0,
+                    help="scale every slice's byte target (keeps all languages)")
+    ap.add_argument("--rebuild-sample", action="store_true")
+    ap.add_argument("--no-truncate", action="store_true",
+                    help="train each vocab size independently (audit path; much slower)")
+    ap.add_argument("--sample-only", action="store_true",
+                    help="build the sample and stop (the network-bound half)")
+    ap.add_argument("--tokenize-bin", default=None)
+    args = ap.parse_args()
+
+    sizes = sorted(int(x) for x in args.vocab_sizes.split(","))
+    work_dir = args.work_dir.expanduser()
+
+    mixture = scale_mixture(DEFAULT_MIXTURE, args.mixture_scale)
+    s3 = resolve_s3()
+    if s3 is None:
+        log("warning: no boto3/S3 client — only a cached sample can be used")
+    log(f"work dir: {work_dir}")
+    corpus = build_sample(work_dir, mixture=mixture, threads=args.threads, s3_client=s3,
+                          rebuild=args.rebuild_sample, log=log)
+    if args.sample_only:
+        return 0
+
+    binary = resolve_tokenize_bin(args.tokenize_bin)
+    tok_dir = work_dir / "tok"
+    tok_dir.mkdir(parents=True, exist_ok=True)
+    tokenizers: Dict[int, Path] = {s: tok_dir / f"vocab-{s}.json" for s in sizes}
+
+    if args.no_truncate:
+        for s in sizes:
+            train_tokenizer(binary, corpus, tokenizers[s], s)
+    else:
+        biggest = sizes[-1]
+        train_tokenizer(binary, corpus, tokenizers[biggest], biggest)
+        for s in sizes[:-1]:
+            truncate_tokenizer(tokenizers[biggest], tokenizers[s], s)
+
+    results_dir = work_dir / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    stats: Dict[int, Dict] = {}
+    for s in sizes:
+        stats[s] = run_stats(binary, tokenizers[s], corpus)
+        (results_dir / f"stats-{s}.json").write_text(json.dumps(stats[s], indent=2) + "\n")
+
+    table = format_table(stats, sizes)
+    checks = sanity_checks(stats, tokenizers, sizes)
+    rule, winner = decide(stats, sizes)
+
+    body = "\n\n".join(["## bytes/token", table, "## sanity checks",
+                        "\n".join(f"- {c}" for c in checks), "## decision rule", rule])
+    (results_dir / "table.md").write_text(body + "\n")
+    print("\n" + body + "\n")
+    log(f"wrote {results_dir / 'table.md'}")
+    return 0 if all(c.startswith("PASS") for c in checks) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/data/stack_v2.py
+++ b/src/data/stack_v2.py
@@ -65,13 +65,17 @@ def download_contents(blob_id: str, src_encoding: str, *, s3_client,
     return body.decode(src_encoding)
 
 
-def _row_to_record(row: Dict[str, Any], content: str) -> Record:
+def _row_to_record(row: Dict[str, Any], content: str, *, lang: str = "typescript") -> Record:
     """Map an HF Stack v2 metadata row + its resolved content to the common corpus schema.
 
     ``detected_licenses`` on Stack v2 is a list (a file can carry more than one detected
     license); we keep the first entry as the record's license — good enough for the
     permissive-only gate downstream, which only needs to know the file is *unambiguously*
-    permissive to keep it."""
+    permissive to keep it.
+
+    ``lang`` is keyword-only with the TypeScript default this module was written for: the
+    corpus is multilingual since #198, so a caller passing a non-TypeScript ``config=`` must
+    be able to tag the records correctly (#251) — but existing callers stay unchanged."""
     licenses = row.get("detected_licenses") or row.get("license") or []
     if isinstance(licenses, str):
         license_value = licenses
@@ -82,7 +86,7 @@ def _row_to_record(row: Dict[str, Any], content: str) -> Record:
     return Record(
         text=content,
         source="stack-v2",
-        lang="typescript",
+        lang=lang,
         license=normalize_license(license_value),
         meta={
             "is_code": True,
@@ -95,6 +99,7 @@ def _row_to_record(row: Dict[str, Any], content: str) -> Record:
 
 def iter_stack_v2_ts(*, limit: int = -1, streaming: bool = True, s3_client=None,
                       dataset: str = "bigcode/the-stack-v2-dedup", config: str = "TypeScript",
+                      lang: str = "typescript",
                       rows: Optional[Iterable[Dict[str, Any]]] = None) -> Iterator[Record]:
     """Stream permissively-licensed TypeScript ``Record``s from Stack v2.
 
@@ -128,7 +133,7 @@ def iter_stack_v2_ts(*, limit: int = -1, streaming: bool = True, s3_client=None,
             break
         content = download_contents(row["blob_id"], row.get("src_encoding") or "utf-8",
                                      s3_client=s3_client)
-        record = _row_to_record(row, content)
+        record = _row_to_record(row, content, lang=lang)
         if not license_ok(record):
             continue
         n += 1

--- a/src/data/stack_v2.py
+++ b/src/data/stack_v2.py
@@ -101,7 +101,13 @@ def iter_stack_v2_ts(*, limit: int = -1, streaming: bool = True, s3_client=None,
                       dataset: str = "bigcode/the-stack-v2-dedup", config: str = "TypeScript",
                       lang: str = "typescript",
                       rows: Optional[Iterable[Dict[str, Any]]] = None) -> Iterator[Record]:
-    """Stream permissively-licensed TypeScript ``Record``s from Stack v2.
+    """Stream permissively-licensed ``Record``s from one Stack v2 language config.
+
+    Despite the ``_ts`` name (its original TypeScript-only scope), ``config`` (the HF
+    language config, e.g. ``"Python"``) and ``lang`` (the tag stamped onto emitted
+    ``Record``s, see #251's rescope to multilingual Essential-Web + Stack-v2) make this
+    multilingual — the defaults (``config="TypeScript"``, ``lang="typescript"``) just
+    keep the historical TypeScript behavior for callers that pass neither.
 
     Resolves each metadata row's file content from Software Heritage via ``s3_client``
     (defaulting to ``resolve_swh_s3()`` when not given) and applies the corpus's
@@ -114,7 +120,16 @@ def iter_stack_v2_ts(*, limit: int = -1, streaming: bool = True, s3_client=None,
     is omitted, ``datasets.load_dataset(dataset, config, split="train",
     streaming=streaming)`` supplies the metadata rows and a resolvable ``s3_client`` (real
     creds) is required.
+
+    Raises ``ValueError`` when ``config`` is overridden to a non-TypeScript language but
+    ``lang`` is left at its ``"typescript"`` default — that combination would silently
+    mislabel every emitted ``Record`` with the wrong language tag.
     """
+    if config != "TypeScript" and lang == "typescript":
+        raise ValueError(
+            f"config={config!r} but lang is still the \"typescript\" default — pass "
+            f"lang= explicitly (e.g. lang={config.lower()!r}) so records aren't mislabeled")
+
     if rows is None:
         from datasets import load_dataset
 

--- a/src/data/vocab_sample.py
+++ b/src/data/vocab_sample.py
@@ -1,0 +1,368 @@
+"""Build the tagged multilingual text sample the vocab-size sweep measures on (#251).
+
+`DEFAULT_VOCAB_SIZE = 16384` was sized when #193 was scoped TypeScript-only; #198 rescoped
+the corpus to general multilingual Essential-Web + Stack-v2. Re-deriving the vocab needs a
+sample drawn from the *rescoped* distribution — prose plus several code languages, each
+document tagged with its language so the sweep can report a per-language bytes/token
+breakdown (the issue's acceptance criterion).
+
+Three things here are not obvious and are load-bearing (all measured, see the #251 plan):
+
+* **`datasets.load_dataset()` is unusable on Essential-Web** — the repo holds 99,896 parquet
+  files and streaming init does not yield a first row in 7+ minutes. We open a *single*
+  parquet file directly through the `hf://` filesystem instead (~2.5 s to open, ~8 MB/s).
+  The same trick serves Stack-v2's metadata.
+* **Stack-v2 carries metadata only** — content lives in Software Heritage's S3 bucket keyed
+  by ``blob_id`` (see ``stack_v2.download_contents``). Serial fetching runs at 0.03 MB/s and
+  is infeasible; a 64-thread pool reaches 1.9 MB/s, which is what makes this job finish.
+* **``detected_licenses`` is empty on ~67% of Stack-v2 rows** and the corpus's permissive
+  gate rejects an empty license for code. The license/vendor/generated/size filter therefore
+  runs on the *metadata columns*, before any S3 GET — otherwise two thirds of the fetch is
+  thrown away.
+
+ABOVE THE SEAM — no ``mlx``/``torch``. ``pyarrow``, ``fsspec`` and ``boto3`` are imported
+LAZILY inside functions (the ``stack_v2`` idiom), so importing this module needs none of them
+(guarded by ``tests/test_import_guard.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Sequence
+
+from .filters import is_permissive
+from .stack_v2 import download_contents
+
+#: HF repo paths. Opened file-by-file rather than through ``load_dataset`` (see module docstring).
+ESSENTIAL_WEB_REPO = "datasets/EssentialAI/essential-web-v1.0"
+ESSENTIAL_WEB_DIR = f"{ESSENTIAL_WEB_REPO}/data/crawl=CC-MAIN-2013-20"
+STACK_V2_REPO = "datasets/bigcode/the-stack-v2-dedup"
+
+#: Metadata pre-filter bounds. Below ``MIN_FILE_BYTES`` a file is mostly a stub/licence header
+#: and contributes little vocabulary; above ``MAX_FILE_BYTES`` it is usually generated or data,
+#: and one document would dominate a language's byte budget.
+MIN_FILE_BYTES = 1024
+MAX_FILE_BYTES = 131072
+
+
+@dataclass(frozen=True)
+class SliceSpec:
+    """One language slice of the sample: where to read it and how many raw UTF-8 bytes to take.
+
+    ``kind`` is ``"essential_web"`` (prose, public, read straight from parquet) or
+    ``"stack_v2"`` (code metadata + a Software Heritage content fetch). ``source`` is the
+    Stack-v2 language directory name for code slices, unused for prose.
+    """
+
+    lang: str
+    kind: str
+    target_bytes: int
+    source: str = ""
+
+
+#: The mixture. No blend weights are locked anywhere in the repo (checked doc 13 and #193), so
+#: the sweep picks one and *records* it in the manifest. TypeScript is deliberately
+#: over-weighted — the program is TypeScript-first. NOTE the per-language rows of the results
+#: table are blend-independent (a language's bytes/token is computed only over its own
+#: documents); only the "overall" row is blend-weighted.
+DEFAULT_MIXTURE: List[SliceSpec] = [
+    SliceSpec("en", "essential_web", 20 * 1024 * 1024),
+    SliceSpec("typescript", "stack_v2", 8 * 1024 * 1024, "TypeScript"),
+    SliceSpec("python", "stack_v2", 4 * 1024 * 1024, "Python"),
+    SliceSpec("javascript", "stack_v2", 4 * 1024 * 1024, "JavaScript"),
+    SliceSpec("java", "stack_v2", 3 * 1024 * 1024, "Java"),
+    SliceSpec("go", "stack_v2", 2 * 1024 * 1024, "Go"),
+    SliceSpec("rust", "stack_v2", 2 * 1024 * 1024, "Rust"),
+    SliceSpec("cpp", "stack_v2", 2 * 1024 * 1024, "C++"),
+    SliceSpec("markdown", "stack_v2", 2 * 1024 * 1024, "Markdown"),
+]
+
+
+def scale_mixture(mixture: Sequence[SliceSpec], scale: float) -> List[SliceSpec]:
+    """Scale every slice's byte target by ``scale``, keeping every language.
+
+    The escape hatch for a slow ingest: halving the targets still clears ~200k unique
+    pre-tokens (4x the largest vocab swept), so the tail merges stay meaningful. Dropping
+    *languages* would not be an acceptable trade — the per-language breakdown is the
+    deliverable.
+    """
+    if scale <= 0:
+        raise ValueError(f"scale must be positive, got {scale}")
+    return [SliceSpec(s.lang, s.kind, max(1, int(s.target_bytes * scale)), s.source)
+            for s in mixture]
+
+
+# --------------------------------------------------------------------------- metadata filter
+
+
+def metadata_ok(row: Dict[str, Any], *, min_bytes: int = MIN_FILE_BYTES,
+                max_bytes: int = MAX_FILE_BYTES) -> bool:
+    """Decide from Stack-v2 *metadata columns alone* whether a row is worth fetching.
+
+    Applied before any S3 GET (finding 4 of the #251 plan: ~67% of rows have an empty
+    ``detected_licenses`` and would be dropped by the permissive gate after being paid for).
+    Skipping vendored/generated files matters specifically for a *vocab* measurement —
+    minified bundles teach garbage merges and distort bytes/token upward.
+    """
+    licenses = row.get("detected_licenses") or []
+    if isinstance(licenses, str):
+        licenses = [licenses]
+    if not licenses or not is_permissive(licenses[0]):
+        return False
+    if row.get("is_vendor") or row.get("is_generated"):
+        return False
+    n = row.get("length_bytes")
+    if n is None or not (min_bytes <= n <= max_bytes):
+        return False
+    return bool(row.get("blob_id"))
+
+
+# --------------------------------------------------------------------------- parquet readers
+
+
+def _hf_parquet(path: str):
+    """Open one HF-hosted parquet file directly (bypassing ``datasets``; see module docstring)."""
+    import fsspec
+    import pyarrow.parquet as pq
+
+    return pq.ParquetFile(fsspec.filesystem("hf").open(path))
+
+
+def _list_parquet(directory: str) -> List[str]:
+    """Sorted parquet shard paths under an HF repo directory — a fixed, reproducible order."""
+    import fsspec
+
+    fs = fsspec.filesystem("hf")
+    return sorted(p for p in fs.ls(directory, detail=False) if p.endswith(".parquet"))
+
+
+def iter_essential_web(target_bytes: int, *, files: Optional[Sequence[str]] = None,
+                       batch_rows: int = 1000,
+                       open_parquet: Optional[Callable[[str], Any]] = None,
+                       ) -> Iterator[str]:
+    """Yield Essential-Web documents in parquet row order until ``target_bytes`` is reached.
+
+    ``files`` defaults to the first shards of one crawl; ``open_parquet`` is injected by tests.
+    Row order from a fixed starting file makes the sample reproducible.
+    """
+    opener = open_parquet or _hf_parquet
+    paths = list(files) if files else [
+        f"{ESSENTIAL_WEB_DIR}/train-{i:05d}-of-04233.parquet" for i in range(4)]
+    total = 0
+    for path in paths:
+        if total >= target_bytes:
+            return
+        pf = opener(path)
+        for batch in pf.iter_batches(batch_size=batch_rows, columns=["text"]):
+            for text in batch.column("text").to_pylist():
+                if not text:
+                    continue
+                total += len(text.encode("utf-8"))
+                yield text
+                if total >= target_bytes:
+                    return
+
+
+def iter_stack_v2_metadata(lang_dir: str, *, batch_rows: int = 2000,
+                           files: Optional[Sequence[str]] = None,
+                           open_parquet: Optional[Callable[[str], Any]] = None,
+                           list_parquet: Optional[Callable[[str], List[str]]] = None,
+                           ) -> Iterator[Dict[str, Any]]:
+    """Yield metadata rows for one Stack-v2 language that pass ``metadata_ok``, in row order."""
+    opener = open_parquet or _hf_parquet
+    lister = list_parquet or _list_parquet
+    paths = list(files) if files else lister(f"{STACK_V2_REPO}/data/{lang_dir}")
+    columns = ["blob_id", "src_encoding", "detected_licenses", "length_bytes",
+               "is_vendor", "is_generated", "path", "repo_name"]
+    for path in paths:
+        pf = opener(path)
+        for batch in pf.iter_batches(batch_size=batch_rows, columns=columns):
+            for row in batch.to_pylist():
+                if metadata_ok(row):
+                    row["_parquet"] = path
+                    yield row
+
+
+# --------------------------------------------------------------------------- threaded fetch
+
+
+@dataclass
+class FetchStats:
+    """Per-slice fetch accounting, recorded in the manifest so the sample is auditable."""
+
+    fetched: int = 0
+    failed: int = 0
+    bytes: int = 0
+    parquet_files: List[str] = field(default_factory=list)
+
+
+def fetch_contents(rows: Iterable[Dict[str, Any]], target_bytes: int, *, s3_client,
+                   threads: int = 64, stats: Optional[FetchStats] = None,
+                   chunk: int = 512) -> Iterator[str]:
+    """Fetch Software Heritage content for ``rows`` concurrently until ``target_bytes``.
+
+    Serial fetching measures 0.03 MB/s against SWH — the pool is not an optimization, it is
+    what makes the job finish (1.9 MB/s at 64 threads). Rows are submitted in chunks so a
+    long metadata stream is not materialized, and results are consumed in submission order so
+    the sample stays deterministic given the same metadata order. Decode/fetch failures are
+    counted and skipped, never fatal: a handful of unreadable blobs must not lose the run.
+    """
+    st = stats if stats is not None else FetchStats()
+    if target_bytes <= 0:
+        return
+    seen_files: set = set()
+
+    def _one(row: Dict[str, Any]) -> Optional[str]:
+        try:
+            return download_contents(row["blob_id"], row.get("src_encoding") or "utf-8",
+                                     s3_client=s3_client)
+        except Exception:
+            return None
+
+    with ThreadPoolExecutor(max_workers=threads) as pool:
+
+        def _drain(batch: List[Dict[str, Any]]) -> Iterator[str]:
+            """Fetch one chunk in parallel, yielding in submission order (determinism)."""
+            for text, src in zip(pool.map(_one, batch), batch):
+                path = src.get("_parquet")
+                if path and path not in seen_files:
+                    seen_files.add(path)
+                    st.parquet_files.append(path)
+                if text is None:
+                    st.failed += 1
+                    continue
+                st.fetched += 1
+                st.bytes += len(text.encode("utf-8"))
+                yield text
+                if st.bytes >= target_bytes:
+                    return
+
+        batch: List[Dict[str, Any]] = []
+        for row in rows:
+            batch.append(row)
+            if len(batch) < chunk:
+                continue
+            yield from _drain(batch)
+            batch = []
+            if st.bytes >= target_bytes:
+                return
+        if batch:
+            yield from _drain(batch)
+
+
+# --------------------------------------------------------------------------- sample assembly
+
+
+def _manifest_matches(manifest: Dict[str, Any], mixture: Sequence[SliceSpec]) -> bool:
+    """True when a cached manifest was built from exactly this mixture (same langs + targets)."""
+    want = {s.lang: s.target_bytes for s in mixture}
+    got = {k: v.get("target_bytes") for k, v in (manifest.get("slices") or {}).items()}
+    return want == got
+
+
+def build_sample(work_dir: Path, *, mixture: Sequence[SliceSpec] = tuple(DEFAULT_MIXTURE),
+                 threads: int = 64, s3_client=None, rebuild: bool = False,
+                 log: Callable[[str], None] = print) -> Path:
+    """Build (or reuse) ``<work_dir>/sample/sample.jsonl`` — ``{"text", "lang"}`` rows.
+
+    Reuse is the important resilience property: a re-run of the sweep after a `stats` bug
+    costs zero network time. A cached sample is reused whenever its manifest records the same
+    mixture, unless ``rebuild``.
+    """
+    sample_dir = Path(work_dir) / "sample"
+    out_path = sample_dir / "sample.jsonl"
+    manifest_path = sample_dir / "manifest.json"
+    if not rebuild and out_path.exists() and manifest_path.exists():
+        try:
+            cached = json.loads(manifest_path.read_text())
+        except (OSError, ValueError):
+            cached = {}
+        if _manifest_matches(cached, mixture):
+            log(f"reusing cached sample: {out_path} "
+                f"({cached.get('total_bytes', 0) / 1e6:.1f} MB, "
+                f"{cached.get('total_docs', 0)} docs)")
+            return out_path
+
+    sample_dir.mkdir(parents=True, exist_ok=True)
+    slices: Dict[str, Any] = {}
+    total_docs = 0
+    total_bytes = 0
+    started = time.time()
+
+    with out_path.open("w", encoding="utf-8") as fh:
+        for spec in mixture:
+            t0 = time.time()
+            stats = FetchStats()
+            docs = 0
+            written = 0
+            if spec.kind == "essential_web":
+                texts: Iterable[str] = iter_essential_web(spec.target_bytes)
+            elif spec.kind == "stack_v2":
+                if s3_client is None:
+                    raise RuntimeError(
+                        "a Software Heritage S3 client is required for stack_v2 slices — "
+                        "run with AWS_PROFILE=monica-swh, or pass s3_client=")
+                texts = fetch_contents(iter_stack_v2_metadata(spec.source), spec.target_bytes,
+                                       s3_client=s3_client, threads=threads, stats=stats)
+            else:
+                raise ValueError(f"unknown slice kind {spec.kind!r}")
+            for text in texts:
+                fh.write(json.dumps({"text": text, "lang": spec.lang},
+                                    ensure_ascii=False) + "\n")
+                docs += 1
+                written += len(text.encode("utf-8"))
+            slices[spec.lang] = {
+                "kind": spec.kind,
+                "source": spec.source,
+                "target_bytes": spec.target_bytes,
+                "bytes": written,
+                "docs": docs,
+                "fetch_failed": stats.failed,
+                "parquet_files": stats.parquet_files,
+                "seconds": round(time.time() - t0, 1),
+            }
+            total_docs += docs
+            total_bytes += written
+            log(f"  {spec.lang:<11} {written / 1e6:6.2f} MB  {docs:6d} docs  "
+                f"{time.time() - t0:6.1f}s"
+                + (f"  ({stats.failed} fetch failures)" if stats.failed else ""))
+
+    manifest = {
+        "built_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "seconds": round(time.time() - started, 1),
+        "threads": threads,
+        "filters": {"min_file_bytes": MIN_FILE_BYTES, "max_file_bytes": MAX_FILE_BYTES,
+                    "permissive_license_required": True,
+                    "skip_vendor": True, "skip_generated": True},
+        "total_docs": total_docs,
+        "total_bytes": total_bytes,
+        "slices": slices,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    log(f"sample: {total_bytes / 1e6:.1f} MB, {total_docs} docs -> {out_path}")
+    return out_path
+
+
+def resolve_s3():
+    """A pooled boto3 S3 client sized for the fetch pool, or ``None`` when unavailable.
+
+    Distinct from ``stack_v2.resolve_swh_s3`` (which builds an unpooled default client and
+    requires the key env vars): here the credentials usually come from ``AWS_PROFILE``, and
+    the connection pool must be at least as large as the thread pool or boto3 serializes the
+    requests it was given threads to parallelize.
+    """
+    try:
+        import boto3
+        from botocore.config import Config
+    except ImportError:
+        return None
+    try:
+        return boto3.client("s3", config=Config(max_pool_connections=96,
+                                                retries={"max_attempts": 5,
+                                                         "mode": "adaptive"}))
+    except Exception:
+        return None

--- a/src/data/vocab_sample.py
+++ b/src/data/vocab_sample.py
@@ -226,8 +226,16 @@ def fetch_contents(rows: Iterable[Dict[str, Any]], target_bytes: int, *, s3_clie
     with ThreadPoolExecutor(max_workers=threads) as pool:
 
         def _drain(batch: List[Dict[str, Any]]) -> Iterator[str]:
-            """Fetch one chunk in parallel, yielding in submission order (determinism)."""
-            for text, src in zip(pool.map(_one, batch), batch):
+            """Fetch one chunk in parallel, yielding in submission order (determinism).
+
+            Rows are submitted as individual futures (not ``pool.map``, which blocks until
+            every future in the chunk is done) so that once ``target_bytes`` is crossed
+            mid-chunk, futures that haven't started running yet can be cancelled instead of
+            paying for the rest of the chunk (up to ``chunk`` wasted S3 fetches otherwise).
+            """
+            futures = [pool.submit(_one, row) for row in batch]
+            for future, src in zip(futures, batch):
+                text = future.result()
                 path = src.get("_parquet")
                 if path and path not in seen_files:
                     seen_files.add(path)
@@ -239,6 +247,8 @@ def fetch_contents(rows: Iterable[Dict[str, Any]], target_bytes: int, *, s3_clie
                 st.bytes += len(text.encode("utf-8"))
                 yield text
                 if st.bytes >= target_bytes:
+                    for f in futures:
+                        f.cancel()
                     return
 
         batch: List[Dict[str, Any]] = []
@@ -258,9 +268,18 @@ def fetch_contents(rows: Iterable[Dict[str, Any]], target_bytes: int, *, s3_clie
 
 
 def _manifest_matches(manifest: Dict[str, Any], mixture: Sequence[SliceSpec]) -> bool:
-    """True when a cached manifest was built from exactly this mixture (same langs + targets)."""
-    want = {s.lang: s.target_bytes for s in mixture}
-    got = {k: v.get("target_bytes") for k, v in (manifest.get("slices") or {}).items()}
+    """True when a cached manifest was built from exactly this mixture.
+
+    Compares ``(kind, source, target_bytes)`` per language, not just the byte target —
+    two slices can share a language tag and byte budget while reading different sources
+    (e.g. a `stack_v2` slice re-tagged from a different language directory, or a slice
+    whose `kind` changed between `essential_web` and `stack_v2`), and reusing that cache
+    would silently invalidate a sweep rerun. ``build_sample`` already writes `kind` and
+    `source` into each manifest slice, so no manifest format change is needed here.
+    """
+    want = {s.lang: (s.kind, s.source, s.target_bytes) for s in mixture}
+    got = {k: (v.get("kind"), v.get("source"), v.get("target_bytes"))
+           for k, v in (manifest.get("slices") or {}).items()}
     return want == got
 
 

--- a/swift/Sources/MonicaTokenizer/BPE.swift
+++ b/swift/Sources/MonicaTokenizer/BPE.swift
@@ -16,7 +16,7 @@ public final class BPE: @unchecked Sendable {   // immutable after init → safe
     public let vocabSize: Int
 
     /// Pack an ordered id pair into one `UInt64` key. Token ids must fit in `UInt32`; the code
-    /// tokenizer's vocab is ≤ 16384 (uint16-packable, #191) — far within that bound.
+    /// tokenizer's vocab is ≤ 65536 (the uint16 packing cap, #191/#251) — far within that bound.
     @inline(__always)
     public static func key(_ a: Int, _ b: Int) -> UInt64 {
         (UInt64(UInt32(a)) << 32) | UInt64(UInt32(b))

--- a/swift/Sources/monica-selfcheck/main.swift
+++ b/swift/Sources/monica-selfcheck/main.swift
@@ -43,6 +43,53 @@ do {
     check(vocab <= 65536, "vocab is uint16-packable (\(vocab) <= 65536)")
 }
 
+// MARK: vocab-size invariants (#251)
+//
+// The vocab sweep trains ONCE at the largest size and derives the smaller ones by truncating
+// `merges`. That is only sound because `Trainer.train` is greedy with no lookahead, which makes
+// a k-vocab merge list a strict prefix of any larger run's. Without a guard that is an
+// undocumented assumption a future trainer optimization could silently break, invalidating the
+// ratified vocab size.
+
+do {
+    // Calibrate off what this corpus can actually produce: `Trainer.train` stops early once no
+    // pair repeats, so a hard-coded small size could silently become vacuous (both runs
+    // exhausting at the same merge count would make the prefix check trivially true). Asking
+    // for exactly half of the big run's merges keeps the check non-vacuous by construction.
+    let big = trained(2000)
+    let half = big.merges.count / 2
+    check(half > 0, "corpus produces enough merges to test the prefix invariant")
+    let small = trained(SPECIALS.count + 256 + half)
+    eq(small.merges.count, half, "smaller run produces exactly the requested merge count")
+    eq(small.merges, Array(big.merges.prefix(half)),
+       "merges of a smaller vocab are a strict prefix of a larger one's")
+
+    // A truncated artifact must still be a *valid* artifact — merge m's parents are all
+    // < baseOffset + m, so prefixes are self-contained. The sweep writes these to disk.
+    let truncated = TokenizerFormat(specialTokens: big.specialTokens, digitGroup: big.digitGroup,
+                                    merges: Array(big.merges.prefix(half)))
+    do { try truncated.validate() } catch { failures.append("truncated format rejected: \(error)") }
+
+    // Special-token layout is vocab-independent: `baseOffset = specialCount + 256`, so the
+    // FIM sentinels keep their ids at every vocab size. True by construction — verified, not
+    // assumed, because the sweep compares token streams across sizes.
+    eq(small.specialTokens, big.specialTokens, "special tokens identical across vocab sizes")
+    let fimProbe = "<|fim_prefix|>x<|fim_suffix|>y<|fim_middle|>"
+    let smallIds = Tokenizer(format: small).encode(fimProbe)
+    let bigIds = Tokenizer(format: big).encode(fimProbe)
+    eq(smallIds.filter { $0 < SPECIALS.count }, [1, 3, 2], "FIM sentinel ids are 1,3,2")
+    eq(smallIds.filter { $0 < SPECIALS.count }, bigIds.filter { $0 < SPECIALS.count },
+       "FIM sentinel ids identical across vocab sizes")
+
+    // Pretokenization never sees the merges, so pre-token counts are a vocab-independent
+    // control in the sweep's per-language table.
+    for s in ["const x = 1234567;", "  indented\tline", "function f(a: number) {}"] {
+        eq(Pretokenizer.pretokenize(s, digitGroup: small.digitGroup).count,
+           Pretokenizer.pretokenize(s, digitGroup: big.digitGroup).count,
+           "pre-token count is vocab-independent")
+    }
+}
+
 // MARK: format validation (a corrupt artifact must fail with an actionable error, not crash)
 
 do {

--- a/swift/Sources/monica-tokenize/main.swift
+++ b/swift/Sources/monica-tokenize/main.swift
@@ -1,6 +1,6 @@
 // monica-tokenize — native CLI for the Monica code tokenizer.
 //
-//   monica-tokenize train  --in <corpus> --out <tokenizer.json> [--vocab-size 16384]
+//   monica-tokenize train  --in <corpus> --out <tokenizer.json> [--vocab-size 49152]
 //   monica-tokenize encode --tokenizer <tokenizer.json> [--in <file>] [--json]
 //   monica-tokenize decode --tokenizer <tokenizer.json> [--in <file>]
 //   monica-tokenize pack   --tokenizer <tokenizer.json> --in <parquet|jsonl|txt|dir> --out <dir>
@@ -21,7 +21,10 @@ let SPECIAL_TOKENS = [
     "<|endoftext|>", "<|fim_prefix|>", "<|fim_middle|>",
     "<|fim_suffix|>", "<|fim_pad|>", "<mask>",
 ]
-let DEFAULT_VOCAB_SIZE = 16384
+// Ratified 2026-08-04 by the #251 sweep (see docs/design/13-code-model-moe.md). 16384 was sized
+// when #193 was scoped TypeScript-only; on the #198 multilingual corpus it costs 7.6% of overall
+// compression and 11.4% on Markdown against 49152. Still under the 65536 uint16 packing cap.
+let DEFAULT_VOCAB_SIZE = 49152
 let DEFAULT_DIGIT_GROUP = 3
 
 func fail(_ msg: String) -> Never {

--- a/swift/Sources/monica-tokenize/main.swift
+++ b/swift/Sources/monica-tokenize/main.swift
@@ -5,6 +5,7 @@
 //   monica-tokenize decode --tokenizer <tokenizer.json> [--in <file>]
 //   monica-tokenize pack   --tokenizer <tokenizer.json> --in <parquet|jsonl|txt|dir> --out <dir>
 //                          [--seq-len 8192] [--shard-size-mb 512] [--chunk-align N]
+//   monica-tokenize stats  --tokenizer <tokenizer.json> --in <jsonl> [--json]
 //
 // `--in` reads stdin when omitted (encode/decode). `train`/`pack` corpus = a `.parquet` file or
 // a directory of `.parquet` shards (reads the `text` column directly, #247 — only
@@ -221,11 +222,125 @@ func cmdPack(_ flags: [String: String]) {
     } catch { fail("pack: \(error)") }
 }
 
+// MARK: - stats
+
+/// One language's accumulated measurement. `bytes` is raw UTF-8 in, `tokens` is what `pack`
+/// would actually write (encode + the appended EOS), so bytes/token is the real packed ratio
+/// rather than an idealized encode.
+struct LangStats {
+    var docs = 0
+    var bytes = 0
+    var tokens = 0
+    var pretokens = 0
+    var maxTokenId = 0
+
+    mutating func add(bytes b: Int, ids: [Int], pretokens p: Int) {
+        docs += 1
+        bytes += b
+        tokens += ids.count + 1        // + EOS, matching cmdPack
+        pretokens += p
+        for id in ids where id > maxTokenId { maxTokenId = id }
+    }
+
+    var json: [String: Any] {
+        ["docs": docs, "bytes": bytes, "tokens": tokens, "pretokens": pretokens,
+         "max_token_id": maxTokenId,
+         "bytes_per_token": tokens > 0 ? Double(bytes) / Double(tokens) : 0]
+    }
+}
+
+/// Read `{"text": ..., "lang": ...}` JSONL for `stats`. Deliberately separate from `readDocs`:
+/// `train`/`pack` depend on that function's exact behavior, and `stats` needs the language tag
+/// it discards. Rows without a `lang` land in "untagged" rather than being dropped silently.
+func readTaggedDocs(_ path: String) -> [(text: String, lang: String)] {
+    guard let content = try? String(contentsOfFile: path, encoding: .utf8) else {
+        fail("stats: cannot read --in file \(path)")
+    }
+    var docs: [(text: String, lang: String)] = []
+    var skipped = 0
+    for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
+        guard let d = line.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
+              let text = obj["text"] as? String else { skipped += 1; continue }
+        docs.append((text, (obj["lang"] as? String) ?? "untagged"))
+    }
+    if skipped > 0 { warn("skipped \(skipped) malformed/text-less JSONL line(s) in \(path)") }
+    return docs
+}
+
+/// Pre-token counts, computed with the same bounded-concurrency shape as `batchEncode`.
+/// `Pretokenizer` never sees the merges, so this number must be identical across vocab sizes —
+/// which is exactly why the sweep measures it (a mismatch means something real broke).
+func pretokenCounts(_ docs: [String], digitGroup: Int) async -> [Int] {
+    var out = [Int](repeating: 0, count: docs.count)
+    let limit = max(1, ProcessInfo.processInfo.activeProcessorCount)
+    await withTaskGroup(of: (Int, Int).self) { group in
+        var next = 0
+        while next < docs.count && next < limit {
+            let i = next
+            group.addTask { (i, Pretokenizer.pretokenize(docs[i], digitGroup: digitGroup).count) }
+            next += 1
+        }
+        for await (i, n) in group {
+            out[i] = n
+            if next < docs.count {
+                let j = next
+                group.addTask { (j, Pretokenizer.pretokenize(docs[j], digitGroup: digitGroup).count) }
+                next += 1
+            }
+        }
+    }
+    return out
+}
+
+func cmdStats(_ flags: [String: String]) async {
+    let tok = loadTokenizer(flags)
+    guard let inPath = flags["in"] else { fail("stats: --in <jsonl> is required") }
+    let tagged = readTaggedDocs(inPath)
+    if tagged.isEmpty { fail("stats: no documents read from \(inPath)") }
+
+    let texts = tagged.map { $0.text }
+    let idsPerDoc = await tok.batchEncode(texts)
+    let pretoks = await pretokenCounts(texts, digitGroup: tok.digitGroup)
+
+    var byLang: [String: LangStats] = [:]
+    var overall = LangStats()
+    for (i, doc) in tagged.enumerated() {
+        let b = doc.text.utf8.count
+        byLang[doc.lang, default: LangStats()].add(bytes: b, ids: idsPerDoc[i], pretokens: pretoks[i])
+        overall.add(bytes: b, ids: idsPerDoc[i], pretokens: pretoks[i])
+    }
+
+    if flags["json"] != nil {
+        let payload: [String: Any] = [
+            "vocab_size": tok.vocabSize,
+            "overall": overall.json,
+            "by_lang": byLang.mapValues { $0.json },
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload,
+                                                     options: [.prettyPrinted, .sortedKeys]) else {
+            fail("stats: could not serialize results")
+        }
+        print(String(decoding: data, as: UTF8.self))
+    } else {
+        func line(_ name: String, _ s: LangStats) -> String {
+            let pad = name.padding(toLength: max(12, name.count), withPad: " ", startingAt: 0)
+            let bpt = s.tokens > 0 ? Double(s.bytes) / Double(s.tokens) : 0
+            return "  \(pad) \(s.docs) docs, \(s.bytes) bytes, \(s.tokens) tokens, "
+                + String(format: "%.4f bytes/token", bpt)
+        }
+        print("vocab_size \(tok.vocabSize)")
+        for lang in byLang.keys.sorted() { print(line(lang, byLang[lang]!)) }
+        print(line("overall", overall))
+        print("  max_token_id \(overall.maxTokenId), pretokens \(overall.pretokens)")
+    }
+}
+
 // MARK: - dispatch
 
 let argv = Array(CommandLine.arguments.dropFirst())
 guard let cmd = argv.first else {
-    fail("usage: monica-tokenize <train|encode|decode|pack> [flags]")
+    fail("usage: monica-tokenize <train|encode|decode|pack|stats> [flags]")
 }
 let flags = parseFlags(Array(argv.dropFirst()))
 switch cmd {
@@ -233,5 +348,6 @@ case "train":  cmdTrain(flags)
 case "encode": cmdEncode(flags)
 case "decode": cmdDecode(flags)
 case "pack":   cmdPack(flags)
-default:       fail("unknown subcommand '\(cmd)' (train|encode|decode|pack)")
+case "stats":  await cmdStats(flags)
+default:       fail("unknown subcommand '\(cmd)' (train|encode|decode|pack|stats)")
 }

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -45,6 +45,7 @@ PORTABLE_MODULES = [
     "src.data.shard",
     "src.data.pack",
     "src.data.stack_v2",
+    "src.data.vocab_sample",
     "src.data.ts_clean",
     "src.data.split",
     "src.data.download",

--- a/tests/test_stack_v2.py
+++ b/tests/test_stack_v2.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import gzip
 import io
 
+import pytest
+
 from src.data.corpus import Record
 from src.data.stack_v2 import _row_to_record, download_contents, iter_stack_v2_ts
 
@@ -135,3 +137,17 @@ def test_iter_stack_v2_ts_defaults_src_encoding_to_utf8():
 
 def test_iter_stack_v2_ts_yields_nothing_for_empty_rows():
     assert list(iter_stack_v2_ts(rows=[], s3_client=_FakeS3Client({}))) == []
+
+
+def test_iter_stack_v2_ts_rejects_a_non_typescript_config_with_the_default_lang():
+    # config overridden but lang left at its "typescript" default would silently
+    # mislabel every emitted Record — fail fast instead (#251 review comment).
+    with pytest.raises(ValueError):
+        list(iter_stack_v2_ts(rows=_rows(), s3_client=_client_for(_rows()), config="Python"))
+
+
+def test_iter_stack_v2_ts_allows_a_non_typescript_config_when_lang_is_also_given():
+    rows = _rows()
+    client = _client_for(rows)
+    out = list(iter_stack_v2_ts(rows=rows, s3_client=client, config="Python", lang="python"))
+    assert all(r.lang == "python" for r in out)

--- a/tests/test_vocab_sample.py
+++ b/tests/test_vocab_sample.py
@@ -201,6 +201,19 @@ def test_fetch_contents_is_a_no_op_for_a_zero_target():
     assert client.calls == []
 
 
+def test_fetch_contents_cancels_unstarted_work_once_target_is_reached_mid_chunk():
+    # With the old `pool.map`, crossing the target early still pays for the rest of the
+    # chunk (the bug this fixes). A single worker makes the savings observable: once the
+    # first result crosses the target, the rest of the chunk is still queued (not yet
+    # running) and gets cancelled, so far fewer than the full chunk is ever fetched.
+    texts = {f"b{i}": gzip.compress(b"z" * 300) for i in range(20)}
+    client = _FakeS3Client(texts)
+    rows = [_row(f"b{i}") for i in range(20)]
+    out = list(fetch_contents(rows, 100, s3_client=client, threads=1, chunk=20))
+    assert len(out) == 1
+    assert len(client.calls) < len(rows)
+
+
 # --- mixture + manifest --------------------------------------------------------------
 def test_default_mixture_covers_prose_and_the_code_languages():
     langs = {s.lang for s in DEFAULT_MIXTURE}
@@ -223,9 +236,30 @@ def test_scale_mixture_rejects_a_non_positive_scale():
 
 def test_manifest_matches_only_the_same_langs_and_targets():
     mixture = [SliceSpec("en", "essential_web", 100)]
-    assert _manifest_matches({"slices": {"en": {"target_bytes": 100}}}, mixture)
-    assert not _manifest_matches({"slices": {"en": {"target_bytes": 200}}}, mixture)
+    assert _manifest_matches(
+        {"slices": {"en": {"kind": "essential_web", "source": "", "target_bytes": 100}}},
+        mixture)
+    assert not _manifest_matches(
+        {"slices": {"en": {"kind": "essential_web", "source": "", "target_bytes": 200}}},
+        mixture)
     assert not _manifest_matches({"slices": {}}, mixture)
+
+
+def test_manifest_matches_rejects_a_different_kind_at_the_same_target_bytes():
+    # A stack_v2 slice re-tagged "en" at the same byte budget as a cached essential_web
+    # slice must NOT be treated as a cache hit -- same lang/target, different source data.
+    mixture = [SliceSpec("en", "stack_v2", 100, "Python")]
+    cached = {"slices": {"en": {"kind": "essential_web", "source": "", "target_bytes": 100}}}
+    assert not _manifest_matches(cached, mixture)
+
+
+def test_manifest_matches_rejects_a_different_stack_v2_source_at_the_same_target_bytes():
+    # Same lang tag, same kind, same byte budget, but a different Stack-v2 language
+    # directory -- reusing this cache would silently swap the corpus content.
+    mixture = [SliceSpec("code", "stack_v2", 100, "Python")]
+    cached = {"slices": {"code": {"kind": "stack_v2", "source": "JavaScript",
+                                  "target_bytes": 100}}}
+    assert not _manifest_matches(cached, mixture)
 
 
 # --- build_sample (end to end, offline) ----------------------------------------------
@@ -261,7 +295,8 @@ def test_build_sample_reuses_a_cached_sample_without_touching_the_network(tmp_pa
     sample_dir.mkdir(parents=True)
     (sample_dir / "sample.jsonl").write_text('{"text": "x", "lang": "en"}\n')
     (sample_dir / "manifest.json").write_text(json.dumps(
-        {"slices": {"en": {"target_bytes": 200}}, "total_bytes": 1, "total_docs": 1}))
+        {"slices": {"en": {"kind": "essential_web", "source": "", "target_bytes": 200}},
+         "total_bytes": 1, "total_docs": 1}))
 
     # No parquet opener patched and no S3 client: any network work would raise.
     out = build_sample(tmp_path, mixture=[SliceSpec("en", "essential_web", 200)],

--- a/tests/test_vocab_sample.py
+++ b/tests/test_vocab_sample.py
@@ -1,0 +1,275 @@
+"""Offline tests for the vocab-sweep sample builder (#251).
+
+Everything here runs with injected fixtures — a fake S3 client, fake parquet openers, no
+`boto3`, no `pyarrow`, no `fsspec`, no credentials, no network. That is the point: the module
+is above the seam and its heavy dependencies are lazy, so the test suite must exercise the
+filter/tagging/fetch logic on a host with none of them installed. Mirrors
+`tests/test_stack_v2.py`.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+
+import pytest
+
+from src.data.vocab_sample import (
+    DEFAULT_MIXTURE, FetchStats, SliceSpec, _manifest_matches, build_sample, fetch_contents,
+    iter_essential_web, iter_stack_v2_metadata, metadata_ok, scale_mixture)
+
+
+class _FakeBody:
+    def __init__(self, data: bytes):
+        self._buf = io.BytesIO(data)
+
+    def read(self) -> bytes:
+        return self._buf.read()
+
+
+class _FakeS3Client:
+    """Serves canned gzip blobs; an unregistered blob_id raises, like a real missing object."""
+
+    def __init__(self, blobs: dict):
+        self.blobs = blobs
+        self.calls = []
+
+    def get_object(self, Bucket: str, Key: str):
+        blob_id = Key.split("/")[-1]
+        self.calls.append(blob_id)
+        if blob_id not in self.blobs:
+            raise KeyError(f"no such blob {blob_id}")
+        return {"Body": _FakeBody(self.blobs[blob_id])}
+
+
+class _FakeColumn:
+    def __init__(self, values):
+        self._values = values
+
+    def to_pylist(self):
+        return list(self._values)
+
+
+class _FakeBatch:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def to_pylist(self):
+        return [dict(r) for r in self._rows]
+
+    def column(self, name):
+        return _FakeColumn([r[name] for r in self._rows])
+
+
+class _FakeParquetFile:
+    """Just enough of `pyarrow.parquet.ParquetFile` for the readers: `iter_batches`."""
+
+    def __init__(self, rows, batch_size=2):
+        self._rows = rows
+        self._batch_size = batch_size
+
+    def iter_batches(self, batch_size=None, columns=None):
+        n = batch_size or self._batch_size
+        for i in range(0, len(self._rows), n):
+            yield _FakeBatch(self._rows[i:i + n])
+
+
+def _row(blob_id="b0", *, licenses=("mit",), length=4096, vendor=False, generated=False):
+    if isinstance(licenses, tuple):
+        licenses = list(licenses)
+    return {"blob_id": blob_id, "src_encoding": "UTF-8",
+            "detected_licenses": licenses,
+            "length_bytes": length, "is_vendor": vendor, "is_generated": generated,
+            "path": "src/a.ts", "repo_name": "acme/app"}
+
+
+# --- metadata pre-filter (the thing that saves two thirds of the S3 spend) ------------
+def test_metadata_filter_keeps_permissive_source_files():
+    assert metadata_ok(_row())
+
+
+def test_metadata_filter_rejects_empty_license():
+    # ~67% of Stack-v2 rows carry an empty `detected_licenses`, and the corpus's permissive
+    # gate rejects an empty license for code — so these must never reach S3.
+    assert not metadata_ok(_row(licenses=()))
+    assert not metadata_ok(_row(licenses=None))
+
+
+def test_metadata_filter_rejects_non_permissive_license():
+    assert not metadata_ok(_row(licenses=("gpl-3.0",)))
+
+
+def test_metadata_filter_accepts_scalar_license_string():
+    assert metadata_ok(_row(licenses="mit"))
+
+
+def test_metadata_filter_rejects_vendored_and_generated():
+    # Minified bundles / codegen would teach garbage merges and distort bytes/token upward.
+    assert not metadata_ok(_row(vendor=True))
+    assert not metadata_ok(_row(generated=True))
+
+
+@pytest.mark.parametrize("length", [0, 1023, 131073, None])
+def test_metadata_filter_rejects_out_of_range_sizes(length):
+    assert not metadata_ok(_row(length=length))
+
+
+def test_metadata_filter_requires_a_blob_id():
+    row = _row()
+    row["blob_id"] = None
+    assert not metadata_ok(row)
+
+
+# --- parquet readers -----------------------------------------------------------------
+def test_iter_essential_web_stops_at_target_bytes():
+    docs = [{"text": "x" * 100} for _ in range(50)]
+    opened = []
+
+    def opener(path):
+        opened.append(path)
+        return _FakeParquetFile(docs, batch_size=5)
+
+    out = list(iter_essential_web(250, files=["f0", "f1"], open_parquet=opener))
+    assert sum(len(t.encode()) for t in out) >= 250
+    assert len(out) == 3           # stops as soon as the target is crossed
+    assert opened == ["f0"]        # never opens a file it does not need
+
+
+def test_iter_essential_web_skips_empty_text():
+    rows = [{"text": ""}, {"text": None}, {"text": "hello"}]
+    out = list(iter_essential_web(1, files=["f0"],
+                                  open_parquet=lambda p: _FakeParquetFile(rows)))
+    assert out == ["hello"]
+
+
+def test_iter_stack_v2_metadata_filters_and_tags_source_file():
+    rows = [_row("keep1"), _row("drop", licenses=()), _row("keep2", vendor=False)]
+    out = list(iter_stack_v2_metadata("TypeScript", files=["p0"],
+                                      open_parquet=lambda p: _FakeParquetFile(rows)))
+    assert [r["blob_id"] for r in out] == ["keep1", "keep2"]
+    assert all(r["_parquet"] == "p0" for r in out)   # recorded in the manifest for auditability
+
+
+def test_iter_stack_v2_metadata_uses_the_lister_when_no_files_given():
+    seen = {}
+
+    def lister(directory):
+        seen["dir"] = directory
+        return ["shard-a"]
+
+    out = list(iter_stack_v2_metadata(
+        "Python", list_parquet=lister,
+        open_parquet=lambda p: _FakeParquetFile([_row("k")])))
+    assert seen["dir"].endswith("/data/Python")
+    assert [r["blob_id"] for r in out] == ["k"]
+
+
+# --- threaded fetch ------------------------------------------------------------------
+def test_fetch_contents_returns_documents_in_submission_order():
+    texts = {f"b{i}": gzip.compress((f"doc{i}" + "y" * 100).encode()) for i in range(10)}
+    client = _FakeS3Client(texts)
+    rows = [_row(f"b{i}") for i in range(10)]
+    out = list(fetch_contents(rows, 10_000, s3_client=client, threads=4, chunk=3))
+    assert [t[:4] for t in out] == [f"doc{i}" for i in range(10)]
+
+
+def test_fetch_contents_stops_at_target_and_reports_stats():
+    texts = {f"b{i}": gzip.compress(b"z" * 100) for i in range(20)}
+    stats = FetchStats()
+    rows = [_row(f"b{i}") for i in range(20)]
+    out = list(fetch_contents(rows, 250, s3_client=_FakeS3Client(texts), threads=4,
+                              stats=stats, chunk=2))
+    assert len(out) == 3
+    assert stats.fetched == 3 and stats.bytes >= 250
+
+
+def test_fetch_contents_counts_failures_without_aborting_the_run():
+    # A handful of unreadable blobs must not lose a 15-minute ingest.
+    texts = {"b0": gzip.compress(b"a" * 50), "b2": gzip.compress(b"c" * 50)}
+    stats = FetchStats()
+    rows = [_row("b0"), _row("b1"), _row("b2")]
+    out = list(fetch_contents(rows, 10_000, s3_client=_FakeS3Client(texts), threads=2,
+                              stats=stats, chunk=8))
+    assert len(out) == 2
+    assert stats.failed == 1
+
+
+def test_fetch_contents_is_a_no_op_for_a_zero_target():
+    client = _FakeS3Client({})
+    assert list(fetch_contents([_row()], 0, s3_client=client)) == []
+    assert client.calls == []
+
+
+# --- mixture + manifest --------------------------------------------------------------
+def test_default_mixture_covers_prose_and_the_code_languages():
+    langs = {s.lang for s in DEFAULT_MIXTURE}
+    assert "en" in langs
+    assert {"typescript", "python", "javascript", "java", "go", "rust", "cpp",
+            "markdown"} <= langs
+
+
+def test_scale_mixture_keeps_every_language():
+    scaled = scale_mixture(DEFAULT_MIXTURE, 0.5)
+    assert [s.lang for s in scaled] == [s.lang for s in DEFAULT_MIXTURE]
+    assert all(b.target_bytes == a.target_bytes // 2
+               for a, b in zip(DEFAULT_MIXTURE, scaled))
+
+
+def test_scale_mixture_rejects_a_non_positive_scale():
+    with pytest.raises(ValueError):
+        scale_mixture(DEFAULT_MIXTURE, 0)
+
+
+def test_manifest_matches_only_the_same_langs_and_targets():
+    mixture = [SliceSpec("en", "essential_web", 100)]
+    assert _manifest_matches({"slices": {"en": {"target_bytes": 100}}}, mixture)
+    assert not _manifest_matches({"slices": {"en": {"target_bytes": 200}}}, mixture)
+    assert not _manifest_matches({"slices": {}}, mixture)
+
+
+# --- build_sample (end to end, offline) ----------------------------------------------
+def test_build_sample_writes_tagged_jsonl_and_a_manifest(tmp_path, monkeypatch):
+    import src.data.vocab_sample as vs
+
+    prose = [{"text": "prose " * 30} for _ in range(5)]
+    code_rows = [_row(f"b{i}") for i in range(5)]
+    blobs = {f"b{i}": gzip.compress(("const x = %d;\n" % i * 20).encode()) for i in range(5)}
+
+    monkeypatch.setattr(vs, "_hf_parquet",
+                        lambda path: _FakeParquetFile(prose if "essential" in path
+                                                      else code_rows))
+    monkeypatch.setattr(vs, "_list_parquet", lambda d: ["shard"])
+
+    mixture = [SliceSpec("en", "essential_web", 200),
+               SliceSpec("typescript", "stack_v2", 200, "TypeScript")]
+    out = build_sample(tmp_path, mixture=mixture, threads=2,
+                       s3_client=_FakeS3Client(blobs), log=lambda m: None)
+
+    rows = [json.loads(line) for line in out.read_text().splitlines()]
+    assert {r["lang"] for r in rows} == {"en", "typescript"}
+    assert all(r["text"] for r in rows)
+
+    manifest = json.loads((tmp_path / "sample" / "manifest.json").read_text())
+    assert set(manifest["slices"]) == {"en", "typescript"}
+    assert manifest["total_bytes"] > 0
+    assert manifest["slices"]["typescript"]["parquet_files"] == ["shard"]
+
+
+def test_build_sample_reuses_a_cached_sample_without_touching_the_network(tmp_path):
+    sample_dir = tmp_path / "sample"
+    sample_dir.mkdir(parents=True)
+    (sample_dir / "sample.jsonl").write_text('{"text": "x", "lang": "en"}\n')
+    (sample_dir / "manifest.json").write_text(json.dumps(
+        {"slices": {"en": {"target_bytes": 200}}, "total_bytes": 1, "total_docs": 1}))
+
+    # No parquet opener patched and no S3 client: any network work would raise.
+    out = build_sample(tmp_path, mixture=[SliceSpec("en", "essential_web", 200)],
+                       log=lambda m: None)
+    assert out.read_text().strip().endswith('"lang": "en"}')
+
+
+def test_build_sample_requires_an_s3_client_for_code_slices(tmp_path):
+    with pytest.raises(RuntimeError, match="S3 client"):
+        build_sample(tmp_path, mixture=[SliceSpec("typescript", "stack_v2", 10, "TypeScript")],
+                     log=lambda m: None)


### PR DESCRIPTION
Closes #251

## Summary

`DEFAULT_VOCAB_SIZE = 16384` was sized when #193 was scoped **TypeScript-only**. #198 rescoped the corpus to general multilingual Essential-Web + Stack-v2 and the vocab never moved. Measured on the rescoped distribution, **16384 costs 7.6% of overall compression and 11.4% on Markdown**. Ratified **49152**, under the 65536 uint16 packing cap. This had to land before the corpus is packed — redoing it after is a full re-tokenize.

## bytes/token

Higher is better (more raw bytes carried per token). `tokens` counts the EOS that `pack` appends, so this is the real packed ratio, not an idealized encode.

| Language | sample bytes | 16384 | 32768 | 49152 | Δ 32768 | Δ 49152 |
|---|---:|---:|---:|---:|---:|---:|
| cpp | 1.05 MB | 2.9998 | 3.2195 | 3.3177 | +7.33% | +10.60% |
| en | 10.58 MB | 3.4368 | 3.7451 | 3.8893 | +8.97% | +13.17% |
| go | 1.05 MB | 3.0427 | 3.2193 | 3.3134 | +5.80% | +8.90% |
| java | 1.58 MB | 3.6480 | 3.9145 | 4.0703 | +7.31% | +11.58% |
| javascript | 2.10 MB | 3.3452 | 3.5518 | 3.6518 | +6.18% | +9.17% |
| markdown | 1.05 MB | 2.8511 | 3.1751 | 3.3509 | +11.37% | +17.53% |
| python | 2.12 MB | 3.5047 | 3.7173 | 3.8233 | +6.07% | +9.09% |
| rust | 1.06 MB | 3.5151 | 3.6811 | 3.7628 | +4.72% | +7.05% |
| typescript | 4.26 MB | 3.5703 | 3.7943 | 3.9201 | +6.28% | +9.80% |
| **overall** | 24.85 MB | 3.4029 | 3.6630 | 3.7920 | +7.64% | +11.43% |

**Per-language rows are blend-independent** — a language's bytes/token is computed only over its own documents. **Only the "overall" row is blend-weighted**, so the decision does not silently depend on mixture weights nobody ratified.

## Two limitations — read the result as weaker than it looks

1. **The tested range did not bracket the knee.** bytes/token is monotonic non-decreasing in vocab size, and 32768→49152 was still yielding a lot (+3.5% overall, +5.25% Markdown). Returns never flattened inside 16k–49k, so the rule returned the **largest candidate tested** — not a located optimum. The honest claim is **≥49152 on this evidence; the ceiling was not located.** The uint16 cap (65536) bounds where it can be, leaving roughly **49k–64k unexplored**. This is visible in the rule trace itself: Rule 2 ("smallest survivor within 2%") was the intended cost brake and never bit, because only one candidate survived Rule 1.
2. **The rule prices the benefit, not the cost.** Since bytes/token improves monotonically, this metric alone has no interior optimum. The counterweight is the **tied-embedding parameter cost** — at `d_model 768` each token costs 768 params in the embedding *and* the output head, and 16384→49152 roughly triples that matrix (for scale: `config/poc.yaml`'s tied embedding is ~38M of ~127M params; M12-small is ~120M-active). The sweep measured **compression only**; the parameter-cost side was **not** evaluated.

A 4th candidate at 64k was considered and declined: it would almost certainly win Rule 1 too, regressing to the uint16 cap and making the answer cap-driven rather than evidence-driven. The missing input is the parameter-cost term, which no further bytes/token measurement supplies.

## Decision rule (pre-registered before the numbers were read)

```
Rule 1 — per-language anti-starvation (reject >3% worse than best on any language):
  16384: worst gap 14.92% (markdown) -> REJECT
  32768: worst gap  5.25% (markdown) -> REJECT
  49152: worst gap  0.00%            -> keep
Rule 2 — smallest survivor within 2% of best overall:  49152, 0.00% off best
Rule 3 — TypeScript tie-break (>3% on the TS row):     no change
WINNER: 49152 (overall 3.7920 bytes/token)
```

## Sample

**24.85 MB / 5,420 docs**, built by the new `src/data/vocab_sample.py`: 10.58 MB Essential-Web prose + 14.27 MB Stack-v2 code across 8 languages (TypeScript over-weighted at 4.26 MB — the program is TypeScript-first). Filters applied to Stack-v2 **metadata columns before any S3 fetch**: permissive license, not vendored, not generated, 1 KiB ≤ `length_bytes` ≤ 128 KiB.

Carries **240,073 unique pre-tokens (122,111 appearing ≥2×)** — 4.9× / 2.5× the 49,152 merges requested. This bar matters: BPE merge count is bounded by unique pre-tokens, and an undersized sample makes the 48k tail noise rather than data. The run produced all **48,890 requested merges without exhausting**.

Three findings that shaped the implementation, all measured:
- `load_dataset()` on Essential-Web is unusable (99,896 parquet files; no first row in 7+ min) — parquet files are opened directly via `hf://`.
- Serial SWH fetch runs at 0.03 MB/s; the 64-thread pool reaches 1.9 MB/s.
- ~67% of Stack-v2 rows carry an empty `detected_licenses`, which the permissive gate rejects — filtering on metadata first avoids paying for two thirds of the fetch.

## Method

One 49,152 train (2,035 s), with 32,768 / 16,384 derived by **truncating `merges`** — `Trainer.train` is greedy with no lookahead, so a k-vocab merge list is a strict prefix of any larger run's. That invariant is now **guarded by `monica-selfcheck`**, not assumed. Reproduce with `scripts/vocab_sweep.py`.

**Invariants that held:** FIM sentinel ids identical across all three sizes; pre-token counts identical (5,884,475 — the pre-tokenizer never sees the merges); `max_token_id` 49,151 < 65,536, with `monica-tokenize pack` confirming the uint16 shard path.

**BPB is unaffected.** BPB is byte-normalized, so a larger vocab does not "cheat" it the way it deflates raw perplexity — the table measures genuine compression.

## Changes

- **`src/data/vocab_sample.py`** (new, portable; heavy imports lazy) — tagged multilingual sample builder.
- **`scripts/vocab_sweep.py`** (new) — sample → one 49,152 train → truncate → `stats` → table + pre-registered decision rule. Sample and tokenizers are cached, so a re-run costs no network time and no retrain.
- **`monica-tokenize stats`** (new subcommand) — per-language bytes/tokens/pre-tokens through the production `batchEncode` on production document boundaries.
- **`monica-selfcheck`** — merge-prefix invariant, FIM-sentinel and pre-tokenizer vocab-independence.
- **`DEFAULT_VOCAB_SIZE`** 16384 → 49152; stale `BPE.swift` comment asserting "vocab is ≤ 16384" corrected.
- **`stack_v2`** — keyword-only `lang` (default unchanged) so a non-TypeScript `config=` tags records correctly.
- **`docs/design/13-code-model-moe.md`** — provisional block replaced with the decision, table, sample, method, limitations.
- **`tests/test_vocab_sample.py`** (new, 24 tests) — offline: fake S3, fake parquet, no creds, no boto3/pyarrow/fsspec needed at import time.

The corpus sample lives outside the repo (`~/monica-data/vocab-sweep-251-half/`), so nothing large lands in git.

## Testing

- [x] Tests added/updated — `tests/test_vocab_sample.py`; `src.data.vocab_sample` added to `test_import_guard.py::PORTABLE_MODULES`
- [x] All tests passing — `pytest -q -rs` → **834 passed, 13 skipped** (same pre-existing skip set; no new skips)
- [x] `swift build` + `monica-selfcheck` → **all checks passed**, including the three new invariants
- [x] Manual testing completed — `monica-tokenize pack` verified the uint16 shard path end-to-end

The M4 smoke gate is **not** required here: no model, backend, or training-loop code is touched. `swift-parity` is unaffected — the trainer itself is unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrGJ9PEaQSRE5MfvxQiwrB