### PR TITLE
feat: [M12] FIM training (PSM collator + sentinel round-trip + distance-bucketed eval)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,13 +268,17 @@ jobs:
         # The cross-platform determinism gate for FIM insertion. A divergent RNG
         # (or any float creeping into the transform) shows up here and nowhere
         # else. manifest.json holds only ints and fixed strings — no paths, no
-        # floats — so it is safely byte-comparable.
+        # floats — so it is safely byte-comparable. Diff the full file lists
+        # (not a hardcoded part-00000.* set) so a future fixture that packs to
+        # multiple shard parts still gets every part compared, not silently
+        # skipped past the first.
         run: |
-          test -s fim-macos/part-00000.bin   # non-empty, or the cmp below is vacuous
-          for f in part-00000.bin part-00000.bounds manifest.json; do
+          test -s fim-macos/part-00000.bin   # non-empty, or the diff below is vacuous
+          diff <(cd fim-macos && find . -type f | sort) <(cd fim-linux && find . -type f | sort)
+          while IFS= read -r f; do
             sha256sum "fim-macos/$f" "fim-linux/$f"
             cmp "fim-macos/$f" "fim-linux/$f"
-          done
+          done < <(cd fim-macos && find . -type f | sort)
 
   # ── Job 7: the Swift/MLX model port's logit parity gate (#166) ────────────
   # Apple-only: swift/engine/ is a SEPARATE SwiftPM package that depends on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,28 @@ jobs:
           name: tokenizer-macos
           path: ${{ runner.temp }}/tokenizer.json
           retention-days: 7
