### PR TITLE
feat: [M12] Training-loop: length curriculum (2k→16k) + dataloader-state checkpoint-resume

### DIFF
--- a/docs/design/05-training.md
+++ b/docs/design/05-training.md
@@ -112,14 +112,22 @@ This separation is the crux of the migration story:
 - **`save_weights`** writes safetensors + a `<path>.config.json` sidecar — portable,
   the bridge between backends.
 - **`CheckpointStore`** writes the same-backend resume bundle (portable weights +
-  optimizer state + step + fp16 loss-scale state) via a backend-supplied serializer —
-  optimizer-state layout *is* backend-specific, and you never need to resume a
-  half-finished MLX run on CUDA. It is **double-buffered and crash-safe**: two slots plus
-  an atomically-flipped `LATEST` pointer, so a checkpoint interrupted mid-write (a spot
-  preemption on a multi-week run) leaves the *previous* checkpoint fully intact. The data
-  order on resume is reconstructed deterministically from `(seed, step, grad_accum)` — no
-  RNG is persisted, because the model has no train-time randomness (dropout-free; weight
-  init is overwritten by the loaded weights).
+  optimizer state + step + fp16 loss-scale state + the dataloader position) via a
+  backend-supplied serializer — optimizer-state layout *is* backend-specific, and you
+  never need to resume a half-finished MLX run on CUDA. It is **double-buffered and
+  crash-safe**: two slots plus an atomically-flipped `LATEST` pointer, so a checkpoint
+  interrupted mid-write (a spot preemption on a multi-week run) leaves the *previous*
+  checkpoint fully intact. No model RNG is persisted, because the model has no train-time
+  randomness (dropout-free; weight init is overwritten by the loaded weights).
+- **The data position used to be *reconstructed*, and since #216 it is *recorded*.** The
+  old rule — "data order on resume is derived deterministically from `(seed, step,
+  grad_accum)`" — holds only while `seq_len`, and therefore `len(loader)`, is constant for
+  the whole run. The length curriculum below breaks that, so `save(data_state=...)`
+  persists the stream's explicit position. It rides **inside the slot's existing
+  `resume_meta.json`**, so it is committed by the same atomic `LATEST` flip as the weights
+  and the step: a checkpoint can never ship weights that disagree with the data position
+  they were trained to. `data_state` is optional and read with `meta.get("data_state")`,
+  so pre-#216 bundles still resume via the old reconstruction.
 
 `safetensors` is imported lazily so the module loads without the dependency present.
 
@@ -144,6 +152,72 @@ Success is read straight off `<out>/metrics.jsonl`: a smoothly decreasing
 on ~1M repetitive bytes — it is fine for short smoke/validation runs but will eventually
 destabilize in fp32 if pushed far past that regime; the poc run (100M params, fp16 +
 dynamic scaling, ~3B diverse tokens) is the regime M5 actually targets.
+
+## Length curriculum + dataloader-state resume (#216)
+
+Two changes that the issue deliberately pairs, because **the first invalidates the
+invariant the second replaces**.
+
+**The curriculum.** `--curriculum "0.25:2048,0.5:4096,1.0:16384"` on `scripts/train.py`
+ramps `seq_len` across the run — short contexts through the early, high-LR steps, long
+context only in the second half. SSMs extend gracefully, and extending late is far
+cheaper than training long throughout. The spec is `until_frac:seq_len[:batch_size]`,
+comma separated, where **`until_frac` is cumulative** (the fraction of the run *ending* at
+that stage) and the last must be `1.0`; it is validated hard, because misreading it as
+"share of the run" would silently produce a plausible-but-wrong allocation. An omitted
+`batch_size` is derived as `max(1, base_batch*base_seq // seq_len_i)` — a **floor**, so a
+derived stage can only ever get cheaper than the reference, never surprise-OOM at 16k.
+Like every other run param, it is a **CLI flag, not model config**.
+
+Two things it deliberately does not do. **Val loss stays pinned at `cfg.seq_len`** — a
+val curve measured at a changing context length is not comparable across the run, which
+would make the POC's primary signal unreadable. And **holding tokens/step constant does
+not hold *cost* constant**: attention is O(L²), so 8× the length at ⅛ the batch is ~8× the
+attention FLOPs and activation memory for the ~12.5% attention layers. `grad_checkpoint:
+true` stays mandatory, and the explicit per-stage `batch_size` field exists precisely so
+an operator can shrink further at 16k.
+
+**Why explicit dataloader state became necessary.** Chunking is `seq_len`-dependent
+(`stride = seq_len + 1`, so `n_chunks` and `len(loader)` both move), which is exactly what
+the old step→position reconstruction assumed was fixed. On an interruptible pod the
+failure would have been *silent*: the run resumes, resamples data it has already seen, and
+its epoch accounting is quietly wrong while every log line looks healthy. So
+[`src/train/stream.py`](../../src/train/stream.py)'s `MicroBatchStream` carries the
+position as five counters — `stage_idx`, `micro_in_stage`, `global_micro`, `epoch_idx`,
+`batches_into_epoch` — and `state_dict()`/`load_state_dict()` round-trip them through the
+checkpoint. **Every failure path raises**; none degrades to "start a fresh epoch".
+`load_state_dict` checks a fingerprint (`seed`, `grad_accum`, per-stage shapes, corpus
+path + size) and an RNG tripwire, and names `--ignore-data-state` as the escape hatch.
+`steps` is deliberately *outside* the fingerprint, so extending a run with a bigger
+`--total-tokens` stays legal.
+
+Details worth carrying:
+
+- **Stage lengths are in optimizer steps**, so a boundary always lands on a step boundary
+  and no single step ever mixes shapes.
+- **`epoch_idx` is global, not per-stage.** The per-epoch shuffle reseeds with
+  `seed + epoch_idx`, so a global counter makes the one-stage case bit-identical to the
+  pre-#216 stream — which is what keeps SFT/DPO and the smoke gate unchanged. `train()`
+  synthesizes that one-stage curriculum when none is passed, so there is a single code
+  path.
+- **`torch.compile` recompiles at each boundary** (CUDA only). Bounded — at most
+  `n_stages - 1` events, and inductor promotes to dynamic shapes after the second distinct
+  `(B, L)` — so the mitigation is *visibility*, not a code change: the startup banner sizes
+  the cost explicitly and the loop emits an `{"event": "stage", ...}` line before each
+  boundary, so a stall there is attributable rather than mysterious. `dynamic=True`,
+  `mark_dynamic`, and CUDA graphs are out of scope.
+- **Acceptance is "kill-and-resume reproduces the exact data stream"**, checked at three
+  levels: `tests/test_stream.py` (pure numpy, kill points mid-epoch / on an epoch boundary
+  / on and after a stage boundary), `tests/test_train_loop.py::test_resume_across_curriculum_boundary`
+  (through the real loop), and the smoke gate's **phase 7**, which drives the real
+  `train()` + `MicroBatchStream` + `CheckpointStore` across a boundary and asserts both
+  that the post-resume loss trajectory matches *and* that the `seq_len` sequence really
+  changed — a curriculum that silently failed to engage must not pass.
+
+The guarantee is exact stream *reproduction*, not "no token is seen twice": `PackedLoader`
+cuts windows from one flat `train.bin` with no document structure, so chunking at a
+different `seq_len` is a different partition of the same corpus and later stages
+necessarily re-cover earlier tokens at a different alignment.
 
 ## Efficiency levers (M12, landed 2026-07-20/21)
 

--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -134,7 +134,10 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
   or ported checkpoint routes as trained) → CUDA MoE backend (#214: dropless routing, shared expert,
   FSDP, sparse-upcycle init) → FIM (#215, **done** — see the resolved note below), length
   curriculum + dataloader-state resume
-  (#216), routing instrumentation (#217), pure-PyTorch Mamba-2 reference for laptop parity (#218).
+  (#216, **done** — `--curriculum "0.25:2048,0.5:4096,1.0:16384"` on `scripts/train.py`, plus
+  explicit `MicroBatchStream` state committed inside the checkpoint slot; see
+  [05-training.md](05-training.md#length-curriculum--dataloader-state-resume-216)),
+  routing instrumentation (#217), pure-PyTorch Mamba-2 reference for laptop parity (#218).
   **Training-efficiency levers** (folded 2026-07-20 from the efficiency-survey review): hybrid
   Muon+AdamW optimizer at the `make_optimizer` seam (#237, **done** — `3b02e6b`), WSD
   warmup-stable-decay LR schedule (#238, **done** — `8fe62f7`), and `torch.compile` default-on for

--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -133,7 +133,10 @@ def main() -> None:
 
     logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 
-    def on_checkpoint(step: int) -> None:
+    # `data_state` is accepted and IGNORED: DPO resume stays step-based, and the #216
+    # length curriculum applies to pretraining only. Persisting a position nothing reads
+    # back would be worse than not persisting one.
+    def on_checkpoint(step: int, data_state=None) -> None:
         store.save(step=step,
                    loss_scale_state=(scaler.state_dict() if scaler else None),
                    weights_serializer=lambda p: policy.save(p),  # checkpoint the POLICY

--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -130,7 +130,10 @@ def main() -> None:
 
     logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 
-    def on_checkpoint(step: int) -> None:
+    # `data_state` is accepted and IGNORED: SFT resume stays step-based, and the #216
+    # length curriculum applies to pretraining only. Persisting a position nothing reads
+    # back would be worse than not persisting one.
+    def on_checkpoint(step: int, data_state=None) -> None:
         store.save(step=step,
                    loss_scale_state=(scaler.state_dict() if scaler else None),
                    weights_serializer=lambda p: model.save(p),  # portable weights + config

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -40,6 +40,12 @@ def main() -> None:
                     help="also run ONE torch.compile'd training step (CUDA + .[cuda-fast] "
                          "pod) and assert it does not hard-error; the main resume-exactness "
                          "run stays eager. Verifies the Triton graph-break path on hardware.")
+    ap.add_argument("--curriculum", type=str, default=None,
+                    help="phase 7 length curriculum (#216), "
+                         "'until_frac:seq_len[:batch_size],...'. Default: a two-stage "
+                         "ramp derived from the config (seq_len//2 -> seq_len).")
+    ap.add_argument("--curriculum-steps", type=int, default=20,
+                    help="phase 7: optimizer steps for the curriculum kill/resume gate")
     args = ap.parse_args()
 
     # Backend selection stays behind the seam factory; only portable modules are
@@ -192,6 +198,125 @@ def main() -> None:
     print(f"[prefill] L={prompt.shape[1]} + {n_decode} decode steps OK  "
           f"max|logit diff|={par['max_abs_diff']:.3e}  "
           f"max|state diff|={par['max_abs_state_diff']:.3e}")
+
+    # --- 7) curriculum kill/resume gate (#216) ----------------------------------
+    # Phases 1-6 drive `step_fn` directly over a PRE-MATERIALIZED batch list, which is
+    # exactly what makes them insensitive to data ordering — and therefore blind to the
+    # thing #216 changes. So this phase drives the REAL `train()` + `MicroBatchStream` +
+    # `CheckpointStore` instead: the wiring between them is the new surface, and a
+    # curriculum that silently failed to engage, or a resume that silently resampled,
+    # would leave every other phase green.
+    from src.train.curriculum import build_curriculum
+    from src.train.loop import TrainConfig, train
+
+    spec = args.curriculum or (f"0.5:{max(1, cfg.seq_len // 2)}:{2 * args.batch_size},"
+                               f"1.0:{cfg.seq_len}:{args.batch_size}")
+    curriculum = build_curriculum(spec, base_seq_len=cfg.seq_len,
+                                  base_batch_size=args.batch_size, grad_accum=1,
+                                  total_steps=args.curriculum_steps)
+    cN = curriculum.total_steps
+    boundary = curriculum.first_steps[1] if len(curriculum.stages) > 1 else cN // 2
+    # Kill strictly AFTER the boundary so the resume starts INSIDE the later stage, with
+    # a partial epoch — the case a boundary-aligned kill would not exercise.
+    cK = min(cN - 1, boundary + 2)
+    if cK <= 0 or cK >= cN:
+        raise SystemExit(f"SMOKE TEST FAILED: phase 7 needs 0 < kill({cK}) < steps({cN}); "
+                         "raise --curriculum-steps.")
+
+    def curric_factory(seq_len, batch_size):
+        return PackedLoader(args.data / "train.bin", seq_len, batch_size,
+                            shuffle=True, seed=args.seed)
+
+    ctcfg = TrainConfig(total_steps=cN, base_lr=3e-4, warmup_steps=max(1, cN // 6),
+                        grad_accum=1, grad_clip=1.0, log_every=1, eval_every=10 ** 9,
+                        ckpt_every=cK, out_dir=str(out), seed=args.seed)
+
+    def curric_run(model, step_fn, logs, **kw):
+        return train(model, None, ctcfg, step_fn, logger=logs.append,
+                     curriculum=curriculum, loader_factory=curric_factory, **kw)
+
+    # 7a) reference: one uninterrupted curriculum run.
+    ref_logs = []
+    cmodel, _, cstep = fresh_model_opt()
+    curric_run(cmodel, cstep, ref_logs)
+    ref_steps = [p for p in ref_logs if "event" not in p]
+
+    # 7b) interrupted: kill AT the checkpoint (as a preempted pod does — the budget is
+    # unchanged), tear down model/optimizer/stream, rebuild from the store, finish.
+    class _Killed(Exception):
+        pass
+
+    cstore = CheckpointStore(str(out / "resume-curriculum"))
+    saved = {}
+    res_logs = []
+    cmodel_a, copt_a, cstep_a = fresh_model_opt()
+
+    def curric_ckpt(step, data_state):
+        cstore.save(step=step, loss_scale_state=None, data_state=data_state,
+                    weights_serializer=lambda p: cmodel_a.save(p),
+                    optimizer_serializer=lambda p: backend.save_optimizer(copt_a, p))
+        saved["step"] = step
+        raise _Killed
+
+    try:
+        curric_run(cmodel_a, cstep_a, res_logs, on_checkpoint=curric_ckpt)
+    except _Killed:
+        pass
+    if saved.get("step") != cK:
+        raise SystemExit(f"SMOKE TEST FAILED: phase 7 checkpoint fired at "
+                         f"{saved.get('step')}, expected {cK}.")
+    del cmodel_a, copt_a, cstep_a                    # "kill" the process state
+
+    backend.seed(args.seed + 999)                    # different RNG: weights from disk
+    cmodel_b = backend.model_cls(cfg)
+    copt_b = backend.make_optimizer(cmodel_b, 3e-4)
+    cmeta = cstore.load(weights_deserializer=lambda p: cmodel_b.load(p),
+                        optimizer_deserializer=lambda p: backend.load_optimizer(copt_b, p))
+    if cmeta.get("data_state") is None:
+        raise SystemExit("SMOKE TEST FAILED: phase 7 resume bundle carries no "
+                         "data_state — the dataloader position was not committed.")
+    curric_run(cmodel_b, backend.make_train_step(cmodel_b, copt_b, grad_clip=1.0),
+               res_logs, start_step=int(cmeta["step"]),
+               start_data_state=cmeta["data_state"])
+    res_steps = [p for p in res_logs if "event" not in p]
+
+    # 7c) the trajectory over the resumed window must match the reference. A resume that
+    # resampled data would diverge here even though every counter looked healthy.
+    ref_loss = {p["step"]: float(p["loss"]) for p in ref_steps}
+    res_loss = {p["step"]: float(p["loss"]) for p in res_steps}
+    missing = [s for s in range(cN) if s not in ref_loss or s not in res_loss]
+    if missing:
+        raise SystemExit(f"SMOKE TEST FAILED: phase 7 missing steps {missing[:5]}...")
+    cdiffs = [abs(ref_loss[s] - res_loss[s]) for s in range(cK, cN)]
+    cmax = max(cdiffs)
+    print(f"[curriculum] {spec}  steps={cN}  boundary={boundary}  kill={cK}  "
+          f"post-resume max|loss diff| over steps {cK}..{cN-1} = {cmax:.3e}")
+    if cmax > args.atol:
+        raise SystemExit(f"SMOKE TEST FAILED: curriculum resume not exact "
+                         f"(max|diff|={cmax:.3e} > {args.atol}).")
+
+    # 7d) ...and the curriculum actually ENGAGED. Without this a curriculum that silently
+    # collapsed to one shape would sail through 7c, since a fixed-shape run resumes fine.
+    for label, steps in (("reference", ref_steps), ("resumed", res_steps)):
+        seq_lens = [p["seq_len"] for p in sorted(steps, key=lambda p: p["step"])]
+        want = [curriculum.stage_at(s).seq_len for s in range(cN)]
+        if seq_lens != want:
+            raise SystemExit(f"SMOKE TEST FAILED: phase 7 {label} seq_len sequence "
+                             f"{seq_lens} != expected {want} — the curriculum did not "
+                             "engage.")
+        if len(set(seq_lens)) < 2:
+            raise SystemExit(f"SMOKE TEST FAILED: phase 7 {label} never changed seq_len; "
+                             "the gate would be vacuous.")
+
+    # 7e) ...and token accounting survived the kill (it is cumulative across stages, and
+    # the resumed run must pick it up rather than restart from zero).
+    want_tokens = sum(curriculum.tokens_at(s) for s in range(cN))
+    got_tokens = max(p["tokens"] for p in res_steps)
+    if got_tokens != want_tokens:
+        raise SystemExit(f"SMOKE TEST FAILED: phase 7 cumulative tokens {got_tokens} != "
+                         f"{want_tokens}.")
+    print(f"[curriculum] stages engaged in both runs; tokens={got_tokens} "
+          f"(cumulative across {len(curriculum.stages)} stages) OK")
 
     print("\nSMOKE TEST PASSED ✅  resume is exact and eval runs.")
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -62,6 +62,17 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--resume", type=Path, default=None,
                     help="resume bundle dir; if omitted, auto-detects <out>/resume")
     ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--curriculum", type=str, default=None,
+                    help="length curriculum (#216): 'until_frac:seq_len[:batch_size],...' "
+                         "e.g. '0.25:2048,0.5:4096,1.0:16384'. until_frac is CUMULATIVE. "
+                         "Omitted batch_size is derived to hold tokens/step ~constant "
+                         "against --batch-size x config seq_len. Default: no curriculum "
+                         "(fixed shape, exactly the pre-#216 behavior).")
+    ap.add_argument("--ignore-data-state", action="store_true",
+                    help="discard a checkpoint's saved dataloader position and "
+                         "reconstruct it from the step instead. ESCAPE HATCH only — it "
+                         "is how you resume after deliberately changing the curriculum "
+                         "or the token budget, and it will resample data.")
     return ap.parse_args()
 
 
@@ -77,6 +88,7 @@ def main() -> None:
     from src.data.loader import PackedLoader
     from src.train.loss_scale import scaler_for_precision
     from src.train.moe_balance import attach_balancer, balancer_for_config
+    from src.train.curriculum import build_curriculum
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
     from src.train.checkpoint import CheckpointStore
@@ -87,8 +99,19 @@ def main() -> None:
     cfg = load_config(str(args.config))                 # validates (vocab < 2**32, head_dim | d_inner, ...)
 
     tokens_per_step = args.batch_size * cfg.seq_len * args.grad_accum
-    total_steps = (args.total_steps if args.total_steps is not None
-                   else max(1, args.total_tokens // tokens_per_step))
+    # Length curriculum (#216): the stage allocation, not the fixed shape, decides how
+    # many optimizer steps the run has — tokens/step varies per stage, so the old
+    # `tokens // (batch*seq*grad_accum)` division no longer describes the run.
+    curriculum = None
+    if args.curriculum:
+        curriculum = build_curriculum(
+            args.curriculum, base_seq_len=cfg.seq_len, base_batch_size=args.batch_size,
+            grad_accum=args.grad_accum, total_tokens=args.total_tokens,
+            total_steps=args.total_steps)
+        total_steps = curriculum.total_steps
+    else:
+        total_steps = (args.total_steps if args.total_steps is not None
+                       else max(1, args.total_tokens // tokens_per_step))
     warmup = args.warmup_steps if args.warmup_steps is not None else max(1, total_steps // 100)
 
     # --- model + optimizer + (dynamic) loss scaling ----------------------------
@@ -110,8 +133,37 @@ def main() -> None:
                                          **balancer_kwargs)
 
     # --- data ------------------------------------------------------------------
-    train_loader = PackedLoader(args.data / "train.bin", cfg.seq_len,
-                                args.batch_size, shuffle=True, seed=args.seed)
+    # ONE construction path for every stage, including stage 0 (`open_packed` returns a
+    # read-only memmap, so a loader per stage costs no data copy).
+    train_path = args.data / "train.bin"
+
+    def loader_factory(seq_len: int, batch_size: int) -> PackedLoader:
+        return PackedLoader(train_path, seq_len, batch_size, shuffle=True, seed=args.seed)
+
+    if curriculum is not None:
+        # Fail fast at startup, not deep inside the stream at a stage boundary 10 days in:
+        # at long seq_len a small corpus can drop below one batch per epoch.
+        for st in curriculum.stages:
+            try:
+                probe = loader_factory(st.seq_len, st.batch_size)
+                n_chunks, n_tokens = probe.n_chunks, probe.n_tokens
+                ok = len(probe) >= 1
+            except ValueError:                  # too small for even one chunk
+                n_chunks, n_tokens, ok = 0, None, False
+            if not ok:
+                raise SystemExit(
+                    f"[curriculum] stage {st.index} (seq_len={st.seq_len}, "
+                    f"batch_size={st.batch_size}) yields no batches per epoch: "
+                    f"{n_tokens} tokens in {train_path} give {n_chunks} chunks, but a "
+                    f"batch needs {st.batch_size}. This stage needs >= "
+                    f"{st.batch_size * (st.seq_len + 1)} tokens.")
+    train_loader = loader_factory(cfg.seq_len if curriculum is None
+                                  else curriculum.stages[0].seq_len,
+                                  args.batch_size if curriculum is None
+                                  else curriculum.stages[0].batch_size)
+    # The val loader stays PINNED at cfg.seq_len — deliberately NOT ramped. A val loss
+    # measured at a changing context length is not comparable across a run, and would make
+    # the POC's primary success signal (a smoothly improving curve / BPB) unreadable.
     val_loader = PackedLoader(args.data / "val.bin", cfg.seq_len,
                               args.batch_size, shuffle=False, drop_last=False)
     np_to = backend.to_numpy
@@ -127,13 +179,24 @@ def main() -> None:
     resuming = store.has_checkpoint()
 
     start_step = 0
+    start_data_state = None
     if resuming:
         meta = store.load(weights_deserializer=lambda p: model.load(p),
                           optimizer_deserializer=lambda p: backend.load_optimizer(opt, p))
         start_step = int(meta["step"])
         if scaler is not None:
             scaler.load_state_dict(meta.get("loss_scale_state") or {})
-        print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})")
+        # #216: pre-#216 bundles have no `data_state` and fall back to reconstructing the
+        # position from the step — correct only at a fixed shape, hence the printed note.
+        start_data_state = meta.get("data_state")
+        if start_data_state is None:
+            data_state_note = "absent (legacy reconstruct from step)"
+        elif args.ignore_data_state:
+            data_state_note = "ignored (--ignore-data-state; will resample)"
+        else:
+            data_state_note = "present"
+        print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})  "
+              f"data_state={data_state_note}")
     # Loss-Free-Balancing (#213): seed the policy from the just-loaded weights (the bias
     # rides in the portable safetensors, D3), push it into the routers, and enable load
     # counting. No-op when balancing is off. `CheckpointStore.save` is unchanged — there
@@ -142,11 +205,14 @@ def main() -> None:
 
     logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 
-    def on_checkpoint(step: int) -> None:
+    def on_checkpoint(step: int, data_state=None) -> None:
+        # `data_state` rides INSIDE resume_meta.json, inside the slot, and is therefore
+        # committed by the same atomic LATEST flip as the weights and the step (#216).
         store.save(step=step,
                    loss_scale_state=(scaler.state_dict() if scaler else None),
                    weights_serializer=lambda p: model.save(p),  # portable weights + config
-                   optimizer_serializer=lambda p: backend.save_optimizer(opt, p))
+                   optimizer_serializer=lambda p: backend.save_optimizer(opt, p),
+                   data_state=data_state)
 
     tcfg = TrainConfig(
         total_steps=total_steps, base_lr=args.base_lr, warmup_steps=warmup,
@@ -161,21 +227,44 @@ def main() -> None:
           f"tokens/step={tokens_per_step}  precision={cfg.precision}  "
           f"schedule={args.lr_schedule}")
 
-    train(model, train_loader, tcfg, train_step,
-          val_eval=val_eval, logger=logger, on_checkpoint=on_checkpoint,
-          start_step=start_step)
+    if curriculum is not None:
+        print(f"[curriculum] {args.curriculum!r} -> {len(curriculum.stages)} stages, "
+              f"total_steps={curriculum.total_steps} (authoritative; each stage gets at "
+              f"least 1 step, so this can differ slightly from a requested --total-steps)")
+        for line in curriculum.describe():
+            print(f"[curriculum] {line}")
+        print("[curriculum] val loss stays measured at the FIXED config seq_len "
+              f"({cfg.seq_len}) so the curve remains comparable across stages.")
+        # Sizing the recompile cost explicitly is a requirement of #216 — leaving it
+        # implicit is how a bounded, expected stall gets misread as a hang. Note this
+        # does NOT change the compile default; that is #239's decision.
+        if backend.name == "cuda" and getattr(cfg, "torch_compile", False) is not False:
+            print(f"[curriculum] CUDA torch.compile is ON: expect ONE inductor recompile "
+                  f"at each of the {len(curriculum.stages) - 1} stage boundaries (tens of "
+                  "seconds each, amortized over the stage; inductor promotes to dynamic "
+                  "shapes after the 2nd distinct (B, L), so later boundaries are usually "
+                  "free). Not a regression — each is preceded by an 'event: stage' log "
+                  "line in metrics.jsonl.")
+
+    result = train(model, train_loader, tcfg, train_step,
+                   val_eval=val_eval, logger=logger, on_checkpoint=on_checkpoint,
+                   start_step=start_step, curriculum=curriculum,
+                   loader_factory=loader_factory if curriculum is not None else None,
+                   start_data_state=start_data_state,
+                   ignore_data_state=args.ignore_data_state)
 
     # --- final checkpoint + full eval ------------------------------------------
     # The loop already checkpoints at `step == total_steps` when total_steps is a
     # multiple of ckpt_every; guard so we don't write (and re-serialize) it twice.
     if total_steps % tcfg.ckpt_every != 0:
-        on_checkpoint(total_steps)
+        on_checkpoint(total_steps, result["data_state"])
     # Materialize the portable weights at the canonical out/weights.safetensors for
     # downstream eval/serving/distillation (the live copy otherwise lives in the slot).
     model.save(weights_path)
     final = evaluate(model, val_loader, max_batches=max_b, to_numpy=np_to)
     logger.close()
-    print(f"[done] step={total_steps}  val_loss={final['val_loss']:.4f}  "
+    print(f"[done] step={total_steps}  tokens={result['tokens_seen']}  "
+          f"val_loss={final['val_loss']:.4f}  "
           f"val_perplexity={final['val_perplexity']:.4f}  metrics={out / 'metrics.jsonl'}")
 
 

--- a/src/train/checkpoint.py
+++ b/src/train/checkpoint.py
@@ -139,9 +139,19 @@ class CheckpointStore:
     survives until the next one is durably committed.
 
     Each slot holds the FULL checkpoint: portable weights (the cross-backend bridge) AND
-    the within-backend resume bundle (optimizer + step + fp16 loss-scale state). Note the
-    loss-scale state is NOT an RNG state — the data order on resume is reconstructed
-    deterministically from (seed, step, grad_accum) and the model has no train-time RNG.
+    the within-backend resume bundle (optimizer + step + fp16 loss-scale state + the
+    dataloader position). Note the loss-scale state is NOT an RNG state, and the model has
+    no train-time RNG.
+
+    Dataloader position (#216). Historically the data order on resume was *reconstructed*
+    from (seed, step, grad_accum), which is only valid while `tokens_per_step` — and hence
+    `len(loader)` — is constant for the whole run. A length curriculum breaks that, so
+    `save(data_state=...)` now persists the stream's **explicit** position inside
+    `resume_meta.json`. It deliberately lives in the existing meta file, INSIDE the slot,
+    so it is committed by the very same `LATEST` flip that commits the step and the
+    weights — a data state that could disagree with the weights it ships with would be
+    worse than none at all. `data_state` is optional: pre-#216 bundles read back as
+    `meta.get("data_state") is None` and fall back to the legacy reconstruction.
     """
 
     _SLOTS = ("slot-a", "slot-b")
@@ -169,12 +179,16 @@ class CheckpointStore:
     # -- write/read -------------------------------------------------------------
     def save(self, *, step: int, loss_scale_state: Any,
              weights_serializer: Callable[[str], None],
-             optimizer_serializer: Callable[[str], None]) -> str:
+             optimizer_serializer: Callable[[str], None],
+             data_state: Any = None) -> str:
         """Write a full checkpoint to the inactive slot, then atomically make it live.
 
         `weights_serializer(path)` writes portable weights (e.g. `model.save`) and
         `optimizer_serializer(path)` the backend optimizer state — both supplied by the
-        caller so this stays backend-free. Returns the slot that was committed.
+        caller so this stays backend-free. `data_state` is the dataloader position
+        (`MicroBatchStream.state_dict()`, #216); it rides in `resume_meta.json` rather
+        than a file of its own, so it adds no entry to the slot and inherits the slot's
+        crash-atomicity for free. Returns the slot that was committed.
         """
         slot = self._inactive_slot()
         slot_dir = self.root / slot
@@ -186,7 +200,8 @@ class CheckpointStore:
 
         weights_serializer(str(slot_dir / "weights.safetensors"))   # + .config.json sidecar
         optimizer_serializer(str(slot_dir / "optimizer.state"))     # backend owns the extension
-        meta = {"step": int(step), "loss_scale_state": _jsonable(loss_scale_state)}
+        meta = {"step": int(step), "loss_scale_state": _jsonable(loss_scale_state),
+                "data_state": _jsonable(data_state)}
         _atomic_write_text(slot_dir / "resume_meta.json", json.dumps(meta))
 
         # Durably flush every file's DATA (the backend optimizer dump may not fsync
@@ -203,7 +218,9 @@ class CheckpointStore:
     def load(self, *, weights_deserializer: Callable[[str], None],
              optimizer_deserializer: Callable[[str], Any]) -> dict:
         """Load the live checkpoint into the model + optimizer. Returns
-        {step, loss_scale_state, optimizer, slot}. Raises if no checkpoint is committed."""
+        {step, loss_scale_state, data_state, optimizer, slot}. Raises if no checkpoint is
+        committed. Read `data_state` with `meta.get("data_state")` — it is absent in
+        pre-#216 bundles, and `None` for runs that persisted no dataloader position."""
         slot = self.latest_slot()
         if slot is None:
             raise RuntimeError(f"no committed checkpoint under {str(self.root)!r}")

--- a/src/train/curriculum.py
+++ b/src/train/curriculum.py
@@ -1,0 +1,233 @@
+"""Length curriculum: ramp `seq_len` up (2k -> 4k -> 16k) as a run progresses (#216).
+
+Why. SSMs extend gracefully, and training long *throughout* is far more expensive than
+extending late — attention is O(L^2) and the activation footprint scales with L. So the
+run spends its early, high-LR steps on short contexts and only pays for long context in
+the second half. `batch_size` shrinks inversely so tokens/step stays roughly constant,
+which keeps the LR schedule (absolute-step units, see `schedule.py`) meaningful.
+
+**What this does and does not guarantee — read this before reasoning about epochs.**
+`PackedLoader` cuts non-overlapping `seq_len + 1` windows out of one flat `train.bin`;
+there is no document structure in the packed stream (see the #215 resolution note in
+`docs/design/13-code-model-moe.md`). Chunking at a *different* `seq_len` is therefore a
+different partition of the same corpus, so a later stage's windows necessarily re-cover
+tokens an earlier stage already saw, at a different alignment. The property #216
+delivers is **exact stream reproduction across a kill/resume** — not "no token is ever
+seen twice". Do not claim the latter.
+
+Portable: pure stdlib math, no numpy, no backend. The spec is a CLI string, not model
+config, matching `config/poc.yaml`'s rule that run params are flags.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_right
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Stage:
+    """One curriculum stage: a shape `(seq_len, batch_size)` held for `steps` steps."""
+
+    index: int
+    until_frac: float       # CUMULATIVE fraction of the run ENDING at this stage
+    seq_len: int
+    batch_size: int
+    steps: int
+
+    def tokens_per_step(self, grad_accum: int) -> int:
+        return self.batch_size * self.seq_len * grad_accum
+
+
+@dataclass(frozen=True)
+class LengthCurriculum:
+    """An ordered, contiguous sequence of stages covering the whole run.
+
+    Stage lengths are in **optimizer steps**, which is what makes a boundary always land
+    on a step boundary — every micro-batch inside one optimizer step therefore has the
+    same shape, and a step never mixes shapes.
+    """
+
+    stages: tuple[Stage, ...]
+    grad_accum: int
+
+    def __post_init__(self) -> None:
+        if not self.stages:
+            raise ValueError("curriculum needs at least one stage")
+        if self.grad_accum < 1:
+            raise ValueError(f"grad_accum must be >= 1 (got {self.grad_accum})")
+
+    # -- geometry ---------------------------------------------------------------
+    @property
+    def total_steps(self) -> int:
+        return sum(s.steps for s in self.stages)
+
+    @property
+    def first_steps(self) -> tuple[int, ...]:
+        """Global step at which each stage begins (cumulative; `first_steps[0] == 0`)."""
+        out, acc = [], 0
+        for s in self.stages:
+            out.append(acc)
+            acc += s.steps
+        return tuple(out)
+
+    def stage_index_at(self, step: int) -> int:
+        """Index of the stage owning `step`, clamped to the last stage past the end.
+
+        The loop never asks past `total_steps`, but the stream can sit exactly at the end
+        after its final micro-batch, and the last stage deliberately never terminates.
+        """
+        if step < 0:
+            raise ValueError(f"step must be >= 0 (got {step})")
+        idx = bisect_right(self.first_steps, step) - 1
+        return min(idx, len(self.stages) - 1)
+
+    def stage_at(self, step: int) -> Stage:
+        return self.stages[self.stage_index_at(step)]
+
+    def tokens_at(self, step: int) -> int:
+        """Tokens consumed by the single optimizer step `step`."""
+        return self.stage_at(step).tokens_per_step(self.grad_accum)
+
+    def tokens_before(self, step: int) -> int:
+        """Total tokens consumed by steps `[0, step)` — the resume seed for `tokens_seen`."""
+        if step < 0:
+            raise ValueError(f"step must be >= 0 (got {step})")
+        total, seen = 0, 0
+        for s in self.stages:
+            take = min(s.steps, max(0, step - seen))
+            total += take * s.tokens_per_step(self.grad_accum)
+            seen += s.steps
+        if step > seen:                       # past the end: charge the last stage's rate
+            total += (step - seen) * self.stages[-1].tokens_per_step(self.grad_accum)
+        return total
+
+    # -- identity ---------------------------------------------------------------
+    def fingerprint(self) -> dict:
+        """The shape identity a persisted dataloader position depends on.
+
+        `steps` is deliberately EXCLUDED: extending a run with a larger `--total-tokens`
+        must stay legal, and the saved position is expressed in counters, not in steps,
+        so it remains exact when the budget grows.
+        """
+        return {"stage_shapes": [[s.seq_len, s.batch_size] for s in self.stages]}
+
+    def describe(self) -> list[str]:
+        """One human-readable line per stage, for the startup banner."""
+        firsts = self.first_steps
+        return [
+            f"stage {s.index}: until_frac={s.until_frac:<6g} seq_len={s.seq_len:<6d} "
+            f"batch_size={s.batch_size:<4d} steps={s.steps:<8d} "
+            f"tokens/step={s.tokens_per_step(self.grad_accum):<10d} first_step={firsts[i]}"
+            for i, s in enumerate(self.stages)
+        ]
+
+    # -- construction -----------------------------------------------------------
+    @classmethod
+    def single(cls, seq_len: int, batch_size: int, steps: int,
+               grad_accum: int) -> "LengthCurriculum":
+        """The degenerate one-stage curriculum — exactly today's fixed-shape behavior.
+
+        `loop.train` synthesizes this when no curriculum is passed, so there is one code
+        path and the no-curriculum case stays byte-identical to the pre-#216 loop.
+        """
+        return cls(stages=(Stage(index=0, until_frac=1.0, seq_len=seq_len,
+                                 batch_size=batch_size, steps=steps),),
+                   grad_accum=grad_accum)
+
+
+def parse_curriculum_spec(spec: str) -> list[tuple[float, int, Optional[int]]]:
+    """Parse `"until_frac:seq_len[:batch_size],..."` into validated stage triples.
+
+    `until_frac` is CUMULATIVE — the fraction of the run *ending* at that stage — which is
+    the wording issue #216 itself uses. That is easy to confuse with "share of the run",
+    so it is validated hard: fractions must be strictly increasing and the last must be
+    exactly 1.0. Every failure names the offending stage and echoes the whole spec.
+
+        >>> parse_curriculum_spec("0.25:2048,0.5:4096,1.0:16384")
+        [(0.25, 2048, None), (0.5, 4096, None), (1.0, 16384, None)]
+    """
+    if not isinstance(spec, str) or not spec.strip():
+        raise ValueError(f"curriculum spec is empty (got {spec!r}); expected "
+                         "'until_frac:seq_len[:batch_size],...'")
+
+    out: list[tuple[float, int, Optional[int]]] = []
+    for i, raw in enumerate(spec.split(",")):
+        field = raw.strip()
+        if not field:
+            raise ValueError(f"curriculum stage {i} is empty in spec {spec!r}")
+        parts = field.split(":")
+        if len(parts) not in (2, 3):
+            raise ValueError(
+                f"curriculum stage {i} ({field!r}) has {len(parts)} fields; expected "
+                f"'until_frac:seq_len' or 'until_frac:seq_len:batch_size' in spec {spec!r}")
+        try:
+            frac = float(parts[0])
+            seq_len = int(parts[1])
+            batch_size = int(parts[2]) if len(parts) == 3 else None
+        except ValueError as exc:
+            raise ValueError(f"curriculum stage {i} ({field!r}) is malformed in spec "
+                             f"{spec!r}: {exc}") from exc
+
+        if not 0.0 < frac <= 1.0:
+            raise ValueError(f"curriculum stage {i} ({field!r}): until_frac must be in "
+                             f"(0, 1], got {frac} in spec {spec!r}")
+        if seq_len < 1:
+            raise ValueError(f"curriculum stage {i} ({field!r}): seq_len must be >= 1, "
+                             f"got {seq_len} in spec {spec!r}")
+        if batch_size is not None and batch_size < 1:
+            raise ValueError(f"curriculum stage {i} ({field!r}): batch_size must be >= 1, "
+                             f"got {batch_size} in spec {spec!r}")
+        if out and frac <= out[-1][0]:
+            raise ValueError(
+                f"curriculum stage {i} ({field!r}): until_frac must strictly increase "
+                f"(previous stage ends at {out[-1][0]}); until_frac is CUMULATIVE, not a "
+                f"per-stage share. Spec {spec!r}")
+        out.append((frac, seq_len, batch_size))
+
+    if abs(out[-1][0] - 1.0) > 1e-9:
+        raise ValueError(f"curriculum's last stage must end at until_frac 1.0 (got "
+                         f"{out[-1][0]}); until_frac is CUMULATIVE. Spec {spec!r}")
+    return out
+
+
+def build_curriculum(spec: str, *, base_seq_len: int, base_batch_size: int,
+                     grad_accum: int, total_tokens: Optional[int] = None,
+                     total_steps: Optional[int] = None) -> LengthCurriculum:
+    """Turn a spec string into a `LengthCurriculum` with a concrete step allocation.
+
+    Batch derivation (when a stage omits an explicit `batch_size`): hold tokens/step
+    roughly constant at the reference `base_batch_size * base_seq_len`, using a **floor**
+    rather than a round — a derived stage can then only ever be *cheaper* than the
+    reference, never a surprise OOM at 16k. It will not be exactly constant, and that is
+    fine; the banner reports the real per-stage figure.
+
+    Step allocation comes from exactly one of `total_tokens` or `total_steps`. Each stage
+    gets at least one step, so `total_steps` on a degenerate spec can differ from the
+    requested `S` by a step or two — `LengthCurriculum.total_steps` is authoritative and
+    the caller prints it.
+    """
+    if (total_tokens is None) == (total_steps is None):
+        raise ValueError("build_curriculum needs exactly one of total_tokens/total_steps")
+    if base_seq_len < 1 or base_batch_size < 1:
+        raise ValueError(f"base shape must be >= 1 (got seq_len={base_seq_len}, "
+                         f"batch_size={base_batch_size})")
+
+    triples = parse_curriculum_spec(spec)
+    reference_tokens = base_batch_size * base_seq_len
+
+    stages: list[Stage] = []
+    prev_frac = 0.0
+    for i, (frac, seq_len, batch_size) in enumerate(triples):
+        bs = batch_size if batch_size is not None else max(1, reference_tokens // seq_len)
+        if total_tokens is not None:
+            share = round(frac * total_tokens) - round(prev_frac * total_tokens)
+            steps = max(1, share // (bs * seq_len * grad_accum))
+        else:
+            steps = max(1, round(frac * total_steps) - round(prev_frac * total_steps))
+        stages.append(Stage(index=i, until_frac=frac, seq_len=seq_len,
+                            batch_size=bs, steps=int(steps)))
+        prev_frac = frac
+
+    return LengthCurriculum(stages=tuple(stages), grad_accum=grad_accum)

--- a/src/train/logging.py
+++ b/src/train/logging.py
@@ -23,7 +23,11 @@ class JsonlLogger:
         self._f.write(json.dumps(payload) + "\n")
         self._f.flush()
         if self.echo:
-            keys = ("step", "lr", "loss", "grad_norm", "val_loss", "val_perplexity")
+            # `event`/`seq_len` make a #216 length-curriculum stage change visible in the
+            # terminal — otherwise a boundary (and the CUDA recompile that follows it)
+            # looks like an unexplained stall.
+            keys = ("event", "step", "seq_len", "lr", "loss", "grad_norm",
+                    "val_loss", "val_perplexity")
             parts = [f"{k}={payload[k]:.4g}" if isinstance(payload.get(k), float)
                      else f"{k}={payload[k]}" for k in keys if k in payload]
             print("  ".join(parts))

--- a/src/train/loop.py
+++ b/src/train/loop.py
@@ -19,11 +19,13 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass
 from itertools import islice
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from ..model.interface import ModelInterface
 from ..data.loader import PackedLoader
+from .curriculum import LengthCurriculum
 from .schedule import make_schedule
+from .stream import MicroBatchStream
 
 
 @dataclass
@@ -50,21 +52,18 @@ TrainStepFn = Callable[[ModelInterface, list, float], dict]
 def _micro_batch_stream(train_loader: PackedLoader, seed: int, start_micro: int = 0):
     """Infinite stream of (inputs, targets), reseeding the shuffle each epoch.
 
-    `start_micro` fast-forwards the stream to the position reached after that many
-    micro-batches — this is what makes resume continue the data sequence instead of
-    replaying the corpus from the top. The stream is fully deterministic given
-    (seed, epoch length), so the position is reconstructed from `start_micro` alone:
-    skip whole epochs for free (just advance the per-epoch reseed) and fast-forward
-    the remainder within the current epoch via `epoch(skip_batches=...)`.
+    The pre-#216 fixed-shape stream, now a thin shim over a single-stage
+    `MicroBatchStream` + `seek_micro`. Kept because it PINS the legacy semantics: the
+    position is reconstructed from `start_micro` alone, which is only valid while
+    `seq_len` — and hence `len(train_loader)` — is fixed for the whole run. A length
+    curriculum breaks that assumption, which is why the real loop now carries explicit
+    dataloader state instead (see `src/train/stream.py`).
     """
-    per_epoch = len(train_loader)
-    if per_epoch <= 0:
-        raise ValueError("train_loader yields no batches per epoch")
-    epoch_idx, skip = divmod(start_micro, per_epoch)
-    while True:
-        yield from train_loader.epoch(reseed=seed + epoch_idx, skip_batches=skip)
-        epoch_idx += 1
-        skip = 0
+    curriculum = LengthCurriculum.single(train_loader.seq_len, train_loader.batch_size,
+                                         steps=1, grad_accum=1)
+    stream = MicroBatchStream(curriculum, lambda sl, bs: train_loader, seed)
+    stream.seek_micro(start_micro)
+    return stream
 
 
 def train(
@@ -75,49 +74,116 @@ def train(
     *,
     val_eval: Optional[Callable[[ModelInterface], dict]] = None,
     logger: Optional[Callable[[dict], None]] = None,
-    on_checkpoint: Optional[Callable[[int], None]] = None,
+    on_checkpoint: Optional[Callable[[int, Any], None]] = None,
     start_step: int = 0,
-) -> None:
+    curriculum: Optional[LengthCurriculum] = None,
+    loader_factory: Optional[Callable[[int, int], Any]] = None,
+    start_data_state: Optional[dict] = None,
+    ignore_data_state: bool = False,
+) -> dict:
     """Run the training loop. `train_step` and the optimizer live in the backend.
 
     Pure orchestration: the backprop/optimizer primitive (`train_step`) and the
-    checkpoint writer (`on_checkpoint(step)`, which persists portable weights + a
-    within-backend resume bundle) are injected so this stays backend-free. Resume
-    is driven by `start_step`. Each step consumes `cfg.grad_accum` micro-batches.
-    `val_eval(model)` returns a metrics dict (e.g. {val_loss, val_perplexity}) that
-    is merged into the logged payload.
+    checkpoint writer (`on_checkpoint(step, data_state)`, which persists portable weights
+    + a within-backend resume bundle) are injected so this stays backend-free. Resume is
+    driven by `start_step` plus, since #216, an explicit `start_data_state`.
+    `val_eval(model)` returns a metrics dict (e.g. {val_loss, val_perplexity}) merged into
+    the logged payload.
+
+    Length curriculum (#216). Pass a `LengthCurriculum` plus a
+    `loader_factory(seq_len, batch_size) -> loader` to ramp `seq_len` (and shrink
+    `batch_size`) across the run. With `curriculum=None` the loop synthesizes the
+    degenerate one-stage curriculum over `train_loader`, so there is exactly ONE code
+    path and the no-curriculum behavior — including for `SFTLoader`/`DPOLoader` — is
+    identical to the pre-#216 loop. `tokens_per_step` is therefore read per step rather
+    than computed once, and `tokens_per_sec` accumulates real tokens instead of
+    multiplying a constant.
+
+    Returns `{"step", "data_state", "tokens_seen"}` so the caller's final out-of-loop
+    checkpoint can persist a correct dataloader position instead of `None`.
     """
+    if curriculum is None:
+        curriculum = LengthCurriculum.single(train_loader.seq_len, train_loader.batch_size,
+                                             steps=cfg.total_steps, grad_accum=cfg.grad_accum)
+        loader_factory = lambda sl, bs: train_loader        # noqa: E731 — trivial shim
+    elif loader_factory is None:
+        raise ValueError("a curriculum needs a loader_factory(seq_len, batch_size)")
+    elif curriculum.total_steps != cfg.total_steps:
+        # The caller derives one from the other; a drift here means the LR schedule and
+        # the stage allocation disagree about where the run ends.
+        raise ValueError(
+            f"curriculum.total_steps ({curriculum.total_steps}) != cfg.total_steps "
+            f"({cfg.total_steps}) — derive TrainConfig.total_steps from the curriculum.")
+
     schedule = make_schedule(cfg)
     step = start_step
     log = logger or (lambda payload: print(payload))
-    tokens_per_step = train_loader.batch_size * train_loader.seq_len * cfg.grad_accum
 
-    stream = _micro_batch_stream(train_loader, cfg.seed,
-                                 start_micro=start_step * cfg.grad_accum)
+    stream = MicroBatchStream(curriculum, loader_factory, cfg.seed)
+    if start_data_state is not None and not ignore_data_state:
+        stream.load_state_dict(start_data_state)
+        want = curriculum.stage_index_at(start_step)
+        if want != stream.stage_idx:
+            raise ValueError(
+                f"resume mismatch: step {start_step} belongs to curriculum stage {want}, "
+                f"but the saved dataloader state is in stage {stream.stage_idx}. The "
+                "stage allocation moved under the checkpoint (usually a changed "
+                "--total-tokens/--total-steps). Restore the original budget, or pass "
+                "--ignore-data-state to discard the saved position and reconstruct it "
+                "from the step instead.")
+    elif len(curriculum.stages) == 1:
+        stream.seek_micro(start_step * cfg.grad_accum)     # exactly the legacy path
+    else:
+        stream.seek_step(start_step)
+
+    tokens_seen = curriculum.tokens_before(start_step)
     t0 = time.perf_counter()
-    steps_since_log = 0
+    tokens_since_log = 0
+    last_stage = None
 
     while step < cfg.total_steps:
+        stage = curriculum.stage_at(step)
+        if stage.index != last_stage and len(curriculum.stages) > 1:
+            # One visible, timestamped line per stage change. On CUDA every torch.compile
+            # recompile is preceded by this, so a stall at a boundary is attributable
+            # rather than mysterious (see scripts/train.py's [curriculum] banner). Only
+            # emitted for a real curriculum — a single-stage run has no boundary, and the
+            # extra payload would be noise in every existing pretrain/SFT/DPO log.
+            log({"event": "stage", "step": step, "stage": stage.index,
+                 "seq_len": stage.seq_len, "batch_size": stage.batch_size,
+                 "tokens_per_step": stage.tokens_per_step(cfg.grad_accum)})
+        last_stage = stage.index
+
         micro = list(islice(stream, cfg.grad_accum))
         if not micro:
             break
         lr = schedule.lr_at(step)
         metrics = train_step(model, micro, lr)            # backend: fwd+bwd+opt
-        steps_since_log += 1
+        tokens_per_step = stage.tokens_per_step(cfg.grad_accum)
+        tokens_since_log += tokens_per_step
+        tokens_seen += tokens_per_step
 
         if step % cfg.log_every == 0:
             now = time.perf_counter()
             dt = now - t0
-            tps = steps_since_log * tokens_per_step / dt if dt > 0 else 0.0
-            payload = {"step": step, "lr": lr, **metrics, "tokens_per_sec": tps}
+            tps = tokens_since_log / dt if dt > 0 else 0.0
+            payload = {"step": step, "lr": lr, **metrics, "tokens_per_sec": tps,
+                       "seq_len": stage.seq_len, "batch_size": stage.batch_size,
+                       "stage": stage.index, "tokens_per_step": tokens_per_step,
+                       "tokens": tokens_seen}
             if val_eval and step % cfg.eval_every == 0:
                 payload.update(val_eval(model))
             log(payload)
             t0 = time.perf_counter()
-            steps_since_log = 0
+            tokens_since_log = 0
 
         step += 1
         if on_checkpoint and step % cfg.ckpt_every == 0:
-            on_checkpoint(step)
+            # Fired after the increment, when the stream has consumed exactly
+            # step*grad_accum micro-batches — i.e. it is positioned at the START of
+            # step `step`, matching the `step` written into the same bundle.
+            on_checkpoint(step, stream.state_dict())
         if step >= cfg.total_steps:
             break
+
+    return {"step": step, "data_state": stream.state_dict(), "tokens_seen": tokens_seen}

--- a/src/train/stream.py
+++ b/src/train/stream.py
@@ -1,0 +1,326 @@
+"""The micro-batch stream: stage-aware, with an EXPLICIT, persistable position (#216).
+
+Why this replaces a bare generator. Pre-#216 the data position on resume was
+*reconstructed* from `(seed, start_step * grad_accum, per_epoch)` where
+`per_epoch = len(loader)` — valid only while `seq_len` (and hence `stride`, `n_chunks`,
+`len(loader)`) is fixed for the whole run. A length curriculum changes `seq_len` mid-run,
+so the reconstruction silently stops being valid: the run would resume, resample
+already-seen data, and get its epoch accounting quietly wrong. On an interruptible pod
+that failure looks exactly like success. So the position becomes explicit state, saved
+inside the checkpoint slot and restored verbatim.
+
+**Every failure path here raises.** None degrade to "start a fresh epoch" — a silent
+resample is the precise bug this module exists to kill.
+
+Portable: no numpy import needed here, no backend. Works with any loader exposing the
+duck-typed contract `__len__`, `epoch(reseed, skip_batches)`, `.seq_len`, `.batch_size`
+(and optionally `.rng`) — i.e. `PackedLoader`, `SFTLoader`, and `DPOLoader` alike.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Optional
+
+from .checkpoint import _jsonable
+from .curriculum import LengthCurriculum
+
+
+STATE_VERSION = 1
+
+# Loader factory: (seq_len, batch_size) -> a loader with the duck-typed contract above.
+LoaderFactory = Callable[[int, int], Any]
+
+
+class MicroBatchStream:
+    """Infinite stream of `(inputs, targets)` that walks a `LengthCurriculum`.
+
+    Position is five counters, and they are the whole of the persisted state:
+
+      * ``stage_idx``          — which curriculum stage is active
+      * ``micro_in_stage``     — micro-batches consumed inside that stage
+      * ``global_micro``       — micro-batches consumed over the whole run
+      * ``epoch_idx``          — **global** epoch counter, NOT per-stage
+      * ``batches_into_epoch`` — position inside the current epoch
+
+    `epoch_idx` being global is load-bearing: the per-epoch shuffle is reseeded with
+    `seed + epoch_idx`, so a global counter makes the single-stage case bit-identical to
+    the pre-#216 `_micro_batch_stream`. That backward-compat property is what the legacy
+    resume test and the M4 smoke gate depend on, and `test_stream.py` pins it.
+
+    The **last stage never terminates** — it keeps cycling epochs. `train()`'s
+    `while step < total_steps` is the only stop condition, which is also what keeps the
+    no-curriculum shim unbounded exactly as before.
+    """
+
+    def __init__(self, curriculum: LengthCurriculum, loader_factory: LoaderFactory,
+                 seed: int, *, extra_fingerprint: Optional[dict] = None):
+        self.curriculum = curriculum
+        self.loader_factory = loader_factory
+        self.seed = int(seed)
+        self.extra_fingerprint = dict(extra_fingerprint or {})
+
+        self.stage_idx = 0
+        self.micro_in_stage = 0
+        self.global_micro = 0
+        self.epoch_idx = 0
+        self.batches_into_epoch = 0
+
+        self._loaders: dict[int, Any] = {}       # memoized per stage (memmap => cheap)
+        self._it = None                          # live, PRIMED epoch iterator
+        self._pending = None                     # the batch priming pulled off it
+
+    # -- active stage ------------------------------------------------------------
+    @property
+    def stage(self):
+        return self.curriculum.stages[self.stage_idx]
+
+    @property
+    def seq_len(self) -> int:
+        return self.stage.seq_len
+
+    @property
+    def batch_size(self) -> int:
+        return self.stage.batch_size
+
+    @property
+    def tokens_per_step(self) -> int:
+        return self.stage.tokens_per_step(self.curriculum.grad_accum)
+
+    @property
+    def _stage_micro(self) -> int:
+        """Micro-batches in the active stage. Stage lengths are in OPTIMIZER STEPS, so a
+        boundary always lands on a step boundary — a single step never mixes shapes."""
+        return self.stage.steps * self.curriculum.grad_accum
+
+    def loader(self, stage_idx: Optional[int] = None):
+        """The loader for a stage, built once and memoized (`open_packed` is a memmap)."""
+        i = self.stage_idx if stage_idx is None else stage_idx
+        if i not in self._loaders:
+            st = self.curriculum.stages[i]
+            loader = self.loader_factory(st.seq_len, st.batch_size)
+            if len(loader) <= 0:
+                # Fail here rather than yielding nothing forever: at long seq_len a small
+                # corpus can drop below one batch per epoch (n_chunks < batch_size).
+                raise ValueError(
+                    f"curriculum stage {i} (seq_len={st.seq_len}, "
+                    f"batch_size={st.batch_size}) yields no batches per epoch — the "
+                    "corpus is too small for this stage's shape")
+            self._loaders[i] = loader
+        return self._loaders[i]
+
+    # -- iteration ---------------------------------------------------------------
+    def __iter__(self):
+        return self
+
+    def _open_epoch(self) -> None:
+        """Open the current epoch's iterator **and prime it**.
+
+        Priming is not an optimization. `loader.epoch(...)` is a generator, so its
+        `reseed` + shuffle only execute on the first `next()`. Without priming, `.rng`
+        would still hold the *previous* epoch's state and the restore tripwire below
+        would compare the wrong thing — a tripwire that fires spuriously (or passes
+        vacuously) is worse than none.
+        """
+        loader = self.loader()
+        self._it = iter(loader.epoch(reseed=self.seed + self.epoch_idx,
+                                     skip_batches=self.batches_into_epoch))
+        self._pending = next(self._it, None)
+
+    def _advance_stage(self) -> None:
+        """Cross into the next stage: abandon the partial epoch, start a fresh one."""
+        self.stage_idx += 1
+        self.micro_in_stage = 0
+        self.epoch_idx += 1              # global — keeps the reseed sequence unique
+        self.batches_into_epoch = 0
+        self._it = None
+        self._pending = None
+
+    def __next__(self):
+        batch = None
+        for _ in range(2):               # at most: finish this epoch, then a fresh one
+            if self._it is None:
+                self._open_epoch()
+            if self._pending is not None:
+                batch, self._pending = self._pending, None
+                break
+            nxt = next(self._it, None)
+            if nxt is not None:
+                batch = nxt
+                break
+            self.epoch_idx += 1          # epoch exhausted — roll to the next one
+            self.batches_into_epoch = 0
+            self._it = None
+        if batch is None:
+            raise ValueError(
+                f"curriculum stage {self.stage_idx} produced no batch for a fresh epoch "
+                "— the loader's epoch() is empty despite len(loader) >= 1")
+
+        self.micro_in_stage += 1
+        self.global_micro += 1
+        self.batches_into_epoch += 1
+
+        # Normalize the boundary EAGERLY so a checkpoint taken exactly ON a stage
+        # boundary names the new stage at micro_in_stage 0 with a fresh epoch, rather
+        # than the exhausted tail of the old one. Nothing is read here — the new stage's
+        # epoch is opened lazily on the next call.
+        if (self.micro_in_stage >= self._stage_micro
+                and self.stage_idx < len(self.curriculum.stages) - 1):
+            self._advance_stage()
+        return batch
+
+    def seek_micro(self, n: int) -> None:
+        """Fast-forward to the position after `n` micro-batches WITHOUT reading them.
+
+        The legacy reconstruction path, kept for pre-#216 resume bundles and for
+        `_micro_batch_stream`'s `start_micro`. Only valid for a single-stage curriculum —
+        that is the only shape for which the old step->position mapping was ever correct,
+        and it is exactly the shape a pre-#216 bundle was written by.
+        """
+        if n < 0:
+            raise ValueError(f"seek_micro needs n >= 0 (got {n})")
+        if n and len(self.curriculum.stages) > 1:
+            raise ValueError(
+                "seek_micro cannot reconstruct a position across a multi-stage "
+                "curriculum — the step->position mapping is only valid at a fixed "
+                "seq_len. Resume from an explicit data_state, or pass "
+                "--ignore-data-state to restart the data stream from the top.")
+        per_epoch = len(self.loader())
+        self.epoch_idx, self.batches_into_epoch = divmod(n, per_epoch)
+        self.micro_in_stage = n
+        self.global_micro = n
+        self._it = None                  # reopened lazily; skipped chunks are never read
+        self._pending = None
+
+    def seek_step(self, step: int) -> None:
+        """Reconstruct the position at optimizer `step`, generalized across stages.
+
+        The fallback when no explicit `data_state` is available: a pre-#216 resume
+        bundle, or an operator who passed `--ignore-data-state`. It replays the counter
+        arithmetic the live stream would have performed — including the extra `epoch_idx`
+        bump each stage boundary contributes — using only `len(loader)` per stage, so it
+        reads no chunk. Deterministic, but it depends on every stage's `steps`, which is
+        exactly the fragility that made explicit state necessary; prefer `data_state`.
+        """
+        if step < 0:
+            raise ValueError(f"seek_step needs step >= 0 (got {step})")
+        ga = self.curriculum.grad_accum
+        stages = self.curriculum.stages
+        epoch_idx, remaining = 0, step
+        for i, st in enumerate(stages):
+            per_epoch = len(self.loader(i))
+            last = i == len(stages) - 1
+            take = remaining if last else min(st.steps, remaining)
+            micro = take * ga
+            # Epochs roll on DETECTED exhaustion, i.e. after per_epoch+1, 2*per_epoch+1,
+            # ... consumptions — hence (micro - 1) // per_epoch, not micro // per_epoch.
+            rolls = (micro - 1) // per_epoch if micro else 0
+            # `remaining == st.steps` on a non-final stage falls through: the live stream
+            # normalizes that boundary eagerly onto stage i+1 at micro_in_stage 0.
+            if last or remaining < st.steps:
+                self.stage_idx = i
+                self.micro_in_stage = micro
+                self.global_micro = step * ga
+                self.epoch_idx = epoch_idx + rolls
+                self.batches_into_epoch = micro - rolls * per_epoch if micro else 0
+                self._it = None
+                self._pending = None
+                return
+            epoch_idx += rolls + 1       # +1: `_advance_stage` bumps at the boundary
+            remaining -= st.steps
+
+    # -- persistence -------------------------------------------------------------
+    def fingerprint(self) -> dict:
+        """The identity a saved position depends on. A change here invalidates it."""
+        return {"seed": self.seed,
+                "grad_accum": self.curriculum.grad_accum,
+                **self.curriculum.fingerprint(),
+                **self.extra_fingerprint}
+
+    def _rng_state(self) -> Any:
+        """The live epoch's loader RNG state, or None when there is no epoch in flight.
+
+        Only meaningful mid-epoch: with `_it is None` (a fresh stream, or the instant
+        after a stage boundary) the loader still holds its *constructor* seed, which
+        would not reproduce on restore. Returning None there makes the tripwire skip
+        rather than fire falsely. `getattr` because `FakeLoader`-style test loaders have
+        no `.rng` at all.
+        """
+        if self._it is None:
+            return None
+        rng = getattr(self._loaders.get(self.stage_idx), "rng", None)
+        return rng.bit_generator.state if rng is not None else None
+
+    def state_dict(self) -> dict:
+        return {
+            "version": STATE_VERSION,
+            "stage_idx": self.stage_idx,
+            "micro_in_stage": self.micro_in_stage,
+            "global_micro": self.global_micro,
+            "epoch_idx": self.epoch_idx,
+            "batches_into_epoch": self.batches_into_epoch,
+            "rng_state": _jsonable(self._rng_state()),
+            # Diagnostics only — recorded for a human reading a bundle, never validated.
+            "stages_at_save": [[s.seq_len, s.batch_size, s.steps]
+                               for s in self.curriculum.stages],
+            "fingerprint": self.fingerprint(),
+        }
+
+    def load_state_dict(self, state: dict, *, strict: bool = True) -> None:
+        """Restore an exact position. Raises on any mismatch — never resumes approximately.
+
+        `strict=False` skips the fingerprint check; the version check always applies,
+        because a state we cannot parse is not a state we can approximate.
+        """
+        if not isinstance(state, dict):
+            raise ValueError(f"data_state must be a dict, got {type(state).__name__}")
+        version = state.get("version")
+        if version != STATE_VERSION:
+            raise ValueError(
+                f"dataloader state version {version!r} != {STATE_VERSION} — this bundle "
+                "was written by a different version of src/train/stream.py. Pass "
+                "--ignore-data-state to discard it and restart the data stream.")
+
+        if strict:
+            want, got = self.fingerprint(), state.get("fingerprint")
+            if got != want:
+                raise ValueError(
+                    "dataloader state does not match this run's configuration, so its "
+                    "saved position is meaningless — refusing to resume with a silently "
+                    "wrong data stream.\n"
+                    f"  saved:   {json.dumps(got, sort_keys=True)}\n"
+                    f"  current: {json.dumps(want, sort_keys=True)}\n"
+                    "Restore the original --curriculum/--batch-size/--grad-accum/--seed "
+                    "and data path, or pass --ignore-data-state to discard the saved "
+                    "position and restart the data stream from the top.")
+
+        n_stages = len(self.curriculum.stages)
+        stage_idx = int(state["stage_idx"])
+        if not 0 <= stage_idx < n_stages:
+            raise ValueError(f"saved stage_idx {stage_idx} is outside this curriculum's "
+                             f"{n_stages} stages")
+
+        self.stage_idx = stage_idx
+        self.micro_in_stage = int(state["micro_in_stage"])
+        self.global_micro = int(state["global_micro"])
+        self.epoch_idx = int(state["epoch_idx"])
+        self.batches_into_epoch = int(state["batches_into_epoch"])
+        self._it = None                  # reopened lazily at the restored position
+        self._pending = None
+
+        # Tripwire: reopen the stage's epoch and check the shuffle RNG lands exactly
+        # where it did at save time. Coarse (the rng only advances at epoch start), but
+        # it catches a wrong seed/epoch_idx pairing and a corpus whose chunk count moved
+        # under us — the silent failure modes this module exists to prevent. Comparison
+        # only, never fed back into numpy, which is what lets `_jsonable` skip an inverse.
+        saved_rng = state.get("rng_state")
+        if saved_rng is not None:
+            self._open_epoch()           # constructs the loader, reseeds, shuffles
+            current = json.loads(json.dumps(_jsonable(self._rng_state())))
+            if current != json.loads(json.dumps(saved_rng)):
+                raise ValueError(
+                    "dataloader RNG tripwire failed after restoring the saved position: "
+                    f"seed={self.seed} epoch_idx={self.epoch_idx} reproduces a different "
+                    "shuffle than the one that was checkpointed. The resumed data stream "
+                    "would NOT match the interrupted run. Pass --ignore-data-state to "
+                    "discard the saved position and restart the data stream.")

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,11 +1,13 @@
 """Unit tests for portable weight save/load and the double-buffered CheckpointStore.
 
 Backend-free: uses numpy weight dicts and dummy weight/optimizer (de)serializers, so it
-runs anywhere. The resume metadata persists `step` + the fp16 `loss_scale_state` (NOT an
-RNG state — the data order on resume is reconstructed deterministically); these tests
-guard `_jsonable` against a realistic nested NumPy structure (nested dict + np.ndarray +
-np scalars — the worst case it handles), which a shallow JSON conversion breaks, plus the
-crash-safety contract (the previous checkpoint survives a write interrupted mid-flight).
+runs anywhere. The resume metadata persists `step`, the fp16 `loss_scale_state`, and —
+since #216 — the dataloader position (`data_state`). These tests guard `_jsonable`
+against a realistic nested NumPy structure (nested dict + np.ndarray + np scalars — the
+worst case it handles), which a shallow JSON conversion breaks; the crash-safety contract
+(the previous checkpoint survives a write interrupted mid-flight); and that `data_state`
+lives INSIDE the slot's existing meta file, so it is committed by the same atomic LATEST
+flip as the weights rather than drifting out of sync with them.
 """
 
 import json
@@ -90,6 +92,74 @@ def test_store_roundtrips_loss_scale_state(tmp_path):
                optimizer_serializer=o_ser)
     meta = store.load(weights_deserializer=w_deser, optimizer_deserializer=o_deser)
     assert meta["loss_scale_state"] == state
+
+
+def test_store_roundtrips_data_state(tmp_path):
+    """#216: the dataloader position rides inside resume_meta.json, so it is committed by
+    the same atomic LATEST flip as the weights and the step. It contains a nested numpy
+    RNG state (the stream's tripwire), which only survives via `_jsonable`."""
+    store = CheckpointStore(str(tmp_path / "resume"))
+    data_state = {
+        "version": 1, "stage_idx": 1, "micro_in_stage": 4, "global_micro": 22,
+        "epoch_idx": 3, "batches_into_epoch": 2,
+        "rng_state": np.random.default_rng(7).bit_generator.state,
+        "stages_at_save": [[2048, 32, 100], [16384, 4, 50]],
+        "fingerprint": {"seed": 0, "grad_accum": 4,
+                        "stage_shapes": [[2048, 32], [16384, 4]]},
+    }
+    _, w_ser, o_ser, w_deser, o_deser = _dummy_io()
+    store.save(step=150, loss_scale_state=None, weights_serializer=w_ser,
+               optimizer_serializer=o_ser, data_state=data_state)
+    meta = store.load(weights_deserializer=w_deser, optimizer_deserializer=o_deser)
+
+    assert meta["data_state"] == _jsonable(data_state)
+    assert meta["data_state"]["global_micro"] == 22
+    assert meta["data_state"]["fingerprint"]["stage_shapes"] == [[2048, 32], [16384, 4]]
+
+
+def test_store_without_data_state_reads_back_as_none(tmp_path):
+    """Backward compatibility: a bundle saved with no dataloader position (SFT/DPO, or a
+    pre-#216 run) must read back as None so callers fall back to reconstruction."""
+    store = CheckpointStore(str(tmp_path / "resume"))
+    _, w_ser, o_ser, w_deser, o_deser = _dummy_io()
+    store.save(step=7, loss_scale_state=None, weights_serializer=w_ser,
+               optimizer_serializer=o_ser)
+    meta = store.load(weights_deserializer=w_deser, optimizer_deserializer=o_deser)
+    assert meta.get("data_state") is None
+
+
+def test_legacy_bundle_missing_the_key_entirely_reads_back_as_none(tmp_path):
+    """A bundle written BEFORE #216 has no `data_state` key at all, not a null one."""
+    store = CheckpointStore(str(tmp_path / "resume"))
+    _, w_ser, o_ser, w_deser, o_deser = _dummy_io()
+    store.save(step=7, loss_scale_state=None, weights_serializer=w_ser,
+               optimizer_serializer=o_ser)
+    slot_meta = tmp_path / "resume" / "slot-a" / "resume_meta.json"
+    legacy = json.loads(slot_meta.read_text())
+    del legacy["data_state"]
+    slot_meta.write_text(json.dumps(legacy))
+
+    meta = store.load(weights_deserializer=w_deser, optimizer_deserializer=o_deser)
+    assert "data_state" not in meta and meta.get("data_state") is None
+    assert meta["step"] == 7
+
+
+def test_data_state_adds_no_file_to_the_slot(tmp_path):
+    """It must live in the EXISTING meta file, never next to LATEST and never as a new
+    slot entry — anything outside the slot would lose the commit protocol's atomicity."""
+    store = CheckpointStore(str(tmp_path / "resume"))
+    _, w_ser, o_ser, _, _ = _dummy_io()
+    store.save(step=1, loss_scale_state=None, weights_serializer=w_ser,
+               optimizer_serializer=o_ser)
+    without = sorted(p.name for p in (tmp_path / "resume" / "slot-a").iterdir())
+
+    store2 = CheckpointStore(str(tmp_path / "resume2"))
+    store2.save(step=1, loss_scale_state=None, weights_serializer=w_ser,
+                optimizer_serializer=o_ser, data_state={"version": 1, "x": 2})
+    with_state = sorted(p.name for p in (tmp_path / "resume2" / "slot-a").iterdir())
+
+    assert without == with_state
+    assert sorted(p.name for p in (tmp_path / "resume2").iterdir()) == ["LATEST", "slot-a"]
 
 
 def test_store_alternates_slots(tmp_path):

--- a/tests/test_curriculum.py
+++ b/tests/test_curriculum.py
@@ -1,0 +1,205 @@
+"""Length-curriculum spec parsing, batch derivation, step allocation, and lookup (#216).
+
+Pure stdlib math — no backend, no data. The validation tests matter as much as the happy
+path: `until_frac` is CUMULATIVE, which is easy to confuse with "share of the run", and a
+silently-misread spec would produce a plausible-looking but wrong stage allocation.
+"""
+
+import pytest
+
+from src.train.curriculum import (
+    LengthCurriculum, Stage, build_curriculum, parse_curriculum_spec,
+)
+
+
+# --- spec parsing -----------------------------------------------------------
+def test_parse_happy_path_without_batch_size():
+    assert parse_curriculum_spec("0.25:2048,0.5:4096,1.0:16384") == [
+        (0.25, 2048, None), (0.5, 4096, None), (1.0, 16384, None)]
+
+
+def test_parse_happy_path_with_explicit_batch_size_and_whitespace():
+    assert parse_curriculum_spec(" 0.5:1024:32 , 1.0:4096:8 ") == [
+        (0.5, 1024, 32), (1.0, 4096, 8)]
+
+
+def test_parse_single_stage():
+    assert parse_curriculum_spec("1.0:512") == [(1.0, 512, None)]
+
+
+@pytest.mark.parametrize("spec, match", [
+    ("", "empty"),
+    ("   ", "empty"),
+    ("0.5:1024,,1.0:2048", "stage 1 is empty"),
+    ("0.5,1.0:2048", "expected"),                       # too few fields
+    ("0.5:1024:8:2,1.0:2048", "expected"),              # too many fields
+    ("x:1024,1.0:2048", "malformed"),
+    ("0.5:abc,1.0:2048", "malformed"),
+    ("0.6:1024,0.5:2048,1.0:4096", "strictly increase"),
+    ("0.5:1024,0.5:2048,1.0:4096", "strictly increase"),
+    ("0.5:1024,0.9:2048", "last stage must end at until_frac 1.0"),
+    ("0.0:1024,1.0:2048", r"until_frac must be in \(0, 1\]"),
+    ("-0.5:1024,1.0:2048", r"until_frac must be in \(0, 1\]"),
+    ("1.5:1024", r"until_frac must be in \(0, 1\]"),
+    ("0.5:0,1.0:2048", "seq_len must be >= 1"),
+    ("0.5:-8,1.0:2048", "seq_len must be >= 1"),
+    ("0.5:1024:0,1.0:2048", "batch_size must be >= 1"),
+])
+def test_parse_rejects_bad_specs(spec, match):
+    with pytest.raises(ValueError, match=match):
+        parse_curriculum_spec(spec)
+
+
+def test_parse_error_echoes_the_whole_spec():
+    """An error naming only the field is useless when the spec came from a shell script."""
+    spec = "0.6:1024,0.5:2048,1.0:4096"
+    with pytest.raises(ValueError, match=r"0\.6:1024,0\.5:2048,1\.0:4096"):
+        parse_curriculum_spec(spec)
+
+
+# --- batch derivation -------------------------------------------------------
+def test_derived_batch_holds_tokens_per_step_roughly_constant():
+    c = build_curriculum("0.5:1024,1.0:4096", base_seq_len=2048, base_batch_size=32,
+                         grad_accum=1, total_steps=100)
+    # reference tokens = 32 * 2048 = 65536
+    assert [s.batch_size for s in c.stages] == [64, 16]
+    assert [s.tokens_per_step(1) for s in c.stages] == [65536, 65536]
+
+
+def test_derived_batch_floors_so_a_stage_is_never_more_expensive():
+    """Floor, not round: a derived stage can only get cheaper than the reference, so a
+    long-context stage can never surprise-OOM by rounding its batch UP."""
+    c = build_curriculum("1.0:3000", base_seq_len=1024, base_batch_size=8,
+                         grad_accum=1, total_steps=10)
+    assert c.stages[0].batch_size == 8192 // 3000 == 2          # not round(2.73) == 3
+    assert c.stages[0].tokens_per_step(1) <= 8 * 1024
+
+
+def test_derived_batch_never_drops_below_one():
+    c = build_curriculum("1.0:65536", base_seq_len=128, base_batch_size=2,
+                         grad_accum=1, total_steps=10)
+    assert c.stages[0].batch_size == 1
+
+
+def test_explicit_batch_size_overrides_derivation():
+    c = build_curriculum("0.5:1024,1.0:4096:3", base_seq_len=2048, base_batch_size=32,
+                         grad_accum=1, total_steps=100)
+    assert [s.batch_size for s in c.stages] == [64, 3]
+
+
+# --- step allocation --------------------------------------------------------
+def test_allocation_from_total_steps_sums_and_splits_by_cumulative_frac():
+    c = build_curriculum("0.25:64,0.75:128,1.0:256", base_seq_len=64, base_batch_size=4,
+                         grad_accum=1, total_steps=100)
+    assert [s.steps for s in c.stages] == [25, 50, 25]
+    assert c.total_steps == 100
+    assert c.first_steps == (0, 25, 75)
+
+
+def test_allocation_from_total_tokens():
+    # 1000 tokens; stage 0 gets 500 at 10 tokens/step -> 50 steps, stage 1 gets 500 at
+    # 20 tokens/step -> 25 steps.
+    c = build_curriculum("0.5:10:1,1.0:20:1", base_seq_len=10, base_batch_size=1,
+                         grad_accum=1, total_tokens=1000)
+    assert [s.steps for s in c.stages] == [50, 25]
+    assert c.total_steps == 75
+
+
+def test_allocation_gives_every_stage_at_least_one_step():
+    """A degenerate spec must not produce a zero-step stage the stream can never leave."""
+    c = build_curriculum("0.001:64,1.0:128", base_seq_len=64, base_batch_size=4,
+                         grad_accum=1, total_steps=3)
+    assert all(s.steps >= 1 for s in c.stages)
+    assert c.total_steps >= 3          # max(1, ...) may push it past the requested S
+
+
+def test_build_requires_exactly_one_budget():
+    for kwargs in ({}, {"total_tokens": 100, "total_steps": 10}):
+        with pytest.raises(ValueError, match="exactly one of total_tokens/total_steps"):
+            build_curriculum("1.0:64", base_seq_len=64, base_batch_size=4,
+                             grad_accum=1, **kwargs)
+
+
+def test_grad_accum_multiplies_tokens_per_step_and_shrinks_step_count():
+    c = build_curriculum("1.0:10:1", base_seq_len=10, base_batch_size=1,
+                         grad_accum=4, total_tokens=1000)
+    assert c.stages[0].tokens_per_step(4) == 40
+    assert c.stages[0].steps == 25
+
+
+# --- lookup -----------------------------------------------------------------
+def _c3():
+    return build_curriculum("0.25:64,0.75:128,1.0:256", base_seq_len=64,
+                            base_batch_size=4, grad_accum=1, total_steps=100)
+
+
+@pytest.mark.parametrize("step, want", [
+    (0, 0), (24, 0),            # last step of stage 0
+    (25, 1), (74, 1),           # first / last step of stage 1
+    (75, 2), (99, 2),           # first / last step of stage 2
+    (100, 2), (10_000, 2),      # past the end: clamped to the last stage
+])
+def test_stage_index_at(step, want):
+    assert _c3().stage_index_at(step) == want
+
+
+def test_stage_index_at_rejects_negative():
+    with pytest.raises(ValueError, match="step must be >= 0"):
+        _c3().stage_index_at(-1)
+
+
+def test_tokens_at_and_tokens_before():
+    c = _c3()                    # 25 steps @ 64*4, 50 @ 128*2, 25 @ 256*1
+    assert [s.batch_size for s in c.stages] == [4, 2, 1]
+    assert c.tokens_at(0) == 256 and c.tokens_at(25) == 256 and c.tokens_at(75) == 256
+    assert c.tokens_before(0) == 0
+    assert c.tokens_before(25) == 25 * 256
+    assert c.tokens_before(100) == 100 * 256
+    # Past the end charges the last stage's rate — the stream may sit there.
+    assert c.tokens_before(101) == 101 * 256
+
+
+def test_tokens_before_with_uneven_stage_rates():
+    c = build_curriculum("0.5:10:4,1.0:20:1", base_seq_len=10, base_batch_size=4,
+                         grad_accum=1, total_steps=20)
+    assert [s.steps for s in c.stages] == [10, 10]
+    assert c.tokens_before(10) == 10 * 40
+    assert c.tokens_before(15) == 10 * 40 + 5 * 20
+
+
+# --- fingerprint / identity -------------------------------------------------
+def test_fingerprint_tracks_shape_but_not_steps():
+    """Extending a run with a bigger budget must stay legal: the persisted position is in
+    counters, not steps, so `steps` is deliberately out of the fingerprint."""
+    a = build_curriculum("0.5:64,1.0:128", base_seq_len=64, base_batch_size=4,
+                         grad_accum=1, total_steps=100)
+    b = build_curriculum("0.5:64,1.0:128", base_seq_len=64, base_batch_size=4,
+                         grad_accum=1, total_steps=400)
+    assert a.total_steps != b.total_steps
+    assert a.fingerprint() == b.fingerprint()
+
+    c = build_curriculum("0.5:64,1.0:256", base_seq_len=64, base_batch_size=4,
+                         grad_accum=1, total_steps=100)
+    assert a.fingerprint() != c.fingerprint()
+
+
+def test_single_is_the_degenerate_one_stage_curriculum():
+    c = LengthCurriculum.single(seq_len=128, batch_size=8, steps=42, grad_accum=2)
+    assert len(c.stages) == 1 and c.total_steps == 42
+    assert c.stages[0] == Stage(index=0, until_frac=1.0, seq_len=128,
+                                batch_size=8, steps=42)
+    assert c.tokens_at(0) == 128 * 8 * 2
+    assert c.stage_index_at(1_000_000) == 0
+
+
+def test_curriculum_rejects_empty_stages_and_bad_grad_accum():
+    with pytest.raises(ValueError, match="at least one stage"):
+        LengthCurriculum(stages=(), grad_accum=1)
+    with pytest.raises(ValueError, match="grad_accum must be >= 1"):
+        LengthCurriculum.single(seq_len=8, batch_size=1, steps=1, grad_accum=0)
+
+
+def test_describe_reports_every_stage():
+    lines = _c3().describe()
+    assert len(lines) == 3
+    assert "seq_len=64" in lines[0] and "first_step=75" in lines[2]

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -71,6 +71,8 @@ PORTABLE_MODULES = [
     "src.train.loss_scale",
     "src.train.moe_balance",
     "src.train.loop",
+    "src.train.curriculum",
+    "src.train.stream",
     "src.train.logging",
     "src.eval.val_loss",
     "src.eval.quantize",

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,414 @@
+"""MicroBatchStream: exact kill-and-resume of the data stream (#216).
+
+This is the acceptance surface for the issue's central property — "kill-and-resume
+reproduces the EXACT data stream". Pure numpy, no backend, so it runs on any host.
+
+The failure this guards against is silent: a run resumes, resamples data it has already
+seen, and its epoch accounting is quietly wrong while every log line looks healthy. So
+the tests check the actual token bytes, not just counters, and every test that could pass
+vacuously is paired with an assertion that the setup was non-degenerate.
+"""
+
+import copy
+
+import numpy as np
+import pytest
+
+from src.data.loader import PackedLoader
+from src.data.pack import pack_ids
+from src.train.curriculum import LengthCurriculum, Stage
+from src.train.loop import _micro_batch_stream
+from src.train.stream import STATE_VERSION, MicroBatchStream
+
+
+def _packed(tmp_path, n_tokens=2048):
+    """A corpus of distinct ascending token ids, so every batch is identifiable."""
+    path = tmp_path / "train.bin"
+    pack_ids(np.arange(n_tokens, dtype=np.uint16) % 60000, path, dtype=np.uint16)
+    return path
+
+
+def _factory(path, seed=0):
+    return lambda sl, bs: PackedLoader(path, sl, bs, shuffle=True, seed=seed)
+
+
+def _take(stream, n):
+    return [(inp.tobytes(), tgt.tobytes()) for inp, tgt in
+            (next(stream) for _ in range(n))]
+
+
+class FakeLoader:
+    """A loader with NO `.rng` — pins the tripwire's `getattr` guard (edge case 9)."""
+
+    def __init__(self, n_batches, batch_size=2, seq_len=4):
+        self.n_batches, self.batch_size, self.seq_len = n_batches, batch_size, seq_len
+
+    def __len__(self):
+        return self.n_batches
+
+    def epoch(self, reseed=None, skip_batches=0):
+        for i in range(skip_batches, self.n_batches):
+            yield (np.array([reseed, i]), np.array([reseed, i]))
+
+
+# --- backward compatibility: single stage == the pre-#216 stream ------------
+def test_single_stage_is_bit_identical_to_legacy_stream(tmp_path):
+    """The pin: `epoch_idx` is GLOBAL and reseeds as `seed + epoch_idx`, which is what
+    makes a one-stage curriculum reproduce `_micro_batch_stream` exactly. The legacy
+    resume test and the M4 smoke gate both depend on this."""
+    path = _packed(tmp_path)
+    seq_len, batch_size, seed = 8, 4, 123
+    legacy = _take(_micro_batch_stream(
+        PackedLoader(path, seq_len, batch_size, shuffle=True, seed=seed), seed), 60)
+
+    c = LengthCurriculum.single(seq_len, batch_size, steps=60, grad_accum=1)
+    new = _take(MicroBatchStream(c, _factory(path, seed), seed), 60)
+
+    assert new == legacy
+    assert legacy[:20] != legacy[20:40], "corpus too big: never crossed an epoch"
+
+
+def test_single_stage_seek_matches_legacy_seek(tmp_path):
+    path = _packed(tmp_path)
+    seq_len, batch_size, seed, k = 8, 4, 7, 37
+    legacy = _take(_micro_batch_stream(
+        PackedLoader(path, seq_len, batch_size, shuffle=True, seed=seed),
+        seed, start_micro=k), 20)
+
+    c = LengthCurriculum.single(seq_len, batch_size, steps=100, grad_accum=1)
+    s = MicroBatchStream(c, _factory(path, seed), seed)
+    s.seek_micro(k)
+    assert _take(s, 20) == legacy
+
+
+# --- the core property: state_dict -> load_state_dict reproduces the tail ---
+def _curriculum(steps_a=6, steps_b=40, grad_accum=1):
+    """Two stages with genuinely different shapes: (seq 8, batch 4) -> (seq 16, batch 2)."""
+    return LengthCurriculum(stages=(
+        Stage(index=0, until_frac=0.5, seq_len=8, batch_size=4, steps=steps_a),
+        Stage(index=1, until_frac=1.0, seq_len=16, batch_size=2, steps=steps_b),
+    ), grad_accum=grad_accum)
+
+
+# On a 512-token corpus: stage 1 is (seq 8, batch 4) -> 56 chunks -> 14 batches/epoch;
+# stage 2 is (seq 16, batch 2) -> 30 chunks -> 15 batches/epoch. The kill points below
+# cover mid-epoch, an epoch boundary, the stage boundary itself, and several epochs in.
+@pytest.mark.parametrize("kill_at, why", [
+    (3, "mid-epoch, inside stage 1"),
+    (6, "exactly ON the stage boundary"),
+    (9, "mid-epoch, inside stage 2 after the crossing"),
+    (21, "exactly on an epoch boundary inside stage 2"),
+    (30, "deep into stage 2, several epochs later"),
+])
+def test_resume_reproduces_the_exact_tail(tmp_path, kill_at, why):
+    path = _packed(tmp_path, n_tokens=512)
+    seed, total = 5, 45
+    c = _curriculum()
+
+    uninterrupted = _take(MicroBatchStream(c, _factory(path, seed), seed), total)
+
+    a = MicroBatchStream(c, _factory(path, seed), seed)
+    head = _take(a, kill_at)
+    state = copy.deepcopy(a.state_dict())
+    del a                                       # "kill" the process state
+
+    b = MicroBatchStream(c, _factory(path, seed), seed)
+    b.load_state_dict(state)
+    tail = _take(b, total - kill_at)
+
+    assert head == uninterrupted[:kill_at], f"head diverged ({why})"
+    assert tail == uninterrupted[kill_at:], f"resumed stream diverged ({why})"
+
+
+def test_state_survives_a_json_round_trip(tmp_path):
+    """The state is persisted through `resume_meta.json`, so it must survive json."""
+    import json
+
+    from src.train.checkpoint import _jsonable
+
+    path = _packed(tmp_path, n_tokens=512)
+    seed, total = 5, 30
+    c = _curriculum()
+    uninterrupted = _take(MicroBatchStream(c, _factory(path, seed), seed), total)
+
+    a = MicroBatchStream(c, _factory(path, seed), seed)
+    _take(a, 9)
+    state = json.loads(json.dumps(_jsonable(a.state_dict())))
+
+    b = MicroBatchStream(c, _factory(path, seed), seed)
+    b.load_state_dict(state)
+    assert _take(b, total - 9) == uninterrupted[9:]
+
+
+# --- the curriculum actually engages (these tests are not vacuous) ----------
+def test_shapes_change_at_the_stage_boundary(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    c = _curriculum(steps_a=6, steps_b=6)
+    s = MicroBatchStream(c, _factory(path), 0)
+    shapes = [next(s)[0].shape for _ in range(12)]
+    assert shapes[:6] == [(4, 8)] * 6
+    assert shapes[6:] == [(2, 16)] * 6
+
+
+def test_counters_at_the_stage_boundary(tmp_path):
+    """Edge case 7: killing exactly ON a boundary must name the NEW stage at
+    micro_in_stage 0 with a fresh epoch — not the exhausted tail of the old one."""
+    path = _packed(tmp_path, n_tokens=512)
+    c = _curriculum(steps_a=6, steps_b=6)
+    s = MicroBatchStream(c, _factory(path), 0)
+    _take(s, 6)
+    st = s.state_dict()
+    assert st["stage_idx"] == 1 and st["micro_in_stage"] == 0
+    assert st["batches_into_epoch"] == 0
+    assert st["global_micro"] == 6
+
+
+def test_epoch_idx_is_monotone_across_stages(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    c = _curriculum(steps_a=6, steps_b=20)
+    s = MicroBatchStream(c, _factory(path), 0)
+    seen = []
+    for _ in range(26):
+        next(s)
+        seen.append(s.epoch_idx)
+    assert seen == sorted(seen), "epoch_idx must never go backwards"
+    assert seen[-1] > seen[0], "test is vacuous: no epoch ever rolled"
+
+
+def test_stage_boundary_lands_on_a_step_boundary(tmp_path):
+    """Edge case 1: stage lengths are in OPTIMIZER steps, so no single step ever mixes
+    shapes — a mixed-shape step would silently corrupt the gradient."""
+    path = _packed(tmp_path, n_tokens=512)
+    ga = 3
+    c = _curriculum(steps_a=4, steps_b=4, grad_accum=ga)
+    s = MicroBatchStream(c, _factory(path), 0)
+    for _ in range(8):                       # 8 optimizer steps
+        shapes = {next(s)[0].shape for _ in range(ga)}
+        assert len(shapes) == 1, f"a single optimizer step mixed shapes: {shapes}"
+
+
+def test_last_stage_never_terminates(tmp_path):
+    """`train()`'s `while step < total_steps` is the only stop condition."""
+    path = _packed(tmp_path, n_tokens=512)
+    c = _curriculum(steps_a=2, steps_b=2)
+    s = MicroBatchStream(c, _factory(path), 0)
+    batches = _take(s, 60)                   # far past the allocated 4 steps
+    assert len(batches) == 60
+    assert s.stage_idx == 1
+
+
+# --- failure paths all RAISE; none degrade to a silent resample -------------
+def test_fingerprint_mismatch_on_seed_raises(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    c = _curriculum()
+    a = MicroBatchStream(c, _factory(path), 1)
+    _take(a, 3)
+    state = a.state_dict()
+
+    b = MicroBatchStream(c, _factory(path), 2)          # different seed
+    with pytest.raises(ValueError, match="does not match this run's configuration"):
+        b.load_state_dict(state)
+
+
+def test_fingerprint_mismatch_on_stage_shape_raises(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    a = MicroBatchStream(_curriculum(), _factory(path), 0)
+    _take(a, 3)
+    state = a.state_dict()
+
+    other = LengthCurriculum(stages=(
+        Stage(index=0, until_frac=0.5, seq_len=8, batch_size=4, steps=6),
+        Stage(index=1, until_frac=1.0, seq_len=32, batch_size=2, steps=40),   # 32 != 16
+    ), grad_accum=1)
+    b = MicroBatchStream(other, _factory(path), 0)
+    with pytest.raises(ValueError, match="does not match this run's configuration"):
+        b.load_state_dict(state)
+
+
+def test_fingerprint_mismatch_on_extra_fingerprint_raises(tmp_path):
+    """scripts/train.py passes {train_path, n_tokens} — swapping the corpus must be loud."""
+    path = _packed(tmp_path, n_tokens=512)
+    c = _curriculum()
+    a = MicroBatchStream(c, _factory(path), 0, extra_fingerprint={"n_tokens": 512})
+    _take(a, 3)
+    state = a.state_dict()
+
+    b = MicroBatchStream(c, _factory(path), 0, extra_fingerprint={"n_tokens": 999})
+    with pytest.raises(ValueError, match="does not match this run's configuration"):
+        b.load_state_dict(state)
+
+
+def test_fingerprint_error_names_the_escape_hatch(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    a = MicroBatchStream(_curriculum(), _factory(path), 1)
+    _take(a, 3)
+    b = MicroBatchStream(_curriculum(), _factory(path), 2)
+    with pytest.raises(ValueError, match="--ignore-data-state"):
+        b.load_state_dict(a.state_dict())
+
+
+def test_version_mismatch_raises_even_when_not_strict(tmp_path):
+    """A state we cannot parse is not a state we can approximate."""
+    path = _packed(tmp_path, n_tokens=512)
+    a = MicroBatchStream(_curriculum(), _factory(path), 0)
+    _take(a, 3)
+    state = a.state_dict()
+    state["version"] = STATE_VERSION + 1
+
+    b = MicroBatchStream(_curriculum(), _factory(path), 0)
+    for strict in (True, False):
+        with pytest.raises(ValueError, match="dataloader state version"):
+            b.load_state_dict(state, strict=strict)
+
+
+def test_non_strict_skips_the_fingerprint_check(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    a = MicroBatchStream(_curriculum(), _factory(path), 0)
+    _take(a, 3)
+    state = a.state_dict()
+    state["fingerprint"] = {"totally": "different"}
+
+    b = MicroBatchStream(_curriculum(), _factory(path), 0)
+    b.load_state_dict(state, strict=False)          # no raise
+    assert b.global_micro == 3
+
+
+def test_rejects_non_dict_state(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    s = MicroBatchStream(_curriculum(), _factory(path), 0)
+    with pytest.raises(ValueError, match="must be a dict"):
+        s.load_state_dict("nope")
+
+
+def test_out_of_range_stage_idx_raises(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    a = MicroBatchStream(_curriculum(), _factory(path), 0)
+    _take(a, 3)
+    state = a.state_dict()
+    state["stage_idx"] = 5
+
+    b = MicroBatchStream(_curriculum(), _factory(path), 0)
+    with pytest.raises(ValueError, match="outside this curriculum's"):
+        b.load_state_dict(state)
+
+
+def test_rng_tripwire_fires_on_a_wrong_epoch_pairing(tmp_path):
+    """The tripwire is coarse but catches the exact silent failure: a position restored
+    against a shuffle it did not come from."""
+    path = _packed(tmp_path, n_tokens=512)
+    c = _curriculum()
+    a = MicroBatchStream(c, _factory(path), 0)
+    _take(a, 3)
+    state = a.state_dict()
+    assert state["rng_state"] is not None, "test is vacuous: no rng state was captured"
+    state["epoch_idx"] = state["epoch_idx"] + 7      # position no longer matches the rng
+
+    b = MicroBatchStream(c, _factory(path), 0)
+    with pytest.raises(ValueError, match="RNG tripwire failed"):
+        b.load_state_dict(state)
+
+
+def test_stage_with_no_batches_per_epoch_raises_clearly(tmp_path):
+    """Edge case 2: at long seq_len a small corpus drops below one batch per epoch.
+
+    512 tokens at seq_len 200 give 2 chunks — enough for `PackedLoader` to construct, but
+    fewer than one batch of 8, so `epoch()` would yield nothing FOREVER rather than fail.
+    """
+    path = _packed(tmp_path, n_tokens=512)
+    c = LengthCurriculum(stages=(
+        Stage(index=0, until_frac=1.0, seq_len=200, batch_size=8, steps=1),),
+        grad_accum=1)
+    s = MicroBatchStream(c, _factory(path), 0)
+    with pytest.raises(ValueError, match="yields no batches per epoch"):
+        next(s)
+
+
+# --- loaders without an rng (edge case 9) -----------------------------------
+def test_loader_without_rng_skips_the_tripwire():
+    c = LengthCurriculum(stages=(
+        Stage(index=0, until_frac=1.0, seq_len=4, batch_size=2, steps=100),),
+        grad_accum=1)
+    a = MicroBatchStream(c, lambda sl, bs: FakeLoader(5), 0)
+    for _ in range(7):
+        next(a)
+    state = a.state_dict()
+    assert state["rng_state"] is None
+
+    b = MicroBatchStream(c, lambda sl, bs: FakeLoader(5), 0)
+    b.load_state_dict(state)                     # no raise, no tripwire
+    assert b.global_micro == 7
+    # ...and the restored position really is position 7: epoch 1 (5 batches/epoch), index 2.
+    assert np.array_equal(next(b)[0], np.array([1, 2]))
+
+
+def test_single_batch_per_epoch_still_advances():
+    """Edge case 3: len(loader) == 1 — the epoch advance must still work."""
+    c = LengthCurriculum(stages=(
+        Stage(index=0, until_frac=1.0, seq_len=4, batch_size=2, steps=100),),
+        grad_accum=1)
+    s = MicroBatchStream(c, lambda sl, bs: FakeLoader(1), 0)
+    reseeds = [int(next(s)[0][0]) for _ in range(5)]
+    assert reseeds == [0, 1, 2, 3, 4], "each epoch must reseed with seed + epoch_idx"
+
+
+# --- seek_micro / seek_step (the no-explicit-state fallbacks) ---------------
+def test_seek_micro_refuses_a_multi_stage_curriculum(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    s = MicroBatchStream(_curriculum(), _factory(path), 0)
+    with pytest.raises(ValueError, match="cannot reconstruct a position across a "
+                                         "multi-stage curriculum"):
+        s.seek_micro(10)
+
+
+def test_seek_micro_zero_is_a_noop_on_a_multi_stage_curriculum(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    s = MicroBatchStream(_curriculum(), _factory(path), 0)
+    s.seek_micro(0)                              # a fresh run must not raise
+    assert s.global_micro == 0
+
+
+def test_seek_step_reconstructs_the_position_across_stages(tmp_path):
+    """The `--ignore-data-state` / pre-#216-bundle fallback. It replays the same counter
+    arithmetic the live stream performs, so its tail must match too."""
+    path = _packed(tmp_path, n_tokens=512)
+    seed, total = 5, 40
+    c = _curriculum(steps_a=6, steps_b=40)
+    uninterrupted = _take(MicroBatchStream(c, _factory(path, seed), seed), total)
+
+    for k in (0, 3, 6, 7, 20, 33):
+        s = MicroBatchStream(c, _factory(path, seed), seed)
+        s.seek_step(k)                           # grad_accum == 1, so step == micro
+        assert _take(s, total - k) == uninterrupted[k:], f"seek_step({k}) diverged"
+
+
+def test_seek_step_agrees_with_the_saved_state(tmp_path):
+    """Both routes to the same position must produce the same counters — otherwise the
+    fallback path silently disagrees with the explicit one."""
+    path = _packed(tmp_path, n_tokens=512)
+    seed = 5
+    c = _curriculum(steps_a=6, steps_b=40)
+    for k in (3, 6, 7, 20):
+        a = MicroBatchStream(c, _factory(path, seed), seed)
+        _take(a, k)
+        b = MicroBatchStream(c, _factory(path, seed), seed)
+        b.seek_step(k)
+        for field in ("stage_idx", "micro_in_stage", "global_micro",
+                      "epoch_idx", "batches_into_epoch"):
+            assert a.state_dict()[field] == b.state_dict()[field], f"{field} at k={k}"
+
+
+def test_seek_step_rejects_negative(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    s = MicroBatchStream(_curriculum(), _factory(path), 0)
+    with pytest.raises(ValueError, match="seek_step needs step >= 0"):
+        s.seek_step(-1)
+
+
+# --- accessors --------------------------------------------------------------
+def test_active_stage_accessors_track_the_boundary(tmp_path):
+    path = _packed(tmp_path, n_tokens=512)
+    c = _curriculum(steps_a=3, steps_b=3, grad_accum=2)
+    s = MicroBatchStream(c, _factory(path), 0)
+    assert (s.seq_len, s.batch_size, s.tokens_per_step) == (8, 4, 8 * 4 * 2)
+    _take(s, 3 * 2)
+    assert (s.seq_len, s.batch_size, s.tokens_per_step) == (16, 2, 16 * 2 * 2)

--- a/tests/test_train_loop.py
+++ b/tests/test_train_loop.py
@@ -5,9 +5,11 @@ through an injected `train_step` that records its calls.
 """
 
 import numpy as np
+import pytest
 
 from src.data.loader import PackedLoader
 from src.data.pack import pack_ids
+from src.train.curriculum import LengthCurriculum, Stage
 from src.train.loop import TrainConfig, train, _micro_batch_stream
 
 
@@ -71,9 +73,14 @@ def test_checkpoint_fires_at_interval():
     loader = FakeLoader(n_batches=100)
     cfg = TrainConfig(total_steps=10, grad_accum=1, warmup_steps=0, log_every=100,
                       eval_every=100, ckpt_every=3)
-    train(None, loader, cfg, fake_step, on_checkpoint=ckpts.append)
+    train(None, loader, cfg, fake_step,
+          on_checkpoint=lambda step, data_state: ckpts.append((step, data_state)))
 
-    assert ckpts == [3, 6, 9]            # post-increment step hits the cadence
+    assert [s for s, _ in ckpts] == [3, 6, 9]   # post-increment step hits the cadence
+    # #216: every checkpoint carries a usable dataloader position, and it is positioned
+    # at the START of the step it is filed under (step*grad_accum micro-batches consumed).
+    for step, state in ckpts:
+        assert state is not None and state["global_micro"] == step * cfg.grad_accum
 
 
 def test_start_step_resume_runs_only_remaining():
@@ -125,6 +132,229 @@ def test_resume_stream_continues_data_not_restart(tmp_path):
     assert resumed == full[resume_k:], "resumed stream diverged from the uninterrupted one"
     # And sanity: the stream is NOT just repeating epoch 0 (would make the test vacuous).
     assert full[:10] != full[10:20]
+
+
+def test_resume_via_explicit_data_state_continues_the_stream(tmp_path):
+    """The #216 form of the P0.1 regression above: the same property, but carried by an
+    EXPLICIT `data_state` rather than reconstructed from the step. This is the path a
+    curriculum run takes, and the one that must hold when `len(loader)` is no longer a
+    constant of the run."""
+    seq_len, batch_size, grad_accum, seed = 4, 2, 1, 123
+    n_chunks = 20                                  # per_epoch = 10 micro-batches
+    packed = tmp_path / "train.bin"
+    pack_ids(np.arange(n_chunks * (seq_len + 1), dtype=np.uint16), packed,
+             dtype=np.uint16)
+    factory = lambda sl, bs: PackedLoader(packed, sl, bs, shuffle=True, seed=seed)
+
+    def recorder(store):
+        def fake_step(model, micro, lr):
+            store.extend(_hashable(b) for b in micro)
+            return {"loss": 1.0, "grad_norm": 0.0}
+        return fake_step
+
+    cfg = TrainConfig(total_steps=25, grad_accum=grad_accum, warmup_steps=0,
+                      log_every=100, eval_every=100, ckpt_every=13, seed=seed)
+    loader = factory(seq_len, batch_size)
+
+    full = []
+    train(None, loader, cfg, recorder(full))
+
+    saved = {}
+    part = []
+    cut = TrainConfig(**{**cfg.__dict__, "total_steps": 13})
+    train(None, loader, cut, recorder(part),
+          on_checkpoint=lambda step, ds: saved.update(step=step, data_state=ds))
+    assert saved["data_state"] is not None
+
+    rest = []
+    train(None, factory(seq_len, batch_size), cfg, recorder(rest),
+          start_step=saved["step"], start_data_state=saved["data_state"])
+
+    assert part == full[:13]
+    assert rest == full[13:], "resume from explicit data_state diverged"
+    assert full[:10] != full[10:20], "test is vacuous: the stream never crossed an epoch"
+
+
+def _two_stage_setup(tmp_path, steps_a=4, steps_b=6, grad_accum=1, seed=9):
+    """A real two-stage curriculum over a packed corpus, with a matching loader factory."""
+    packed = tmp_path / "train.bin"
+    pack_ids(np.arange(600, dtype=np.uint16), packed, dtype=np.uint16)
+    curriculum = LengthCurriculum(stages=(
+        Stage(index=0, until_frac=0.5, seq_len=8, batch_size=4, steps=steps_a),
+        Stage(index=1, until_frac=1.0, seq_len=16, batch_size=2, steps=steps_b),
+    ), grad_accum=grad_accum)
+    factory = lambda sl, bs: PackedLoader(packed, sl, bs, shuffle=True, seed=seed)
+    return curriculum, factory
+
+
+def test_resume_across_curriculum_boundary(tmp_path):
+    """THE acceptance test, through the real loop: kill strictly AFTER a stage boundary
+    and resume from the saved `data_state`; every micro-batch must match the
+    uninterrupted run byte for byte."""
+    grad_accum, seed = 2, 9
+    curriculum, factory = _two_stage_setup(tmp_path, steps_a=4, steps_b=6,
+                                           grad_accum=grad_accum, seed=seed)
+    total = curriculum.total_steps                             # 10 steps, boundary at 4
+
+    def recorder(store):
+        def fake_step(model, micro, lr):
+            store.extend((b[0].shape, _hashable(b)) for b in micro)
+            return {"loss": 1.0, "grad_norm": 0.0}
+        return fake_step
+
+    def cfg_for(steps, ckpt_every=1000):
+        return TrainConfig(total_steps=steps, grad_accum=grad_accum, warmup_steps=0,
+                           log_every=100, eval_every=1000, ckpt_every=ckpt_every,
+                           seed=seed)
+
+    full = []
+    train(None, None, cfg_for(total), recorder(full), curriculum=curriculum,
+          loader_factory=factory)
+
+    # Kill the way a preemptible pod does: mid-run, at a checkpoint, with the run's real
+    # total_steps intact — NOT by shortening the budget (that would move the boundary).
+    class Killed(Exception):
+        pass
+
+    kill = 6                                                   # boundary(4) + 2
+    saved, part = {}, []
+
+    def kill_at(step, data_state):
+        saved.update(step=step, data_state=data_state)
+        raise Killed
+
+    with pytest.raises(Killed):
+        train(None, None, cfg_for(total, ckpt_every=kill), recorder(part),
+              curriculum=curriculum, loader_factory=factory, on_checkpoint=kill_at)
+
+    rest = []
+    train(None, None, cfg_for(total), recorder(rest), curriculum=curriculum,
+          loader_factory=factory, start_step=saved["step"],
+          start_data_state=saved["data_state"])
+
+    assert part == full[:kill * grad_accum]
+    assert rest == full[kill * grad_accum:], "resume across the boundary diverged"
+    # Not vacuous: the shape really did change at the boundary.
+    shapes = [s for s, _ in full]
+    assert shapes[:4 * grad_accum] == [(4, 8)] * (4 * grad_accum)
+    assert shapes[4 * grad_accum:] == [(2, 16)] * (6 * grad_accum)
+
+
+def test_curriculum_payload_carries_stage_seq_len_and_cumulative_tokens(tmp_path):
+    curriculum, factory = _two_stage_setup(tmp_path, steps_a=4, steps_b=6)
+    cfg = TrainConfig(total_steps=curriculum.total_steps, grad_accum=1, warmup_steps=0,
+                      log_every=1, eval_every=1000, ckpt_every=1000, seed=9)
+    logs = []
+    result = train(None, None, cfg, lambda m, mb, lr: {"loss": 1.0}, logger=logs.append,
+                   curriculum=curriculum, loader_factory=factory)
+
+    steps = [p for p in logs if "event" not in p]
+    assert [p["seq_len"] for p in steps] == [8] * 4 + [16] * 6
+    assert [p["stage"] for p in steps] == [0] * 4 + [1] * 6
+    # tokens is cumulative over the REAL per-stage tokens/step, not steps * a constant.
+    assert [p["tokens"] for p in steps] == [
+        32, 64, 96, 128, 160, 192, 224, 256, 288, 320]
+    assert result["tokens_seen"] == 4 * 32 + 6 * 32
+    assert set(result) == {"step", "data_state", "tokens_seen"}
+    assert result["step"] == curriculum.total_steps
+
+
+def test_curriculum_logs_one_stage_event_per_boundary(tmp_path):
+    """The anti-silent-regression measure: every CUDA recompile is preceded by a visible,
+    timestamped line, so a stall at a boundary is attributable."""
+    curriculum, factory = _two_stage_setup(tmp_path, steps_a=3, steps_b=3)
+    cfg = TrainConfig(total_steps=6, grad_accum=1, warmup_steps=0, log_every=1,
+                      eval_every=1000, ckpt_every=1000, seed=9)
+    logs = []
+    train(None, None, cfg, lambda m, mb, lr: {"loss": 1.0}, logger=logs.append,
+          curriculum=curriculum, loader_factory=factory)
+
+    events = [p for p in logs if p.get("event") == "stage"]
+    assert [(e["step"], e["stage"], e["seq_len"]) for e in events] == [(0, 0, 8), (3, 1, 16)]
+
+
+def test_no_curriculum_emits_no_stage_events():
+    """A single-stage run has no boundary; the extra payload would be noise in every
+    existing pretrain/SFT/DPO log."""
+    cfg = TrainConfig(total_steps=4, grad_accum=1, warmup_steps=0, log_every=1,
+                      eval_every=100, ckpt_every=100)
+    logs = []
+    train(None, FakeLoader(n_batches=100), cfg, lambda m, mb, lr: {"loss": 1.0},
+          logger=logs.append)
+    assert not [p for p in logs if "event" in p]
+
+
+def test_curriculum_total_steps_must_match_cfg(tmp_path):
+    curriculum, factory = _two_stage_setup(tmp_path, steps_a=4, steps_b=6)
+    cfg = TrainConfig(total_steps=99, grad_accum=1, warmup_steps=0, log_every=100,
+                      eval_every=100, ckpt_every=100)
+    with pytest.raises(ValueError, match=r"curriculum.total_steps \(10\) != cfg"):
+        train(None, None, cfg, lambda m, mb, lr: {"loss": 1.0}, curriculum=curriculum,
+              loader_factory=factory)
+
+
+def test_curriculum_requires_a_loader_factory(tmp_path):
+    curriculum, _ = _two_stage_setup(tmp_path)
+    cfg = TrainConfig(total_steps=curriculum.total_steps, grad_accum=1, warmup_steps=0)
+    with pytest.raises(ValueError, match="needs a loader_factory"):
+        train(None, None, cfg, lambda m, mb, lr: {"loss": 1.0}, curriculum=curriculum)
+
+
+def test_resume_with_a_stale_stage_index_raises(tmp_path):
+    """Edge case 4: resuming with a changed budget can move the stage boundary out from
+    under the saved position. That must be loud and name the escape hatch, never a silent
+    resample."""
+    curriculum, factory = _two_stage_setup(tmp_path, steps_a=4, steps_b=6)
+    cfg = TrainConfig(total_steps=curriculum.total_steps, grad_accum=1, warmup_steps=0,
+                      log_every=100, eval_every=100, ckpt_every=6, seed=9)
+    saved = {}
+    train(None, None, cfg, lambda m, mb, lr: {"loss": 1.0}, curriculum=curriculum,
+          loader_factory=factory,
+          on_checkpoint=lambda step, ds: saved.update(step=step, data_state=ds))
+    assert saved["data_state"]["stage_idx"] == 1        # step 6 is inside stage 2
+
+    # Same SHAPES (so the fingerprint still matches) but a later boundary: step 6 now
+    # belongs to stage 0.
+    moved, _ = _two_stage_setup(tmp_path, steps_a=8, steps_b=2)
+    cfg2 = TrainConfig(**{**cfg.__dict__, "total_steps": moved.total_steps})
+    with pytest.raises(ValueError, match="--ignore-data-state"):
+        train(None, None, cfg2, lambda m, mb, lr: {"loss": 1.0}, curriculum=moved,
+              loader_factory=factory, start_step=saved["step"],
+              start_data_state=saved["data_state"])
+
+
+def test_ignore_data_state_falls_back_to_step_reconstruction(tmp_path):
+    """The escape hatch reconstructs from the step instead of raising — and on an
+    UNCHANGED curriculum it reproduces the same stream, so it is a safe fallback."""
+    curriculum, factory = _two_stage_setup(tmp_path, steps_a=4, steps_b=6)
+
+    def recorder(store):
+        def fake_step(model, micro, lr):
+            store.extend(_hashable(b) for b in micro)
+            return {"loss": 1.0}
+        return fake_step
+
+    cfg = TrainConfig(total_steps=curriculum.total_steps, grad_accum=1, warmup_steps=0,
+                      log_every=100, eval_every=100, ckpt_every=1000, seed=9)
+    full = []
+    train(None, None, cfg, recorder(full), curriculum=curriculum, loader_factory=factory)
+
+    rest = []
+    train(None, None, cfg, recorder(rest), curriculum=curriculum, loader_factory=factory,
+          start_step=6, start_data_state={"version": 1, "bogus": True},
+          ignore_data_state=True)
+    assert rest == full[6:]
+
+
+def test_legacy_bundle_without_data_state_reconstructs_from_step():
+    """Edge case 5: a pre-#216 resume bundle has no `data_state` at all."""
+    calls = []
+    cfg = TrainConfig(total_steps=10, grad_accum=1, warmup_steps=0, log_every=100,
+                      eval_every=100, ckpt_every=100)
+    train(None, FakeLoader(n_batches=100), cfg,
+          lambda m, mb, lr: calls.append(lr) or {"loss": 1.0},
+          start_step=7, start_data_state=None)
+    assert len(calls) == 3
 
 
 def _itertools_take(it, n):


### PR DESCRIPTION
Closes #216

## Summary

Two upgrades the issue deliberately pairs, because **(a) invalidates the invariant that (b) has to replace**.

**(a) Length curriculum.** `--curriculum "0.25:2048,0.5:4096,1.0:16384"` on `scripts/train.py` ramps `seq_len` across the run and shrinks `batch_size` inversely so tokens/step stays roughly constant. `until_frac` is **cumulative** (the fraction of the run *ending* at that stage) and is validated hard — misreading it as "share of the run" would silently produce a plausible-but-wrong allocation. An omitted `batch_size` is derived with a **floor**, so a derived stage can only ever get cheaper than the reference, never surprise-OOM at 16k. Like every other run param, it is a CLI flag, not model config.

**(b) Explicit dataloader-state resume.** The data position used to be *reconstructed* from `(seed, step, grad_accum)`, which holds only while `seq_len` — and hence `stride`, `n_chunks`, `len(loader)` — is fixed for the whole run. A curriculum breaks that **silently**: the run resumes, resamples data it has already seen, and its epoch accounting is quietly wrong while every log line looks healthy. So `MicroBatchStream` (`src/train/stream.py`) carries the position as five explicit counters, and `CheckpointStore.save(data_state=...)` persists them.

### Where the state lives, and why

`data_state` rides **inside the slot's existing `resume_meta.json`** — not a new file, and never next to `LATEST`. It is therefore committed by the *same* atomic `LATEST` flip as the weights and the step, so a bundle can never ship weights that disagree with the data position they were trained to. It also adds no entry to the slot, which is why the three pinned slot tests (`test_store_crash_mid_write_preserves_previous_checkpoint`, `test_store_alternates_slots`, `test_store_save_leaves_no_temp_files`) are untouched by construction. Backward compatible via `meta.get("data_state")`: pre-#216 bundles read back as `None` and fall back to the old reconstruction.

**Every failure path in `load_state_dict` raises** — fingerprint mismatch, version mismatch, an RNG tripwire. None degrades to "start a fresh epoch", because a silent resample is the exact bug this issue exists to kill. `steps` is deliberately *outside* the fingerprint so extending a run with a bigger `--total-tokens` stays legal.

### Scope notes

- **`epoch_idx` is global, not per-stage**, so the one-stage case is bit-identical to the pre-#216 stream. `train()` synthesizes that degenerate curriculum when none is passed — one code path, and SFT/DPO and the smoke gate are unchanged.
- **Stage lengths are in optimizer steps**, so a boundary always lands on a step boundary and no single step ever mixes shapes.
- **Val loss stays pinned at `cfg.seq_len`** — deliberately not ramped. A val curve measured at a changing context length is not comparable across a run and would make the POC's primary signal unreadable.
- Startup **fails fast** if any stage's shape yields < 1 batch/epoch, naming the stage, the token count, and the required minimum — rather than surfacing deep in the stream at a boundary days in.

### `torch.compile` recompile cost — sized, not absorbed

`src/model/cuda_backend.py:759-775` has no `dynamic=`, so each stage boundary triggers one inductor recompile on CUDA. Per the issue's instruction this is **documented rather than silently absorbed**: it is bounded (≤ `n_stages - 1` events; inductor promotes to dynamic shapes after the second distinct `(B, L)`; dynamo's cache-size limit of 8 is far above a 3–4 stage curriculum), so the mitigation is **visibility**, not a code change — the startup banner states the expected cost explicitly, and the loop emits an `{"event": "stage", ...}` log line before each boundary so a stall there is attributable rather than mysterious. `dynamic=True`, `mark_dynamic`, and CUDA graphs are explicitly out of scope, and the compile default is untouched (that is #239's decision).

### Honest framing

The guarantee is **exact stream reproduction across a kill/resume**, not "no token is seen twice". `PackedLoader` cuts windows from one flat `train.bin` with no document structure, so chunking at a different `seq_len` is a different partition of the same corpus and later stages necessarily re-cover earlier tokens at a different alignment. This is stated in the module docstring and the design doc.

## Files

**New (both portable, both added to `PORTABLE_MODULES`):** `src/train/curriculum.py`, `src/train/stream.py`, `tests/test_curriculum.py`, `tests/test_stream.py`.
**Modified:** `src/train/{loop,checkpoint,logging}.py`, `scripts/{train,smoke_test,sft,dpo}.py`, `tests/test_{train_loop,checkpoint,import_guard}.py`, `docs/design/{05-training,13-code-model-moe}.md`.

`sft.py`/`dpo.py` accept and **ignore** `data_state` (one comment line): their resume stays step-based, and persisting a position nothing reads back would be worse than not persisting one.

## Testing

- [x] Tests added/updated — **+104 tests** across `test_curriculum.py` (44), `test_stream.py` (31), plus extensions to `test_train_loop.py` and `test_checkpoint.py`.
- [x] All tests passing — full suite **976 passed, 13 skipped**.
- [x] Manual testing completed.

**Acceptance ("kill-and-resume reproduces the EXACT data stream") is checked at three levels:**

1. `tests/test_stream.py` — pure numpy, five kill points: mid-epoch, on an epoch boundary, exactly *on* the stage boundary, just after the crossing, and several epochs into stage 2. Compares actual token bytes, not counters.
2. `tests/test_train_loop.py::test_resume_across_curriculum_boundary` — through the real loop, killing at a checkpoint the way a preempted pod does (budget intact), asserting every micro-batch matches byte for byte.
3. **Smoke gate phase 7 (new)** — drives the *real* `train()` + `MicroBatchStream` + `CheckpointStore` across a boundary. Phases 1–6 drive `step_fn` over a pre-materialized batch list, which is exactly what makes them blind to data ordering; phase 7 asserts both that the post-resume loss trajectory matches **and** that the `seq_len` sequence really changed, so a curriculum that silently failed to engage cannot pass.

**M4 smoke gate (fresh toy split, fp32):**

```
[match] post-resume max|loss diff| over steps 25..49 = 1.192e-07
[eval] val_loss=1.5449  val_perplexity=4.6875
[prefill] L=16 + 4 decode steps OK
[curriculum] 0.5:64:16,1.0:128:8  steps=20  boundary=10  kill=12  post-resume max|loss diff| over steps 12..19 = 4.768e-07
[curriculum] stages engaged in both runs; tokens=20480 (cumulative across 2 stages) OK
SMOKE TEST PASSED ✅
```

> Phase 1–6 `[match]` alternates between `1.192e-07` and `2.384e-07` run to run. That is **not** from this change: an A/B of three serial runs each on `main`@`05021fe` and on this branch produced the same distribution on both (`{2.384e-07, 2.384e-07, 1.192e-07}` vs `{1.192e-07, 2.384e-07, 1.192e-07}`). It is one ULP of fp32 at loss ≈ 1.5, ~3 orders of magnitude under the 1e-4 gate.

**Real `scripts/train.py` runs (toy config):** curriculum engages with derived batches holding tokens/step at exactly 2048 across both stages; auto-resume prints `data_state=present` and resumes correctly; **extending the budget** 20 → 40 steps resumes cleanly (`steps` is out of the fingerprint); the final out-of-loop checkpoint carries a real `data_state` when `total_steps % ckpt_every != 0`; and the too-long-stage and malformed-spec paths both fail fast with actionable messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uRT2cJmofSFEyv1bZ8oAg