+      - name: Pack the parity corpus with FIM (#215)
+        # FIM insertion is seeded (SplitMix64, integer-only, no stdlib random
+        # conveniences) precisely so this output is bit-identical to the Linux
+        # job's. An in-process "pack twice, same bytes" check runs on ONE machine
+        # and therefore cannot catch a platform-divergent RNG; only the cmp in
+        # swift-parity can. `--fim-rate 0.5` sits at the top of #215's intended
+        # 0.4-0.5 band, so this exercises the transform on most documents.
+        working-directory: swift
+        run: |
+          swift run monica-tokenize pack \
+            --tokenizer "$RUNNER_TEMP/tokenizer.json" \
+            --in Fixtures/parity-corpus.jsonl --out "$RUNNER_TEMP/fim-shards" \
+            --seq-len 64 --shard-size-mb 1 --fim-rate 0.5 --fim-seed 1234 | tee "$RUNNER_TEMP/fim.log"
+          # An empty pack would leave swift-parity cmp-ing two nonexistent files
+          # and reading as a pass. A check that cannot observe its target is BLIND.
+          grep -qE '^packed [1-9][0-9]* seq' "$RUNNER_TEMP/fim.log"
+          grep -qE '^fim: [1-9][0-9]*/' "$RUNNER_TEMP/fim.log"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fim-shards-macos
+          path: ${{ runner.temp }}/fim-shards
+          retention-days: 7
 
   # ── Job 5: native Swift toolchain, Linux (#246) ───────────────────────────
   # The official swift image (Ubuntu 24.04, glibc 2.39) — the same toolchain the
@@ -194,6 +216,21 @@ jobs:
           name: tokenizer-linux
           path: ${{ runner.temp }}/tokenizer.json
           retention-days: 7
+      - name: Pack the parity corpus with FIM (#215)
+        # Must match the macOS job's flags exactly — swift-parity cmp's the two.
+        working-directory: swift
+        run: |
+          swift run monica-tokenize pack \
+            --tokenizer "$RUNNER_TEMP/tokenizer.json" \
+            --in Fixtures/parity-corpus.jsonl --out "$RUNNER_TEMP/fim-shards" \
+            --seq-len 64 --shard-size-mb 1 --fim-rate 0.5 --fim-seed 1234 | tee "$RUNNER_TEMP/fim.log"
+          grep -qE '^packed [1-9][0-9]* seq' "$RUNNER_TEMP/fim.log"
+          grep -qE '^fim: [1-9][0-9]*/' "$RUNNER_TEMP/fim.log"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: fim-shards-linux
+          path: ${{ runner.temp }}/fim-shards
+          retention-days: 7
 
   # ── Job 6: the bit-identical guarantee itself (#246) ──────────────────────
   # #191/#245's whole premise is that the Swift tokenizer produces identical
@@ -219,6 +256,25 @@ jobs:
         run: |
           sha256sum macos/tokenizer.json linux/tokenizer.json
           cmp macos/tokenizer.json linux/tokenizer.json
+      - uses: actions/download-artifact@v4
+        with:
+          name: fim-shards-macos
+          path: fim-macos
+      - uses: actions/download-artifact@v4
+        with:
+          name: fim-shards-linux
+          path: fim-linux
+      - name: Diff the two FIM-packed shard sets (#215)
+        # The cross-platform determinism gate for FIM insertion. A divergent RNG
+        # (or any float creeping into the transform) shows up here and nowhere
+        # else. manifest.json holds only ints and fixed strings — no paths, no
+        # floats — so it is safely byte-comparable.
+        run: |
+          test -s fim-macos/part-00000.bin   # non-empty, or the cmp below is vacuous
+          for f in part-00000.bin part-00000.bounds manifest.json; do
+            sha256sum "fim-macos/$f" "fim-linux/$f"
+            cmp "fim-macos/$f" "fim-linux/$f"
+          done
 
   # ── Job 7: the Swift/MLX model port's logit parity gate (#166) ────────────
   # Apple-only: swift/engine/ is a SEPARATE SwiftPM package that depends on

--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -132,8 +132,8 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
   balancing router (#213, **done on MLX** — portable `MoEBalancer` policy above the seam +
   selection-only route bias in `MoEBlock`; the bias rides in the portable safetensors so a served
   or ported checkpoint routes as trained) → CUDA MoE backend (#214: dropless routing, shared expert,
-  FSDP, sparse-upcycle init) → FIM collator (#215 — consumes the Swift-packed shards; the FIM
-  insertion transform may live in the Swift `pack` path), length curriculum + dataloader-state resume
+  FSDP, sparse-upcycle init) → FIM (#215, **done** — see the resolved note below), length
+  curriculum + dataloader-state resume
   (#216), routing instrumentation (#217), pure-PyTorch Mamba-2 reference for laptop parity (#218).
   **Training-efficiency levers** (folded 2026-07-20 from the efficiency-survey review): hybrid
   Muon+AdamW optimizer at the `make_optimizer` seam (#237, **done** — `3b02e6b`), WSD
@@ -146,7 +146,48 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
   is already mature on the survey's biggest axes — data dedup/filtering, fused AdamW, SDPA, the
   mamba-ssm kernels, grad-checkpoint — so these four are the net-new levers; #216 is the
   length-curriculum lever.)
+> **Resolved 2026-08-06 (#215) — FIM insertion is in the Swift `pack` path, not a Python
+> collator.** An earlier draft left this open ("*may* live in the Swift pack path"). It is settled:
+> the transform is `swift/Sources/MonicaTokenizer/FIM.swift`, driven by `monica-tokenize pack
+> --fim-rate <0..1> --fim-seed <n>`.
+>
+> *Why.* FIM needs **document boundaries**, and pack time is the only place they still exist as
+> objects. `src/data/split.py` drops the `.bounds` sidecars, so the trainer reads a flat
+> `train.bin` through `PackedLoader`, which cuts fixed `seq_len` windows and cannot see doc
+> structure. Reconstructing boundaries in the loader to feed a collator is a far larger change
+> than doing the transform where the documents are still whole.
+>
+> *Trade-offs, accepted.* Changing the FIM rate requires a **re-pack** of the corpus, not a config
+> edit. The transform sits outside the pytest gate because it is Swift — `monica-selfcheck` is its
+> test runner (the package declares no `.testTarget`), backed by `tests/test_swift_fim.py`, which
+> shells out to the built binary.
+>
+> *Shape.* PSM only (SPM is out of scope): `[fim_prefix] prefix [fim_suffix] suffix [fim_middle]
+> middle`. The **rate band is 0.4–0.5** — explicitly *not* the 0.5–0.9 reported elsewhere; a rate
+> outside the band warns rather than fails so an ablation is not blocked. Cuts are on UTF-8 **byte**
+> offsets of the document text, not on token ids: slicing ids would make every middle begin exactly
+> on a token boundary, the classic silent FIM distribution bug (StarCoder2 shipped one).
+>
+> *Determinism is a CI gate.* Insertion is seeded per document with SplitMix64 (integer-only, no
+> stdlib random conveniences, no floats, no hashed-collection iteration, no grapheme indexing), and
+> `.github/workflows/ci.yml`'s `swift-parity` job now `cmp`s macOS-packed FIM shards against
+> Linux-packed ones. `--fim-rate` defaults to 0, so pre-#215 pack output is byte-identical.
+>
+> *Architectural consequence — configuration guidance, not a validator rule.* In PSM the suffix is
+> consumed **before** the middle is generated, so every middle token depends on recalling the suffix
+> out of state — the fixed-width-state bottleneck the hybrid exists to patch. Therefore **the final
+> block should be an attention block**: `n_layers % attn_every == 0`, from `layer i is attention iff
+> (i+1) % attn_every == 0` (`src/model/blocks.py:192`). `config/toy-hybrid.yaml` satisfies it
+> (4 layers, `attn_every 2` → `[Mamba, Attn, Mamba, Attn]`); `config/student-1b.yaml` (28 layers,
+> `attn_every 8` → attention at 7/15/23, top block Mamba) does **not**, so a future MHM config must
+> not copy that shape. This is deliberately *not* a `MambaConfig.validate()` rule — that validator
+> is shared with reserve configs that legitimately violate it. `src/eval/fim_eval.py`'s
+> `attention_after_suffix()` is the advisory check.
+
 - **MHM-P2e — Evals** (build first): code eval suite (#221), BPB (#192, primary).
+  Distance-bucketed FIM eval ships with #215 as `src/eval/fim_eval.py` (portable, pure numpy,
+  teacher-forced loss over the middle span with per-instance records); **#215 owns that module and
+  #221 extends it** rather than writing a second one.
 - **MHM-P3 — Small-model ablation sweep** (#219, ~$80–120 each): attention ratio 8/12/16%,
   d_state 128 vs 256, Jamba vs Routing-Mamba.
 - **MHM-P4 — Small-model full run** (#222, 50–70B tokens): the small **MoE** rung

--- a/src/eval/fim_eval.py
+++ b/src/eval/fim_eval.py
@@ -1,0 +1,348 @@
+"""Distance-bucketed fill-in-the-middle (FIM) evaluation (#215).
+
+ABOVE THE SEAM. Pure numpy — never imports `mlx` or `torch`. It touches a model only through
+`ModelInterface.forward`, with a `to_numpy` converter supplied at the seam (identity by default;
+on MLX pass a converter), exactly like `src/eval/val_loss.py` and `src/eval/long_context.py`.
+
+What it measures
+----------------
+A PSM stream is `[fim_prefix] prefix [fim_suffix] suffix [fim_middle] middle`, so the whole
+suffix is consumed *before* the first middle token is predicted. On a mostly-SSM backbone that
+recall has to survive the fixed-width state — which is precisely the weakness the hybrid's
+attention layers exist to patch. Reporting one aggregate FIM loss would hide it, so every score
+here is bucketed by distance (short / medium / long by default) and every example also carries
+its own record.
+
+Scoring is **teacher-forced and loss-based**, not generative: cross-entropy over the middle span
+only, plus token accuracy and exact match. No pass@1 gating — at the small rung a generative gate
+is noise (see #221).
+
+The architectural consequence — configuration guidance, not code
+----------------------------------------------------------------
+Because the middle is generated after the suffix has scrolled past, **the final block should be
+an attention block**: `n_layers % attn_every == 0`, from the `layer i is attention iff
+(i+1) % attn_every == 0` rule at `src/model/blocks.py:192`. `config/toy-hybrid.yaml` satisfies it
+(4 layers, `attn_every 2` -> `[Mamba, Attn, Mamba, Attn]`); `config/student-1b.yaml` (28 layers,
+`attn_every 8` -> attention at 7/15/23, top block Mamba) does not, so a future MHM config must
+not copy that shape. This is an M12 training-recipe constraint, deliberately NOT a
+`MambaConfig.validate()` rule: that validator is shared with reserve configs that legitimately
+violate it. `attention_after_suffix()` below is the advisory check — arithmetic over two ints,
+no model import, and it never raises.
+
+Where the FIM streams come from
+-------------------------------
+Insertion itself lives in the Swift `pack` path (`swift/Sources/MonicaTokenizer/FIM.swift`, #215)
+because that is where document boundaries still exist. Python has no code tokenizer any more
+(retired with #245), so this module consumes **already-tokenized** documents:
+`documents_from_shards` recovers them from a Swift-packed shard dir via `src.data.shard`. Point
+it at the *shard* dir, not a split dir — `src/data/split.py` drops the `.bounds` sidecars that
+carry the doc starts.
+
+Ownership: **#215 owns this module; #221 (code eval suite) extends it.** Hence the split between
+example *construction* and *scoring*, the callable bucket key, and the per-instance record schema
+— #221's "FIM-by-prefix-distance" probe should import these, not re-implement them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from ..eval.val_loss import masked_cross_entropy, perplexity
+
+# Default bucket edges over a distance in tokens: (name, lo_inclusive, hi_exclusive_or_None).
+DEFAULT_BUCKETS: Tuple[Tuple[str, int, Optional[int]], ...] = (
+    ("short", 0, 256),
+    ("medium", 256, 1024),
+    ("long", 1024, None),
+)
+
+
+@dataclass(frozen=True)
+class FIMSentinels:
+    """Reserved special-token ids. These match the Swift tokenizer's fixed layout
+    (`swift/Sources/monica-tokenize/main.swift`: `<|endoftext|>`, `<|fim_prefix|>`,
+    `<|fim_middle|>`, `<|fim_suffix|>`, `<|fim_pad|>`, `<mask>` at ids 0..5)."""
+
+    prefix: int = 1
+    suffix: int = 3
+    middle: int = 2
+    eos: int = 0
+    pad: int = 4
+
+    @property
+    def all_sentinels(self) -> Tuple[int, int, int]:
+        return (self.prefix, self.suffix, self.middle)
+
+
+@dataclass(frozen=True)
+class FIMExample:
+    """One teacher-forcing example: the full PSM stream plus the spans needed to score and
+    bucket it. `middle_start` is the index of the `fim_middle` sentinel — which is also the
+    input position whose prediction is the first middle token."""
+
+    tokens: np.ndarray
+    middle_start: int
+    prefix_len: int
+    middle_len: int
+    suffix_len: int
+    doc_index: int
+
+    @property
+    def recall_distance(self) -> int:
+        """Tokens the model must carry state across before emitting the first middle token:
+        the whole prefix + suffix + their two sentinels, i.e. `middle_start`. This is the
+        SSM-relevant distance, as distinct from `prefix_len` (the literal 'prefix distance')."""
+        return self.middle_start
+
+
+def make_fim_example(doc_ids: Sequence[int], cut_a: int, cut_b: int,
+                     sentinels: FIMSentinels = FIMSentinels(),
+                     doc_index: int = 0) -> FIMExample:
+    """Build a PSM stream from an already-tokenized document and two cut points `0 <= a <= b <= n`.
+
+    Cuts are on **token** indices here, whereas the Swift pack-time transform cuts on UTF-8 byte
+    offsets so that middles can begin mid-token. That difference is deliberate and harmless for
+    evaluation: this module measures loss as a function of distance, and the trained-on
+    distribution is the packed corpus's, not this constructor's. Use `documents_from_shards` when
+    you want to score the real, Swift-inserted streams instead.
+    """
+    ids = np.asarray(doc_ids, dtype=np.int64).reshape(-1)
+    n = int(ids.size)
+    if not (0 <= cut_a <= cut_b <= n):
+        raise ValueError(f"cut points must satisfy 0 <= a <= b <= {n}, got a={cut_a}, b={cut_b}")
+
+    prefix, middle, suffix = ids[:cut_a], ids[cut_a:cut_b], ids[cut_b:]
+    stream = np.concatenate([
+        np.array([sentinels.prefix], dtype=np.int64), prefix,
+        np.array([sentinels.suffix], dtype=np.int64), suffix,
+        np.array([sentinels.middle], dtype=np.int64), middle,
+    ])
+    middle_start = 1 + int(prefix.size) + 1 + int(suffix.size)
+    return FIMExample(tokens=stream, middle_start=middle_start,
+                      prefix_len=int(prefix.size), middle_len=int(middle.size),
+                      suffix_len=int(suffix.size), doc_index=doc_index)
+
+
+def build_fim_examples(docs: Iterable[Sequence[int]], rng: np.random.Generator, *,
+                       sentinels: FIMSentinels = FIMSentinels(),
+                       n_per_doc: int = 1, min_middle: int = 1) -> List[FIMExample]:
+    """Sample `n_per_doc` PSM examples per document with uniform two-point cuts.
+
+    `rng` is an explicit `np.random.Generator` — there is no module-level RNG, so a given seed
+    reproduces a given eval set exactly. Documents shorter than `min_middle` are skipped (they
+    cannot yield a non-empty middle); an all-too-short corpus therefore yields `[]`, which
+    `evaluate_fim` turns into a loud failure rather than a perfect score.
+    """
+    if min_middle < 1:
+        raise ValueError(f"min_middle must be >= 1, got {min_middle}")
+    examples: List[FIMExample] = []
+    for doc_index, doc in enumerate(docs):
+        ids = np.asarray(doc, dtype=np.int64).reshape(-1)
+        n = int(ids.size)
+        if n < min_middle:
+            continue
+        for _ in range(n_per_doc):
+            cut_a = int(rng.integers(0, n - min_middle + 1))
+            cut_b = int(rng.integers(cut_a + min_middle, n + 1))
+            examples.append(make_fim_example(ids, cut_a, cut_b, sentinels, doc_index))
+    return examples
+
+
+def documents_from_shards(shard_dir, *, min_len: int = 1,
+                          max_docs: Optional[int] = None) -> List[np.ndarray]:
+    """Recover per-document token arrays from a Swift-packed (or `src/data/shard.py`-packed)
+    shard directory, using the `.bounds` doc-start flags.
+
+    Must point at the **shard** dir, not a split dir: `src/data/split.py` drops `.bounds`.
+    The final document of each shard is truncated at the shard edge (packing is a flat token
+    stream), which is why `min_len` exists — it drops the fragments too small to be worth scoring.
+    """
+    from ..data.shard import doc_start_offsets, open_shard, read_manifest
+
+    shard_dir = Path(shard_dir)
+    manifest = read_manifest(shard_dir)
+    docs: List[np.ndarray] = []
+    for shard in manifest["shards"]:
+        toks, bnds = open_shard(shard_dir, shard["name"])
+        starts = doc_start_offsets(bnds)
+        for i, start in enumerate(starts):
+            end = starts[i + 1] if i + 1 < len(starts) else len(toks)
+            ids = np.asarray(toks[start:end], dtype=np.int64)
+            if ids.size >= min_len:
+                docs.append(ids)
+            if max_docs is not None and len(docs) >= max_docs:
+                return docs
+    return docs
+
+
+def bucket_of(value: int,
+              buckets: Sequence[Tuple[str, int, Optional[int]]] = DEFAULT_BUCKETS) -> str:
+    """Name of the first bucket whose `[lo, hi)` contains `value` (`hi=None` = open-ended)."""
+    for name, lo, hi in buckets:
+        if value >= lo and (hi is None or value < hi):
+            return name
+    raise ValueError(f"value {value} falls in no bucket of {[b[0] for b in buckets]}")
+
+
+def attention_after_suffix(n_layers: int, attn_every: Optional[int]) -> bool:
+    """True when the model's **final** block is an attention block.
+
+    From `src/model/blocks.py:192`, layer `i` is attention iff `attn_every and (i+1) % attn_every
+    == 0`; the last layer is `i = n_layers - 1`, so the condition is `n_layers % attn_every == 0`.
+    Advisory only (see the module docstring): PSM consumes the suffix before the middle, so a
+    top attention block is what lets the middle re-read it rather than recall it from SSM state.
+    """
+    if not attn_every or attn_every <= 0 or n_layers <= 0:
+        return False
+    return n_layers % attn_every == 0
+
+
+def _score_batch(model, batch: Sequence[FIMExample], sentinels: FIMSentinels,
+                 to_numpy) -> List[dict]:
+    """Teacher-forced scores for one padded batch. One `forward` call, per-example results."""
+    max_len = max(int(ex.tokens.size) for ex in batch)
+    padded = np.full((len(batch), max_len), sentinels.pad, dtype=np.int64)
+    for i, ex in enumerate(batch):
+        padded[i, :ex.tokens.size] = ex.tokens
+
+    inputs = padded[:, :-1]
+    targets = padded[:, 1:]
+    # Mask the positions that predict middle tokens. Target index j holds stream[j+1], and the
+    # middle span is stream[middle_start+1 : middle_start+1+middle_len], so j runs over
+    # [middle_start, middle_start + middle_len).
+    mask = np.zeros_like(inputs, dtype=np.float64)
+    for i, ex in enumerate(batch):
+        mask[i, ex.middle_start:ex.middle_start + ex.middle_len] = 1.0
+
+    # Right-padding is safe *because the model is causal*: a position can only attend to (or
+    # accumulate state from) positions at or before itself, so tokens appended after an example's
+    # own end cannot influence any of its scored positions. That is what makes a short example's
+    # score identical whether it is batched alone or alongside a longer one.
+    logits = np.asarray(to_numpy(model.forward(inputs)))
+
+    records: List[dict] = []
+    for i, ex in enumerate(batch):
+        sel = mask[i] > 0
+        n_middle = int(sel.sum())
+        if n_middle == 0:
+            # An empty middle is a legitimate draw at pack time but carries no signal; record it
+            # with an explicit None rather than folding a 0-token example into the mean.
+            records.append({"ce_nats": None, "n_middle_tokens": 0,
+                            "token_accuracy": None, "exact_match": None})
+            continue
+        ce = masked_cross_entropy(logits[i:i + 1], targets[i:i + 1], mask[i:i + 1])
+        pred = np.argmax(logits[i][sel], axis=-1)
+        correct = pred == targets[i][sel]
+        records.append({
+            "ce_nats": float(ce),
+            "n_middle_tokens": n_middle,
+            "token_accuracy": float(correct.mean()),
+            "exact_match": float(bool(correct.all())),
+        })
+    return records
+
+
+def evaluate_fim(model, examples: Sequence[FIMExample], *, batch_size: int = 8,
+                 buckets: Sequence[Tuple[str, int, Optional[int]]] = DEFAULT_BUCKETS,
+                 key: Callable[[FIMExample], int] = lambda ex: ex.prefix_len,
+                 sentinels: FIMSentinels = FIMSentinels(),
+                 to_numpy=np.asarray) -> dict:
+    """Score `examples` and aggregate by bucket.
+
+    `key` picks the bucketed distance — `ex.prefix_len` by default (#215's literal
+    "prefix distance"). Pass `lambda ex: ex.recall_distance` for the SSM-relevant distance;
+    every record carries both either way, so #221 needs no second module.
+
+    Returns `{"records": [...], "by_bucket": {name: agg | None}, "overall": agg, "advisory": str
+    | None}`. A bucket with no scored example is `None`, not a zero row (the `long_context.py`
+    convention). If *nothing* scored at all this raises — a silently empty eval would report a
+    perfect model (the `val_loss.evaluate` precedent).
+    """
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+
+    records: List[dict] = []
+    for start in range(0, len(examples), batch_size):
+        batch = list(examples[start:start + batch_size])
+        for ex, scored in zip(batch, _score_batch(model, batch, sentinels, to_numpy)):
+            records.append({
+                "doc_index": ex.doc_index,
+                "bucket": bucket_of(int(key(ex)), buckets),
+                "prefix_len": ex.prefix_len,
+                "middle_len": ex.middle_len,
+                "suffix_len": ex.suffix_len,
+                "recall_distance": ex.recall_distance,
+                **scored,
+            })
+
+    scored_records = [r for r in records if r["n_middle_tokens"] > 0]
+    if not scored_records:
+        raise ValueError(
+            "evaluate_fim(): no middle tokens scored — the example set is empty or every "
+            "example has an empty middle span"
+        )
+
+    def aggregate(rows: List[dict]) -> dict:
+        n_tokens = sum(r["n_middle_tokens"] for r in rows)
+        ce = sum(r["ce_nats"] * r["n_middle_tokens"] for r in rows) / n_tokens
+        acc = sum(r["token_accuracy"] * r["n_middle_tokens"] for r in rows) / n_tokens
+        return {
+            "ce": float(ce),
+            "perplexity": perplexity(float(ce)),
+            "token_accuracy": float(acc),
+            "exact_match_rate": float(np.mean([r["exact_match"] for r in rows])),
+            "n_examples": len(rows),
+            "n_tokens": int(n_tokens),
+        }
+
+    by_bucket: dict = {}
+    for name, _lo, _hi in buckets:
+        rows = [r for r in scored_records if r["bucket"] == name]
+        by_bucket[name] = aggregate(rows) if rows else None
+
+    return {
+        "records": records,
+        "by_bucket": by_bucket,
+        "overall": aggregate(scored_records),
+        "advisory": _architecture_advisory(model),
+    }
+
+
+def _architecture_advisory(model) -> Optional[str]:
+    """Non-fatal note when the model's top block is not attention (see the module docstring).
+    Returns None when the config doesn't expose the two fields — this must never raise, and an
+    unreadable config is 'unknown', never 'fine'."""
+    config = getattr(model, "config", None)
+    n_layers = getattr(config, "n_layers", None)
+    if not isinstance(n_layers, int):
+        return None
+    attn_every = getattr(config, "attn_every", None)
+    if attention_after_suffix(n_layers, attn_every):
+        return None
+    return (f"final block is not attention (n_layers={n_layers}, attn_every={attn_every}); "
+            "in PSM the suffix is consumed before the middle, so the top block should be "
+            "attention — see src/eval/fim_eval.py and docs/design/13-code-model-moe.md")
+
+
+def format_fim_table(results: dict) -> str:
+    """One line per bucket + an overall line, for logging / posting to the tracker."""
+    lines = ["FIM loss by distance bucket:"]
+    for name, agg in results["by_bucket"].items():
+        if agg is None:
+            lines.append(f"  {name:<8} (no examples in this bucket)")
+        else:
+            lines.append(f"  {name:<8} ce={agg['ce']:.4f}  ppl={agg['perplexity']:.4f}  "
+                         f"tok_acc={agg['token_accuracy']:.4f}  "
+                         f"exact={agg['exact_match_rate']:.4f}  "
+                         f"({agg['n_examples']} ex, {agg['n_tokens']} tok)")
+    o = results["overall"]
+    lines.append(f"  {'overall':<8} ce={o['ce']:.4f}  ppl={o['perplexity']:.4f}  "
+                 f"tok_acc={o['token_accuracy']:.4f}  exact={o['exact_match_rate']:.4f}  "
+                 f"({o['n_examples']} ex, {o['n_tokens']} tok)")
+    if results.get("advisory"):
+        lines.append(f"  advisory: {results['advisory']}")
+    return "\n".join(lines)

--- a/swift/Sources/MonicaTokenizer/FIM.swift
+++ b/swift/Sources/MonicaTokenizer/FIM.swift
@@ -1,0 +1,213 @@
+// Fill-in-the-middle (FIM) document transform (#215).
+//
+// WHERE THIS LIVES AND WHY (settled — see docs/design/13-code-model-moe.md, MHM-P2):
+// FIM insertion happens at **pack** time, in Swift, not in a Python collator. FIM needs whole
+// **documents**, and pack time is the only place they still exist as objects: `src/data/split.py`
+// drops the `.bounds` sidecars, so the Python trainer reads a flat `train.bin` through
+// `PackedLoader`, which cuts fixed `seq_len` windows and cannot see doc structure. Doing the
+// transform here is far smaller than reconstructing boundaries in the loader.
+//
+// Accepted trade-offs (recorded, not open questions):
+//   * Changing the FIM rate requires a **re-pack** of the corpus, not a config edit.
+//   * This code sits outside the pytest gate — it is Swift. `monica-selfcheck` is the test runner
+//     (the package declares no `.testTarget`), backed by `tests/test_swift_fim.py`, which shells
+//     out to the built binary.
+//
+// DETERMINISM IS A HARD CI REQUIREMENT. `.github/workflows/ci.yml`'s `swift-parity` job `cmp`s
+// macOS-packed shards against Linux-packed shards, so every decision here must be bit-identical
+// across platforms and toolchain versions. That rules out, deliberately:
+//   * `SystemRandomNumberGenerator`, `arc4random`, `Date`, `UUID`, `ProcessInfo` — non-reproducible;
+//   * `Int.random(in:using:)` / `shuffled(using:)` / `randomElement(using:)` — the number of
+//     `next()` calls and the bias-correction algorithm are stdlib *implementation details*, not
+//     ABI, and may change between Swift versions. The bounded draw is implemented here instead,
+//     and `SplitMix64` deliberately does NOT conform to `RandomNumberGenerator` so no stdlib
+//     convenience can be reached through it by accident;
+//   * `Double`/`Float` anywhere in the transform — the rate arrives as integer basis points, and
+//     the one Double→Int conversion happens at the CLI boundary (`monica-tokenize`);
+//   * iterating a `Set`/`Dictionary` — Swift's `Hasher` is per-process randomly seeded, so their
+//     order is not stable even run-to-run on one machine. Arrays only;
+//   * `Character`/grapheme-cluster indexing — grapheme breaking depends on the toolchain's Unicode
+//     tables, which is exactly the kind of thing that can differ between the macOS and Linux
+//     builds. Cut points are UTF-8 **byte** offsets snapped forward with table-free bit arithmetic.
+//
+// The RNG is seeded **per document** (from the global seed mixed with the document's index), not
+// as one stream across the corpus. That makes each document's outcome independent of processing
+// order, so the packed output is identical whether `cmdPack` stays serial or later moves to
+// `batchEncode`-style bounded concurrency. This is the property that lets the design survive a
+// future parallelization without breaking the cross-platform `cmp`.
+//
+// PSM only. SPM (suffix-prefix-middle) mode is deliberately out of scope for #215 — its absence
+// is a scoping decision, not an oversight.
+
+/// SplitMix64 (Steele/Lea/Flood) — a fixed, fully specified integer PRNG. Every operation is an
+/// explicitly wrapping 64-bit integer op, so the stream is identical on every platform and Swift
+/// version. Intentionally not `RandomNumberGenerator` (see the file header).
+public struct SplitMix64 {
+    private var state: UInt64
+
+    public init(seed: UInt64) { state = seed }
+
+    public mutating func next() -> UInt64 {
+        state = state &+ 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    /// Unbiased draw in `[0, bound)` by rejection sampling. Written out here on purpose rather
+    /// than calling a stdlib convenience: the rejection threshold and the redraw count are part
+    /// of this file's reproducibility contract.
+    public mutating func next(upperBound bound: UInt64) -> UInt64 {
+        if bound <= 1 { return 0 }
+        let threshold = (0 &- bound) % bound   // 2^64 mod bound — the biased tail to reject
+        while true {
+            let r = next()
+            if r >= threshold { return r % bound }
+        }
+    }
+}
+
+/// How `FIM.transform` behaves. `rateBasisPoints` is integer parts-per-10000 (4500 = 0.45);
+/// `0` disables the transform entirely, which is the default and keeps `pack` output
+/// byte-identical to the pre-#215 pipeline.
+public struct FIMOptions {
+    public var rateBasisPoints: Int
+    public var seed: UInt64
+    public var prefixId: Int
+    public var suffixId: Int
+    public var middleId: Int
+
+    public init(rateBasisPoints: Int = 0, seed: UInt64 = 0,
+                prefixId: Int = 1, suffixId: Int = 3, middleId: Int = 2) {
+        self.rateBasisPoints = rateBasisPoints
+        self.seed = seed
+        self.prefixId = prefixId
+        self.suffixId = suffixId
+        self.middleId = middleId
+    }
+
+    public var isEnabled: Bool { rateBasisPoints > 0 }
+}
+
+/// Counts for the one-line report `pack` prints. `eligible` is documents that passed the
+/// short/sentinel filters and therefore got a rate roll; `transformed` is the subset the roll
+/// selected. Skips are reported, never silent — a corpus that silently stopped being FIM'd would
+/// be indistinguishable from one that never was.
+public struct FIMStats {
+    public var eligible: Int = 0
+    public var transformed: Int = 0
+    public var skippedShort: Int = 0
+    public var skippedSentinel: Int = 0
+    public init() {}
+}
+
+public enum FIM {
+
+    /// The three reserved sentinel ids in *stream* order for PSM: prefix, suffix, middle.
+    public static func sentinels(_ o: FIMOptions) -> [Int] { [o.prefixId, o.suffixId, o.middleId] }
+
+    /// Derive this document's RNG seed from the global seed and the document's index. One
+    /// SplitMix64 step over a Weyl-shifted index, so neighbouring indices land far apart in the
+    /// stream and no document's outcome depends on any other's.
+    public static func documentSeed(_ globalSeed: UInt64, _ index: Int) -> UInt64 {
+        let idx = UInt64(bitPattern: Int64(index))
+        var g = SplitMix64(seed: globalSeed &+ (idx &* 0x9E37_79B9_7F4A_7C15))
+        return g.next()
+    }
+
+    /// Token ids for one document, FIM-transformed with probability `options.rateBasisPoints`.
+    /// EOS is the **caller's** job (matching `cmdPack`), and `Packing.pack` is untouched — that
+    /// matters because `tests/test_swift_parquet.py` asserts byte-identical `pack` output.
+    ///
+    /// PSM layout (the stream order the selfcheck pins as ids `1, 3, 2`):
+    ///
+    ///     [fim_prefix] encode(prefix) [fim_suffix] encode(suffix) [fim_middle] encode(middle)
+    ///
+    /// so `decode(prefix) + decode(middle) + decode(suffix)` reassembles the original document.
+    public static func transform(document: String, index: Int, tokenizer: Tokenizer,
+                                 options: FIMOptions, stats: inout FIMStats) -> [Int] {
+        if !options.isEnabled { return tokenizer.encode(document) }
+
+        let bytes = Array(document.utf8)
+        if bytes.isEmpty { return [] }
+
+        // Nothing meaningful to split below 3 bytes (an empty prefix AND an empty middle AND an
+        // empty suffix is the only reachable shape), so skip rather than emit a degenerate frame.
+        if bytes.count < 3 {
+            stats.skippedShort += 1
+            return tokenizer.encode(document)
+        }
+
+        // A document that literally contains one of the reserved special strings would have it
+        // split out into a real sentinel id by `Tokenizer.encode` (Tokenizer.swift:70-84), which
+        // would corrupt the PSM frame — two `<|fim_prefix|>` ids in one stream, or a sentinel
+        // inside the middle span. Skip FIM for that document; never emit a malformed frame.
+        // The scan is on raw UTF-8 bytes (not `String.contains`, which compares Characters and
+        // therefore drags in grapheme/canonical-equivalence tables) to keep it platform-stable.
+        for special in tokenizer.specials where containsSubsequence(bytes, Array(special.text.utf8)) {
+            stats.skippedSentinel += 1
+            return tokenizer.encode(document)
+        }
+
+        stats.eligible += 1
+        var rng = SplitMix64(seed: documentSeed(options.seed, index))
+        if rng.next(upperBound: 10000) >= UInt64(options.rateBasisPoints) {
+            return tokenizer.encode(document)
+        }
+        stats.transformed += 1
+
+        // Uniform two-point sampling over byte offsets (Bavarian et al.). An empty prefix, middle,
+        // or suffix is a legitimate draw and is KEPT — the model must learn both "complete from
+        // nothing" and "nothing left to complete". Resampling would distort the distribution.
+        let n = UInt64(bytes.count + 1)
+        var a = Int(rng.next(upperBound: n))
+        var b = Int(rng.next(upperBound: n))
+        if a > b { let t = a; a = b; b = t }
+        a = snapToScalarBoundary(bytes, a)
+        b = snapToScalarBoundary(bytes, b)   // snapping is monotonic, so a <= b still holds
+
+        // Split the document TEXT, not the token ids. Slicing ids instead would make every middle
+        // begin exactly on a token boundary, teaching the model it never has to complete a partial
+        // token — the classic silent FIM distribution bug.
+        let prefix = String(decoding: bytes[0..<a], as: UTF8.self)
+        let middle = String(decoding: bytes[a..<b], as: UTF8.self)
+        let suffix = String(decoding: bytes[b...], as: UTF8.self)
+
+        var ids: [Int] = []
+        ids.reserveCapacity(bytes.count / 2 + 3)
+        ids.append(options.prefixId)
+        tokenizer.encode(prefix, into: &ids)
+        ids.append(options.suffixId)
+        tokenizer.encode(suffix, into: &ids)
+        ids.append(options.middleId)
+        tokenizer.encode(middle, into: &ids)
+        return ids
+    }
+
+    // MARK: - internals (stdlib-only, table-free)
+
+    /// Smallest index `>= i` that starts a UTF-8 scalar. Continuation bytes match `0b10xxxxxx`;
+    /// `count` (one past the end) is always a boundary. Pure bit arithmetic — deliberately not
+    /// `String.Index`/`Character` arithmetic, which depends on the toolchain's Unicode tables.
+    static func snapToScalarBoundary(_ bytes: [UInt8], _ i: Int) -> Int {
+        var j = i
+        while j < bytes.count && (bytes[j] & 0xC0) == 0x80 { j += 1 }
+        return j
+    }
+
+    /// Naive byte-level substring search. The needles are the six ASCII special-token strings and
+    /// are short, so this is cheap next to BPE; correctness and platform-stability beat cleverness.
+    static func containsSubsequence(_ haystack: [UInt8], _ needle: [UInt8]) -> Bool {
+        if needle.isEmpty || needle.count > haystack.count { return false }
+        let last = haystack.count - needle.count
+        var i = 0
+        while i <= last {
+            var k = 0
+            while k < needle.count && haystack[i + k] == needle[k] { k += 1 }
+            if k == needle.count { return true }
+            i += 1
+        }
+        return false
+    }
+}

--- a/swift/Sources/MonicaTokenizer/Tokenizer.swift
+++ b/swift/Sources/MonicaTokenizer/Tokenizer.swift
@@ -41,6 +41,29 @@ public final class Tokenizer: @unchecked Sendable {   // immutable after init â†
 
     public func decode(_ ids: [Int]) -> String { bpe.decode(ids) }
 
+    /// Append `text`'s ids to `ids`. Public (it was `private`) so `FIM.transform` (#215) can
+    /// assemble a PSM stream â€” sentinel, piece, sentinel, piece â€” without three throwaway arrays,
+    /// and so it goes through exactly this encoder rather than a second copy of it.
+    public func encode(_ text: String, into ids: inout [Int]) {
+        if specials.isEmpty { encodeSegment(text, into: &ids); return }
+        var idx = text.startIndex
+        var segStart = idx
+        let end = text.endIndex
+        while idx < end {
+            var hit: (text: String, id: Int)? = nil
+            for sp in specials where text[idx...].hasPrefix(sp.text) { hit = sp; break }
+            if let m = hit {
+                if segStart < idx { encodeSegment(String(text[segStart..<idx]), into: &ids) }
+                ids.append(m.id)
+                idx = text.index(idx, offsetBy: m.text.count)
+                segStart = idx
+            } else {
+                idx = text.index(after: idx)
+            }
+        }
+        if segStart < end { encodeSegment(String(text[segStart..<end]), into: &ids) }
+    }
+
     /// Encode many documents concurrently (data-parallel across docs; identical on Mac/Linux).
     /// Concurrency is **bounded** to `maxConcurrency` in-flight tasks (default = core count):
     /// a large corpus would otherwise spawn one task per document and pile up memory. Output
@@ -65,26 +88,6 @@ public final class Tokenizer: @unchecked Sendable {   // immutable after init â†
     }
 
     // MARK: - internals
-
-    private func encode(_ text: String, into ids: inout [Int]) {
-        if specials.isEmpty { encodeSegment(text, into: &ids); return }
-        var idx = text.startIndex
-        var segStart = idx
-        let end = text.endIndex
-        while idx < end {
-            var hit: (text: String, id: Int)? = nil
-            for sp in specials where text[idx...].hasPrefix(sp.text) { hit = sp; break }
-            if let m = hit {
-                if segStart < idx { encodeSegment(String(text[segStart..<idx]), into: &ids) }
-                ids.append(m.id)
-                idx = text.index(idx, offsetBy: m.text.count)
-                segStart = idx
-            } else {
-                idx = text.index(after: idx)
-            }
-        }
-        if segStart < end { encodeSegment(String(text[segStart..<end]), into: &ids) }
-    }
 
     private func encodeSegment(_ segment: String, into ids: inout [Int]) {
         for pretoken in Pretokenizer.pretokenize(segment, digitGroup: digitGroup) {

--- a/swift/Sources/monica-selfcheck/main.swift
+++ b/swift/Sources/monica-selfcheck/main.swift
@@ -191,6 +191,225 @@ do {
           "pack throws on overflowing shardSizeMB")
 }
 
+// MARK: FIM (#215)
+//
+// StarCoder2 shipped a silent FIM bug — a malformed frame trains fine and only shows up as a
+// model that cannot infill. The reassembly assertion below is the guard: it must pass before any
+// compute is spent. It extends the tokenizer-level sentinel check above (ids 1,3,2) to the actual
+// pack path: transform → decode the three spans → get the original document back.
+
+/// Split a PSM stream into its (prefix, suffix, middle) id runs. `nil` if the frame is malformed,
+/// which the caller must report as a failure — never as "no FIM here".
+func psmSpans(_ ids: [Int], _ o: FIMOptions) -> (p: [Int], s: [Int], m: [Int])? {
+    guard let pi = ids.firstIndex(of: o.prefixId),
+          let si = ids.firstIndex(of: o.suffixId),
+          let mi = ids.firstIndex(of: o.middleId),
+          pi == 0, pi < si, si < mi else { return nil }
+    return (Array(ids[1..<si]), Array(ids[(si + 1)..<mi]), Array(ids[(mi + 1)...]))
+}
+
+do {
+    // --- 1. RNG determinism and a known-answer vector -----------------------------------------
+    // The known answers are the *published* SplitMix64 outputs for seed 0, not values harvested
+    // from this implementation — an externally-anchored vector is what catches a toolchain or
+    // refactor silently altering the stream (which would break the macOS-vs-Linux shard cmp).
+    do {
+        var r1 = SplitMix64(seed: 42)
+        var r2 = SplitMix64(seed: 42)
+        var a: [UInt64] = [], b: [UInt64] = []
+        for _ in 0..<16 { a.append(r1.next()); b.append(r2.next()) }
+        eq(a, b, "SplitMix64 is reproducible from a seed")
+        check(Set(a).count > 8, "SplitMix64 stream is not a constant")
+
+        var ref = SplitMix64(seed: 0)
+        eq(ref.next(), 0xE220_A839_7B1D_CDAF, "SplitMix64 reference vector, seed 0, draw 1")
+        eq(ref.next(), 0x6E78_9E6A_A1B9_65F4, "SplitMix64 reference vector, seed 0, draw 2")
+        eq(ref.next(), 0x06C4_5D18_8009_454F, "SplitMix64 reference vector, seed 0, draw 3")
+
+        var bounded = SplitMix64(seed: 7)
+        var maxDraw: UInt64 = 0
+        for _ in 0..<20000 { maxDraw = max(maxDraw, bounded.next(upperBound: 10000)) }
+        check(maxDraw < 10000, "next(upperBound: 10000) stays in range (max \(maxDraw))")
+        check(maxDraw > 9000, "next(upperBound: 10000) covers the range (max \(maxDraw))")
+        var degenerate = SplitMix64(seed: 7)
+        eq(degenerate.next(upperBound: 1), 0, "next(upperBound: 1) is always 0")
+        eq(degenerate.next(upperBound: 0), 0, "next(upperBound: 0) is 0, not a division trap")
+    }
+
+    let tok = Tokenizer(format: trained())
+    let forceAll = FIMOptions(rateBasisPoints: 10000, seed: 1234)
+
+    let fimDocs = [
+        "function add(a: number, b: number): number { return a + b; }",
+        "const greet = (name: string): string => `hello ${name}`;",
+        "export class Vec {\n  constructor(public x: number, public y: number) {}\n}\n",
+        "const s = 'π≈3.14'; // 数字 🚀 mixed-width unicode",
+        "\t\tif (x) {\n\t\t\treturn 0;\n\t\t}",
+        "abc",                                   // exactly the 3-byte minimum
+        String(repeating: "let z = 0;\n", count: 40),
+    ]
+
+    // --- 2. Round trip: the headline check ----------------------------------------------------
+    do {
+        var stats = FIMStats()
+        for (i, doc) in fimDocs.enumerated() {
+            let ids = FIM.transform(document: doc, index: i, tokenizer: tok,
+                                    options: forceAll, stats: &stats)
+            eq(ids.first, forceAll.prefixId, "FIM stream starts with <|fim_prefix|> (doc \(i))")
+            for sentinel in FIM.sentinels(forceAll) {
+                eq(ids.filter { $0 == sentinel }.count, 1,
+                   "sentinel \(sentinel) appears exactly once (doc \(i))")
+            }
+            guard let spans = psmSpans(ids, forceAll) else {
+                failures.append("malformed PSM frame for doc \(i)")
+                continue
+            }
+            eq(tok.decode(spans.p) + tok.decode(spans.m) + tok.decode(spans.s), doc,
+               "prefix+middle+suffix reassembles the original document (doc \(i))")
+            let specialsInSpans = (spans.p + spans.m + spans.s).filter { $0 < SPECIALS.count }
+            eq(specialsInSpans, [], "no sentinel id leaks inside a span (doc \(i))")
+        }
+        eq(stats.transformed, fimDocs.count, "rate 1.0 transforms every eligible doc")
+        eq(stats.skippedShort, 0, "no fixture doc was skipped as short")
+        eq(stats.skippedSentinel, 0, "no fixture doc was skipped as sentinel-bearing")
+    }
+
+    // --- 3. The rate is actually honoured -----------------------------------------------------
+    // A deliberately loose band: this is a wiring check (is the roll connected to the flag?),
+    // not a statistics test, and it must never flake.
+    do {
+        var stats = FIMStats()
+        let synthetic = (0..<200).map { "const value\($0) = compute(\($0)) + offset;" }
+        for (i, doc) in synthetic.enumerated() {
+            _ = FIM.transform(document: doc, index: i, tokenizer: tok,
+                              options: FIMOptions(rateBasisPoints: 5000, seed: 99), stats: &stats)
+        }
+        eq(stats.eligible, synthetic.count, "every synthetic doc is FIM-eligible")
+        check(stats.transformed >= 70 && stats.transformed <= 130,
+              "rate 0.5 transforms roughly half (\(stats.transformed)/200)")
+    }
+
+    // --- 4. Determinism at the pack level, plus the anti-vacuity guard ------------------------
+    // Same seed -> byte-identical shards; different seed -> different tokens. Without the second
+    // half, a transform that silently did nothing would pass the identity check vacuously.
+    do {
+        func packWith(_ options: FIMOptions, into dir: URL) -> Bool {
+            var stats = FIMStats()
+            var tokenized: [[Int]] = []
+            for (i, doc) in SAMPLE.enumerated() {
+                var ids = FIM.transform(document: doc, index: i, tokenizer: tok,
+                                        options: options, stats: &stats)
+                ids.append(tok.eosTokenId)
+                tokenized.append(ids)
+            }
+            // `try?` rather than do/catch: in top-level code the compiler already treats thrown
+            // errors as handled, so a `catch` here warns as unreachable. A nil result is the
+            // failure signal, and it is reported — never swallowed.
+            guard (try? Packing.pack(docs: tokenized, outDir: dir, seqLen: 16, shardSizeMB: 1)) != nil else {
+                failures.append("FIM pack failed for seed \(options.seed)")
+                return false
+            }
+            return true
+        }
+
+        func artifacts(_ dir: URL) -> [String: Data] {
+            var out: [String: Data] = [:]
+            let names = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+            for name in names.sorted() {
+                out[name] = (try? Data(contentsOf: dir.appendingPathComponent(name))) ?? Data()
+            }
+            return out
+        }
+
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("monica-fim-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dirA = root.appendingPathComponent("a")
+        let dirB = root.appendingPathComponent("b")
+        let dirC = root.appendingPathComponent("c")
+        let seeded = FIMOptions(rateBasisPoints: 5000, seed: 1234)
+        let reseeded = FIMOptions(rateBasisPoints: 5000, seed: 4321)
+
+        if packWith(seeded, into: dirA), packWith(seeded, into: dirB), packWith(reseeded, into: dirC) {
+            let a = artifacts(dirA), b = artifacts(dirB), c = artifacts(dirC)
+            check(!a.isEmpty, "FIM pack produced artifacts (an empty compare would be vacuous)")
+            eq(a.keys.sorted(), b.keys.sorted(), "same-seed packs write the same file set")
+            for name in a.keys.sorted() {
+                eq(a[name], b[name], "same-seed pack is byte-identical: \(name)")
+            }
+            check(a["part-00000.bin"] != c["part-00000.bin"],
+                  "a different --fim-seed produces different tokens (anti-vacuity)")
+        }
+    }
+
+    // --- 5. Rate 0 is a true no-op (this is what keeps the pre-#215 pipeline byte-identical) --
+    do {
+        var stats = FIMStats()
+        let off = FIMOptions(rateBasisPoints: 0, seed: 1234)
+        for (i, doc) in fimDocs.enumerated() {
+            eq(FIM.transform(document: doc, index: i, tokenizer: tok, options: off, stats: &stats),
+               tok.encode(doc), "rate 0 returns a plain encode (doc \(i))")
+        }
+        eq(stats.transformed, 0, "rate 0 transforms nothing")
+    }
+
+    // --- 6. Edge cases ------------------------------------------------------------------------
+    do {
+        var stats = FIMStats()
+        eq(FIM.transform(document: "", index: 0, tokenizer: tok, options: forceAll, stats: &stats),
+           [], "empty doc yields no tokens and no sentinels")
+
+        for short in ["a", "ab"] {
+            let ids = FIM.transform(document: short, index: 1, tokenizer: tok,
+                                    options: forceAll, stats: &stats)
+            eq(ids, tok.encode(short), "sub-3-byte doc is left unchanged")
+        }
+        eq(stats.skippedShort, 2, "short docs are counted, not silently dropped")
+
+        // A doc that literally contains a sentinel string would otherwise get a real sentinel id
+        // mid-span from `Tokenizer.encode`, corrupting the frame. It must be skipped and counted.
+        let hostile = "before <|fim_prefix|> after the sentinel string"
+        let ids = FIM.transform(document: hostile, index: 2, tokenizer: tok,
+                                options: forceAll, stats: &stats)
+        eq(ids, tok.encode(hostile), "sentinel-bearing doc is left unchanged")
+        eq(stats.skippedSentinel, 1, "sentinel-bearing docs are counted")
+
+        // Empty prefix / middle / suffix are legitimate draws and must round-trip too.
+        for (a, b) in [(0, 0), (0, 3), (3, 3)] {
+            let doc = "abc"
+            let bytes = Array(doc.utf8)
+            var frame: [Int] = [forceAll.prefixId]
+            tok.encode(String(decoding: bytes[0..<a], as: UTF8.self), into: &frame)
+            frame.append(forceAll.suffixId)
+            tok.encode(String(decoding: bytes[b...], as: UTF8.self), into: &frame)
+            frame.append(forceAll.middleId)
+            tok.encode(String(decoding: bytes[a..<b], as: UTF8.self), into: &frame)
+            guard let spans = psmSpans(frame, forceAll) else {
+                failures.append("degenerate PSM frame (\(a),\(b)) did not parse")
+                continue
+            }
+            eq(tok.decode(spans.p) + tok.decode(spans.m) + tok.decode(spans.s), doc,
+               "degenerate split (\(a),\(b)) still reassembles")
+        }
+
+        // Cut points never land inside a UTF-8 scalar: snapping forward is idempotent and
+        // monotonic, so every transformed multi-byte-scalar doc must decode losslessly.
+        let unicodeDoc = "π≈3.14 数字 🚀 πππ 数数数 🚀🚀🚀 tail"
+        for seed in UInt64(0)..<64 {
+            var s = FIMStats()
+            let out = FIM.transform(document: unicodeDoc, index: 0, tokenizer: tok,
+                                    options: FIMOptions(rateBasisPoints: 10000, seed: seed),
+                                    stats: &s)
+            guard let spans = psmSpans(out, forceAll) else {
+                failures.append("unicode doc produced a malformed frame at seed \(seed)")
+                continue
+            }
+            eq(tok.decode(spans.p) + tok.decode(spans.m) + tok.decode(spans.s), unicodeDoc,
+               "unicode doc reassembles at seed \(seed)")
+        }
+    }
+}
+
 // MARK: parquet
 //
 // Covers the pure-Swift Parquet reader (swift/Sources/MonicaTokenizer/Parquet/, #247) on both

--- a/swift/Sources/monica-tokenize/main.swift
+++ b/swift/Sources/monica-tokenize/main.swift
@@ -5,6 +5,7 @@
 //   monica-tokenize decode --tokenizer <tokenizer.json> [--in <file>]
 //   monica-tokenize pack   --tokenizer <tokenizer.json> --in <parquet|jsonl|txt|dir> --out <dir>
 //                          [--seq-len 8192] [--shard-size-mb 512] [--chunk-align N]
+//                          [--fim-rate 0.0] [--fim-seed 0]
 //   monica-tokenize stats  --tokenizer <tokenizer.json> --in <jsonl> [--json]
 //
 // `--in` reads stdin when omitted (encode/decode). `train`/`pack` corpus = a `.parquet` file or
@@ -63,6 +64,33 @@ func intFlag(_ flags: [String: String], _ name: String, default def: Int) -> Int
     guard let raw = flags[name], !raw.isEmpty else { return def }
     guard let v = Int(raw) else { fail("--\(name) must be an integer, got '\(raw)'") }
     return v
+}
+
+/// A `UInt64` flag, or `def` when absent. Separate from `intFlag` so a FIM seed can span the
+/// full 64-bit space (the RNG's seed type) instead of being clamped to `Int`'s signed range.
+func uint64Flag(_ flags: [String: String], _ name: String, default def: UInt64) -> UInt64 {
+    guard let raw = flags[name], !raw.isEmpty else { return def }
+    guard let v = UInt64(raw) else {
+        fail("--\(name) must be a non-negative integer in [0, \(UInt64.max)], got '\(raw)'")
+    }
+    return v
+}
+
+/// `--fim-rate 0.45` → 4500 basis points. The **only** floating-point step in the whole FIM path:
+/// rounding happens once, here, so the transform itself is integer-only and cannot drift between
+/// the macOS and Linux FP paths (which would break the `swift-parity` shard `cmp`). Absent → 0,
+/// i.e. FIM off, which keeps `pack` output byte-identical to the pre-#215 pipeline.
+func rateBasisPoints(_ flags: [String: String], _ name: String) -> Int {
+    guard let raw = flags[name], !raw.isEmpty else { return 0 }
+    guard let v = Double(raw) else { fail("--\(name) must be a number in [0, 1], got '\(raw)'") }
+    guard v >= 0 && v <= 1 else { fail("--\(name) must be in [0, 1], got '\(raw)'") }
+    let bp = Int((v * 10000).rounded())
+    // #215 pins the intended band at 0.4–0.5 (explicitly NOT the 0.5–0.9 reported elsewhere).
+    // Warn rather than fail: hard-failing would block a deliberate ablation sweep.
+    if bp > 0 && (bp < 4000 || bp > 5000) {
+        warn("--\(name) \(raw) is outside the intended 0.4–0.5 FIM band (#215); proceeding")
+    }
+    return bp
 }
 
 /// Text from `--in <file>` (failing fast if it can't be read — never a silent empty
@@ -212,16 +240,38 @@ func cmdPack(_ flags: [String: String]) {
         chunkAlign = nil
     }
 
+    // FIM insertion (#215) happens here, at pack time, because this is the only place documents
+    // still exist as whole objects — `src/data/split.py` drops the `.bounds` sidecars, so the
+    // Python trainer never sees doc structure. Trade-off, accepted and recorded in FIM.swift:
+    // changing the rate means re-packing the corpus, not editing a config.
+    let fimOptions = FIMOptions(rateBasisPoints: rateBasisPoints(flags, "fim-rate"),
+                                seed: uint64Flag(flags, "fim-seed", default: 0))
+    var fimStats = FIMStats()
+
     let docs = readDocs(inPath)
     let eos = tok.eosTokenId
-    let tokenized = docs.map { doc -> [Int] in
-        var ids = tok.encode(doc); ids.append(eos); return ids
+    var tokenized: [[Int]] = []
+    tokenized.reserveCapacity(docs.count)
+    for (i, doc) in docs.enumerated() {
+        // The index is `readDocs`'s, which is stable regardless of which docs `pack` later drops
+        // as empty — so a document's FIM outcome never depends on its neighbours.
+        var ids = FIM.transform(document: doc, index: i, tokenizer: tok,
+                                options: fimOptions, stats: &fimStats)
+        ids.append(eos)
+        tokenized.append(ids)
     }
     do {
         let m = try Packing.pack(docs: tokenized, outDir: URL(fileURLWithPath: outPath),
                                  seqLen: seqLen, shardSizeMB: shardMB,
                                  tokenizer: "code", chunkAlign: chunkAlign)
         print("packed \(m.n_sequences) seq x \(seqLen) (\(m.n_tokens) tokens, \(m.shards.count) shard(s)) -> \(outPath)")
+        if fimOptions.isEnabled {
+            let rate = String(format: "%.4f", Double(fimOptions.rateBasisPoints) / 10000.0)
+            print("fim: \(fimStats.transformed)/\(docs.count) docs transformed "
+                  + "(rate \(rate), seed \(fimOptions.seed); \(fimStats.eligible) eligible, "
+                  + "skipped \(fimStats.skippedShort) short, "
+                  + "\(fimStats.skippedSentinel) sentinel-bearing)")
+        }
     } catch { fail("pack: \(error)") }
 }
 

--- a/tests/test_fim_eval.py
+++ b/tests/test_fim_eval.py
@@ -1,0 +1,336 @@
+"""Portable tests for the distance-bucketed FIM eval (#215, `src/eval/fim_eval.py`).
+
+No backend: the model is a fake whose logits depend only on the token at each position, which
+makes it causal by construction — exactly what the right-padding batching scheme relies on.
+"""
+
+import numpy as np
+import pytest
+
+from src.eval.fim_eval import (
+    DEFAULT_BUCKETS,
+    FIMExample,
+    FIMSentinels,
+    attention_after_suffix,
+    bucket_of,
+    build_fim_examples,
+    documents_from_shards,
+    evaluate_fim,
+    format_fim_table,
+    make_fim_example,
+)
+
+VOCAB = 32
+
+
+class _FakeModel:
+    """`forward(inputs) -> (B, L, V)`; logits at position t depend ONLY on `inputs[b, t]`.
+
+    That is a strictly causal model (each position ignores everything after it), which is the
+    property `evaluate_fim`'s right-padding assumes. A model that peeked at the padded tail would
+    break `test_padding_does_not_change_a_short_examples_score`.
+    """
+
+    def __init__(self, vocab_size=VOCAB, n_layers=4, attn_every=2):
+        self.vocab_size = vocab_size
+
+        class _Cfg:
+            pass
+
+        self.config = _Cfg()
+        self.config.n_layers = n_layers
+        self.config.attn_every = attn_every
+        # A fixed random embedding table -> deterministic, non-degenerate logits.
+        self._table = np.random.default_rng(0).standard_normal((vocab_size, vocab_size))
+
+    def forward(self, inputs):
+        inputs = np.asarray(inputs)
+        return self._table[inputs % self.vocab_size].astype(np.float32)
+
+
+class _OracleModel:
+    """Predicts the next id as `(current + 1) % vocab` with huge confidence.
+
+    Fed a document of consecutive ids this is a perfect predictor *inside* the middle span, but
+    the first middle token is predicted from the `fim_middle` sentinel, which carries no such
+    relation — so `bridge` overrides that one row (sentinel id -> the actual first middle token).
+    Still causal: every position depends only on its own input id.
+    """
+
+    def __init__(self, vocab_size=VOCAB, bridge=None):
+        self.vocab_size = vocab_size
+        self._table = np.full((vocab_size, vocab_size), -50.0, dtype=np.float32)
+        for i in range(vocab_size):
+            self._table[i, (i + 1) % vocab_size] = 50.0
+        for src, dst in (bridge or {}).items():
+            self._table[src] = -50.0
+            self._table[src, dst] = 50.0
+
+    def forward(self, inputs):
+        return self._table[np.asarray(inputs) % self.vocab_size]
+
+
+def _doc(n, start=6):
+    """A document of consecutive ids, all above the 0..5 special range."""
+    return np.array([(start + i) % VOCAB for i in range(n)], dtype=np.int64)
+
+
+# --------------------------------------------------------------------------------------- #
+# PSM layout
+# --------------------------------------------------------------------------------------- #
+
+def test_psm_layout_and_reassembly():
+    s = FIMSentinels()
+    doc = _doc(10)
+    ex = make_fim_example(doc, 3, 7, s, doc_index=4)
+
+    assert ex.tokens[0] == s.prefix
+    assert ex.tokens[1 + 3] == s.suffix
+    assert ex.middle_start == 1 + 3 + 1 + 3
+    assert ex.tokens[ex.middle_start] == s.middle
+    assert (ex.prefix_len, ex.middle_len, ex.suffix_len) == (3, 4, 3)
+    assert ex.doc_index == 4
+    assert ex.recall_distance == ex.middle_start == ex.prefix_len + ex.suffix_len + 2
+
+    prefix = ex.tokens[1:1 + ex.prefix_len]
+    suffix = ex.tokens[2 + ex.prefix_len:2 + ex.prefix_len + ex.suffix_len]
+    middle = ex.tokens[ex.middle_start + 1:]
+    np.testing.assert_array_equal(np.concatenate([prefix, middle, suffix]), doc)
+
+    for sentinel in s.all_sentinels:
+        assert int((ex.tokens == sentinel).sum()) == 1
+
+
+@pytest.mark.parametrize("a,b", [(0, 0), (0, 10), (10, 10), (4, 4)])
+def test_degenerate_cuts_still_reassemble(a, b):
+    doc = _doc(10)
+    ex = make_fim_example(doc, a, b)
+    prefix = ex.tokens[1:1 + ex.prefix_len]
+    suffix = ex.tokens[2 + ex.prefix_len:2 + ex.prefix_len + ex.suffix_len]
+    middle = ex.tokens[ex.middle_start + 1:]
+    np.testing.assert_array_equal(np.concatenate([prefix, middle, suffix]), doc)
+
+
+def test_invalid_cuts_raise():
+    with pytest.raises(ValueError):
+        make_fim_example(_doc(10), 7, 3)
+    with pytest.raises(ValueError):
+        make_fim_example(_doc(10), 0, 11)
+
+
+# --------------------------------------------------------------------------------------- #
+# Buckets
+# --------------------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("value,expected", [
+    (0, "short"), (255, "short"), (256, "medium"), (1023, "medium"),
+    (1024, "long"), (10 ** 6, "long"),
+])
+def test_bucket_boundaries(value, expected):
+    assert bucket_of(value, DEFAULT_BUCKETS) == expected
+
+
+def test_bucket_of_raises_when_nothing_matches():
+    with pytest.raises(ValueError):
+        bucket_of(500, (("tiny", 0, 10),))
+
+
+# --------------------------------------------------------------------------------------- #
+# Construction determinism
+# --------------------------------------------------------------------------------------- #
+
+def test_same_generator_seed_yields_identical_examples():
+    docs = [_doc(20), _doc(35, start=9), _doc(12, start=11)]
+    a = build_fim_examples(docs, np.random.default_rng(7), n_per_doc=3)
+    b = build_fim_examples(docs, np.random.default_rng(7), n_per_doc=3)
+    assert len(a) == len(b) == 9
+    for x, y in zip(a, b):
+        np.testing.assert_array_equal(x.tokens, y.tokens)
+        assert (x.middle_start, x.middle_len, x.doc_index) == (y.middle_start, y.middle_len,
+                                                               y.doc_index)
+
+
+def test_build_skips_docs_that_cannot_yield_a_middle():
+    exs = build_fim_examples([_doc(0), _doc(1), _doc(9)], np.random.default_rng(0),
+                             n_per_doc=1, min_middle=2)
+    assert [e.doc_index for e in exs] == [2]
+    assert all(e.middle_len >= 2 for e in exs)
+
+
+# --------------------------------------------------------------------------------------- #
+# Scoring
+# --------------------------------------------------------------------------------------- #
+
+def test_mask_covers_exactly_the_middle_span():
+    """A model that is perfect on the middle span and WRONG everywhere else still scores CE ~ 0.
+
+    That only holds if the mask covers the middle span and nothing else: the oracle mispredicts
+    every prefix/suffix/sentinel position, so a mask that were one position too wide would blow
+    the CE up to ~100 nats.
+    """
+    doc = _doc(24)
+    ex = make_fim_example(doc, 5, 15)
+    oracle = _OracleModel(bridge={FIMSentinels().middle: int(doc[5])})
+    res = evaluate_fim(oracle, [ex], batch_size=1)
+    rec = res["records"][0]
+    assert rec["n_middle_tokens"] == ex.middle_len
+    assert rec["ce_nats"] < 1e-6
+    assert rec["token_accuracy"] == 1.0
+    assert rec["exact_match"] == 1.0
+    assert res["overall"]["perplexity"] == pytest.approx(1.0, abs=1e-5)
+    assert res["overall"]["exact_match_rate"] == 1.0
+
+
+def test_mask_one_position_wider_would_be_caught():
+    """Anti-vacuity for the test above: the same oracle scored over a span shifted by one is
+    catastrophically wrong, so 'CE ~ 0' is a real assertion about the mask, not about the model."""
+    doc = _doc(24)
+    ex = make_fim_example(doc, 5, 15)
+    oracle = _OracleModel(bridge={FIMSentinels().middle: int(doc[5])})
+    shifted = FIMExample(tokens=ex.tokens, middle_start=ex.middle_start - 1,
+                         prefix_len=ex.prefix_len, middle_len=ex.middle_len,
+                         suffix_len=ex.suffix_len, doc_index=0)
+    assert evaluate_fim(oracle, [shifted], batch_size=1)["records"][0]["ce_nats"] > 1.0
+
+
+def test_aggregate_is_the_token_weighted_mean_of_the_records():
+    docs = [_doc(30), _doc(24, start=8)]
+    exs = build_fim_examples(docs, np.random.default_rng(3), n_per_doc=2, min_middle=2)
+    res = evaluate_fim(_FakeModel(), exs, batch_size=3)
+    rows = [r for r in res["records"] if r["n_middle_tokens"] > 0]
+    n = sum(r["n_middle_tokens"] for r in rows)
+    expected = sum(r["ce_nats"] * r["n_middle_tokens"] for r in rows) / n
+    assert res["overall"]["ce"] == pytest.approx(expected, rel=1e-12)
+    assert res["overall"]["n_tokens"] == n
+    assert res["overall"]["n_examples"] == len(rows)
+
+
+def test_padding_does_not_change_a_short_examples_score():
+    """THE key correctness test for the batching scheme: batching a short example with a much
+    longer one must not move its score. Right-padding is only safe because the model is causal."""
+    short = make_fim_example(_doc(12), 3, 8, doc_index=0)
+    long = make_fim_example(_doc(400, start=7), 100, 300, doc_index=1)
+    model = _FakeModel()
+
+    batched = evaluate_fim(model, [short, long], batch_size=2)["records"]
+    alone = evaluate_fim(model, [short], batch_size=1)["records"]
+    plus = evaluate_fim(model, [long], batch_size=1)["records"]
+
+    assert batched[0]["ce_nats"] == pytest.approx(alone[0]["ce_nats"], rel=1e-12)
+    assert batched[1]["ce_nats"] == pytest.approx(plus[0]["ce_nats"], rel=1e-12)
+    assert batched[0]["token_accuracy"] == alone[0]["token_accuracy"]
+
+
+def test_records_carry_both_distances_and_bucket_by_the_key():
+    """`key` selects what gets bucketed; every record carries both distances regardless, so #221
+    can bucket on recall distance without a second module."""
+    ex = make_fim_example(_doc(600), 300, 400)     # prefix_len 300, recall_distance 502
+    model = _FakeModel()
+
+    by_prefix = evaluate_fim(model, [ex], batch_size=1)["records"][0]
+    by_recall = evaluate_fim(model, [ex], batch_size=1,
+                             key=lambda e: e.recall_distance)["records"][0]
+
+    assert by_prefix["prefix_len"] == 300 and by_prefix["recall_distance"] == 502
+    assert by_prefix["bucket"] == "medium"          # 300 -> [256, 1024)
+    assert by_recall["bucket"] == "medium"          # 502 -> [256, 1024)
+
+    far = make_fim_example(_doc(2400), 1200, 1400)
+    assert evaluate_fim(model, [far], batch_size=1)["records"][0]["bucket"] == "long"
+
+
+def test_empty_bucket_is_none_not_a_crash():
+    exs = [make_fim_example(_doc(20), 4, 12)]      # short bucket only
+    res = evaluate_fim(_FakeModel(), exs, batch_size=1)
+    assert res["by_bucket"]["short"] is not None
+    assert res["by_bucket"]["medium"] is None
+    assert res["by_bucket"]["long"] is None
+    assert "no examples in this bucket" in format_fim_table(res)
+
+
+def test_no_examples_raises_rather_than_reporting_a_perfect_model():
+    with pytest.raises(ValueError, match="no middle tokens scored"):
+        evaluate_fim(_FakeModel(), [], batch_size=2)
+
+
+def test_empty_middle_is_recorded_but_not_scored():
+    empty = make_fim_example(_doc(10), 4, 4)       # zero-length middle
+    real = make_fim_example(_doc(10), 2, 8)
+    res = evaluate_fim(_FakeModel(), [empty, real], batch_size=2)
+    assert res["records"][0]["n_middle_tokens"] == 0
+    assert res["records"][0]["ce_nats"] is None
+    assert res["overall"]["n_examples"] == 1       # the empty one contributes nothing
+
+
+def test_all_empty_middles_raises():
+    exs = [make_fim_example(_doc(10), 4, 4), make_fim_example(_doc(10), 0, 0)]
+    with pytest.raises(ValueError, match="no middle tokens scored"):
+        evaluate_fim(_FakeModel(), exs, batch_size=2)
+
+
+def test_batch_size_must_be_positive():
+    with pytest.raises(ValueError):
+        evaluate_fim(_FakeModel(), [make_fim_example(_doc(10), 2, 6)], batch_size=0)
+
+
+# --------------------------------------------------------------------------------------- #
+# Advisory (requirement 5 — documentation + config guidance, no model code)
+# --------------------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("n_layers,attn_every,expected", [
+    (4, 2, True),        # config/toy-hybrid.yaml — [Mamba, Attn, Mamba, Attn]
+    (28, 8, False),      # config/student-1b.yaml — attention at 7/15/23, top block is Mamba
+    (24, None, False),   # pure Mamba
+    (24, 0, False),
+    (0, 2, False),
+    (24, 8, True),
+])
+def test_attention_after_suffix_truth_table(n_layers, attn_every, expected):
+    assert attention_after_suffix(n_layers, attn_every) is expected
+
+
+def test_advisory_present_only_when_the_top_block_is_not_attention():
+    ex = make_fim_example(_doc(20), 4, 12)
+    ok = evaluate_fim(_FakeModel(n_layers=4, attn_every=2), [ex], batch_size=1)
+    bad = evaluate_fim(_FakeModel(n_layers=28, attn_every=8), [ex], batch_size=1)
+    assert ok["advisory"] is None
+    assert "final block is not attention" in bad["advisory"]
+    assert "advisory:" in format_fim_table(bad)
+
+
+def test_advisory_never_raises_on_a_config_less_model():
+    class _Bare:
+        def forward(self, inputs):
+            return np.zeros((*np.asarray(inputs).shape, VOCAB), dtype=np.float32)
+
+    res = evaluate_fim(_Bare(), [make_fim_example(_doc(20), 4, 12)], batch_size=1)
+    assert res["advisory"] is None
+
+
+# --------------------------------------------------------------------------------------- #
+# Shard bridge
+# --------------------------------------------------------------------------------------- #
+
+def test_documents_from_shards_round_trips_doc_boundaries(tmp_path):
+    from src.data.shard import pack_sequences
+
+    docs = [[6, 7, 8, 9], [10, 11, 12, 13, 14, 15, 16, 17], [18, 19, 20, 21]]
+    pack_sequences(iter(docs), tmp_path, seq_len=4, shard_size_mb=1)
+    recovered = documents_from_shards(tmp_path, min_len=1)
+    assert len(recovered) == len(docs)
+    assert list(recovered[0]) == docs[0]
+
+
+def test_documents_from_shards_honours_max_docs(tmp_path):
+    from src.data.shard import pack_sequences
+
+    docs = [[6, 7, 8, 9] for _ in range(6)]
+    pack_sequences(iter(docs), tmp_path, seq_len=4, shard_size_mb=1)
+    assert len(documents_from_shards(tmp_path, max_docs=2)) == 2
+
+
+def test_fim_example_is_frozen():
+    ex = make_fim_example(_doc(10), 2, 6)
+    assert isinstance(ex, FIMExample)
+    with pytest.raises(Exception):
+        ex.middle_start = 0

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -75,6 +75,7 @@ PORTABLE_MODULES = [
     "src.eval.val_loss",
     "src.eval.quantize",
     "src.eval.long_context",
+    "src.eval.fim_eval",
     "src.eval.olmes_adapter",
     "src.eval.bfcl_adapter",
     "src.eval.retrieval_probe",

--- a/tests/test_swift_fim.py
+++ b/tests/test_swift_fim.py
@@ -1,0 +1,161 @@
+"""Differential / determinism test for FIM insertion in the Swift `pack` path (#215).
+
+`monica-selfcheck` is the Swift package's own test runner and covers the round-trip reassembly
+in-process. This file covers what only a shell-out can: that the **CLI flags** are wired to the
+transform, that two packs with the same `--fim-seed` are byte-identical while a different seed
+is not (anti-vacuity — a no-op transform would pass the identity check trivially), that
+`--fim-rate 0` is byte-identical to omitting the flag entirely (the no-regression proof for the
+existing pipeline and for `tests/test_swift_parquet.py`), and that the **Python trainer** sees
+the sentinels where the PSM frame says they should be.
+
+Note what this file cannot prove: a single machine cannot catch a platform-divergent RNG. That
+is `swift-parity`'s job in `.github/workflows/ci.yml`, which `cmp`s macOS-packed shards against
+Linux-packed ones.
+
+Skips cleanly if `monica-tokenize` isn't built (`cd swift && swift build`).
+"""
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.data.shard import doc_start_offsets, open_shard, read_manifest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = REPO_ROOT / "swift" / "Fixtures" / "parity-corpus.jsonl"
+
+PREFIX_ID, MIDDLE_ID, SUFFIX_ID = 1, 2, 3
+
+
+def _find_monica_tokenize() -> Path | None:
+    env = os.environ.get("MONICA_TOKENIZE")
+    if env and Path(env).exists():
+        return Path(env)
+    swift_dir = REPO_ROOT / "swift"
+    for mode in ("release", "debug"):
+        cand = swift_dir / ".build" / mode / "monica-tokenize"
+        if cand.exists():
+            return cand
+    return None
+
+
+@pytest.fixture(scope="module")
+def monica_tokenize() -> Path:
+    binary = _find_monica_tokenize()
+    if binary is None:
+        pytest.skip("monica-tokenize not built (cd swift && swift build)")
+    return binary
+
+
+@pytest.fixture(scope="module")
+def tokenizer(monica_tokenize, tmp_path_factory) -> Path:
+    """One tokenizer for the whole module — training it per test would dominate the runtime and
+    prove nothing extra (training determinism is already `monica-selfcheck`'s job)."""
+    if not FIXTURE.exists():
+        pytest.skip(f"fixture corpus missing: {FIXTURE}")
+    out = tmp_path_factory.mktemp("tok") / "tok.json"
+    r = _run(monica_tokenize, "train", "--in", str(FIXTURE), "--out", str(out),
+             "--vocab-size", "2000")
+    assert r.returncode == 0, r.stderr
+    return out
+
+
+def _run(binary: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run([str(binary), *args], capture_output=True, text=True)
+
+
+def _pack(binary: Path, tok: Path, out: Path, *extra: str) -> subprocess.CompletedProcess:
+    r = _run(binary, "pack", "--tokenizer", str(tok), "--in", str(FIXTURE), "--out", str(out),
+             "--seq-len", "64", "--shard-size-mb", "1", *extra)
+    assert r.returncode == 0, r.stderr
+    # An empty pack would make every byte-comparison below vacuous — a check that cannot observe
+    # its target reports BLIND, not healthy.
+    manifest = json.loads((out / "manifest.json").read_text())
+    assert manifest["n_sequences"] > 0, f"pack produced no sequences: {manifest}"
+    return r
+
+
+def _dir_bytes(d: Path) -> dict[str, bytes]:
+    return {p.name: p.read_bytes() for p in sorted(d.iterdir())}
+
+
+def test_same_seed_packs_are_byte_identical(monica_tokenize, tokenizer, tmp_path):
+    a, b = tmp_path / "a", tmp_path / "b"
+    for out in (a, b):
+        _pack(monica_tokenize, tokenizer, out, "--fim-rate", "0.5", "--fim-seed", "1234")
+    assert _dir_bytes(a) == _dir_bytes(b)
+
+
+def test_a_different_seed_changes_the_tokens(monica_tokenize, tokenizer, tmp_path):
+    """Anti-vacuity: without this, a transform that silently did nothing would pass the
+    same-seed identity test."""
+    a, c = tmp_path / "a", tmp_path / "c"
+    _pack(monica_tokenize, tokenizer, a, "--fim-rate", "0.5", "--fim-seed", "1234")
+    _pack(monica_tokenize, tokenizer, c, "--fim-rate", "0.5", "--fim-seed", "4321")
+    assert (a / "part-00000.bin").read_bytes() != (c / "part-00000.bin").read_bytes()
+
+
+def test_rate_zero_is_identical_to_omitting_the_flag(monica_tokenize, tokenizer, tmp_path):
+    """The no-regression proof: the pre-#215 pipeline (and `tests/test_swift_parquet.py`'s
+    byte-identity assertion) must not move because FIM exists."""
+    off1, off2 = tmp_path / "off1", tmp_path / "off2"
+    _pack(monica_tokenize, tokenizer, off1)
+    _pack(monica_tokenize, tokenizer, off2, "--fim-rate", "0")
+    assert _dir_bytes(off1) == _dir_bytes(off2)
+
+
+def test_fim_changes_the_output_relative_to_no_fim(monica_tokenize, tokenizer, tmp_path):
+    off, on = tmp_path / "off", tmp_path / "on"
+    _pack(monica_tokenize, tokenizer, off)
+    _pack(monica_tokenize, tokenizer, on, "--fim-rate", "0.5", "--fim-seed", "1234")
+    assert (off / "part-00000.bin").read_bytes() != (on / "part-00000.bin").read_bytes()
+
+
+def test_stats_line_reports_the_transform(monica_tokenize, tokenizer, tmp_path):
+    r = _pack(monica_tokenize, tokenizer, tmp_path / "out",
+              "--fim-rate", "0.5", "--fim-seed", "1234")
+    line = next(ln for ln in r.stdout.splitlines() if ln.startswith("fim:"))
+    assert "seed 1234" in line
+    transformed = int(line.split()[1].split("/")[0])
+    assert transformed > 0, f"no document was FIM-transformed: {line}"
+
+
+def test_rate_outside_the_intended_band_warns_but_proceeds(monica_tokenize, tokenizer, tmp_path):
+    r = _pack(monica_tokenize, tokenizer, tmp_path / "out", "--fim-rate", "0.9")
+    assert "0.4" in r.stderr and "#215" in r.stderr
+
+
+@pytest.mark.parametrize("bad", ["1.5", "-0.1", "abc"])
+def test_invalid_rate_fails_fast(monica_tokenize, tokenizer, tmp_path, bad):
+    r = _run(monica_tokenize, "pack", "--tokenizer", str(tokenizer), "--in", str(FIXTURE),
+             "--out", str(tmp_path / f"out-{bad}"), "--seq-len", "64", "--fim-rate", bad)
+    assert r.returncode != 0
+    assert "fim-rate" in r.stderr
+
+
+def test_python_reads_the_psm_frame_the_swift_packer_wrote(monica_tokenize, tokenizer, tmp_path):
+    """End-to-end: the trainer's own shard reader must see `<|fim_prefix|>` at a document start
+    and `<|fim_suffix|>` before `<|fim_middle|>` within that document. This is the assertion that
+    a Swift-inserted FIM stream is what the Python side actually consumes."""
+    out = tmp_path / "fim"
+    _pack(monica_tokenize, tokenizer, out, "--fim-rate", "0.5", "--fim-seed", "1234")
+
+    manifest = read_manifest(out)
+    fim_docs = 0
+    for shard in manifest["shards"]:
+        toks, bnds = open_shard(out, shard["name"])
+        starts = doc_start_offsets(bnds)
+        for i, start in enumerate(starts):
+            end = starts[i + 1] if i + 1 < len(starts) else len(toks)
+            doc = [int(t) for t in toks[start:end]]
+            if not doc or doc[0] != PREFIX_ID:
+                continue
+            fim_docs += 1
+            assert doc.count(PREFIX_ID) == 1
+            # The doc may be truncated at the shard edge, so a sentinel can legitimately be
+            # missing — but whenever both are present, suffix must precede middle (PSM order).
+            if SUFFIX_ID in doc and MIDDLE_ID in doc:
+                assert doc.index(SUFFIX_ID) < doc.index(MIDDLE_ID)
+    assert fim_docs > 0, "no FIM-framed document reached the Python shard reader"


### PR DESCRIPTION
Closes #215

## Summary

**FIM insertion lands in the Swift `pack` path, not a Python collator.** FIM needs document
boundaries, and pack time is the only place they still exist as objects: `src/data/split.py`
drops the `.bounds` sidecars, so the trainer reads a flat `train.bin` through `PackedLoader` and
cannot see doc structure. This closes the "*may* live in the Swift pack path" clause in
`docs/design/13-code-model-moe.md`.

- **`swift/Sources/MonicaTokenizer/FIM.swift`** — SplitMix64 (explicitly seeded, wrapping integer
  ops only) + the PSM transform. Determinism is a hard CI requirement, so: no stdlib random
  conveniences (`Int.random(in:using:)` et al. are implementation details, not ABI), no floating
  point, no hashed-collection iteration, no grapheme-cluster indexing. Cut points are UTF-8 **byte**
  offsets snapped forward with bit arithmetic. The RNG is seeded **per document** from
  (global seed, doc index), so output is order-independent and survives a future parallel `cmdPack`.
- The document **text** is split, not its token ids — slicing ids would make every middle begin
  exactly on a token boundary, the classic silent FIM distribution bug. Sentinel-bearing and
  sub-3-byte documents are skipped and counted, never emitted as a malformed frame. PSM only;
  SPM is out of scope.
- **`monica-tokenize pack --fim-rate --fim-seed`.** Rate defaults to **0 (FIM off)** so today's
  pack output is byte-identical — `tests/test_swift_parquet.py` (#247) does not move. The single
  Double→basis-points conversion happens once at the CLI boundary. Rates outside the intended
  **0.4–0.5** band warn rather than fail, so an ablation is not blocked.
- **`monica-selfcheck`** (the package's only test runner — no `.testTarget`) gains the round-trip
  gate, before any compute: `decode(prefix) + decode(middle) + decode(suffix) == the original
  document`, sentinels exactly once each in PSM order, a **published** SplitMix64 known-answer
  vector, same-seed pack byte-identity **plus** a different-seed anti-vacuity check, rate-0 no-op,
  and the edge cases (empty / sub-3-byte / sentinel-bearing / degenerate splits / unicode over 64
  seeds).
- **`src/eval/fim_eval.py`** — distance-bucketed FIM eval, portable pure numpy, in
  `PORTABLE_MODULES`. Teacher-forced CE over the **middle span only**, bucketed short/medium/long,
  with per-instance records. Built to be **extended by #221, not duplicated**: construction is
  split from scoring, the bucket key is a callable, and every record carries prefix/middle/suffix
  lengths and recall distance.
- **`attention_after_suffix()`** is the advisory config check the PSM ordering implies — the final
  block should be attention (`n_layers % attn_every == 0`). Deliberately **not** a
  `MambaConfig.validate()` rule: that validator is shared with reserve configs that legitimately
  violate it. No `src/model/` change.
- **CI** — `swift-macos` and `swift-linux` each pack the parity fixture with
  `--fim-rate 0.5 --fim-seed 1234`; `swift-parity` now `cmp`s the two shard sets **in addition to**
  the existing `tokenizer.json` `cmp`. An in-process "pack twice, same bytes" check runs on one
  machine and cannot catch a platform-divergent RNG; only this can. Both pack steps grep their own
  output for non-zero sequence and transform counts, so an empty artifact fails loudly instead of
  making the `cmp` vacuous.

## Testing

- [x] Tests added/updated — `tests/test_fim_eval.py` (38 portable cases incl. the right-padding
      batching invariant and an anti-vacuity check on the middle mask),
      `tests/test_swift_fim.py` (10 differential cases over the built binary), the new
      `monica-selfcheck` FIM section, `src.eval.fim_eval` added to `PORTABLE_MODULES`.
- [x] All tests passing — `swift build && swift run monica-selfcheck` → `OK — all checks passed`;
      `.venv/bin/python -m pytest -q -rs` → **887 passed, 13 skipped** (skips are pre-existing:
      no CUDA device, no prettier toolchain, torch.compile unusable on this host, #214-blocked fp8).
- [x] Manual testing completed — packed `Fixtures/parity-corpus.jsonl` twice at
      `--fim-seed 1234` (byte-identical), once at `4321` (differs), and confirmed
      `--fim-rate 0` is byte-identical to omitting the flag.

Not run: `scripts/smoke_test.py`. This touches no backend and no model code; the smoke gate covers
resume-exactness/eval, which nothing here moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uRT2cJmofSFEyv1bZ8oAg