### PR TITLE
feat: [M12] MoE in the CUDA backend — grouped-gather routing, shared expert, sparse-upcycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,46 @@ jobs:
         run: |
           python scripts/smoke_test.py --backend cuda \
                  --data "$RUNNER_TEMP/toy/split" --out "$RUNNER_TEMP/smoke"
+      - name: Smoke gate (CUDA backend, MoE config, gather impl)
+        # --moe-impl is new (#214); this is the only CI coverage of the gather
+        # dispatch path end-to-end through the real training loop/resume path,
+        # not just the unit-level tests/test_cuda_moe_gather.py comparisons.
+        run: |
+          python scripts/smoke_test.py --backend cuda --config config/toy-moe.yaml \
+                 --moe-impl gather --data "$RUNNER_TEMP/toy/split" --out "$RUNNER_TEMP/smoke-moe"
 
-  # ── Job 3: full suite + smoke gate on macOS/MLX (arm64) ───────────────────
+  # ── Job 3: CUDA test suite on CPU torch (#214) ─────────────────────────────
+  # Without this job, EVERY test_cuda_*.py test skips in CI: `portable` has no torch
+  # (by design — the seam guard needs that ambiguity-free) and `smoke-linux` installs
+  # torch but runs no pytest, only scripts/smoke_test.py. This is deliberately a
+  # SEPARATE job from `portable`, not a step in it, for the same reason smoke-linux is
+  # separate: torch must never enter portable's environment. `[dev,data]` (no `cuda`
+  # extra) is enough — torch itself is installed from the CPU wheel index first, same
+  # as smoke-linux, so the CUDA backend's "torch on CPU" fallback path is what runs
+  # here (fused=False, no real GPU). bitsandbytes/transformer-engine are NOT installed
+  # (`cuda-8bit`/`cuda-fp8` are separate extras) — the 8-bit-optimizer and fp8 tests
+  # stay hardware/library-gated and skip here too; see docs/infrastructure.md's manual
+  # verification section for what only a real GPU pod can confirm.
+  cuda-cpu:
+    name: CUDA test suite (Linux, CPU torch)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install --index-url https://download.pytorch.org/whl/cpu torch
+          pip install -e ".[dev,data]"
+      - name: pytest (CUDA backend + backend_parity tests only)
+        run: pytest -q -rs tests/test_cuda_*.py tests/test_backend_parity.py
+
+  # ── Job 4: full suite + smoke gate on macOS/MLX (arm64) ───────────────────
   # macos-latest is arm64, so the mlx wheel installs and the ~19 mlx-gated
   # test files actually run instead of skipping.
   full-macos:
@@ -122,7 +160,7 @@ jobs:
           python scripts/smoke_test.py --backend mlx \
                  --data "$RUNNER_TEMP/toy/split" --out "$RUNNER_TEMP/smoke"
 
-  # ── Job 4: native Swift toolchain, macOS (#246) ───────────────────────────
+  # ── Job 5: native Swift toolchain, macOS (#246) ───────────────────────────
   # swift/Package.swift declares NO .testTarget and there is no Tests/ dir, so
   # `swift test` finds nothing — monica-selfcheck is the actual runner
   # (dependency-free, no XCTest, exits non-zero on any failure). Swift ships
@@ -180,7 +218,7 @@ jobs:
           path: ${{ runner.temp }}/fim-shards
           retention-days: 7
 
-  # ── Job 5: native Swift toolchain, Linux (#246) ───────────────────────────
+  # ── Job 6: native Swift toolchain, Linux (#246) ───────────────────────────
   # The official swift image (Ubuntu 24.04, glibc 2.39) — the same toolchain the
   # CUDA host would use. Zero external package dependencies, and the image
   # already carries git/tar, so no apt step is needed.
@@ -232,7 +270,7 @@ jobs:
           path: ${{ runner.temp }}/fim-shards
           retention-days: 7
 
-  # ── Job 6: the bit-identical guarantee itself (#246) ──────────────────────
+  # ── Job 7: the bit-identical guarantee itself (#246) ──────────────────────
   # #191/#245's whole premise is that the Swift tokenizer produces identical
   # vocab/ids on the Mac dev box and the Linux/CUDA host. This job is what
   # makes that claim a gate rather than a comment.
@@ -280,7 +318,7 @@ jobs:
             cmp "fim-macos/$f" "fim-linux/$f"
           done < <(cd fim-macos && find . -type f | sort)
 
-  # ── Job 7: the Swift/MLX model port's logit parity gate (#166) ────────────
+  # ── Job 8: the Swift/MLX model port's logit parity gate (#166) ────────────
   # Apple-only: swift/engine/ is a SEPARATE SwiftPM package that depends on
   # mlx-swift, deliberately kept OUT of swift/Package.swift so the tokenizer
   # package stays dependency-free and swift-linux keeps needing no network for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,10 @@ and asserts no backend leaked into `sys.modules`. **When adding code above the s
 do not import a backend — and add new portable modules to that test's
 `PORTABLE_MODULES` list.** Keep MLX-only imports local (inside functions), as
 `scripts/smoke_test.py` does, when a portable-ish entry point needs the backend.
+`src/train/upcycle.py` (#214's sparse-upcycle transform — dense checkpoint to MoE init)
+is a recent example: numpy-only, no backend import, lives above the seam in
+`PORTABLE_MODULES` despite reading/writing the same safetensors weights the two
+below-seam backends produce.
 
 **A third category — the `swift/` native toolchain (the repo's first Swift package).** The
 code tokenizer (#191, PR #245) is a native, cross-platform Swift package (`swift/MonicaTokenizer`
@@ -195,12 +199,18 @@ The smoke gate stresses exactly this round-trip.
 - The **active program is M12 — the from-scratch Mamba-2 hybrid MoE code model** (**GitHub issue
   #198**, the live tracker; design record `docs/design/13-code-model-moe.md`): the "MHM" spine
   (own BPE #191 **— done: native Swift, PR #245** → Essential-Web + Stack-v2 corpus #193 →
-  aux-loss-free MoE router #213 → CUDA MoE backend #214 → FIM/curriculum/eval build → ablation
-  sweep #219 → small full run #222 → sparse-upcycled large run #223), with **SSI**
+  aux-loss-free MoE router #213 **— done** → CUDA MoE backend #214 **— done: dropless
+  grouped-gather routing, shared expert, `src/train/upcycle.py` sparse-upcycle init; fp8
+  expert GEMMs (#240) and 8-bit AdamW moments wired but hardware-unverified; FSDP/ZeRO-2 +
+  expert parallel split into a follow-up issue that blocks #223, not #222** →
+  FIM/curriculum/eval build → ablation sweep #219 → small full run #222 → sparse-upcycled
+  large run #223), with **SSI**
   (structural-signal integration) as a secondary
   measurement/training-signal axis (completion-list logit masking #226, diagnostic supervision
   #227, RLVR/opengrep verifier reward #230, under the #225 measurement contract + escape-hatch
-  gate). The bulk of the net-new work is the MoE build (#213/#214) — MoE is MLX-toy-only today.
+  gate). The MoE build (#213/#214) is done on both backends; remaining net-new work ahead of
+  the #222/#223 runs is FSDP/ZeRO-2 + expert parallel and resolving #223's `d_model`
+  conflict with #200 (see `docs/design/13-code-model-moe.md`'s "Open (#223)" note).
 - **Reserve/history — M10 distillation (#65) was dropped 2026-07-19; its code was removed from the
   tree (#189).** The teacher/student/distill modules, `scripts/distill.py`/`sweep.py`/
   `precompute_teacher.py`, `distill_manifest`, and the corpus tooling are gone (recoverable via git

--- a/config/toy-moe-8bit.yaml
+++ b/config/toy-moe-8bit.yaml
@@ -1,0 +1,48 @@
+# Toy MoE config + 8-bit AdamW moments (#214). CONFIG-SURFACE FIXTURE ONLY — this is
+# NOT runnable in CI or on the Mac dev box: `optimizer_8bit: true` requires
+# `bitsandbytes`, which ships CUDA-only prebuilt wheels (the `[cuda-8bit]` extra), and
+# there is no CPU/macOS fallback path (unlike `torch` itself, which runs the CUDA
+# backend on CPU for parity). What IS covered by the test suite without a GPU: this
+# file loads and `validate()`s cleanly, `optimizer_sizing_key` resolves to
+# `adam8bit_fp32`, `backend.py::_mlx_backend` raises `NotImplementedError` on it, and
+# the `bitsandbytes` import stays lazy (tests/test_import_guard.py's FORBIDDEN_ROOTS).
+# The actual 8-bit numerics — moment quantization error, resume fidelity through a
+# bitsandbytes state-dict round trip, the tied-embedding 32-bit override actually
+# taking effect — are UNVERIFIABLE here and go on the manual pod checklist in
+# docs/infrastructure.md alongside the fp8 lever.
+#
+# `optimizer: adamw` (NOT muon) is deliberate: `optimizer_8bit` composes with Muon,
+# but Muon already owns the expert gate/up/down matrices and the tied embedding is
+# forced back to 32-bit regardless (see backend.py's `_adamw` helper), so stacking
+# `muon` + 8-bit saves almost nothing — the real payoff is plain `adamw` + 8-bit,
+# which is what this fixture exercises.
+d_model: 64
+n_layers: 4
+d_state: 16            # SSM state width N (per head)
+expand: 2              # d_inner = 128
+d_conv: 4
+head_dim: 16           # Mamba-2/SSD: 128/16 = 8 SSM heads (scalar A per head)
+dt_rank: auto
+
+moe_every: 2
+n_experts: 4
+top_k: 2
+moe_d_ff: null
+moe_balance_rate: null
+
+vocab_size: 256        # byte-fallback tokenizer for offline tests
+seq_len: 64
+tie_embeddings: true
+
+precision: fp32        # correctness first; fp32 makes forward/step parity exact
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false # tiny; keep tests cheap
+
+# --- optimizer (#214) ---
+optimizer: adamw
+optimizer_8bit: true
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/config/toy-moe-dense.yaml
+++ b/config/toy-moe-dense.yaml
@@ -1,0 +1,53 @@
+# Sparse-upcycle SOURCE fixture (#214): a degenerate n_experts=1 "MoE" block, which IS a
+# plain dense SwiGLU FFN (softmax over one logit is exactly 1.0, MoEBlock._moe takes the
+# k==E branch — see MambaConfig.validate()'s n_experts==1 carve-out). This is the shape
+# #200's real dense checkpoint is trained at: NOT a plain non-MoE config, because
+# `scripts/upcycle.py` needs `experts.0.{gate,up,down}` keys to replicate into the real
+# target's expert slots, and only an n_experts=1 MoE block has them.
+#
+# Pairs with toy-moe-fine.yaml (the upcycle TARGET) below. `check_upcycle_compatible`
+# requires the pair to agree on every NON-expert dimension (d_model, n_layers, d_state,
+# expand, d_conv, head_dim, dt_rank, vocab_size, tie_embeddings, attn_every, moe_every,
+# and moe_d_ff itself) — only n_experts/top_k/moe_balance_rate may differ. Matching the
+# non-expert backbone is NECESSARY but NOT SUFFICIENT to make a real dense checkpoint a
+# valid upcycle source for a real MoE target: moe_d_ff also has to be sized the way the
+# fine-grained target wants it (see toy-moe-fine.yaml's comment) — that extra constraint
+# is not written down anywhere else in the design docs, and this fixture pair is where it
+# first becomes visible in the tree.
+d_model: 64
+n_layers: 4
+d_state: 16            # SSM state width N (per head)
+expand: 2               # d_inner = 128
+d_conv: 4
+head_dim: 16            # Mamba-2/SSD: 128/16 = 8 SSM heads (scalar A per head)
+dt_rank: auto
+
+# Sparse MoE: every 2nd block is a SwiGLU MoE FFN instead of a Mamba block, matching
+# toy-moe-fine.yaml's interleave exactly (both are required to for the upcycle).
+moe_every: 2            # layers 1 and 3 (0-indexed (i+1)%2==0) are MoE
+n_experts: 1             # degenerate: ONE expert == a plain dense SwiGLU FFN (#214)
+top_k: 1                 # validate() REQUIRES top_k==1 whenever n_experts==1
+# Fine-grained width (d_inner/8 = 128/8 = 16), NOT the usual d_inner default. At Large
+# A's real scale (#223), 64 full-width (moe_d_ff == d_inner) experts per MoE layer would
+# cost ~906M params PER LAYER — far past budget. The fine-grained target
+# (toy-moe-fine.yaml) therefore sizes each expert at d_inner/8, and #200's real dense
+# checkpoint must be dimensioned THE SAME WAY (moe_d_ff: 16 here, matching this toy's
+# d_inner/8) so a single dense expert is upcycle-compatible with 64 narrow ones later —
+# not the usual null (-> d_inner) default a non-upcycle dense config would use.
+moe_d_ff: 16
+# A single expert can never be balanced (sign(mean - load) == sign(0) == 0 forever, since
+# the one expert's load IS the mean); validate() REJECTS a non-null rate here.
+moe_balance_rate: null
+
+vocab_size: 256          # byte-fallback tokenizer for offline tests
+seq_len: 64
+tie_embeddings: true
+
+precision: fp32           # correctness first; fp32 makes forward/step parity exact
+chunk_size: null          # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false    # tiny; keep tests cheap
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/config/toy-moe-fine.yaml
+++ b/config/toy-moe-fine.yaml
@@ -1,0 +1,42 @@
+# Sparse-upcycle TARGET fixture (#214): the real fine-grained MoE (64 experts, top-6)
+# that `scripts/upcycle.py` upcycles toy-moe-dense.yaml's single dense expert into.
+# "Fine-grained" (many narrow experts, DeepSeekMoE style) rather than few wide ones: at
+# Large A's real scale (#223), 64 FULL-WIDTH experts (moe_d_ff == d_inner) per MoE layer
+# would run ~906M params per layer — so each expert is narrowed to d_inner/8 instead,
+# trading width for count at ~constant total capacity per layer.
+#
+# IDENTICAL to toy-moe-dense.yaml in EVERY dimension `check_upcycle_compatible` requires
+# to match (d_model, n_layers, d_state, expand, d_conv, head_dim, dt_rank, vocab_size,
+# tie_embeddings, attn_every, moe_every, moe_d_ff) — ONLY n_experts, top_k, and
+# moe_balance_rate differ. Do not change one of the pair without the other; the upcycle
+# test fixture (tests/test_upcycle.py) and `scripts/upcycle.py --dry-run` both fail loudly
+# if they drift apart.
+d_model: 64
+n_layers: 4
+d_state: 16            # SSM state width N (per head)
+expand: 2               # d_inner = 128
+d_conv: 4
+head_dim: 16            # Mamba-2/SSD: 128/16 = 8 SSM heads (scalar A per head)
+dt_rank: auto
+
+moe_every: 2             # layers 1 and 3 — same interleave as toy-moe-dense.yaml
+n_experts: 64             # the real fine-grained expert count
+top_k: 6                  # ~6/64 active per token (sparse)
+moe_d_ff: 16              # MUST match toy-moe-dense.yaml's moe_d_ff (see its comment)
+# Loss-Free-Balancing (#213) ON: 64 experts is exactly the regime that collapses without
+# it (a handful of experts absorb most tokens early and never recover). A small positive
+# rate in logit units; see src/train/moe_balance.py for the update rule.
+moe_balance_rate: 0.001
+
+vocab_size: 256          # byte-fallback tokenizer for offline tests
+seq_len: 64
+tie_embeddings: true
+
+precision: fp32           # correctness first; fp32 makes step-0 upcycle-exactness exact
+chunk_size: null          # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false    # tiny; keep tests cheap
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/config/toy-moe-muon.yaml
+++ b/config/toy-moe-muon.yaml
@@ -1,0 +1,39 @@
+# Toy MoE config + Muon (#214/#237): identical to toy-moe.yaml, plus `optimizer: muon`.
+# Exists so tests/test_cuda_muon.py's real-model partition test covers an MoE model too
+# — expert gate/up/down matrices (2D) go to Muon, the router (2D but excluded by
+# `is_muon_param`'s router carve-out) and everything else stays on AdamW. CUDA backend
+# only; runs on CPU on the Mac dev box like every other toy-*.yaml.
+d_model: 64
+n_layers: 4
+d_state: 16            # SSM state width N (per head)
+expand: 2              # d_inner = 128
+d_conv: 4
+head_dim: 16           # Mamba-2/SSD: 128/16 = 8 SSM heads (scalar A per head)
+dt_rank: auto
+
+# Sparse MoE: every 2nd block is a SwiGLU MoE FFN instead of a Mamba block.
+moe_every: 2           # layers 1 and 3 (0-indexed (i+1)%2==0) are MoE
+n_experts: 4           # route each token to top_k of these
+top_k: 2               # 2/4 experts active per token (sparse)
+moe_d_ff: null         # expert hidden width (null -> d_inner = 128)
+moe_balance_rate: null # balancing OFF — this config is for the optimizer partition, not balance
+
+vocab_size: 256        # byte-fallback tokenizer for offline tests
+seq_len: 64
+tie_embeddings: true
+
+precision: fp32        # correctness first; fp32 makes forward/step parity exact
+chunk_size: null       # SSD chunk length Q (null -> backend default 64)
+grad_checkpoint: false # tiny; keep tests cheap
+
+# --- optimizer (#237) ---
+optimizer: muon
+# muon_lr omitted on purpose: derives to base_lr at optimizer-build time (lr_scale ==
+# 1.0), the simplest/most-deterministic path. NOT a tuned value.
+muon_momentum: 0.95
+muon_ns_steps: 5
+
+# dt-projection bias init (load-bearing — identical across all configs by design)
+dt_min: 0.001
+dt_max: 0.1
+dt_init_floor: 0.0001

--- a/docs/design/05-training.md
+++ b/docs/design/05-training.md
@@ -60,7 +60,13 @@ sparse-upcycle branch, #223), which cosine cannot give you without re-running th
 Both schedules are indexed by `step` over `total_steps` and WSD's decay window is a
 *fraction* (`decay_frac`) of it, so nothing here depends on `total_steps` being fixed —
 which is what keeps it compatible with the length curriculum (#216), where tokens/step
-varies.
+varies. `scripts/train.py --init <path>` (#214) is the missing half of this lever: it
+loads foreign PORTABLE weights (via `check_weight_keys`, `strict=True`-equivalent) as a
+fresh step-0 start with a NEW LR schedule/optimizer state, which is exactly what a WSD
+re-decay branch needs — `--resume` (same-backend, same schedule, same optimizer state)
+answers a different question and always wins if both are passed (see
+[Sparse-upcycle init (#214)](#sparse-upcycle-init-214) below for `--init`'s other
+consumer).
 
 ## The backend step: clipping + loss scaling
 
@@ -153,6 +159,39 @@ on ~1M repetitive bytes — it is fine for short smoke/validation runs but will 
 destabilize in fp32 if pushed far past that regime; the poc run (100M params, fp16 +
 dynamic scaling, ~3B diverse tokens) is the regime M5 actually targets.
 
+## Sparse-upcycle init (#214)
+
+`scripts/train.py --init <path>` starts a FRESH step-0 run from a foreign checkpoint's
+PORTABLE weights (safetensors + config sidecar), rather than resuming its optimizer
+state/step/schedule the way `--resume` does. `--resume` **wins unconditionally** if both
+are passed, and the ignore is printed, never silent — a mistyped `--init` on an
+already-resumable run must not silently do the wrong thing. `check_weight_keys`
+(`src/train/checkpoint.py`) enforces `strict=True`-equivalent key matching on load: CUDA's
+`load_state_dict(strict=True)` already refuses a missing/extra/wrong-shaped key, but MLX's
+`_load_portable` (`mlx_backend.py:1006`) ends in a plain `self.update(...)`, which is
+*silently lenient* — a missing key leaves that param at random init and a wrong-shaped
+tensor is silently rebound. `check_weight_keys` closes that gap so `--init` is equally safe
+on both backends.
+
+`src/train/upcycle.py` (portable, numpy-only) is the actual sparse-upcycle transform this
+flag is built for: `upcycle_dense_to_moe(...)` takes a **dense** checkpoint — specifically
+a degenerate `n_experts: 1, top_k: 1` "MoE" block, which validate() permits and which IS a
+plain SwiGLU FFN (softmax over one logit is exactly 1.0) — and replicates its
+`experts.0.{gate,up,down}` into every expert slot of a real MoE target, re-initializes the
+router (`U(±1/sqrt(d_model))`, matching what both backends' `nn.Linear` already produces —
+no new magic constant), and zeros the shared expert's `down` projection so the combined
+block reproduces the dense forward exactly at step 0 regardless of the combination
+formula. `check_upcycle_compatible(src_cfg, dst_cfg)` reports **every** dimension mismatch
+at once (not one-at-a-time raises, which is how a run ends up mis-dimensioned) and hard-
+`UpcycleError`s on any `d_model` mismatch — expert replication can copy a tensor, not widen
+it; see [13-code-model-moe.md](13-code-model-moe.md#the-ssi-fold-structural-signal-integration--secondary)'s
+"Open (#223)" note for why that is a live constraint, not a hypothetical one.
+`scripts/upcycle.py` runs this offline as an explicit, one-shot CLI (never implicitly
+inside `train.py` — a mistyped `--init` reshaping instead of erroring would burn a whole
+run on a wrong init that still produces a plausible-looking loss curve), writing one
+weights artifact plus a `.upcycle.json` manifest (source sha256, seed, both configs) next
+to it.
+
 ## Length curriculum + dataloader-state resume (#216)
 
 Two changes that the issue deliberately pairs, because **the first invalidates the
@@ -231,7 +270,8 @@ mamba-ssm kernels, grad checkpointing), so these are the net-new ones.
 | Hybrid **Muon + AdamW** optimizer | #237 / `3b02e6b` | `src/model/cuda_muon.py`, selected at the `make_optimizer` seam in `src/model/backend.py` | **landed** |
 | **WSD** LR schedule | #238 / `8fe62f7` | `src/train/schedule.py` (`WSDSchedule`) — see above | **landed** |
 | **`torch.compile`** default-on for real CUDA runs | #239 / `7a71073` | `src/model/cuda_backend.py` | **landed** |
-| **fp8** MoE-expert linears (Transformer Engine, Hopper) | #240 / `c57a8e6` | `src/model/cuda_backend.py` (`_te_linear_cls`, `fp8_status`) | **design-only**, gated on #214 |
+| **fp8** MoE-expert linears (Transformer Engine, Hopper) | #240, landed with #214 | `src/model/cuda_backend.py` (`_te_linear_cls`, `MoEBlock._fp8_ctx`, `_layer_forward`'s TE-checkpoint branch) | **wired**, hardware-unverified (no Hopper CI runner) |
+| **8-bit AdamW moments** (bitsandbytes) | #214 | `src/model/backend.py` (`_cuda_backend._make_optimizer`'s `_adamw` helper) | **wired**, hardware-unverified (no CUDA CI runner) |
 
 Two details worth carrying:
 
@@ -245,9 +285,41 @@ Two details worth carrying:
   eager. fp8's `te.Linear` graph-breaks `torch.compile` the same way `mamba-ssm` does —
   safe, but it is why the fp8 path is opaque to inductor.
 
-The fp8 code is **defined but never called** until the CUDA MoE backend (#214) lands, since
-there are no CUDA expert linears to attach it to yet. Do not read `fp8_experts: bool` in
-`MambaConfig` as a working switch.
+The fp8 code is now live: `_Expert`'s linears are built by `_expert_linear` (a `te.Linear`
+when `fp8_experts` resolves TE on a Hopper+ device, else the bf16/fp16 `nn.Linear`
+fallback), and `MoEBlock._fp8_ctx` wraps the expert-compute region — dense/gather
+dispatch plus the shared-expert sum, but deliberately NOT the router (a plain `nn.Linear`
+that always routes in fp32) — in `transformer_engine.pytorch.fp8_autocast(...)`, since a
+`te.Linear` called outside that context silently runs in bf16. Grad-checkpointed MoE
+layers under `fp8_experts` route through `transformer_engine.pytorch.checkpoint` instead
+of the plain `torch.utils.checkpoint` call every other layer uses — plain checkpoint's
+recompute pass would double-update the fp8 amax history TE calibrates its scale from.
+None of this is CI-verified (no Hopper runner); see `tests/test_cuda_fp8.py`'s two
+Hopper-gated acceptance tests and docs/infrastructure.md's manual-verification checklist.
+
+### 8-bit AdamW moments (#214)
+
+`optimizer_8bit: bool` on `MambaConfig` is an axis **orthogonal to** `optimizer`
+(`adamw`/`muon`), not a third enum value, so it composes with the Muon hybrid: Muon
+already routes 2D hidden weight matrices (including MoE expert gate/up/down) through
+Newton-Schulz orthogonalization with its own (non-Adam) state, so `optimizer_8bit` only
+changes how the **AdamW-routed remainder** stores its moments — embeddings, norms,
+biases, the router, `dt_proj` under `muon`, or literally everything under plain `adamw`.
+`backend.py::_cuda_backend._make_optimizer`'s `_adamw(params)` helper is the ONE place
+the 8-bit switch appears, shared by both branches: it builds `bnb.optim.AdamW8bit`
+(`bitsandbytes`, imported lazily — a missing `[cuda-8bit]` install surfaces as a legible
+`SystemExit` naming the extra, not a bare `ImportError`) and then forces the tied
+embedding's optimizer state back to 32-bit via `bnb.optim.GlobalOptimManager`, since it
+is the single largest AdamW-routed tensor and is touched every step regardless of batch
+content. **`muon` + `optimizer_8bit` saves almost nothing** — Muon already owns the
+memory-heavy expert matrices, and the embedding is forced back to 32-bit either way — so
+the lever's real payoff is plain `adamw` + `optimizer_8bit`, not the stacked combination.
+`bnb.optim.AdamW8bit` has no `fused` kwarg (a `TypeError` at run start if one is passed,
+unlike stock `torch.optim.AdamW`). The MLX backend raises `NotImplementedError` on
+`optimizer_8bit`, mirroring the existing Muon raise — bitsandbytes has no MLX/Metal port,
+and a silent 32-bit fallback would make a Mac memory measurement quietly wrong.
+Hardware-unverified like fp8, above; see `config/toy-moe-8bit.yaml` (a config-surface
+fixture only) and docs/infrastructure.md's manual-verification checklist.
 
 ## Related
 

--- a/docs/design/07-configs-and-decisions.md
+++ b/docs/design/07-configs-and-decisions.md
@@ -15,6 +15,10 @@ scale run) — but they are no longer the whole surface.
 | `toy.yaml` | milestone-1..4 smoke test; tiny + fp32 so fixed-seed resume is exactly reproducible | **live** (the gate) |
 | `toy-hybrid.yaml` | tiny Mamba-2 with config-gated attention layers (#67) — parity + sizing tests exercise both block types | live |
 | `toy-moe.yaml` | tiny Mamba-2 with config-gated sparse-MoE FFN layers (#53) — parity + sizing tests exercise the MoE block | live |
+| `toy-moe-dense.yaml` | degenerate `n_experts: 1, top_k: 1` MoE block (IS a plain dense SwiGLU FFN) — the sparse-upcycle SOURCE fixture (#214) | live |
+| `toy-moe-fine.yaml` | 64 x top-6, `moe_d_ff = d_inner/8`, balancing ON — the sparse-upcycle TARGET fixture, pairs with `toy-moe-dense.yaml` (#214) | live |
+| `toy-moe-muon.yaml` | `toy-moe.yaml` + `optimizer: muon` — covers expert gate/up/down (Muon) and the router (AdamW) in one real model (#214) | live |
+| `toy-moe-8bit.yaml` | `toy-moe.yaml` + `optimizer_8bit: true` — config-surface fixture ONLY, not runnable without `bitsandbytes`/a CUDA host (#214) | live (surface-only) |
 | `toy-muon.yaml` | toy.yaml's shape with `optimizer: muon` (#237) — exercises the hybrid optimizer | live |
 | `small.yaml` | ~2.6M params, byte vocab — fast local iteration | live |
 | `poc.yaml` | ~127M OLMo-vocab from-scratch scale run | reserve (validated foundation, #75) |
@@ -32,7 +36,12 @@ scale run) — but they are no longer the whole surface.
 
 The M12 code model's own configs (small ~120M-active/700M-total, "Large A"
 ~700M-active/3.5B-total) do **not** exist yet — they arrive with #200/#219. See
-[13-code-model-moe.md](13-code-model-moe.md).
+[13-code-model-moe.md](13-code-model-moe.md). **Note (#200):** whatever `d_model` #200
+lands at, Large A's sparse-upcycle source must match it exactly — `src/train/upcycle.py`
+hard-raises `UpcycleError` on any `d_model` mismatch (expert replication copies a tensor,
+it cannot widen one). #200's currently-assumed `d_model 768` does not match Large A's
+current default of `d_model 1536`; see [13-code-model-moe.md](13-code-model-moe.md)'s
+"Open (#223)" note and its follow-up issue before dimensioning #200.
 
 ## `config/toy.yaml`
 

--- a/docs/design/08-corpus-pipeline.md
+++ b/docs/design/08-corpus-pipeline.md
@@ -153,8 +153,9 @@ Dedup/decontam produce `cleaned/` once; the tokenized views are cheap to regener
   2. **CUDA smoke gate** — build a tiny toy split on the pod and run
      `scripts/smoke_test.py --backend cuda --data <toy split>`. This proves the torch
      backend resumes bit-exactly through the [double-buffered `CheckpointStore`](05-training.md)
-     end to end. Use `config/toy.yaml` (a dense config) — the gate refuses a MoE config,
-     since MoE-Mamba (#53) is MLX-only.
+     end to end. `config/toy.yaml` (dense) is the standard fixture; `config/toy-moe.yaml
+     --moe-impl gather` exercises the CUDA MoE path the same way (#214 — MoE is no longer
+     MLX-only).
   3. **Train-step bench** — `scripts/bench_cuda_train_step.py --config config/poc.yaml
      --batch 32 --grad-accum 4` reports s/step, tokens/s, and **peak GPU memory** for the
      production path (`CUDAMambaModel` + AdamW + `make_train_step`, wired exactly as

--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -10,19 +10,27 @@ from-scratch code model, described below.
 
 ## What this is
 
-> **Read this section as the target design, not as shipped state.** As of 2026-08-03 the MHM
-> components that are **built** are the tokenizer (MHM-P1b, #191/#245) and aux-loss-free load
-> balancing on MLX (MHM-P2-T0, #213). `MambaConfig` carries the MoE and hybrid-attention knobs
-> (`moe_every`, `n_experts`, `top_k`, `attn_every`, `fp8_experts`, `moe_balance_rate`) and the MLX
-> backend's `MoEBlock` now has a DeepSeek-V3 Loss-Free-Balancing router: a per-expert bias steers
-> top-k **selection** only, updated outside the gradient from per-expert load counts, with no aux
-> loss on the objective (portable policy in `src/train/moe_balance.py`; `moe_balance_rate: null`
-> keeps the pre-#213 router byte-identical). It still has **no shared expert**, and it densely
-> evaluates every expert (sparse *combination*, not sparse compute) — a capacity experiment, not a
-> production kernel. The CUDA backend still raises `NotImplementedError` for MoE (#214), which will
-> reuse `src/train/moe_balance.py` unchanged. The shared expert, FIM, the Essential-Web + Stack-v2
-> mixture, and repo-context packing described below are **designed, not implemented**. Per-item
-> status is in the MHM-P# list that follows; when the two disagree, the P# list wins.
+> **Read this section as the target design, not as shipped state.** As of 2026-08-07 the MHM
+> components that are **built** are the tokenizer (MHM-P1b, #191/#245), aux-loss-free load
+> balancing (MHM-P2-T0, #213, portable — shared by both backends), and the **CUDA MoE backend**
+> (MHM-P2-T1, #214). `MambaConfig` carries the MoE and hybrid-attention knobs (`moe_every`,
+> `n_experts`, `top_k`, `n_shared_experts`, `moe_impl`, `attn_every`, `fp8_experts`,
+> `optimizer_8bit`, `moe_balance_rate`). Both the MLX and CUDA `MoEBlock`s now have a shared
+> expert (DeepSeek-V2/V3 form, additive, outside the router softmax/top-k renormalization) and
+> the Loss-Free-Balancing router: a per-expert bias steers top-k **selection** only, updated
+> outside the gradient from per-expert load counts, with no aux loss on the objective (portable
+> policy in `src/train/moe_balance.py`; `moe_balance_rate: null` keeps the pre-#213 router
+> byte-identical). MLX still densely evaluates every expert (sparse *combination*, not sparse
+> compute — a capacity experiment, not a production kernel); the CUDA backend adds a real
+> **grouped-gather dispatch** (`moe_impl: gather`, dispatch-only-to-chosen-experts, with a
+> deterministic backward so it stays inside the bit-exact-fp32-resume smoke gate), alongside the
+> dense path as its always-kept oracle. fp8 expert GEMMs (Transformer Engine, Hopper+) and an
+> 8-bit AdamW-moments switch (bitsandbytes) are wired but **hardware-unverified** — see
+> docs/infrastructure.md's manual-verification checklist. `src/train/upcycle.py` +
+> `scripts/upcycle.py` (#214) turn a dense (degenerate `n_experts: 1`) checkpoint into a sparse-MoE
+> init that matches the dense forward at step 0. FIM, the Essential-Web + Stack-v2 mixture, and
+> repo-context packing described below are **designed, not implemented**. Per-item status is in
+> the MHM-P# list that follows; when the two disagree, the P# list wins.
 
 A from-scratch, **TypeScript-first Mamba-2 hybrid Mixture-of-Experts (MoE) code model**. The
 backbone is mostly Mamba-2/SSD state-space layers with a **minority (~12.5%) of full-attention
@@ -131,9 +139,11 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
 - **MHM-P2 — Architecture & harness build** (the large net-new engineering): aux-loss-free
   balancing router (#213, **done on MLX** — portable `MoEBalancer` policy above the seam +
   selection-only route bias in `MoEBlock`; the bias rides in the portable safetensors so a served
-  or ported checkpoint routes as trained) → CUDA MoE backend (#214: dropless routing, shared expert,
-  FSDP, sparse-upcycle init) → FIM (#215, **done** — see the resolved note below), length
-  curriculum + dataloader-state resume
+  or ported checkpoint routes as trained) → CUDA MoE backend (#214, **done** — dropless
+  grouped-gather routing, shared expert, `src/train/upcycle.py` sparse-upcycle init, 8-bit AdamW
+  moments and fp8 expert GEMMs wired but hardware-unverified; **FSDP/ZeRO-2 + expert parallel
+  split out to #271, blocking #223 but not #222) → FIM (#215, **done** — see the
+  resolved note below), length curriculum + dataloader-state resume
   (#216, **done** — `--curriculum "0.25:2048,0.5:4096,1.0:16384"` on `scripts/train.py`, plus
   explicit `MicroBatchStream` state committed inside the checkpoint slot; see
   [05-training.md](05-training.md#length-curriculum--dataloader-state-resume-216)),
@@ -143,8 +153,10 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
   warmup-stable-decay LR schedule (#238, **done** — `8fe62f7`), and `torch.compile` default-on for
   real CUDA runs (#239, **done** — `7a71073`) — all three landed ahead of the #219 sweep, so it
   and the #222/#223 runs carry them; plus fp8 MoE-expert linears
-  (Transformer Engine / Hopper, #240 — **design-only**, `c57a8e6`: the probe landed but the code is
-  never called), *gated on #214* and ahead of the #223 large run. See
+  (Transformer Engine / Hopper, #240 — **wired, hardware-unverified**: `_expert_linear` builds
+  `te.Linear` on Hopper+, `MoEBlock._fp8_ctx` wraps the expert-compute region in `fp8_autocast`,
+  and `_layer_forward` selects `transformer_engine.pytorch.checkpoint` for MoE layers — landed with
+  #214 since it shares `_Expert`/`MoEBlock`), *ahead of the #223 large run*. See
   [05-training.md](05-training.md#efficiency-levers-m12-landed-2026-07-2021). (The repo
   is already mature on the survey's biggest axes — data dedup/filtering, fused AdamW, SDPA, the
   mamba-ssm kernels, grad-checkpoint — so these four are the net-new levers; #216 is the
@@ -253,12 +265,32 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
 > ~$100s rather than first being exercised on the ~$1.2k large run. It also means **#200 must be
 > re-dimensioned** off `poc-small.yaml`'s 97M shape to match the small rung's non-expert backbone
 > — otherwise the upcycle won't line up.
+
+> **Open (#223) — #200's `d_model` doesn't match Large A.** The table above names #200
+> (`d_model 768`, the small rung) as *the single upcycle source for both MoE runs*, but Large A's
+> current default dims are `d_model 1536` — and `src/train/upcycle.py::check_upcycle_compatible`
+> hard-**raises `UpcycleError`** on any `d_model` mismatch between source and target (#214, by
+> design: expert replication can copy a dense FFN into E expert slots, but it cannot *widen* a
+> tensor). #200-at-768 is therefore NOT a valid upcycle source for Large A as currently dimensioned.
+> Four exits, tracked in #272 (blocks #223's budget):
+>  1. A **second dense run at `d_model 1536`** — the simplest fix, at the cost of a second (larger)
+>     dense pretrain before Large A can start.
+>  2. **Width-expansion upcycling** (Net2Net / bert2BERT-style tensor widening) as its own
+>     from-scratch mechanism — reuses #200-at-768, but is real new research/engineering, not a
+>     config change.
+>  3. **Large A from scratch** — abandons sparse-upcycle entirely for the large run, giving up the
+>     "upcycled init matches dense at step 0" cost savings this PR (#214) built.
+>  4. **Re-shape Large A to `d_model 768`** — keeps the single-source plan intact by changing the
+>     large-model target instead of the source, at the cost of Large A's stated ~700M-active/
+>     3.5B-total budget (more experts / more layers would need to make up the difference).
+
 - **Cross-cutting:** rented-pod ops runbook (#224). **Parked:** post-training SFT (#101) / RLVR
   (#103).
 
-Today the MoE is **MLX-only** (the MLX router is a toy dense softmax-top-k; the CUDA backend
-explicitly rejects MoE), so scaling on RunPod requires the #213/#214 build — this is the bulk of
-the net-new work.
+The MoE backend build (#213/#214, **done**) scales on both MLX and CUDA now — the CUDA backend
+builds dropless grouped-gather MoE with a shared expert and a sparse-upcycle init path. What
+remains before a real RunPod run is FSDP/ZeRO-2 + expert parallel (#271, blocking #223 but not
+#222) and resolving the `d_model` conflict above (#272).
 
 ## The SSI fold (structural signal integration — secondary)
 

--- a/docs/design/14-inference-engine.md
+++ b/docs/design/14-inference-engine.md
@@ -242,7 +242,11 @@ DPO/GRPO step factories.
   branch, and the `moe_route_bias.*` load path — gated by the `toy-moe` and `toy-moe-biased`
   fixtures. Still Swift-side out of scope, as *training* surfaces with no effect on logits: load
   counting (`_count_loads`/`pop_load`) and the `set_route_bias` write path, both for #195.
-  `src/model/cuda_backend.py:665` still raises `NotImplementedError` — that is #214.
+  `src/model/cuda_backend.py`'s CUDA `MoEBlock`/`_Expert` landed with #214 (dropless
+  grouped-gather routing, shared expert) — the `NotImplementedError` this line used to cite
+  is gone. Swift porting the CUDA-specific gather dispatch remains out of scope for #166
+  (Swift is inference-only and evaluates every expert the same way the MLX/dense reference
+  does; gather is a training-throughput optimization with no logit effect to port).
 - **`SessionStore`'s budget math ignores the attention KV cache.** `per_session_state_floats`
   (`src/serve/sessions.py:40`) charges every layer a conv window plus an SSM state and has **no
   attention term**. That is exact for a pure-Mamba config, but the M12 hybrid's ~12.5% attention

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -324,7 +324,10 @@ pip install -e ".[dev,data,cuda-fast]"
 
 # 2. CUDA smoke gate — prove the torch backend resumes bit-exactly through the
 #    double-buffered CheckpointStore. Build a tiny toy split on the pod, then:
-python scripts/smoke_test.py --backend cuda --data <toy-split>     # use config/toy.yaml (dense; MoE is MLX-only)
+python scripts/smoke_test.py --backend cuda --data <toy-split>     # config/toy.yaml (dense)
+#    Or exercise the CUDA MoE path (#214 — MoE is no longer MLX-only) the same way:
+python scripts/smoke_test.py --backend cuda --config config/toy-moe.yaml --moe-impl gather \
+    --data <toy-split>
 
 # 3. Train-step bench — s/step, tokens/s, and PEAK GPU MEMORY for the real path,
 #    BEFORE paying for big cards:
@@ -338,6 +341,54 @@ python scripts/train.py --backend cuda --config config/<student-or-poc>.yaml \
 Bring the pod up **in that order** so a config or throughput problem surfaces *before* the long
 run. The CUDA backend is already done and A40-verified (the full suite is green on a rented
 A40); the fused kernels auto-detect at runtime and degrade gracefully when absent.
+
+### Manual verification: 8-bit optimizer + fp8 experts (#214)
+
+Both levers are real code paths, not stubs, but neither is CI-testable: `cuda-cpu` runs on CPU
+torch with no `bitsandbytes`/`transformer-engine` installed at all, and `full-macos`/`portable`
+have no CUDA. What CI DOES cover (`tests/test_cuda_8bit_optimizer.py`, `tests/test_cuda_fp8.py`):
+config surface, `optimizer_sizing_key`, the `SystemExit`/`NotImplementedError` seam guards, and
+the lazy-import guarantee (`tests/test_import_guard.py`'s `FORBIDDEN_ROOTS`). Everything below
+needs real hardware and is a merge-adjacent checklist item, not a blocking gate.
+
+**8-bit AdamW (`optimizer_8bit: true`, any Ampere+ card):**
+
+```bash
+pip install -e ".[dev,data,cuda-8bit]"     # bitsandbytes — CUDA-only wheels, no macOS build
+python scripts/smoke_test.py --backend cuda --config config/toy-moe-8bit.yaml --data <toy-split>
+```
+- [ ] Model builds and trains without the `SystemExit`/`ImportError` path firing.
+- [ ] `nvidia-smi`/`torch.cuda.max_memory_allocated()` shows a lower optimizer-state footprint
+      than the same config with `optimizer_8bit: false` (the whole point of the lever).
+- [ ] The resume-exactness phase of the smoke gate still passes — a bitsandbytes state-dict
+      round trip through `CheckpointStore` must not silently drop or requantize state.
+- [ ] Confirm the tied embedding's optimizer state actually stayed 32-bit: inspect
+      `bnb.optim.GlobalOptimManager.get_instance().pid2config` for `id(model.embedding.weight)`,
+      or diff its per-param memory footprint against a non-embedding AdamW8bit param of similar
+      size.
+- [ ] `muon` + `optimizer_8bit` stacked: confirm the memory savings are small relative to plain
+      `adamw` + `optimizer_8bit` — Muon already owns the expert matrices and the embedding is
+      forced to 32-bit either way, so this is a sanity check, not a real lever.
+
+**fp8 MoE experts (`fp8_experts: true`, Hopper+/sm_90 only — H100, H200, etc.):**
+
+```bash
+pip install -e ".[dev,data,cuda-fp8]"      # transformer-engine — Hopper-only prebuilt wheels
+pytest -q tests/test_cuda_fp8.py           # un-skips the two Hopper-gated acceptance tests here
+python scripts/smoke_test.py --backend cuda --config config/toy-moe.yaml --moe-impl gather \
+    --data <toy-split>   # then repeat with fp8_experts: true set in the config
+```
+- [ ] `[cuda] fp8 MoE experts ACTIVE (Transformer Engine, Hopper+).` printed at model build
+      (`_report_fp8_status_once`) — a silent bf16 fallback here is a throughput trap, not a
+      correctness bug, so it is easy to miss without checking this line.
+- [ ] `tests/test_cuda_fp8.py::test_fp8_expert_forward_matches_bf16` and
+      `::test_fp8_expert_checkpoint_backward_finite_grads` pass (both skip everywhere else).
+- [ ] A real training step under `grad_checkpoint: true` + `fp8_experts: true` runs several
+      hundred steps without the fp8 amax history diverging into non-finite loss — the `te.
+      checkpoint` vs plain-checkpoint distinction this PR wires in is exactly the failure mode
+      a short smoke run would not catch (amax drift compounds over many steps).
+- [ ] `torch.compile` (`--compile` on `smoke_test.py`, or `torch_compile: true`) still graph-breaks
+      cleanly around `te.Linear`/`te.checkpoint` rather than hard-erroring.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,13 @@ cuda-fast = ["torch>=2.0", "mamba-ssm>=2.0", "causal-conv1d>=1.0"]
 # `cuda_backend._te_linear_cls()` and degrades to bf16/fp16 `nn.Linear` when absent or
 # pre-Hopper. DESIGN-ONLY today (blocked on #214's CUDA MoE experts).
 cuda-fp8 = ["torch>=2.0", "transformer-engine>=1.0"]
+# 8-bit AdamW optimizer states (#214) via bitsandbytes, a SEPARATE extra from
+# `cuda`/`cuda-fast`/`cuda-fp8`: bitsandbytes ships CUDA-only prebuilt wheels (no
+# manylinux/CPU/macOS wheel), so it cannot ride in any extra that `cuda-cpu` CI or the
+# Mac dev box installs. Imported lazily inside `backend.py::_cuda_backend._make_optimizer`
+# only when `config.optimizer_8bit=True`, so a missing install surfaces as a legible
+# `SystemExit` naming this extra, not an `ImportError` at module import.
+cuda-8bit = ["torch>=2.0", "bitsandbytes>=0.43"]
 # Experiment logging.
 logging = ["wandb>=0.16"]
 # Tier-2 OLMES/lm-eval benchmark harness. A heavy optional dependency (some

--- a/scripts/bench_cuda_train_step.py
+++ b/scripts/bench_cuda_train_step.py
@@ -88,10 +88,11 @@ def main() -> None:
     if args.chunk_size is not None:
         cfg = dataclasses.replace(cfg, chunk_size=args.chunk_size)
         cfg.validate()
-    if cfg.n_moe_layers > 0:
-        raise SystemExit(
-            "MoE-Mamba (#53) is MLX-only; the CUDA backend can't build it. Bench a dense "
-            "config (e.g. config/poc.yaml / config/toy.yaml).")
+    # A dense-config-only restriction used to sit here ("MoE is MLX-only"). That is now
+    # false (#214) — the CUDA backend builds and trains MoE — so an MoE config now
+    # benchmarks like a dense one; the timing includes its grouped-gather dispatch's
+    # `counts.tolist()` host sync when `moe_impl` resolves to "gather", which is real
+    # (not benchmark-artifact) overhead worth seeing in the s/step number.
 
     # Fail fast on the one request the backend cannot satisfy.
     if args.device == "cuda" and not torch.cuda.is_available():

--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -93,10 +93,13 @@ def main() -> None:
     ref = backend.model_cls(cfg)
     # #214: MLX's load is silently lenient (missing key -> stays at random init, wrong
     # shape -> silently rebound), so check explicitly before loading. ref/policy share
-    # the same cfg, so one check against a fresh model's expected keys covers both.
-    check_weight_keys(load_weights_dict(str(args.init)), ref._portable_state_dict(),
+    # the same cfg, so one check against a fresh model's expected keys covers both. Load
+    # the safetensors once and reuse the dict for ref here and policy below (init path
+    # only) instead of re-reading it for each of ref/policy.
+    init_weights = load_weights_dict(str(args.init))
+    check_weight_keys(init_weights, ref._portable_state_dict(),
                       where=f"--init {args.init}")
-    ref.load(str(args.init))                             # frozen reference (never updated)
+    ref._load_portable(init_weights)                     # frozen reference (never updated)
     opt = backend.make_optimizer(policy, args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
     # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch. Both backends'
@@ -128,7 +131,7 @@ def main() -> None:
             scaler.load_state_dict(meta.get("loss_scale_state") or {})
         print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})")
     else:
-        policy.load(str(args.init))                      # init policy from SFT weights
+        policy._load_portable(init_weights)               # init policy from SFT weights
         print(f"[init] policy + reference from {args.init}")
     # Loss-Free-Balancing (#213): adopt the bias that came in with the policy weights
     # (D3), push it into the routers, enable load counting. The frozen reference is left

--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -72,7 +72,7 @@ def main() -> None:
     from src.train.moe_balance import attach_balancer, balancer_for_config
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
-    from src.train.checkpoint import CheckpointStore
+    from src.train.checkpoint import CheckpointStore, check_weight_keys, load_weights_dict
     from src.train.dpo_math import evaluate_dpo
 
     backend = get_backend(args.backend)
@@ -91,6 +91,11 @@ def main() -> None:
     backend.seed(args.seed)
     policy = backend.model_cls(cfg)
     ref = backend.model_cls(cfg)
+    # #214: MLX's load is silently lenient (missing key -> stays at random init, wrong
+    # shape -> silently rebound), so check explicitly before loading. ref/policy share
+    # the same cfg, so one check against a fresh model's expected keys covers both.
+    check_weight_keys(load_weights_dict(str(args.init)), ref._portable_state_dict(),
+                      where=f"--init {args.init}")
     ref.load(str(args.init))                             # frozen reference (never updated)
     opt = backend.make_optimizer(policy, args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)

--- a/scripts/dpo.py
+++ b/scripts/dpo.py
@@ -94,13 +94,12 @@ def main() -> None:
     ref.load(str(args.init))                             # frozen reference (never updated)
     opt = backend.make_optimizer(policy, args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
-    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch and why the
-    # kwarg is conditional (CUDA's make_dpo_train_step has no balancer param).
+    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch. Both backends'
+    # make_dpo_train_step accept `balancer=` (#214); None is a no-op on either.
     balancer = balancer_for_config(cfg)
-    balancer_kwargs = {"balancer": balancer} if balancer is not None else {}
     train_step = backend.make_dpo_train_step(policy, ref, opt, beta=args.beta,
                                              grad_clip=args.grad_clip, scaler=scaler,
-                                             **balancer_kwargs)
+                                             balancer=balancer)
 
     np_to = backend.to_numpy
     max_b = args.eval_batches or None

--- a/scripts/rlvr.py
+++ b/scripts/rlvr.py
@@ -87,10 +87,13 @@ def main() -> None:
     cfg = load_config(str(args.config))
     model = backend.model_cls(cfg)
     # #214: MLX's load is silently lenient (missing key -> stays at random init, wrong
-    # shape -> silently rebound), so check explicitly before loading.
-    check_weight_keys(load_weights_dict(str(args.init)), model._portable_state_dict(),
+    # shape -> silently rebound), so check explicitly before loading. Load the
+    # safetensors once and reuse the dict for both the check and the load itself
+    # (matches scripts/train.py's --init path) rather than reading it twice.
+    init_weights = load_weights_dict(str(args.init))
+    check_weight_keys(init_weights, model._portable_state_dict(),
                       where=f"--init {args.init}")
-    model.load(str(args.init))
+    model._load_portable(init_weights)
     tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
     eos = getattr(tok, "eos_token_id", None)
     store = SessionStore(model)

--- a/scripts/rlvr.py
+++ b/scripts/rlvr.py
@@ -81,10 +81,15 @@ def main() -> None:
     from src.serve.sampling import sample
     from src.data.tokenize import ByteTokenizer, load_olmo_tokenizer
     from src.train.moe_balance import attach_balancer, balancer_for_config
+    from src.train.checkpoint import check_weight_keys, load_weights_dict
 
     backend = get_backend()
     cfg = load_config(str(args.config))
     model = backend.model_cls(cfg)
+    # #214: MLX's load is silently lenient (missing key -> stays at random init, wrong
+    # shape -> silently rebound), so check explicitly before loading.
+    check_weight_keys(load_weights_dict(str(args.init)), model._portable_state_dict(),
+                      where=f"--init {args.init}")
     model.load(str(args.init))
     tok = ByteTokenizer() if args.byte_fallback else load_olmo_tokenizer(args.model_id)
     eos = getattr(tok, "eos_token_id", None)

--- a/scripts/rlvr.py
+++ b/scripts/rlvr.py
@@ -91,13 +91,12 @@ def main() -> None:
     store = SessionStore(model)
     np_to = backend.to_numpy
     opt = backend.make_optimizer(model, args.lr)
-    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch and why the
-    # kwarg is conditional (CUDA's make_grpo_train_step has no balancer param). The bias
+    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch. The bias
     # arrives with `--init`'s portable weights (D3); attach_balancer adopts it, pushes it
-    # into the routers, and enables load counting. No-op when balancing is off.
+    # into the routers, and enables load counting. `balancer=None` is a no-op on either
+    # backend's make_grpo_train_step (#214).
     balancer = balancer_for_config(cfg)
-    grpo_step = backend.make_grpo_train_step(
-        model, opt, **({"balancer": balancer} if balancer is not None else {}))
+    grpo_step = backend.make_grpo_train_step(model, opt, balancer=balancer)
     attach_balancer(balancer, model)
     reward_fn = math_reward if args.reward == "math" else exact_match_reward
 

--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -94,12 +94,11 @@ def main() -> None:
     model = backend.model_cls(cfg)
     opt = backend.make_optimizer(model, args.base_lr)
     scaler = scaler_for_precision(cfg.precision, args.init_loss_scale)
-    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch and why the
-    # kwarg is conditional (CUDA's make_sft_train_step has no balancer param).
+    # Loss-Free-Balancing (#213): see scripts/train.py for the off-switch. Both backends'
+    # make_sft_train_step accept `balancer=` (#214); None is a no-op on either.
     balancer = balancer_for_config(cfg)
-    balancer_kwargs = {"balancer": balancer} if balancer is not None else {}
     train_step = backend.make_sft_train_step(model, opt, grad_clip=args.grad_clip,
-                                             scaler=scaler, **balancer_kwargs)
+                                             scaler=scaler, balancer=balancer)
 
     np_to = backend.to_numpy
     max_b = args.eval_batches or None

--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -73,7 +73,7 @@ def main() -> None:
     from src.train.moe_balance import attach_balancer, balancer_for_config
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
-    from src.train.checkpoint import CheckpointStore
+    from src.train.checkpoint import CheckpointStore, check_weight_keys, load_weights_dict
     from src.eval.val_loss import evaluate_masked
 
     backend = get_backend(args.backend)
@@ -121,6 +121,10 @@ def main() -> None:
             scaler.load_state_dict(meta.get("loss_scale_state") or {})
         print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})")
     else:
+        # #214: MLX's load is silently lenient (missing key -> stays at random init,
+        # wrong shape -> silently rebound), so check explicitly before loading.
+        check_weight_keys(load_weights_dict(str(args.init)), model._portable_state_dict(),
+                          where=f"--init {args.init}")
         model.load(str(args.init))                       # initialize from pretrained base
         print(f"[init] from pretrained base {args.init}")
     # Loss-Free-Balancing (#213): adopt the bias that came in with the weights (D3), push

--- a/scripts/sft.py
+++ b/scripts/sft.py
@@ -122,10 +122,13 @@ def main() -> None:
         print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})")
     else:
         # #214: MLX's load is silently lenient (missing key -> stays at random init,
-        # wrong shape -> silently rebound), so check explicitly before loading.
-        check_weight_keys(load_weights_dict(str(args.init)), model._portable_state_dict(),
+        # wrong shape -> silently rebound), so check explicitly before loading. Load the
+        # safetensors once and reuse the dict for both the check and the load itself
+        # (matches scripts/train.py's --init path) rather than reading it twice.
+        init_weights = load_weights_dict(str(args.init))
+        check_weight_keys(init_weights, model._portable_state_dict(),
                           where=f"--init {args.init}")
-        model.load(str(args.init))                       # initialize from pretrained base
+        model._load_portable(init_weights)                # initialize from pretrained base
         print(f"[init] from pretrained base {args.init}")
     # Loss-Free-Balancing (#213): adopt the bias that came in with the weights (D3), push
     # it into the routers, enable load counting. No-op when balancing is off.

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -22,6 +22,7 @@ ordering. The portable loop (train.loop) is exercised separately.
 from __future__ import annotations
 
 import argparse
+import dataclasses
 from pathlib import Path
 
 
@@ -46,6 +47,9 @@ def main() -> None:
                          "ramp derived from the config (seq_len//2 -> seq_len).")
     ap.add_argument("--curriculum-steps", type=int, default=20,
                     help="phase 7: optimizer steps for the curriculum kill/resume gate")
+    ap.add_argument("--moe-impl", choices=("auto", "dense", "gather"), default=None,
+                    help="#214: override config.moe_impl (the MoE compute strategy) "
+                         "without editing the YAML; no-op on a config with no MoE layers")
     args = ap.parse_args()
 
     # Backend selection stays behind the seam factory; only portable modules are
@@ -59,15 +63,17 @@ def main() -> None:
 
     backend = get_backend(args.backend)
     cfg = load_config(str(args.config))
+    if args.moe_impl is not None:
+        cfg = dataclasses.replace(cfg, moe_impl=args.moe_impl)
+        cfg.validate()
     assert cfg.precision == "fp32", "smoke test requires fp32 for exact resume"
-    # Pin the CUDA gate to a DENSE config (e.g. config/toy.yaml). MoE-Mamba (#53) is
-    # MLX-only, so CUDAMambaModel refuses to build it — fail here with that reason
-    # rather than deep inside model construction. (toy-moe.yaml is also fp32, so the
-    # precision assert above would not catch it.)
-    if backend.name == "cuda":
-        assert cfg.n_moe_layers == 0, (
-            f"CUDA smoke gate needs a dense config (got {args.config} with "
-            f"{cfg.n_moe_layers} MoE layers); MoE is MLX-only. Use config/toy.yaml.")
+    # A dense-config-only restriction used to sit here ("MoE is MLX-only"). That is now
+    # false (#214): the CUDA backend builds and trains MoE, and its grouped-gather
+    # dispatch was deliberately built on a deterministic `index_select` backward (never
+    # an atomic `index_add_`) SPECIFICALLY so discrete top-k routing stays inside this
+    # gate's bit-exact-fp32-resume contract rather than needing a carve-out from it —
+    # see the determinism note in `cuda_backend.py::MoEBlock._moe_gather`. A MoE config
+    # now runs this gate exactly like a dense one, `--moe-impl gather` included.
     N = args.steps
     half = N // 2
     np_to = backend.to_numpy
@@ -146,7 +152,6 @@ def main() -> None:
         if backend.name != "cuda":
             print("[compile] skipped (only meaningful on the CUDA backend)")
         else:
-            import dataclasses
             import math as _math
 
             ccfg = dataclasses.replace(cfg, torch_compile=True)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -61,6 +61,12 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--init-loss-scale", type=float, default=2.0 ** 13)
     ap.add_argument("--resume", type=Path, default=None,
                     help="resume bundle dir; if omitted, auto-detects <out>/resume")
+    ap.add_argument("--init", type=Path, default=None,
+                    help="portable base weights to initialize from (e.g. a "
+                         "sparse-upcycled checkpoint from scripts/upcycle.py) — NOT a "
+                         "resume bundle: optimizer/step/loss-scale all start fresh. "
+                         "IGNORED (with a printed note) when --resume is active; "
+                         "--resume always wins.")
     ap.add_argument("--seed", type=int, default=0)
     ap.add_argument("--curriculum", type=str, default=None,
                     help="length curriculum (#216): 'until_frac:seq_len[:batch_size],...' "
@@ -91,7 +97,7 @@ def main() -> None:
     from src.train.curriculum import build_curriculum
     from src.train.loop import TrainConfig, train
     from src.train.logging import JsonlLogger
-    from src.train.checkpoint import CheckpointStore
+    from src.train.checkpoint import CheckpointStore, check_weight_keys, load_weights_dict
     from src.eval.val_loss import evaluate
 
     backend = get_backend(args.backend)
@@ -195,6 +201,19 @@ def main() -> None:
             data_state_note = "present"
         print(f"[resume] from step {start_step} slot={meta['slot']} (out={out})  "
               f"data_state={data_state_note}")
+        if args.init is not None:
+            # --resume always wins (a resume bundle is the authoritative, in-progress
+            # state of THIS run); printed, not silently dropped, so a stale --init left
+            # on the command line after the first successful resume doesn't read as
+            # "it did something."
+            print(f"[init] IGNORED — --resume is active (from step {start_step}); "
+                  f"--init={args.init} has no effect. --resume always wins over --init.")
+    elif args.init is not None:
+        init_weights = load_weights_dict(str(args.init))
+        check_weight_keys(init_weights, model._portable_state_dict(),
+                          where=f"--init {args.init}")
+        model._load_portable(init_weights)
+        print(f"[init] from {args.init}")
     # Loss-Free-Balancing (#213): seed the policy from the just-loaded weights (the bias
     # rides in the portable safetensors, D3), push it into the routers, and enable load
     # counting. No-op when balancing is off. `CheckpointStore.save` is unchanged — there

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -124,13 +124,11 @@ def main() -> None:
               "(loss scaling is fp16-only; expected for bf16)")
     # Loss-Free-Balancing (#213): None for dense/hybrid configs and for MoE configs with
     # moe_balance_rate unset (the default) — balancer_for_config is the single source of
-    # truth for the off-switch. Passed as a kwarg only when set, so the CUDA backend's
-    # make_train_step (which has no balancer param; CUDA rejects MoE entirely, #214) is
-    # untouched.
+    # truth for the off-switch. Both backends' make_train_step accept `balancer=` (#214);
+    # None is a no-op on either.
     balancer = balancer_for_config(cfg)
-    balancer_kwargs = {"balancer": balancer} if balancer is not None else {}
     train_step = backend.make_train_step(model, opt, grad_clip=args.grad_clip, scaler=scaler,
-                                         **balancer_kwargs)
+                                         balancer=balancer)
 
     # --- data ------------------------------------------------------------------
     # ONE construction path for every stage, including stage 0 (`open_packed` returns a

--- a/scripts/upcycle.py
+++ b/scripts/upcycle.py
@@ -1,0 +1,132 @@
+"""Sparse-upcycle driver (#214): turn a dense (`n_experts=1`) checkpoint into a real MoE
+one, exact at step 0.
+
+Standalone, offline, and imports NO hardware backend at all (not even to build a model)
+— the transform (`src.train.upcycle.upcycle_dense_to_moe`) operates purely on portable
+`{name: np.ndarray}` weight dicts. Explicit and one-shot ON PURPOSE (issue #214 rejected
+doing this implicitly inside `train.py --init`): a mistyped `--init` there would silently
+RESHAPE a checkpoint into something plausible-looking rather than raise, and a run could
+burn a full training budget on a wrong init before anyone noticed the loss curve was
+merely "fine", not right.
+
+    # Inspect the plan without touching disk (no --src-config needed if <src> has a
+    # <src>.config.json sidecar, written by save_weights since day one):
+    python scripts/upcycle.py --src runs/dense/weights.safetensors \\
+        --config config/toy-moe-fine.yaml --out /tmp/upcycled.safetensors \\
+        --seed 214 --dry-run
+
+    # Actually write it:
+    python scripts/upcycle.py --src runs/dense/weights.safetensors \\
+        --config config/toy-moe-fine.yaml --out runs/upcycled/weights.safetensors --seed 214
+
+Writes `<out>` (+ its own `<out>.config.json` sidecar, via `save_weights`) and a
+`<out>.upcycle.json` manifest recording exactly what produced it (source path + sha256,
+seed, and the init knobs) so the run is reproducible without re-deriving anything from
+the weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--src", type=Path, required=True,
+                    help="dense (n_experts=1) portable weights (.safetensors)")
+    ap.add_argument("--config", type=Path, required=True,
+                    help="TARGET MoE config (n_experts>1) to upcycle into")
+    ap.add_argument("--out", type=Path, required=True,
+                    help="output .safetensors path (+ .config.json sidecar written "
+                         "by save_weights, + a .upcycle.json manifest)")
+    ap.add_argument("--src-config", type=Path, default=None,
+                    help="source config yaml; default reads <src>.config.json (the "
+                         "sidecar save_weights has always written)")
+    ap.add_argument("--seed", type=int, required=True,
+                    help="RNG seed for the fresh router (and any synthesized shared "
+                         "expert) init — required so a run is always reproducible")
+    ap.add_argument("--router-init-scale", type=float, default=1.0,
+                    help="router init bound scale: U(+-scale/sqrt(d_model))")
+    ap.add_argument("--shared-expert-init", choices=("zero_down", "forbid"),
+                    default="zero_down",
+                    help="how to init a target shared expert with no source "
+                         "counterpart: zero_down (default, step-0 exact) or forbid "
+                         "(raise instead of guessing)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print the plan and exit before touching --src or --out")
+    return ap.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    from src.model.blocks import load_config
+    from src.train.checkpoint import (
+        load_config_sidecar, load_weights_dict, save_weights,
+    )
+    from src.train.upcycle import (
+        check_upcycle_compatible, upcycle_dense_to_moe, upcycle_manifest,
+    )
+    from src.eval.code_suite import sha256_file
+
+    dst_cfg = load_config(str(args.config))
+    if args.src_config is not None:
+        src_cfg = load_config(str(args.src_config))
+    else:
+        src_cfg = load_config_sidecar(str(args.src))
+        if src_cfg is None:
+            raise SystemExit(
+                f"no {args.src}.config.json sidecar found, and --src-config was not "
+                "given — pass --src-config <yaml> to name the source config explicitly."
+            )
+
+    # Before ANY weights IO (the potentially-large safetensors read): a bad pairing
+    # should fail in milliseconds, not after loading gigabytes of tensors.
+    check_upcycle_compatible(src_cfg, dst_cfg)
+
+    moe_layers = sorted(i for i in range(dst_cfg.n_layers) if dst_cfg.is_moe_layer(i))
+    print(f"[upcycle] src={args.src}  config={args.config}")
+    print(f"[upcycle] MoE layers: {moe_layers}")
+    print(f"[upcycle] experts per MoE layer: 1 -> {dst_cfg.n_experts}  "
+          f"(top_k {src_cfg.top_k} -> {dst_cfg.top_k})")
+    print(f"[upcycle] router: [1, {dst_cfg.d_model}] -> "
+          f"[{dst_cfg.n_experts}, {dst_cfg.d_model}]  (fresh U(+-"
+          f"{args.router_init_scale}/sqrt({dst_cfg.d_model})), seed={args.seed})")
+    if dst_cfg.n_shared_experts:
+        print(f"[upcycle] shared experts per MoE layer: {src_cfg.n_shared_experts} -> "
+              f"{dst_cfg.n_shared_experts}  (new ones: {args.shared_expert_init})")
+    print(f"[upcycle] num_parameters: {src_cfg.num_parameters():,} -> "
+          f"{dst_cfg.num_parameters():,}")
+    print(f"[upcycle] active_num_parameters: {src_cfg.active_num_parameters():,} -> "
+          f"{dst_cfg.active_num_parameters():,}")
+
+    if args.dry_run:
+        print("[upcycle] --dry-run: exiting before reading --src or writing --out")
+        return
+
+    weights = load_weights_dict(str(args.src))
+    out = upcycle_dense_to_moe(
+        weights, src_cfg, dst_cfg, seed=args.seed,
+        router_init_scale=args.router_init_scale,
+        shared_expert_init=args.shared_expert_init,
+    )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    save_weights(out, str(args.out), config=dst_cfg)   # writes <out>.config.json too
+
+    src_sha256 = sha256_file(str(args.src))
+    manifest = upcycle_manifest(
+        src=str(args.src), src_sha256=src_sha256, seed=args.seed,
+        router_init_scale=args.router_init_scale,
+        shared_expert_init=args.shared_expert_init, src_cfg=src_cfg, dst_cfg=dst_cfg,
+    )
+    import json
+    Path(str(args.out) + ".upcycle.json").write_text(json.dumps(manifest, indent=2))
+    print(f"[upcycle] wrote {args.out} (+.config.json, +.upcycle.json)  "
+          f"src_sha256={src_sha256[:12]}...")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upcycle.py
+++ b/scripts/upcycle.py
@@ -9,8 +9,9 @@ RESHAPE a checkpoint into something plausible-looking rather than raise, and a r
 burn a full training budget on a wrong init before anyone noticed the loss curve was
 merely "fine", not right.
 
-    # Inspect the plan without touching disk (no --src-config needed if <src> has a
-    # <src>.config.json sidecar, written by save_weights since day one):
+    # Inspect the plan without reading the (potentially large) --src weights file or
+    # writing --out — it still reads --config (and the <src>.config.json sidecar, no
+    # --src-config needed, if <src> has one written by save_weights since day one):
     python scripts/upcycle.py --src runs/dense/weights.safetensors \\
         --config config/toy-moe-fine.yaml --out /tmp/upcycled.safetensors \\
         --seed 214 --dry-run

--- a/src/model/backend.py
+++ b/src/model/backend.py
@@ -103,6 +103,13 @@ def _mlx_backend() -> Backend:
                 "Muon is CUDA-only (#237); the MLX Newton-Schulz port is a scoped "
                 "follow-up."
             )
+        if model.config.optimizer_8bit:
+            # bitsandbytes ships CUDA-only wheels — there is no MLX/Metal port to fall
+            # back to. Raise loudly rather than silently training in 32-bit moments: a
+            # silent downgrade would make a Mac memory measurement quietly wrong (#214).
+            raise NotImplementedError(
+                "optimizer_8bit is CUDA-only (bitsandbytes has no MLX/Metal port)."
+            )
         return optim.AdamW(learning_rate=base_lr)
 
     return Backend(
@@ -175,20 +182,60 @@ def _cuda_backend() -> Backend:
         # CUDA device, so gate on it; on CPU (torch-CPU parity runs) fall back to the default.
         fused = _dev.startswith("cuda")
         cfg = model.config
+
+        def _adamw(params):
+            """AdamW for a non-Muon parameter group, with `optimizer_8bit` (#214) as an
+            orthogonal switch — the ONE place that switch appears, shared by the `adamw`
+            branch below AND the `muon` branch's AdamW remainder side. `bitsandbytes` is
+            imported lazily so a missing `[cuda-8bit]` install only surfaces when 8-bit is
+            actually requested, as a legible SystemExit (not an ImportError at plain module
+            import, which would defeat the seam guard's lazy-import contract)."""
+            params = list(params)
+            if not cfg.optimizer_8bit:
+                return torch.optim.AdamW(params, lr=base_lr, fused=fused)
+            try:
+                import bitsandbytes as bnb
+            except ModuleNotFoundError as e:
+                if e.name != "bitsandbytes":
+                    raise
+                raise SystemExit(
+                    "bitsandbytes not found — optimizer_8bit requires the '[cuda-8bit]' "
+                    "extra on a CUDA host:\n"
+                    "    pip install -e '.[cuda-8bit]'\n"
+                    "(bitsandbytes ships CUDA-only prebuilt wheels; it does not install "
+                    "on macOS, so this is a GPU-pod-only path — see "
+                    "docs/infrastructure.md's manual-verification section.)"
+                ) from e
+            # `bnb.optim.AdamW8bit` has NO `fused` kwarg — passing one is a TypeError at
+            # run start on the pod (not a slow no-op), so it is deliberately omitted here.
+            opt = bnb.optim.AdamW8bit(params, lr=base_lr)
+            if getattr(model, "_tie_embeddings", False):
+                # Force the tied embedding's optimizer state back to 32-bit: it is the
+                # single largest AdamW-routed tensor (vocab_size x d_model), read/written
+                # on every step regardless of batch content, so 8-bit quantization noise
+                # there is the highest-leverage place it could hurt convergence.
+                bnb.optim.GlobalOptimManager.get_instance().register_module_override(
+                    model.embedding, "weight", {"optim_bits": 32})
+            return opt
+
         if cfg.optimizer == "adamw":
-            return torch.optim.AdamW(model.parameters(), lr=base_lr, fused=fused)
+            return _adamw(model.parameters())
         if cfg.optimizer == "muon":
             # Hybrid optimizer (#237): 2D hidden weight matrices go through Newton-Schulz
             # orthogonalization (Muon); everything else stays on AdamW. `is_muon_param` is
             # portable (src.model.blocks); the Muon/HybridOptimizer classes are torch-only
             # and stay lazily imported here, matching this module's lazy-import style.
+            # NOTE: `muon` + `optimizer_8bit` saves almost nothing — Muon already owns the
+            # expert matrices (the memory-heavy MoE params) and the embedding is forced
+            # back to 32-bit above, so the AdamW remainder 8-bit can shrink is small. The
+            # real payoff of `optimizer_8bit` is on plain `adamw`, not stacked with Muon.
             from .blocks import is_muon_param
             from .cuda_muon import Muon, HybridOptimizer
             muon_params, adam_params = [], []
             for name, p in model.named_parameters():
                 (muon_params if is_muon_param(name, p.ndim) else adam_params).append(p)
             muon_lr = cfg.muon_lr if cfg.muon_lr is not None else base_lr
-            adam = torch.optim.AdamW(adam_params, lr=base_lr, fused=fused) if adam_params else None
+            adam = _adamw(adam_params) if adam_params else None
             muon = Muon(muon_params, lr=base_lr, lr_scale=muon_lr / base_lr,
                        momentum=cfg.muon_momentum, ns_steps=cfg.muon_ns_steps) if muon_params else None
             return HybridOptimizer(adam, muon)

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -78,6 +78,13 @@ class MambaConfig:
     muon_lr: Optional[float] = None
     muon_momentum: float = 0.95
     muon_ns_steps: int = 5
+    # 8-bit Adam moments (#214), an ORTHOGONAL axis to `optimizer` (not a third enum
+    # value) so it composes with the Muon hybrid: Muon already owns the 2D hidden
+    # matrices, and `optimizer_8bit` only changes how the AdamW-routed remainder
+    # (embeddings/norms/biases/router/dt_proj, or everything under plain "adamw")
+    # stores its moments. CUDA-only; MLX raises NotImplementedError, mirroring Muon.
+    # See `optimizer_sizing_key` below for the sizing-table consequence.
+    optimizer_8bit: bool = False
 
     # SSD chunk length Q. None => the backend default (64). The chunked-matmul scan
     # processes the sequence in chunks of Q; the sequence is padded up to a multiple
@@ -133,6 +140,18 @@ class MambaConfig:
     # weights stay the unbiased softmax. See `src/train/moe_balance.py` (the portable
     # policy) and `MoEBlock._moe` (src/model/mlx_backend.py) for the mechanism.
     moe_balance_rate: Optional[float] = None
+    # Extra experts run on EVERY token (DeepSeek-V2/V3 form), additive to the routed
+    # top_k combination: output = shared(x) + sum_{i in top_k}(gate_i * expert_i(x)),
+    # OUTSIDE the router softmax/renormalization so the routed gates still sum to 1.
+    # 0 (default) = OFF, byte-identical to pre-#214 (no shared_experts params exist).
+    n_shared_experts: int = 0
+    # Expert-compute strategy: "auto" (default) picks dense when top_k >= n_experts or
+    # n_experts == 1, else a grouped-gather kernel (CUDA-only, #214); "dense" forces the
+    # evaluate-every-expert-then-mask path (both backends; the MLX/Swift reference
+    # implementation, so it stays available as the oracle gather is checked against);
+    # "gather" forces the grouped-gather kernel explicitly (CUDA-only — the MLX backend
+    # raises NotImplementedError rather than silently downgrading to dense).
+    moe_impl: str = "auto"
     # fp8 expert GEMMs via NVIDIA Transformer Engine (#240), CUDA/Hopper-only. A separate
     # bool rather than a `precision` value: fp8 applies ONLY to the three expert linears
     # (gate/up/down), not the whole model — everything else stays at `precision`. A no-op
@@ -274,12 +293,16 @@ class MambaConfig:
         return bd
 
     def _moe_layer_params(self, n_active_experts: int) -> int:
-        """Params of one MoE block counting `n_active_experts` experts: pre-norm + router
-        + experts (SwiGLU gate+up+down, bias-free). Used both for total capacity
-        (n_active_experts = n_experts) and active compute (= top_k)."""
+        """Params of one MoE block counting `n_active_experts` routed experts plus every
+        shared expert (SwiGLU gate+up+down, bias-free — shared experts run on EVERY
+        token, so they count in full regardless of whether this call is for total
+        capacity (n_active_experts = n_experts) or active compute (= top_k)), plus the
+        pre-norm + router. Default `n_shared_experts=0` leaves this arithmetic
+        unchanged from pre-#214."""
         d_model, d_ff = self.d_model, self.moe_d_ff_resolved
         expert = 3 * d_model * d_ff
-        return d_model + self.n_experts * d_model + n_active_experts * expert
+        return (d_model + self.n_experts * d_model
+                + (n_active_experts + self.n_shared_experts) * expert)
 
     def num_parameters(self) -> int:
         """Total trainable parameters (sum of `parameter_breakdown()`)."""
@@ -303,6 +326,16 @@ class MambaConfig:
     def packing_dtype(self) -> str:
         """The token packing dtype implied by the vocab: 'uint16' (< 65536) or 'uint32'."""
         return "uint16" if self.vocab_size < 65536 else "uint32"
+
+    @property
+    def optimizer_sizing_key(self) -> str:
+        """Which `sizing.OPTIMIZER_BYTES_PER_PARAM` key models THIS config's real
+        training memory. This repo trains with fp32 master weights, cast to the
+        compute dtype at the matmul site (see `cuda_backend.py`'s `_f32`/`_cast`), never
+        the lean all-bf16 regime `sizing.py`'s plain "adamw"/"adam8bit" keys model — so
+        the fp32-master variant is always the honest pick here, selected by whether
+        `optimizer_8bit` (#214's orthogonal 8-bit-moments axis) is set."""
+        return "adam8bit_fp32" if self.optimizer_8bit else "adamw_fp32"
 
     def validate(self) -> None:
         if self.n_layers <= 0:
@@ -346,18 +379,45 @@ class MambaConfig:
                     f"n_attn_heads={nah} must divide d_model={self.d_model} "
                     "(attn_head_dim = d_model // n_attn_heads)."
                 )
+        if self.moe_impl not in ("auto", "dense", "gather"):
+            raise ValueError(
+                f"unknown moe_impl {self.moe_impl!r} (expected one of auto, dense, gather)"
+            )
+        if self.n_shared_experts < 0:
+            raise ValueError(f"n_shared_experts={self.n_shared_experts} must be >= 0")
+        if self.n_shared_experts > 0 and self.n_moe_layers == 0:
+            raise ValueError(
+                f"n_shared_experts={self.n_shared_experts} requires an MoE model "
+                "(set moe_every so at least one layer is MoE); a shared expert with no "
+                "routed MoE block to attach it to is meaningless."
+            )
         if self.moe_every is not None:
             if self.moe_every <= 0:
                 raise ValueError("moe_every must be a positive int or None")
-            if self.n_experts < 2:
+            if self.n_experts < 1:
                 raise ValueError(
-                    f"n_experts={self.n_experts} must be >= 2 when moe_every is set "
-                    "(a sparse MoE needs at least two experts to route between)."
+                    f"n_experts={self.n_experts} must be >= 1 when moe_every is set."
                 )
             if not (1 <= self.top_k <= self.n_experts):
                 raise ValueError(
                     f"top_k={self.top_k} must be in [1, n_experts={self.n_experts}]."
                 )
+            if self.n_experts == 1:
+                # The degenerate E=1 block IS a plain SwiGLU FFN (softmax over one logit
+                # is exactly 1.0, `_moe` takes the k==E branch) — the dense-upcycle source
+                # (#214). top_k must be 1 (already implied by the range check above, but
+                # spelled out here) and balancing one expert is a provable no-op
+                # (sign(mean - load) == sign(0) == 0 forever), so reject it rather than
+                # silently accepting a rate that can never do anything.
+                if self.top_k != 1:
+                    raise ValueError(
+                        f"n_experts=1 requires top_k=1 (got top_k={self.top_k})."
+                    )
+                if self.moe_balance_rate is not None:
+                    raise ValueError(
+                        "moe_balance_rate must be None when n_experts=1 (balancing a "
+                        "single expert is a no-op: there is nothing to route between)."
+                    )
             if self.moe_d_ff_resolved <= 0:
                 raise ValueError("moe_d_ff must be positive or None")
             if self.n_moe_layers == 0:

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -17,6 +17,7 @@ it stays out of `tests/test_import_guard.py`'s portable set.
 
 from __future__ import annotations
 
+import contextlib
 import math
 from typing import List, Tuple
 
@@ -110,14 +111,14 @@ def _report_fast_path_once(device: "torch.device") -> None:
 
 
 # --------------------------------------------------------------------------- #
-# fp8 MoE-expert linears (#240, DESIGN-ONLY still — the probe below is complete and
-# tested, but nothing calls `_report_fp8_status_once` yet, since no config sets
-# `fp8_experts=True`): NVIDIA Transformer Engine (TE) `te.Linear` on Hopper+ (sm_90) for
-# the expert gate/up/down GEMMs only. Mirrors the `_fused_scan()` /
-# `_report_fast_path_once()` lazy-probe + warn-once pattern above. `_Expert`/`MoEBlock`
-# (#214, below) already build their linears via `_expert_linear`, so this probe DOES
-# have a live caller now — just not yet an active fp8 one (that GEMM/amax wiring is
-# #240's job).
+# fp8 MoE-expert linears (#214/#240, live): NVIDIA Transformer Engine (TE) `te.Linear`
+# on Hopper+ (sm_90) for the expert gate/up/down GEMMs only. Mirrors the
+# `_fused_scan()` / `_report_fast_path_once()` lazy-probe + warn-once pattern above.
+# `_Expert`/`MoEBlock` (below) build their linears via `_expert_linear` AND wrap the
+# expert-compute region in `MoEBlock._fp8_ctx`'s `fp8_autocast`, so a config that sets
+# `fp8_experts: true` on a Hopper+ box now actually runs the GEMMs in fp8 — not just
+# reachable code. Un-verified without Hopper hardware (see `tests/test_cuda_fp8.py`'s
+# GPU-gated acceptance tests and `docs/infrastructure.md`'s manual checklist).
 # --------------------------------------------------------------------------- #
 _TE_LINEAR_CLS = None      # sentinel: None = untried, False = unavailable/pre-Hopper
 
@@ -149,10 +150,10 @@ _FP8_STATUS_REPORTED = False
 
 
 def _report_fp8_status_once(device: "torch.device") -> None:
-    """On the first CUDA model built with `fp8_experts=True`, log whether TE fp8 is
-    active. Like `_report_fast_path_once`, a silent bf16 fallback on a GPU is a
-    throughput trap during a sweep — make it loud. Not called yet: no CUDA model
-    build path sets `fp8_experts` until #214 adds the CUDA MoE experts."""
+    """On the first CUDA model built with `fp8_experts=True` and at least one MoE
+    layer, log whether TE fp8 is active. Like `_report_fast_path_once`, a silent bf16
+    fallback on a GPU is a throughput trap during a sweep — make it loud. Called from
+    `CUDAMambaModel.__init__` (#214)."""
     global _FP8_STATUS_REPORTED
     if _FP8_STATUS_REPORTED or device.type != "cuda":
         return
@@ -169,25 +170,22 @@ def _report_fp8_status_once(device: "torch.device") -> None:
             RuntimeWarning, stacklevel=2)
 
 
-# === expert linear construction (#214 live; full fp8 wiring is #240, still LATER) ====
+# === expert linear construction (#214, fully wired) =======================
 # `_Expert.__init__` (below) builds its three linears (gate/up/down) via this helper:
 # `te.Linear` when fp8 is available (TE keeps fp32 master weights and casts to fp8 at
 # the GEMM, analogous to `_linear`'s cast-at-matmul above), else a plain bf16/fp16
-# `nn.Linear`. Today `config.fp8_experts` is always False in every shipped config, so
-# this always resolves to the `nn.Linear` fallback — the TE branch is reachable code,
-# not yet a live path. Remaining work for #240 to light it up:
-#   MoE grad-checkpoint wraps in `transformer_engine.pytorch.checkpoint`, NOT
-#     `torch.utils.checkpoint` — plain checkpoint double-updates the fp8 amax history
-#     on the recompute pass (it has no `use_reentrant` kwarg either).
-#   The expert-compute region needs an `fp8_autocast()` context (`nullcontext()` when
-#     off) — a `te.Linear` called outside one runs in bf16, not fp8.
-#   model build calls `_report_fp8_status_once(device)` once fp8_experts is wired.
-# `te.Linear` graph-breaks `torch.compile` like `mamba-ssm` (safe/opaque, same as the
-# fused scan above).
+# `nn.Linear`. `device`/`params_dtype=torch.float32` are passed through explicitly so
+# TE builds the weight directly on the right device, in fp32 — the same
+# fp32-master-weights invariant `_linear`'s cast-at-matmul documents everywhere else in
+# this module (mixed precision never stores a low-precision master copy). A `te.Linear`
+# called OUTSIDE an `fp8_autocast()` context still runs — but silently in bf16, not
+# fp8 — so `MoEBlock._fp8_ctx` (below) must wrap every call site. `te.Linear` also
+# graph-breaks `torch.compile` like `mamba-ssm` (safe/opaque, same as the fused scan
+# above).
 def _expert_linear(d_in: int, d_out: int, config: MambaConfig, device):
     cls = _te_linear_cls() if getattr(config, "fp8_experts", False) else None
     if cls is not None:
-        return cls(d_in, d_out, bias=False)        # TE fp8 GEMM, fp32 master weights
+        return cls(d_in, d_out, bias=False, device=device, params_dtype=torch.float32)
     return nn.Linear(d_in, d_out, bias=False)       # bf16/fp16 fallback (no TE / pre-Hopper)
 # ===========================================================================
 
@@ -728,9 +726,11 @@ class AttentionBlock(nn.Module):
 # --------------------------------------------------------------------------- #
 class _Expert(nn.Module):
     """A SwiGLU FFN expert: down(silu(gate(x)) * up(x)). Bias-free. Torch port of
-    `mlx_backend._Expert`, built via `_expert_linear` (the `# BLOCKED-ON-#214` scaffolding
-    above, now live): a plain `nn.Linear` unless `config.fp8_experts` resolves a
-    Transformer Engine `te.Linear` (the fp8 GEMM wiring itself is a later dispatch, #240).
+    `mlx_backend._Expert`, built via `_expert_linear`: a plain `nn.Linear` unless
+    `config.fp8_experts` resolves a Transformer Engine `te.Linear` (fp32 master
+    weights, fp8 GEMM). The fp8_autocast context that actually makes a `te.Linear` run
+    in fp8 (rather than silently in bf16) is entered by the CALLER — see
+    `MoEBlock._fp8_ctx` — not here, so this class stays agnostic to it.
 
     `_linear` (this module's helper) reaches into `layer.weight` directly to cast
     operands to the compute dtype at the matmul site — correct for `nn.Linear`, but it
@@ -837,6 +837,22 @@ class MoEBlock(nn.Module):
         self._load_counts.zero_()
         return [float(c) for c in counts.tolist()]
 
+    def _fp8_ctx(self):
+        """Context manager for the expert-compute region (#214/#240). A `te.Linear`
+        called OUTSIDE an `fp8_autocast` context silently runs in bf16, not fp8, so
+        `_expert_linear` alone does not turn fp8 on — every expert GEMM call site in
+        `_moe` must be wrapped in this. `contextlib.nullcontext()` when fp8 is off or
+        unavailable, so the non-fp8 path is untouched byte-for-byte (no TE import even
+        attempted). The router's logits/probs are computed by the CALLER, above this
+        context — the router is a plain `nn.Linear` and always routes in fp32, and
+        must stay bit-identical between fp8 and bf16 runs regardless (see the
+        zero-tolerance routing-identity test in `tests/test_cuda_fp8.py`)."""
+        if not (self.config.fp8_experts and fp8_status()):
+            return contextlib.nullcontext()
+        import transformer_engine.pytorch as te
+        from transformer_engine.common.recipe import DelayedScaling
+        return te.fp8_autocast(enabled=True, fp8_recipe=DelayedScaling())
+
     def _moe_dense(self, xn: Array, cd, gate: Array) -> Array:
         outs = torch.stack([e(xn, cd) for e in self.experts], dim=-2)   # (...,E,d_model)
         return torch.sum(gate.unsqueeze(-1) * _f32(outs), dim=-2)       # combine in fp32
@@ -923,23 +939,26 @@ class MoEBlock(nn.Module):
                     topk_ids.reshape(-1), minlength=E).to(self._load_counts.dtype)
                 self._load_counts += counts
 
-            if self._use_gather:
-                gate_kept = torch.gather(probs, -1, topk_ids)
-                gate_kept = gate_kept / gate_kept.sum(-1, keepdim=True)
-                y = self._moe_gather(xn, cd, topk_ids, gate_kept)
-            else:
-                mask = torch.zeros_like(probs, dtype=torch.bool)
-                mask.scatter_(-1, topk_ids, True)
-                gate = torch.where(mask, probs, torch.zeros_like(probs))
-                gate = gate / gate.sum(-1, keepdim=True)      # renormalize the kept gates
-                y = self._moe_dense(xn, cd, gate)
+            with self._fp8_ctx():                          # expert GEMMs only (#214/#240)
+                if self._use_gather:
+                    gate_kept = torch.gather(probs, -1, topk_ids)
+                    gate_kept = gate_kept / gate_kept.sum(-1, keepdim=True)
+                    y = self._moe_gather(xn, cd, topk_ids, gate_kept)
+                else:
+                    mask = torch.zeros_like(probs, dtype=torch.bool)
+                    mask.scatter_(-1, topk_ids, True)
+                    gate = torch.where(mask, probs, torch.zeros_like(probs))
+                    gate = gate / gate.sum(-1, keepdim=True)   # renormalize the kept gates
+                    y = self._moe_dense(xn, cd, gate)
         else:
-            y = self._moe_dense(xn, cd, probs)                # softmax already sums to 1
+            with self._fp8_ctx():
+                y = self._moe_dense(xn, cd, probs)            # softmax already sums to 1
 
         if len(self.shared_experts):
             # Additive, OUTSIDE the router softmax/top-k renormalization (DeepSeek-V2/V3
             # form). Guarded so n_shared_experts=0 takes the exact pre-#214 path.
-            y = y + sum(_f32(se(xn, cd)) for se in self.shared_experts)
+            with self._fp8_ctx():
+                y = y + sum(_f32(se(xn, cd)) for se in self.shared_experts)
         return _cast(y, cd)
 
     def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:
@@ -989,6 +1008,8 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         self._state = None
         self.to(self._device)
         _report_fast_path_once(self._device)
+        if config.fp8_experts and config.n_moe_layers:
+            _report_fp8_status_once(self._device)
         # torch.compile (#145, #239): fuse the pure-tensor forward (layer loop + head) via
         # inductor. Tri-state config.torch_compile: None = AUTO (compile only on a real CUDA
         # device with torch>=2.1 — the real-run path), True/False = explicit override honored
@@ -1031,6 +1052,17 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         # retaining its activations. Only meaningful under autograd; use_reentrant=False
         # runs normally in no-grad (eval/parity) contexts.
         if self.config.grad_checkpoint and torch.is_grad_enabled():
+            if self.config.fp8_experts and isinstance(layer, MoEBlock):
+                # `transformer_engine.pytorch.checkpoint`, NOT `torch.utils.checkpoint`
+                # (#214/#240): plain checkpoint's recompute pass re-runs the fp8_autocast
+                # region and double-updates the amax history TE uses to calibrate the fp8
+                # scale, which `te.checkpoint` knows to skip. It has NO `use_reentrant`
+                # kwarg — passing one is a TypeError, unlike the plain-checkpoint call
+                # below.
+                import transformer_engine.pytorch as te
+                if seg_ids is None:
+                    return te.checkpoint(layer.forward_seq, h)
+                return te.checkpoint(layer.forward_seq, h, seg_ids)
             if seg_ids is None:
                 return _checkpoint(layer.forward_seq, h, use_reentrant=False)
             return _checkpoint(layer.forward_seq, h, seg_ids, use_reentrant=False)

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -110,12 +110,14 @@ def _report_fast_path_once(device: "torch.device") -> None:
 
 
 # --------------------------------------------------------------------------- #
-# fp8 MoE-expert linears (#240, DESIGN-ONLY, blocked on #214): NVIDIA Transformer
-# Engine (TE) `te.Linear` on Hopper+ (sm_90) for the expert gate/up/down GEMMs only.
-# Mirrors the `_fused_scan()` / `_report_fast_path_once()` lazy-probe + warn-once
-# pattern above. TE is not wired to any expert module yet — #214 has not built the
-# CUDA MoE `_Expert`/`MoEBlock` (that lives only in `mlx_backend.py:499-560` today) —
-# so this probe is complete and tested, but has no live caller besides its own tests.
+# fp8 MoE-expert linears (#240, DESIGN-ONLY still — the probe below is complete and
+# tested, but nothing calls `_report_fp8_status_once` yet, since no config sets
+# `fp8_experts=True`): NVIDIA Transformer Engine (TE) `te.Linear` on Hopper+ (sm_90) for
+# the expert gate/up/down GEMMs only. Mirrors the `_fused_scan()` /
+# `_report_fast_path_once()` lazy-probe + warn-once pattern above. `_Expert`/`MoEBlock`
+# (#214, below) already build their linears via `_expert_linear`, so this probe DOES
+# have a live caller now — just not yet an active fp8 one (that GEMM/amax wiring is
+# #240's job).
 # --------------------------------------------------------------------------- #
 _TE_LINEAR_CLS = None      # sentinel: None = untried, False = unavailable/pre-Hopper
 
@@ -167,17 +169,18 @@ def _report_fp8_status_once(device: "torch.device") -> None:
             RuntimeWarning, stacklevel=2)
 
 
-# === BLOCKED-ON-#214: CUDA MoE experts do not exist yet ======================
-# When #214 adds the CUDA `_Expert`/`MoEBlock` (mirroring `mlx_backend.py:499-560`),
-# its three expert linears (gate/up/down) build via this helper: `te.Linear` when fp8
-# is available (TE keeps fp32 master weights and casts to fp8 at the GEMM, analogous
-# to `_linear`'s cast-at-matmul above), else a plain bf16/fp16 `nn.Linear`. This
-# function is DEFINED BUT NEVER CALLED until #214 lands — no CUDA `_Expert` exists to
-# call it. Un-dormanting is mechanical:
-#   _Expert.__init__: self.gate/up/down = _expert_linear(d_in, d_out, config, device)
+# === expert linear construction (#214 live; full fp8 wiring is #240, still LATER) ====
+# `_Expert.__init__` (below) builds its three linears (gate/up/down) via this helper:
+# `te.Linear` when fp8 is available (TE keeps fp32 master weights and casts to fp8 at
+# the GEMM, analogous to `_linear`'s cast-at-matmul above), else a plain bf16/fp16
+# `nn.Linear`. Today `config.fp8_experts` is always False in every shipped config, so
+# this always resolves to the `nn.Linear` fallback — the TE branch is reachable code,
+# not yet a live path. Remaining work for #240 to light it up:
 #   MoE grad-checkpoint wraps in `transformer_engine.pytorch.checkpoint`, NOT
 #     `torch.utils.checkpoint` — plain checkpoint double-updates the fp8 amax history
-#     on the recompute pass.
+#     on the recompute pass (it has no `use_reentrant` kwarg either).
+#   The expert-compute region needs an `fp8_autocast()` context (`nullcontext()` when
+#     off) — a `te.Linear` called outside one runs in bf16, not fp8.
 #   model build calls `_report_fp8_status_once(device)` once fp8_experts is wired.
 # `te.Linear` graph-breaks `torch.compile` like `mamba-ssm` (safe/opaque, same as the
 # fused scan above).
@@ -718,6 +721,240 @@ class AttentionBlock(nn.Module):
         return x + _linear(self.o_proj, _cast(out, cd), cd), (k_cache, v_cache)
 
 
+# --------------------------------------------------------------------------- #
+# Sparse Mixture-of-Experts FFN block (#53, CUDA grouped-gather routing #214) — torch
+# port of mlx_backend's MoE block, now with a real gathered-dispatch kernel alongside
+# the dense evaluate-every-expert reference.
+# --------------------------------------------------------------------------- #
+class _Expert(nn.Module):
+    """A SwiGLU FFN expert: down(silu(gate(x)) * up(x)). Bias-free. Torch port of
+    `mlx_backend._Expert`, built via `_expert_linear` (the `# BLOCKED-ON-#214` scaffolding
+    above, now live): a plain `nn.Linear` unless `config.fp8_experts` resolves a
+    Transformer Engine `te.Linear` (the fp8 GEMM wiring itself is a later dispatch, #240).
+
+    `_linear` (this module's helper) reaches into `layer.weight` directly to cast
+    operands to the compute dtype at the matmul site — correct for `nn.Linear`, but it
+    would silently bypass a `te.Linear`'s own fp8 GEMM/amax bookkeeping entirely. `self._te`
+    is cached at construction so `forward` can branch: a TE linear is always called
+    directly (module `__call__`), never routed through `_linear`.
+    """
+
+    def __init__(self, d_model: int, d_ff: int, config: MambaConfig, device):
+        super().__init__()
+        cls = _te_linear_cls() if getattr(config, "fp8_experts", False) else None
+        self._te = cls is not None
+        self.gate = _expert_linear(d_model, d_ff, config, device)
+        self.up = _expert_linear(d_model, d_ff, config, device)
+        self.down = _expert_linear(d_ff, d_model, config, device)
+
+    def forward(self, xn: Array, cd) -> Array:
+        if self._te:
+            # TE linears own their GEMM (fp8 under an fp8_autocast context — not yet
+            # wired, #240 — or bf16/fp16 outside one); call the modules directly.
+            return self.down(_silu(self.gate(xn)) * self.up(xn))
+        return _linear(self.down,
+                       _silu(_linear(self.gate, xn, cd)) * _linear(self.up, xn, cd), cd)
+
+
+class MoEBlock(nn.Module):
+    """Sparse Mixture-of-Experts FFN block (#53), interleaved like `AttentionBlock` —
+    torch port of `mlx_backend.MoEBlock`, plus a real grouped-gather dispatch kernel
+    (#214) alongside the dense evaluate-every-expert reference. Same `forward_seq(x)->x`
+    / `step(x, state)->(x, state)` contract as the other blocks; stateless (pointwise
+    over the sequence), so forward and step compute the same function by construction.
+
+    `moe_impl` picks the compute strategy, resolved once at construction:
+      * "dense"  — evaluate every expert, mask+renormalize the top_k gates. Exact and
+        FLOP-accountable but not wall-clock-sparse. This is the MLX/Swift reference — the
+        oracle every gather test below is checked against, so it must never be deleted.
+      * "gather" — dispatch each token only to its top_k chosen experts.
+      * "auto"   — dense when top_k >= n_experts or n_experts == 1 (gather buys nothing
+        there), else gather.
+    """
+
+    _MOE_BIAS_PREFIX = "moe_route_bias."   # kept for symmetry with the model-level prefix
+
+    def __init__(self, config: MambaConfig, device):
+        super().__init__()
+        self.config = config
+        self.norm = RMSNorm(config.d_model)
+        self.router = nn.Linear(config.d_model, config.n_experts, bias=False)
+        d_ff = config.moe_d_ff_resolved
+        self.experts = nn.ModuleList(
+            [_Expert(config.d_model, d_ff, config, device) for _ in range(config.n_experts)])
+        # Shared experts (#214, DeepSeek-V2/V3 form): every token goes through every
+        # shared expert unconditionally; combined ADDITIVELY in `_moe`, outside the
+        # router softmax/top-k renormalization. Empty ModuleList for n_shared_experts=0.
+        self.shared_experts = nn.ModuleList(
+            [_Expert(config.d_model, d_ff, config, device)
+             for _ in range(config.n_shared_experts)])
+
+        E = config.n_experts
+        if config.moe_impl == "dense":
+            self._use_gather = False
+        elif config.moe_impl == "gather":
+            self._use_gather = True
+        else:                                          # "auto"
+            self._use_gather = not (config.top_k >= E or E == 1)
+
+        # Loss-Free-Balancing (#213 D1), torch port. MLX excludes the bias/counts from
+        # the parameter tree via a leading-underscore-attribute convention baked into
+        # `nn.Module.valid_parameter_filter`; torch has no such convention, so
+        # `register_buffer(..., persistent=False)` does the ACTUAL work here — verified:
+        # absent from `named_parameters()` AND `state_dict()`, `load_state_dict(strict=
+        # True)` does not demand it, and — unlike a plain attribute — it IS moved by
+        # `.to()` (a plain attribute would silently stay on the wrong device the first
+        # time a bias activates on GPU; `persistent=True` would make every load raise on
+        # a missing key). The leading underscore on these names is therefore load-bearing
+        # in MLX but purely COSMETIC here — kept only for cross-backend name parity.
+        self.register_buffer("_route_bias", torch.zeros(E), persistent=False)
+        self._bias_active = False
+        self._count_loads = False
+        self.register_buffer("_load_counts", torch.zeros(E), persistent=False)
+
+    def set_route_bias(self, vec) -> None:
+        """Set the per-expert selection bias (#213) — `vec` a `list[float]` of length
+        `n_experts`. Mutates the buffer IN PLACE (`copy_`), never rebinds it, so it stays
+        the exact object `.to()` already placed on the right device."""
+        if len(vec) != self.config.n_experts:
+            raise ValueError(
+                f"route bias has {len(vec)} entries, expected "
+                f"n_experts={self.config.n_experts}."
+            )
+        self._route_bias.copy_(
+            torch.as_tensor(vec, dtype=torch.float32, device=self._route_bias.device))
+        self._bias_active = True
+
+    def route_bias(self) -> list:
+        return [float(b) for b in self._route_bias.tolist()] if self._bias_active else []
+
+    def set_load_counting(self, flag: bool) -> None:
+        self._count_loads = bool(flag)
+
+    def pop_load(self) -> list:
+        """Per-expert token counts accumulated since the last pop, then reset."""
+        counts = self._load_counts.clone()
+        self._load_counts.zero_()
+        return [float(c) for c in counts.tolist()]
+
+    def _moe_dense(self, xn: Array, cd, gate: Array) -> Array:
+        outs = torch.stack([e(xn, cd) for e in self.experts], dim=-2)   # (...,E,d_model)
+        return torch.sum(gate.unsqueeze(-1) * _f32(outs), dim=-2)       # combine in fp32
+
+    def _moe_gather(self, xn: Array, cd, topk_ids: Array, gate_kept: Array) -> Array:
+        """Grouped-gather routing (#214): dispatch each token only to its top_k chosen
+        experts, instead of `_moe_dense`'s evaluate-every-expert-then-mask.
+
+        Two-step gather — `expand` then `index_select` — is DELIBERATELY NOT the
+        one-shot `flat.index_select(0, perm // k)`: that form's backward is `index_add_`
+        with repeated indices, a CUDA atomic reduction whose summation order varies run
+        to run and would break the bit-exact resume the smoke gate asserts (see the
+        determinism note at `cuda_muon.py:25-27`). This form's backward is a
+        deterministic `sum` (from the `expand`) composed with a permutation
+        `index_select` — at the cost of one extra `(N*k, D)` buffer, noted for the FSDP
+        follow-up.
+
+        Loops over ALL E experts, deliberately with no `if count == 0: continue`: a
+        zero-row GEMM still yields a real, exactly-zero, finite `weight.grad` (matching
+        the dense path), whereas skipping the call leaves that expert's `.grad` as
+        `None` and `Muon.step` (`cuda_muon.py:65-67`) then skips its momentum decay
+        while the dense path decays it — a silent, impl-dependent training divergence.
+        """
+        E, k = self.config.n_experts, self.config.top_k
+        D = xn.shape[-1]
+        lead_shape = xn.shape[:-1]
+        flat_x = xn.reshape(-1, D)
+        N = flat_x.shape[0]
+        flat_ids = topk_ids.reshape(N, k)
+        flat_gate = gate_kept.reshape(N, k)
+
+        # (N,D) -> (N,k,D) -> (N*k,D): each token's row repeated once per chosen expert
+        # (its own dispatch copy), so the backward through this step is a deterministic
+        # sum over the k repeats — never an atomic scatter-add.
+        dispatch = flat_x.unsqueeze(1).expand(N, k, D).reshape(N * k, D)
+        dispatch_expert = flat_ids.reshape(-1)              # (N*k,) expert id per slot
+
+        perm = torch.argsort(dispatch_expert, stable=True)  # group dispatch slots by expert
+        sorted_expert = dispatch_expert[perm]
+        sorted_x = dispatch.index_select(0, perm)            # deterministic gather
+
+        counts = torch.bincount(sorted_expert, minlength=E).tolist()   # one host sync
+        chunks = []
+        offset = 0
+        for e in range(E):                     # ALL experts — see the no-`continue` note above
+            c = counts[e]
+            chunks.append(self.experts[e](sorted_x[offset:offset + c], cd))
+            offset += c
+        out_sorted = torch.cat(chunks, dim=0)                 # (N*k, D)
+
+        inv_perm = torch.argsort(perm)                        # undo the grouping sort
+        out_dispatch = out_sorted.index_select(0, inv_perm).reshape(N, k, D)
+        combined = torch.sum(_f32(out_dispatch) * flat_gate.unsqueeze(-1), dim=1)   # (N,D)
+        return combined.reshape(*lead_shape, D)
+
+    def _moe(self, xn: Array) -> Array:
+        cd = _DTYPES[self.config.precision]
+        E, k = self.config.n_experts, self.config.top_k
+        logits = _f32(_linear(self.router, xn, cd))          # (..., E) — route in fp32
+        probs = F.softmax(logits, dim=-1)                    # UNBIASED — always the gate weight
+
+        if k < E:                                             # keep EXACTLY top_k per token
+            # Loss-Free-Balancing (#213 D2): when active, rank by the BIASED selection
+            # score `logits + route_bias` (LOGIT space); the gate weight below stays
+            # `probs` (unbiased) regardless. Unbiased: rank by `probs`, NOT `logits` —
+            # softmax can collide two distinct fp32 logits into one prob, so the two
+            # tie-break differently; this must mirror `mlx_backend.py:694` literally.
+            sel = (logits + self._route_bias) if self._bias_active else probs
+            # `stable=True` is the WHOLE tie-break contract: verified to match MLX's
+            # `argsort(argsort(-x)) < k` double-argsort on every tested tie pattern.
+            # `torch.topk` is DISQUALIFIED — it diverges from that on ties (see the
+            # explicit negative test in tests/test_cuda_moe.py).
+            order = torch.argsort(-sel, dim=-1, stable=True)       # descending rank
+            topk_ids, _ = torch.sort(order[..., :k], dim=-1)       # ascending: dense-order sum
+
+            if self._count_loads:
+                # Per-expert load bookkeeping for the balancer (#213), detached from the
+                # graph (topk_ids already carries no grad) and accumulated; `pop_load()`
+                # reads + resets it. Counted only here (k < E): with k == E every expert
+                # takes every token and balancing is vacuous. Shared between dense/gather
+                # (both derive from the same topk_ids), so `pop_moe_load()` agrees exactly
+                # between impls.
+                counts = torch.bincount(
+                    topk_ids.reshape(-1), minlength=E).to(self._load_counts.dtype)
+                self._load_counts += counts
+
+            if self._use_gather:
+                gate_kept = torch.gather(probs, -1, topk_ids)
+                gate_kept = gate_kept / gate_kept.sum(-1, keepdim=True)
+                y = self._moe_gather(xn, cd, topk_ids, gate_kept)
+            else:
+                mask = torch.zeros_like(probs, dtype=torch.bool)
+                mask.scatter_(-1, topk_ids, True)
+                gate = torch.where(mask, probs, torch.zeros_like(probs))
+                gate = gate / gate.sum(-1, keepdim=True)      # renormalize the kept gates
+                y = self._moe_dense(xn, cd, gate)
+        else:
+            y = self._moe_dense(xn, cd, probs)                # softmax already sums to 1
+
+        if len(self.shared_experts):
+            # Additive, OUTSIDE the router softmax/top-k renormalization (DeepSeek-V2/V3
+            # form). Guarded so n_shared_experts=0 takes the exact pre-#214 path.
+            y = y + sum(_f32(se(xn, cd)) for se in self.shared_experts)
+        return _cast(y, cd)
+
+    def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:
+        return x + self._moe(self.norm(x))                   # pointwise: seg_ids irrelevant
+
+    def forward_prefill(self, x: Array, seg_ids: Array = None) -> Tuple[Array, State]:
+        # Stateless: emit the SAME placeholder pair `init_state` builds for a MoE layer.
+        B_ = x.shape[0]
+        z = x.new_zeros((B_, 0))
+        return x + self._moe(self.norm(x)), (z, z)
+
+    def step(self, x: Array, state: State) -> Tuple[Array, State]:
+        return x + self._moe(self.norm(x)), state            # stateless: pass state through
+
+
 def _torch_ge_21() -> bool:
     # "2.3.1+cu121" -> (2, 3); robust to the +cuXXX / +cpu local suffix.
     parts = torch.__version__.split("+")[0].split(".")
@@ -729,26 +966,22 @@ def _torch_ge_21() -> bool:
 # Top-level model implementing the seam
 # --------------------------------------------------------------------------- #
 class CUDAMambaModel(ModelInterface, nn.Module):
+    # `moe_route_bias.{layer_index}` — the MoE route bias's key prefix in the portable
+    # weights (#213 D3). Not a parameter (see MoEBlock.__init__), so it is added/popped
+    # explicitly around the state_dict path rather than riding it.
+    _MOE_BIAS_PREFIX = "moe_route_bias."
+
     def __init__(self, config: MambaConfig, device: str = "cpu"):
         nn.Module.__init__(self)
         config.validate()
-        # Fail fast rather than silently build a DENSE model: the sparse-MoE block (#53) is
-        # MLX-only for now, but MambaConfig.num_parameters()/parameter_breakdown() already
-        # account for MoE capacity — so a `moe_every` config here would disagree with the
-        # formula and skew any cross-backend sizing/comparison.
-        if config.n_moe_layers > 0:
-            raise NotImplementedError(
-                "MoE-Mamba (#53) is not implemented in the CUDA backend; "
-                "build a config without `moe_every` (it is an MLX-only experiment)."
-            )
         self.config = config
         self._cd = _DTYPES[config.precision]         # compute dtype for the heavy GEMMs
         self._device = torch.device(device)
         self.embedding = nn.Embedding(config.vocab_size, config.d_model)
-        # Hybrid (#67): attention blocks replace Mamba blocks at the gated positions.
-        self.layers = nn.ModuleList(
-            [AttentionBlock(config) if config.is_attention_layer(i) else MambaBlock(config)
-             for i in range(config.n_layers)])
+        # Hybrid (#67): attention blocks replace Mamba blocks at the gated positions;
+        # MoE (#53/#214): sparse-FFN blocks replace Mamba blocks at their gated positions
+        # (attention takes precedence on a collision, matching `is_moe_layer`).
+        self.layers = nn.ModuleList([self._make_layer(i) for i in range(config.n_layers)])
         self.norm_f = RMSNorm(config.d_model)
         self._tie_embeddings = config.tie_embeddings
         if not config.tie_embeddings:
@@ -773,6 +1006,16 @@ class CUDAMambaModel(ModelInterface, nn.Module):
             self._compiled = bool(config.torch_compile)
         if self._compiled:
             self._forward_compute = torch.compile(self._forward_compute)
+
+    def _make_layer(self, i: int):
+        """Attention -> MoE -> Mamba precedence, mirroring `mlx_backend.MLXMambaModel.
+        _make_layer` (and `MambaConfig.is_moe_layer`'s own attention-takes-precedence
+        rule)."""
+        if self.config.is_attention_layer(i):
+            return AttentionBlock(self.config)
+        if self.config.is_moe_layer(i):
+            return MoEBlock(self.config, self._device)
+        return MambaBlock(self.config)
 
     def _head(self, h: Array) -> Array:
         # Logits + cross-entropy run in fp32 (wide-vocab softmax stability); h is upcast
@@ -858,16 +1101,40 @@ class CUDAMambaModel(ModelInterface, nn.Module):
 
     def mixing_matrices(self, token_batch: Array) -> List[Tuple[int, Array]]:
         """For the `mixing-match` stage: each Mamba layer's head-averaged mixing matrix
-        `(B, L, L)` paired with its layer index. Attention layers are skipped. Torch port of
+        `(B, L, L)` paired with its layer index. Attention AND MoE layers are skipped
+        (`MoEBlock` has no `mixing_matrix` — it is pointwise, not a mixer). Torch port of
         `mlx_backend.MLXMambaModel.mixing_matrices`."""
         ids = torch.as_tensor(np.asarray(token_batch), dtype=torch.long, device=self._device)
         h = _cast(self.embedding(ids), self._cd)
         out: List[Tuple[int, Array]] = []
         for i, layer in enumerate(self.layers):
-            if not self.config.is_attention_layer(i):
+            if not self.config.is_attention_layer(i) and not self.config.is_moe_layer(i):
                 out.append((i, layer.mixing_matrix(h).mean(dim=1)))     # head-average -> (B,L,L)
             h = self._layer_forward(layer, h)
         return out
+
+    # --- Loss-Free-Balancing accessors (#213/#214), torch mirrors of the MLX ones ----
+    def moe_blocks(self) -> List["MoEBlock"]:
+        return [l for l in self.layers if isinstance(l, MoEBlock)]
+
+    def set_moe_biases(self, biases: List[List[float]]) -> None:
+        blocks = self.moe_blocks()
+        if len(biases) != len(blocks):
+            raise ValueError(
+                f"got {len(biases)} bias vectors for {len(blocks)} MoE layers."
+            )
+        for block, vec in zip(blocks, biases):
+            block.set_route_bias(vec)
+
+    def moe_biases(self) -> List[List[float]]:
+        return [block.route_bias() for block in self.moe_blocks()]
+
+    def set_moe_load_counting(self, flag: bool) -> None:
+        for block in self.moe_blocks():
+            block.set_load_counting(flag)
+
+    def pop_moe_load(self) -> List[List[float]]:
+        return [block.pop_load() for block in self.moe_blocks()]
 
     def init_state(self, batch_size: int) -> State:
         c = self.config
@@ -877,10 +1144,14 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         dev = self._device
         # Per Mamba layer: (conv window (B,k-1,di), SSM state (B,H,P,N)), fp32.
         # Per attention layer: a zero-length KV cache (k,v), each (B,Ha,0,Dh), grown by step.
+        # Per MoE layer: a zero-length placeholder pair (stateless FFN).
         def layer_state(i):
             if c.is_attention_layer(i):
                 z = torch.zeros((batch_size, Ha, 0, Dh), device=dev)
                 return (z, z)
+            if c.is_moe_layer(i):
+                z = torch.zeros((batch_size, 0), device=dev)
+                return (z, z)                     # keeps clone_state's (a, b) unpack valid
             return (torch.zeros((batch_size, k - 1, di), device=dev),
                     torch.zeros((batch_size, H, P, N), device=dev))
         return [layer_state(i) for i in range(self.config.n_layers)]
@@ -914,14 +1185,44 @@ class CUDAMambaModel(ModelInterface, nn.Module):
             if k.endswith(".conv.weight"):
                 arr = arr.transpose(1, 2)            # (out,1,k) -> (out,k,1)
             out[k] = arr.numpy()
+        # Loss-Free-Balancing bias (#213 D3): rides in the PORTABLE weights, not the
+        # resume bundle — it is routing state that changes the model's function at
+        # inference. `_route_bias` is a non-persistent buffer (see MoEBlock.__init__),
+        # so it never appears in `named_parameters()` above; emitted explicitly, and only
+        # for a block whose bias is ACTIVE — an unconditional key would break
+        # `sum(v.size) == cfg.num_parameters()` (tests/test_moe.py / test_sizing.py), and
+        # the bias genuinely is not a parameter, so it does not belong in
+        # `num_parameters()` either way. Mirrors `mlx_backend.py:986-1003`.
+        for i, layer in enumerate(self.layers):
+            if isinstance(layer, MoEBlock) and layer._bias_active:
+                out[f"{self._MOE_BIAS_PREFIX}{i}"] = layer._route_bias.detach().cpu().numpy()
         return out
 
     def _load_portable(self, weights: dict) -> None:
-        tensors = {}
+        # Pop the non-parameter route-bias keys FIRST — they must never reach
+        # `load_state_dict`, which only knows about the real parameter/buffer tree and
+        # would raise (strict=True) on an unexpected key. Absent keys (an old checkpoint,
+        # balancing off, a dense model) simply leave every block inactive. Mirrors
+        # `mlx_backend.py:1005-1028`.
+        biases, tensors = {}, {}
         for k, v in weights.items():
+            if k.startswith(self._MOE_BIAS_PREFIX):
+                biases[int(k[len(self._MOE_BIAS_PREFIX):])] = v
+                continue
             t = torch.as_tensor(np.asarray(v))
             if k.endswith(".conv.weight"):
                 t = t.transpose(1, 2)                # (out,k,1) -> (out,1,k)
             tensors[k] = t
         self.load_state_dict(tensors, strict=True)
         self.to(self._device)
+        for i, vec in biases.items():
+            # Check the key names a real MoE layer before indexing: a balanced checkpoint
+            # loaded into a dense or differently-interleaved config would otherwise die on
+            # an IndexError deep in the load, with nothing pointing at the real mismatch.
+            if not (0 <= i < len(self.layers)) or not isinstance(self.layers[i], MoEBlock):
+                raise ValueError(
+                    f"checkpoint has {self._MOE_BIAS_PREFIX}{i}, but layer {i} of this "
+                    "config is not an MoE layer — the weights and the config disagree "
+                    "about the MoE interleave."
+                )
+            self.layers[i].set_route_bias(np.asarray(vec).reshape(-1).tolist())

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -1052,13 +1052,16 @@ class CUDAMambaModel(ModelInterface, nn.Module):
         # retaining its activations. Only meaningful under autograd; use_reentrant=False
         # runs normally in no-grad (eval/parity) contexts.
         if self.config.grad_checkpoint and torch.is_grad_enabled():
-            if self.config.fp8_experts and isinstance(layer, MoEBlock):
+            if self.config.fp8_experts and fp8_status() and isinstance(layer, MoEBlock):
                 # `transformer_engine.pytorch.checkpoint`, NOT `torch.utils.checkpoint`
                 # (#214/#240): plain checkpoint's recompute pass re-runs the fp8_autocast
                 # region and double-updates the amax history TE uses to calibrate the fp8
                 # scale, which `te.checkpoint` knows to skip. It has NO `use_reentrant`
                 # kwarg — passing one is a TypeError, unlike the plain-checkpoint call
-                # below.
+                # below. Gated on `fp8_status()` (not just the config flag) so this import
+                # only fires when TE/Hopper is actually available — `fp8_experts=True` on
+                # CPU/CI or non-Hopper CUDA must fall through to the plain-checkpoint path
+                # below, matching `MoEBlock._fp8_ctx`'s own fp8_status() gate.
                 import transformer_engine.pytorch as te
                 if seg_ids is None:
                     return te.checkpoint(layer.forward_seq, h)

--- a/src/model/cuda_train_step.py
+++ b/src/model/cuda_train_step.py
@@ -20,6 +20,8 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
+from ..train.moe_balance import MoEBalancer
+
 
 def _global_grad_norm(params) -> torch.Tensor:
     leaves = [p.grad for p in params if p.grad is not None]
@@ -27,8 +29,8 @@ def _global_grad_norm(params) -> torch.Tensor:
     return torch.sqrt(sq)
 
 
-def _accumulate_and_step(optimizer, params, loss_fn, micro_batches, lr,
-                         grad_clip, scaler) -> dict:
+def _accumulate_and_step(model, optimizer, params, loss_fn, micro_batches, lr,
+                         grad_clip, scaler, balancer=None) -> dict:
     """Shared accumulate -> (unscale) -> clip -> optimizer-step tail.
 
     `loss_fn(micro_batch) -> scalar torch loss` is the only objective-specific piece;
@@ -36,6 +38,15 @@ def _accumulate_and_step(optimizer, params, loss_fn, micro_batches, lr,
     clipping, the optimizer update, and the returned metrics dict) is identical for
     pretraining, SFT, DPO, and GRPO, so they all funnel through here — the torch mirror of
     `mlx_train_step._accumulate_and_step`.
+
+    `model` is the model whose MoE routers the `balancer` hook (below) reads/writes — for
+    DPO this MUST be the policy model, never the frozen reference (see
+    `make_dpo_train_step`). `balancer` (a `MoEBalancer`, #213/#214) is the Loss-Free-
+    Balancing policy: on a successful (non-skipped) step it reads this step's per-expert
+    load counts off the model (`pop_moe_load`), nudges the bias OUTSIDE the gradient
+    (`update` — no aux loss ever touches the objective above), and pushes the new biases
+    back into the model's MoE blocks (`set_moe_biases`) for the next forward. `None`
+    (dense/hybrid models, or MoE without balancing) is a no-op.
     """
     n = len(micro_batches)
     s = scaler.scale if scaler else 1.0
@@ -77,11 +88,23 @@ def _accumulate_and_step(optimizer, params, loss_fn, micro_batches, lr,
     if scaler:
         out["loss_scale"] = scaler.scale
         out["skipped"] = False
+    if balancer is not None:
+        # Loss-Free-Balancing (#213/#214): update the bias from this step's routed-token
+        # counts, OUTSIDE the gradient, then push the new biases back into the model for
+        # the next forward. `pop_moe_load` returns `[]` for a model with no MoE layers.
+        # Placed at the VERY END, after `out` is assembled — i.e. AFTER the fp16 overflow
+        # early-return above, so a skipped step does NOT pop the counters (intentional,
+        # mirrors `mlx_backend.py:717-720` — do not "fix" with a `finally`).
+        loads = model.pop_moe_load()
+        if loads:
+            balancer.update(loads)
+            model.set_moe_biases(balancer.biases())
+            out["moe_util_var"] = max(MoEBalancer.utilization_variance(loads))
     return out
 
 
 def make_train_step(model, optimizer, *, grad_clip: float = 1.0,
-                    scaler=None) -> Callable:
+                    scaler=None, balancer=None) -> Callable:
     """Build a `train_step(model, micro_batches, lr) -> dict` (pretraining CE).
 
     `micro_batches` is a list of `(inputs, targets)` numpy pairs; the step averages
@@ -92,6 +115,8 @@ def make_train_step(model, optimizer, *, grad_clip: float = 1.0,
     grads are unscaled before the optimizer step. On a non-finite gradient the step is
     SKIPPED and the scale is backed off; the returned dict carries `loss_scale`/`skipped`.
     Pass None for fp32 (toy/smoke) — numerically identical to a plain unscaled step.
+    `balancer` (a `MoEBalancer`, #213/#214) is the Loss-Free-Balancing policy; None (the
+    default) for dense/hybrid models and for MoE configs with `moe_balance_rate` unset.
     """
     params = list(model.parameters())
 
@@ -105,8 +130,8 @@ def make_train_step(model, optimizer, *, grad_clip: float = 1.0,
         return F.cross_entropy(logits.reshape(-1, V).float(), t, reduction="mean")
 
     def train_step(model, micro_batches, lr: float) -> dict:
-        return _accumulate_and_step(optimizer, params, _loss, micro_batches, lr,
-                                    grad_clip, scaler)
+        return _accumulate_and_step(model, optimizer, params, _loss, micro_batches, lr,
+                                    grad_clip, scaler, balancer)
 
     return train_step
 
@@ -119,12 +144,13 @@ def make_train_step(model, optimizer, *, grad_clip: float = 1.0,
 # against. All four objectives share `_accumulate_and_step`.
 # --------------------------------------------------------------------------- #
 def make_sft_train_step(model, optimizer, *, grad_clip: float = 1.0,
-                        scaler=None) -> Callable:
+                        scaler=None, balancer=None) -> Callable:
     """Build an SFT `train_step(model, micro_batches, lr) -> dict` (masked CE).
 
     `micro_batches` is a list of `(inputs, targets, mask)` (the `SFTLoader` 3-tuple). The
     loss is the per-token cross-entropy averaged over the *response* tokens only:
     `sum(mask * CE) / sum(mask)`, so prompt/padding positions (mask 0) never contribute.
+    `balancer` (#213/#214) as in `make_train_step`.
     """
     params = list(model.parameters())
 
@@ -139,8 +165,8 @@ def make_sft_train_step(model, optimizer, *, grad_clip: float = 1.0,
         return (ce * m).sum() / torch.clamp(m.sum(), min=1.0)    # response-token mean
 
     def train_step(model, micro_batches, lr: float) -> dict:
-        return _accumulate_and_step(optimizer, params, _loss, micro_batches, lr,
-                                    grad_clip, scaler)
+        return _accumulate_and_step(model, optimizer, params, _loss, micro_batches, lr,
+                                    grad_clip, scaler, balancer)
 
     return train_step
 
@@ -161,14 +187,17 @@ def _masked_seq_logprob(model, inputs, targets, mask) -> torch.Tensor:
 
 
 def make_dpo_train_step(policy_model, ref_model, optimizer, *, beta: float = 0.1,
-                        grad_clip: float = 1.0, scaler=None) -> Callable:
+                        grad_clip: float = 1.0, scaler=None, balancer=None) -> Callable:
     """Build a DPO `train_step(model, micro_batches, lr) -> dict`.
 
     `micro_batches` is a list of the `DPOLoader` 6-tuple `(c_in, c_tgt, c_mask, r_in,
     r_tgt, r_mask)`. The loss is `-mean(log sigmoid(beta * (pi_logratio - ref_logratio)))`.
     Gradients flow through `policy_model` only: the optimizer holds the policy params and
     the reference forward runs under `torch.no_grad()` (and `ref_model` is a distinct
-    object never handed to the optimizer), so the reference stays frozen.
+    object never handed to the optimizer), so the reference stays frozen. `balancer`
+    (#213/#214) as in `make_train_step` — its `pop_moe_load`/`set_moe_biases` calls MUST
+    target `policy_model`, never `ref_model`: the reference is frozen and keeps whatever
+    bias its checkpoint carried (see `src/train/moe_balance.py`'s driver-wiring note).
     """
     params = list(policy_model.parameters())
 
@@ -183,20 +212,21 @@ def make_dpo_train_step(policy_model, ref_model, optimizer, *, beta: float = 0.1
         return -F.logsigmoid(margin).mean()
 
     def train_step(model, micro_batches, lr: float) -> dict:
-        return _accumulate_and_step(optimizer, params, _loss, micro_batches, lr,
-                                    grad_clip, scaler)
+        return _accumulate_and_step(policy_model, optimizer, params, _loss, micro_batches,
+                                    lr, grad_clip, scaler, balancer)
 
     return train_step
 
 
 def make_grpo_train_step(model, optimizer, *, grad_clip: float = 1.0,
-                         scaler=None) -> Callable:
+                         scaler=None, balancer=None) -> Callable:
     """Build a GRPO `train_step(model, micro_batches, lr) -> dict`.
 
     `micro_batches` is a list of `(inputs, targets, mask, advantages)`: sampled rollouts
     (mask = 1 on the completion tokens) and their group-standardized advantages (one per
     sequence, precomputed via `train.grpo.group_advantages`). The loss is
     `-mean(advantage * logpθ(completion))` — REINFORCE with the GRPO group baseline.
+    `balancer` (#213/#214) as in `make_train_step`.
     """
     params = list(model.parameters())
 
@@ -208,8 +238,8 @@ def make_grpo_train_step(model, optimizer, *, grad_clip: float = 1.0,
         return -(adv * logp).mean()
 
     def train_step(model, micro_batches, lr: float) -> dict:
-        return _accumulate_and_step(optimizer, params, _loss, micro_batches, lr,
-                                    grad_clip, scaler)
+        return _accumulate_and_step(model, optimizer, params, _loss, micro_batches, lr,
+                                    grad_clip, scaler, balancer)
 
     return train_step
 

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -607,11 +607,26 @@ class MoEBlock(nn.Module):
 
     def __init__(self, config: MambaConfig):
         super().__init__()
+        if config.moe_impl == "gather":
+            # Grouped-gather routing is a real dispatch-kernel change (CUDA-only, #214) —
+            # not something the dense MLX path can silently approximate. Fail loudly at
+            # construction rather than quietly falling back to dense under an explicit
+            # request for a different compute strategy.
+            raise NotImplementedError(
+                "moe_impl='gather' is CUDA-only (grouped-gather routing, #214); the MLX "
+                "backend only implements the dense (auto/dense) path."
+            )
         self.config = config
         self.norm = RMSNorm(config.d_model)
         self.router = nn.Linear(config.d_model, config.n_experts, bias=False)
         d_ff = config.moe_d_ff_resolved
         self.experts = [_Expert(config.d_model, d_ff) for _ in range(config.n_experts)]
+        # Shared experts (#214, DeepSeek-V2/V3 form): plain Python list exactly like
+        # `self.experts`, so `tree_flatten` gives `layers.{i}.shared_experts.{j}.*` for
+        # free. Combined ADDITIVELY in `_moe`, outside the router softmax/top-k
+        # renormalization — every token goes through every shared expert, unconditionally.
+        self.shared_experts = [_Expert(config.d_model, d_ff)
+                                for _ in range(config.n_shared_experts)]
         # Loss-Free-Balancing (#213 D1): a per-expert route BIAS and a per-expert LOAD-COUNT
         # accumulator. Both names start with an underscore ON PURPOSE — DO NOT "clean this
         # up". `nn.Module.valid_parameter_filter` is
@@ -723,6 +738,12 @@ class MoEBlock(nn.Module):
             gate = probs                                          # softmax already sums to 1
         outs = mx.stack([e(xn, cd) for e in self.experts], axis=-2)   # (..., E, d_model)
         y = mx.sum(gate[..., None] * _f32(outs), axis=-2)    # combine in fp32
+        if self.shared_experts:
+            # Additive, OUTSIDE the router softmax/top-k renormalization (DeepSeek-V2/V3
+            # form): shared experts see every token and are never gated. Guarded by the
+            # `if` (never `sum()` an empty generator) so `n_shared_experts=0` takes the
+            # exact same path as before #214 — byte-identical.
+            y = y + sum(_f32(se(xn, cd)) for se in self.shared_experts)
         return _cast(y, cd)
 
     def forward_seq(self, x: Array, seg_ids: Array = None) -> Array:

--- a/src/model/sizing.py
+++ b/src/model/sizing.py
@@ -130,7 +130,7 @@ def family_row(name: str, cfg: MambaConfig) -> dict:
         "tier": name,
         "params": n,
         "weights_gb": inference_bytes(cfg, "bf16") / GIB,   # bf16 weights == inference footprint
-        "train_gb": training_bytes(cfg)["total"] / GIB,
+        "train_gb": training_bytes(cfg, optimizer=cfg.optimizer_sizing_key)["total"] / GIB,
         "gpu_train": gpu,
         "ram_infer": ram,
     }

--- a/src/model/sizing.py
+++ b/src/model/sizing.py
@@ -24,14 +24,36 @@ GIB = 1024 ** 3
 # Bytes per element for the weight/activation dtype.
 BYTES_PER_DTYPE = {"fp32": 4, "fp16": 2, "bf16": 2}
 
-# Training memory ~ (weights + grads + optimizer state) per parameter. Both options
-# below are the epic's "VRAM-tight" levers vs the classic ~16 B/param fp32 AdamW:
-#   adamw    ~8 B/param : lean all-bf16 Adam — bf16 weight(2) + bf16 grad(2)
-#                         + bf16 Adam m,v(2+2), no fp32 master copy.
-#   adam8bit ~10 B/param: 8-bit Adam moments + an fp32 master weight copy for
-#                         stability — fp32 master(4) + bf16 weight(2) + bf16 grad(2)
-#                         + 8-bit m,v(1+1). The VRAM-tight lever called out in #65.
-OPTIMIZER_BYTES_PER_PARAM = {"adamw": 8, "adam8bit": 10}
+# Training memory ~ (weights + grads + optimizer state) per parameter, keyed by regime.
+# Four keys, two REGIMES (all-bf16 vs fp32-master), each with a plain/8-bit variant:
+#   adamw         ~8 B/param : lean ALL-BF16 Adam — bf16 weight(2) + bf16 grad(2) +
+#                              bf16 Adam m,v(2+2), no fp32 master copy. A real,
+#                              intentionally different regime from what this repo trains
+#                              (kept as a planning option; pinned on purpose at
+#                              `tests/test_sizing.py:109-110` — do not "fix" it to match
+#                              adam8bit).
+#   adam8bit      ~10 B/param: 8-bit Adam moments + an fp32 master weight copy for
+#                              stability — fp32 master(4) + bf16 weight(2) + bf16 grad(2)
+#                              + 8-bit m,v(1+1). The VRAM-tight lever called out in #65.
+#   adamw_fp32    ~16 B/param: classic FP32-MASTER AdamW — fp32 weight(4) + fp32 grad(4)
+#                              + fp32 Adam m,v(4+4). This is the regime THIS REPO
+#                              actually trains in: params stay fp32, cast to the
+#                              backend's compute dtype only at the matmul site (see
+#                              `cuda_backend.py`'s `_f32`/`_cast`, ~:202-221; mirrored on
+#                              MLX). `MambaConfig.optimizer_sizing_key` (#214) resolves
+#                              to this key when `optimizer_8bit` is False.
+#   adam8bit_fp32 ~10 B/param: 8-bit Adam moments on top of the same fp32-master weights
+#                              — numerically identical to `adam8bit` above (that key
+#                              already models an fp32 master copy), kept as a distinct
+#                              name so `optimizer_sizing_key` always names the regime
+#                              this repo is actually in rather than borrowing a key whose
+#                              docstring describes a different one.
+OPTIMIZER_BYTES_PER_PARAM = {
+    "adamw": 8,
+    "adam8bit": 10,
+    "adamw_fp32": 16,
+    "adam8bit_fp32": 10,
+}
 
 # Crude per-token activation footprint: a handful of (batch, seq, d_model) tensors
 # live per layer in the block (in_proj output ~2*d_inner, conv, ssm y, ...). We fold

--- a/src/train/checkpoint.py
+++ b/src/train/checkpoint.py
@@ -19,7 +19,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import numpy as np
 
@@ -115,6 +115,91 @@ def load_weights(model: Any, path: str) -> None:
             "Backend must implement `_load_portable(dict)` to map portable weights."
         )
     model._load_portable(weights)
+
+
+def load_config_sidecar(weights_path: str) -> Optional[Any]:
+    """Read `<weights_path>.config.json` and reconstruct a `MambaConfig` — the first
+    READER of the sidecar `save_weights` has been writing since day one (#214). Fields
+    in the JSON that are unknown to the CURRENT `MambaConfig` dataclass (e.g. a sidecar
+    written before a config field existed) are dropped, with a printed note, rather than
+    raising a `TypeError` from an unexpected kwarg. Returns `None` if no sidecar exists
+    (a legacy weights-only file, or one written without `config=`) — the caller decides
+    whether that is fatal (e.g. `scripts/upcycle.py` requires either a sidecar or an
+    explicit `--src-config`).
+    """
+    from dataclasses import fields
+    from ..model.blocks import MambaConfig     # local: keeps this module import-light
+
+    p = Path(str(weights_path) + ".config.json")
+    if not p.exists():
+        return None
+    raw = json.loads(p.read_text())
+    known = {f.name for f in fields(MambaConfig)}
+    dropped = sorted(set(raw) - known)
+    if dropped:
+        print(f"[load_config_sidecar] {p}: dropping fields unknown to this "
+              f"MambaConfig: {dropped}")
+    cfg = MambaConfig(**{k: v for k, v in raw.items() if k in known})
+    cfg.validate()
+    return cfg
+
+
+def check_weight_keys(weights: Dict[str, Any], expected: Dict[str, Any], *,
+                      where: str, cap: int = 10) -> None:
+    """Raise `ValueError` unless `weights` (a portable weight dict, or anything
+    `{name: array-like}`) matches `expected` (`{name: array-like}` OR `{name: shape
+    tuple}` — both accepted so callers can pass either a freshly-built model's
+    `_portable_state_dict()` or a precomputed shape table) EXACTLY: same key set, same
+    shapes. Missing, unexpected, AND mis-shaped keys are collected and reported TOGETHER
+    (each category capped at `cap` entries) rather than one raise per problem — a
+    `--init` from a slightly-wrong checkpoint should fail with the whole picture, not a
+    whack-a-mole loop of fix-one-rerun.
+
+    `moe_route_bias.*` keys are ignored on BOTH sides: they are non-parameter routing
+    state (see `MoEBlock.__init__` in either backend) that `_load_portable` pops before
+    the strict `load_state_dict` call this helper exists to guard, and an `expected`
+    built from a freshly-constructed (bias-inactive) model never contains them either —
+    treating them as ordinary keys would flag every balanced checkpoint's `--init` as
+    broken for a reason that isn't real.
+
+    Exists because MLX's `Module.update` (what `_load_portable` uses on that backend) is
+    silently lenient: a missing key leaves that parameter at random init, and a
+    wrong-shaped tensor is silently REBOUND rather than raising. CUDA's `strict=True`
+    catches both automatically; this makes the same guarantee available — and, per the
+    call sites in `scripts/{train,sft,dpo,rlvr}.py`, MANDATORY — on MLX too, so `--init`
+    is safe on either backend.
+    """
+    def _shapes(d: Dict[str, Any]) -> Dict[str, Tuple[int, ...]]:
+        out = {}
+        for k, v in d.items():
+            if k.startswith("moe_route_bias."):
+                continue
+            out[k] = tuple(int(x) for x in v) if isinstance(v, (tuple, list)) \
+                else tuple(np.asarray(v).shape)
+        return out
+
+    w, exp = _shapes(weights), _shapes(expected)
+    missing = sorted(set(exp) - set(w))
+    unexpected = sorted(set(w) - set(exp))
+    mismatched = sorted(k for k in (set(exp) & set(w)) if w[k] != exp[k])
+    if not (missing or unexpected or mismatched):
+        return
+
+    def _fmt(names):
+        shown = list(names[:cap])
+        more = f" (+{len(names) - cap} more)" if len(names) > cap else ""
+        return "[" + ", ".join(shown) + more + "]"
+
+    parts = []
+    if missing:
+        parts.append(f"missing {len(missing)}: {_fmt(missing)}")
+    if unexpected:
+        parts.append(f"unexpected {len(unexpected)}: {_fmt(unexpected)}")
+    if mismatched:
+        want = {k: exp[k] for k in mismatched[:cap]}
+        got = {k: w[k] for k in mismatched[:cap]}
+        parts.append(f"mis-shaped {len(mismatched)}: {_fmt(mismatched)} want={want} got={got}")
+    raise ValueError(f"weight-key check failed for {where}: " + "; ".join(parts))
 
 
 # --- within-backend resume: double-buffered, crash-safe ---------------------

--- a/src/train/upcycle.py
+++ b/src/train/upcycle.py
@@ -1,0 +1,337 @@
+"""Sparse-upcycle: turn a dense (degenerate `n_experts=1`) MoE checkpoint into a real
+`n_experts>1` MoE checkpoint that computes the SAME function at step 0 (#214).
+
+Portable — numpy + stdlib + `..model.blocks` only, NEVER `mlx` or `torch` (see
+`tests/test_import_guard.py::PORTABLE_MODULES`). This is what lets `scripts/upcycle.py`
+stay a standalone, offline, no-backend tool: the transform operates on plain
+`{name: np.ndarray}` dicts, exactly the shape `checkpoint.load_weights_dict` returns.
+
+Why the source must be `n_experts=1, top_k=1`, not a plain non-MoE config: at E=1,
+`softmax` over one logit is exactly 1.0 and `MoEBlock._moe` takes the `k == E` branch —
+the degenerate MoE block IS a plain SwiGLU FFN (see `MambaConfig.validate()`'s
+`n_experts == 1` carve-out). So #200's dense checkpoint is trained as a "1-expert MoE"
+from the start, and this module's whole trick is: replicate that one expert into every
+slot of the real (E>1) target, so every token's top_k selection sees `n_experts` COPIES
+of the function it was already computing. Combined with a fresh, additively-neutral
+router seed (below), the target reproduces the source's logits at step 0 EXACTLY, up to
+float rounding.
+
+**Deliberately NOT implemented: upcycling from a source with `n_experts > 1`.** Step-0
+exactness does not survive it — the target's top_k selection over N replicas of each of
+E>1 distinct experts does not select the same subset of "logical" experts the source's
+top_k selected, so the combined output changes. The E=1 restriction is not an
+implementation gap; it is the only case where this transform is exact.
+
+Also NOT implemented: width-changing upcycle (source `d_model` != target `d_model`).
+Expert replication only ADDS expert slots at a FIXED width — it cannot widen the
+existing tensors. Widening is Net2Net / bert2BERT-style function-preserving width
+expansion, a materially different technique this module does not implement. See the
+`d_model` mismatch branch of `check_upcycle_compatible` and the open #223 issue (Large
+A's `d_model` relative to the dense checkpoint's is not yet decided).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Tuple
+
+import numpy as np
+
+from ..model.blocks import MambaConfig
+
+# Fields that MUST agree between the source and target config for the transform to be
+# well-defined. Deliberately compares RESOLVED properties (`dt_rank_resolved`, `d_inner`,
+# `n_heads`, `n_attn_heads_resolved`, `moe_d_ff_resolved`) rather than the raw
+# `Optional[str|int]` fields (`dt_rank`, `moe_d_ff`) they derive from, so `"auto"`/`None`
+# on one side and an equal concrete value on the other compare equal — exactly how the
+# two configs' TENSORS would compare.
+_MUST_MATCH = (
+    "d_model", "n_layers", "d_state", "expand", "d_conv", "head_dim",
+    "dt_rank_resolved", "d_inner", "n_heads", "vocab_size", "tie_embeddings",
+    "attn_every", "n_attn_heads_resolved", "moe_every", "moe_d_ff_resolved",
+)
+
+_EXPERT_LINS = ("gate", "up", "down")
+# Kept in lockstep with `MLXMambaModel._portable_state_dict` / `CUDAMambaModel.
+# _portable_state_dict` (verified byte-identical between the two backends). Not a
+# parameter — see `MoEBlock.__init__` in either backend for why the leading underscore
+# excludes it from `parameters()`/`named_parameters()`.
+_MOE_BIAS_PREFIX = "moe_route_bias."
+
+
+class UpcycleError(ValueError):
+    """Raised for any source/target config mismatch or malformed source checkpoint that
+    would make the upcycle transform ill-defined."""
+
+
+def check_upcycle_compatible(src_cfg: MambaConfig, dst_cfg: MambaConfig) -> None:
+    """Raise `UpcycleError` unless `src_cfg` is a valid dense-upcycle source for
+    `dst_cfg`. Reports EVERY mismatch at once (not just the first) — one-at-a-time
+    raises are exactly how a run ends up mis-dimensioned (#223): a fix-one/re-run loop
+    can silently stop after clearing the first error while a second, unrelated mismatch
+    is still live.
+    """
+    if not (src_cfg.n_experts == 1 and src_cfg.top_k == 1):
+        raise UpcycleError(
+            f"upcycle source must be a degenerate n_experts=1/top_k=1 MoE block (a "
+            f"plain dense SwiGLU FFN in disguise — see the module docstring), got "
+            f"n_experts={src_cfg.n_experts} top_k={src_cfg.top_k}. An ALREADY-MoE "
+            "checkpoint is not a valid upcycle source "
+            "(docs/design/13-code-model-moe.md:234-255): start from #200's dense "
+            "checkpoint (trained with n_experts=1, top_k=1) instead."
+        )
+
+    mismatches = []
+    for name in _MUST_MATCH:
+        sv, dv = getattr(src_cfg, name), getattr(dst_cfg, name)
+        if sv != dv:
+            mismatches.append((name, sv, dv))
+
+    src_moe = {i for i in range(src_cfg.n_layers) if src_cfg.is_moe_layer(i)}
+    dst_moe = {i for i in range(dst_cfg.n_layers) if dst_cfg.is_moe_layer(i)}
+    moe_set_mismatch = src_moe != dst_moe
+    if moe_set_mismatch:
+        mismatches.append(("moe_layer_indices", sorted(src_moe), sorted(dst_moe)))
+
+    if not mismatches:
+        return
+
+    lines = [f"  {name}: src={sv!r} dst={dv!r}" for name, sv, dv in mismatches]
+    msg = ("upcycle requires the source and target configs to agree on every "
+           "non-expert dimension; found mismatch(es):\n" + "\n".join(lines))
+    if any(name == "d_model" for name, _, _ in mismatches):
+        # A dedicated paragraph, not just another bullet: this is the one mismatch that
+        # is NOT a config-fixing exercise — expert replication (this module) cannot
+        # widen tensors at all.
+        msg += (
+            "\n\nd_model differs between source and target: expert REPLICATION (what "
+            "this module does) can only add expert SLOTS at a fixed width — it cannot "
+            "widen the underlying tensors. Widening a checkpoint is Net2Net / "
+            "bert2BERT-style function-preserving width expansion, a different "
+            "technique that is not implemented here. This is the open #223 question "
+            "(Large A's d_model relative to the dense source) — resolve it there "
+            "before attempting a width-changing upcycle."
+        )
+    raise UpcycleError(msg)
+
+
+def upcycle_dense_to_moe(weights: Dict[str, np.ndarray], src_cfg: MambaConfig,
+                         dst_cfg: MambaConfig, *, seed: int,
+                         router_init_scale: float = 1.0,
+                         shared_expert_init: str = "zero_down") -> Dict[str, np.ndarray]:
+    """Transform a dense (`src_cfg`, `n_experts=1`) portable weight dict into a real MoE
+    (`dst_cfg`, `n_experts>1`) one, exact at step 0.
+
+    Per MoE layer (layer indices come from `dst_cfg.is_moe_layer`, NEVER from key-pattern
+    sniffing — the configs are the source of truth; key patterns are used only to
+    validate the source actually has what `src_cfg` claims):
+
+      * Experts — `.copy()` `experts.0.{gate,up,down}.weight` into all `dst_cfg.n_experts`
+        slots. `.copy()`, not a shared reference: `load_weights_dict` returns
+        safetensors-backed arrays that may be read-only mmaps, and even when they are
+        not, aliasing would make an in-place training update to one "expert" silently
+        mutate all of them.
+      * Router — the source's `[1, d_model]` router is DISCARDED (a 1-row router carries
+        no routing information to preserve) and replaced with a fresh
+        `U(-router_init_scale/sqrt(d_model), +router_init_scale/sqrt(d_model))` draw from
+        `np.random.default_rng(seed)`, filled in ascending MoE-layer-index order for
+        reproducibility. That bound is exactly what both backends' `nn.Linear` init
+        already produces at `router_init_scale=1.0` (MLX: `U(±1/sqrt(fan_in))`; torch:
+        `kaiming_uniform_(a=sqrt(5))` reduces to the same bound for a linear layer) — so
+        this introduces no new magic constant. Router init does not threaten step-0
+        exactness: EVERY expert computes the identical function (copied from the same
+        source expert), so no matter which top_k the fresh router selects, or what
+        renormalized gate weights it assigns them, the weighted combination of top_k
+        IDENTICAL functions equals that same function again (weights sum to 1 after
+        renormalization).
+      * Shared experts (`dst_cfg.n_shared_experts`) — DeepSeek-V2/V3-style, additive and
+        OUTSIDE the router softmax (see `MoEBlock._moe`). For an index `j` present in
+        BOTH configs (`j < src_cfg.n_shared_experts`), the source's shared expert is
+        copied through unchanged. For a NEW index (`j >= src_cfg.n_shared_experts`,
+        including the common `n_shared_experts: 0 -> 1` case), the default
+        `shared_expert_init="zero_down"` draws a fresh `gate`/`up` at the same
+        `U(±1/sqrt(fan_in))` bound and sets `down` to EXACT ZEROS. A shared expert
+        contributes `down(silu(gate(x)) * up(x))`; zeroing `down` makes the WHOLE
+        expression identically zero regardless of `gate`/`up`, which is what makes step-0
+        exactness hold REGARDLESS of how the block combines the shared and routed paths
+        (additive, gated, pre- or post-norm — whatever the combination formula turns out
+        to be). This is why zeroing `down` beats the naive "split the dense FFN width in
+        half between routed and shared": that alternative is also exact, but only under
+        the SPECIFIC combination formula it was derived for, and silently wrong under any
+        other. `shared_expert_init="forbid"` raises instead of synthesizing a new shared
+        expert (the escape hatch for a caller that wants an error, not a guess, when the
+        configs disagree on shared-expert count).
+      * `moe_route_bias.*` — dropped unconditionally, from every layer. PROVABLY lossless
+        at `n_experts=1`: `MoEBalancer.update` moves each layer's bias by
+        `rate * sign(mean(load) - load_i)`; with exactly one expert, `load_i IS the
+        mean(load)` for every step, so `sign(0) == 0` and the bias is 0 forever (also
+        enforced structurally: `MambaConfig.validate()` REQUIRES `moe_balance_rate is
+        None` whenever `n_experts == 1`, so a #214-era dense source could not have a
+        nonzero bias to begin with). Even if a stray length-1 bias vector were present,
+        it could not be broadcast onto a length-`dst_cfg.n_experts` router bias at any
+        `n_experts > 1` — so dropping it is both correct and the only option.
+
+    Every OTHER key (embedding, non-MoE layers, norms, the LM head if untied) is copied
+    through unchanged; `check_upcycle_compatible` having already required identical
+    non-expert dimensions and an identical MoE-layer-index SET means a non-MoE-layer
+    key's name and shape are identical in both configs by construction.
+
+    Raises `UpcycleError` (via `check_upcycle_compatible`) on any config mismatch, on a
+    source checkpoint missing an expected `experts.0.*` key, on an unknown
+    `shared_expert_init`, or if the final output's key set/shapes don't exactly match
+    `dst_cfg`'s expected layout (an internal consistency assertion, not something a
+    caller should be able to trigger with a valid source+configs).
+    """
+    check_upcycle_compatible(src_cfg, dst_cfg)
+    if shared_expert_init not in ("zero_down", "forbid"):
+        raise UpcycleError(
+            f"unknown shared_expert_init {shared_expert_init!r} "
+            "(expected 'zero_down' or 'forbid')"
+        )
+
+    rng = np.random.default_rng(seed)
+    out: Dict[str, np.ndarray] = {
+        k: v for k, v in weights.items() if not k.startswith(_MOE_BIAS_PREFIX)
+    }
+
+    d_model = dst_cfg.d_model
+    d_ff = dst_cfg.moe_d_ff_resolved
+    router_bound = router_init_scale / math.sqrt(d_model)
+    gate_up_bound = 1.0 / math.sqrt(d_model)          # fan_in of gate/up is d_model
+
+    moe_idx = sorted(i for i in range(dst_cfg.n_layers) if dst_cfg.is_moe_layer(i))
+    for i in moe_idx:
+        prefix = f"layers.{i}."
+        src_expert = {}
+        for lin in _EXPERT_LINS:
+            key = f"{prefix}experts.0.{lin}.weight"
+            if key not in weights:
+                raise UpcycleError(
+                    f"source weights are missing {key!r} — layer {i} is a MoE layer in "
+                    "both configs, so the source (n_experts=1) must carry a single "
+                    "experts.0.* expert there."
+                )
+            src_expert[lin] = np.asarray(weights[key])
+
+        # Drop whatever expert keys the source had at this layer (exactly experts.0.*
+        # for a valid src_cfg, but be robust) before writing the dst_cfg.n_experts copies.
+        for k in list(out.keys()):
+            if k.startswith(f"{prefix}experts."):
+                del out[k]
+        for j in range(dst_cfg.n_experts):
+            for lin in _EXPERT_LINS:
+                out[f"{prefix}experts.{j}.{lin}.weight"] = src_expert[lin].copy()
+
+        out[f"{prefix}router.weight"] = rng.uniform(
+            -router_bound, router_bound, size=(dst_cfg.n_experts, d_model)
+        ).astype(np.float32)
+
+        for j in range(dst_cfg.n_shared_experts):
+            se_prefix = f"{prefix}shared_experts.{j}."
+            if j < src_cfg.n_shared_experts:
+                continue                              # already in `out`, copied through
+            if shared_expert_init == "forbid":
+                raise UpcycleError(
+                    f"target has shared expert {j} at layer {i} with no source "
+                    "counterpart (src n_shared_experts="
+                    f"{src_cfg.n_shared_experts}), and shared_expert_init='forbid' "
+                    "rejects synthesizing a new one."
+                )
+            out[f"{se_prefix}gate.weight"] = rng.uniform(
+                -gate_up_bound, gate_up_bound, size=(d_ff, d_model)).astype(np.float32)
+            out[f"{se_prefix}up.weight"] = rng.uniform(
+                -gate_up_bound, gate_up_bound, size=(d_ff, d_model)).astype(np.float32)
+            # Exact zeros: down(silu(gate(x)) * up(x)) is identically 0 regardless of
+            # gate/up, which is the whole trick (see the docstring above).
+            out[f"{se_prefix}down.weight"] = np.zeros((d_model, d_ff), dtype=np.float32)
+        # A target with FEWER shared experts than the source (unusual, but not excluded
+        # by check_upcycle_compatible) drops the extras rather than carrying dead keys.
+        for k in list(out.keys()):
+            if k.startswith(f"{prefix}shared_experts."):
+                j = int(k[len(f"{prefix}shared_experts."):].split(".", 1)[0])
+                if j >= dst_cfg.n_shared_experts:
+                    del out[k]
+
+    expected = _expected_keys(dst_cfg)
+    got_keys = set(out)
+    if got_keys != set(expected):
+        missing = sorted(set(expected) - got_keys)
+        unexpected = sorted(got_keys - set(expected))
+        raise UpcycleError(
+            "internal error: upcycle output key set does not match dst_cfg's expected "
+            f"layout — missing={missing[:10]} unexpected={unexpected[:10]}"
+        )
+    bad_shape = sorted(
+        k for k, shp in expected.items() if tuple(np.asarray(out[k]).shape) != shp
+    )
+    if bad_shape:
+        raise UpcycleError(
+            "internal error: upcycle output has wrong shapes for: "
+            f"{[(k, tuple(np.asarray(out[k]).shape), expected[k]) for k in bad_shape[:10]]}"
+        )
+    return out
+
+
+def _expected_keys(cfg: MambaConfig) -> Dict[str, Tuple[int, ...]]:
+    """Portable mirror of `MLXMambaModel._portable_state_dict()` /
+    `CUDAMambaModel._portable_state_dict()`'s key layout (verified byte-identical between
+    the two backends), used ONLY as `upcycle_dense_to_moe`'s internal safety-net
+    assertion — this module deliberately never imports a backend to build a real model.
+    Keep in lockstep with both backends; `tests/test_upcycle.py` cross-checks this
+    against a real MLX model's `_portable_state_dict()` keys so a drift here is caught
+    immediately rather than silently defeating the assertion it exists to make."""
+    d_model, d_inner, H, N = cfg.d_model, cfg.d_inner, cfg.n_heads, cfg.d_state
+    dt_rank = cfg.dt_rank_resolved
+    out: Dict[str, Tuple[int, ...]] = {"embedding.weight": (cfg.vocab_size, d_model)}
+    for i in range(cfg.n_layers):
+        p = f"layers.{i}."
+        out[f"{p}norm.weight"] = (d_model,)
+        if cfg.is_attention_layer(i):
+            nah, dh = cfg.n_attn_heads_resolved, cfg.attn_head_dim
+            d_attn = nah * dh
+            out[f"{p}qkv_proj.weight"] = (3 * d_attn, d_model)
+            out[f"{p}o_proj.weight"] = (d_model, d_attn)
+        elif cfg.is_moe_layer(i):
+            d_ff = cfg.moe_d_ff_resolved
+            out[f"{p}router.weight"] = (cfg.n_experts, d_model)
+            for j in range(cfg.n_experts):
+                out[f"{p}experts.{j}.gate.weight"] = (d_ff, d_model)
+                out[f"{p}experts.{j}.up.weight"] = (d_ff, d_model)
+                out[f"{p}experts.{j}.down.weight"] = (d_model, d_ff)
+            for j in range(cfg.n_shared_experts):
+                out[f"{p}shared_experts.{j}.gate.weight"] = (d_ff, d_model)
+                out[f"{p}shared_experts.{j}.up.weight"] = (d_ff, d_model)
+                out[f"{p}shared_experts.{j}.down.weight"] = (d_model, d_ff)
+        else:
+            out[f"{p}in_proj.weight"] = (2 * d_inner, d_model)
+            out[f"{p}conv.weight"] = (d_inner, cfg.d_conv, 1)   # MLX-canonical (out,k,in/groups)
+            out[f"{p}conv.bias"] = (d_inner,)
+            out[f"{p}ssm.x_proj.weight"] = (dt_rank + 2 * N, d_inner)
+            out[f"{p}ssm.dt_proj.weight"] = (H, dt_rank)
+            out[f"{p}ssm.dt_proj.bias"] = (H,)
+            out[f"{p}ssm.A_log"] = (H,)
+            out[f"{p}ssm.D"] = (H,)
+            out[f"{p}out_proj.weight"] = (d_model, d_inner)
+    out["norm_f.weight"] = (d_model,)
+    if not cfg.tie_embeddings:
+        out["lm_head.weight"] = (cfg.vocab_size, d_model)
+    return out
+
+
+def upcycle_manifest(*, src: str, src_sha256: str, seed: int, router_init_scale: float,
+                     shared_expert_init: str, src_cfg: MambaConfig,
+                     dst_cfg: MambaConfig) -> Dict[str, Any]:
+    """The `<out>.upcycle.json` sidecar `scripts/upcycle.py` writes: enough to know
+    exactly what produced an upcycled checkpoint (and to re-run it) without re-deriving
+    anything from the weights themselves."""
+    moe_layers = sorted(i for i in range(dst_cfg.n_layers) if dst_cfg.is_moe_layer(i))
+    return {
+        "src": str(src),
+        "src_sha256": src_sha256,
+        "seed": int(seed),
+        "router_init_scale": float(router_init_scale),
+        "shared_expert_init": shared_expert_init,
+        "n_experts_src": src_cfg.n_experts,
+        "n_experts_dst": dst_cfg.n_experts,
+        "moe_layers": moe_layers,
+    }

--- a/tests/test_cuda_8bit_optimizer.py
+++ b/tests/test_cuda_8bit_optimizer.py
@@ -1,0 +1,108 @@
+"""8-bit AdamW moments (#214), an orthogonal axis to `optimizer` composing with the Muon
+hybrid — see `MambaConfig.optimizer_8bit` and `backend.py::_cuda_backend._make_optimizer`'s
+`_adamw` helper.
+
+`bitsandbytes` ships CUDA-only prebuilt wheels (no CPU/macOS wheel at all), so its actual
+8-bit numerics are UNVERIFIABLE without a real CUDA box with the `[cuda-8bit]` extra
+installed — see docs/infrastructure.md's manual-verification checklist. What runs here,
+everywhere, without a GPU: the config surface, the sizing-table consequence, the MLX
+rejection, and — the load-bearing one — that a missing `bitsandbytes` install surfaces as
+a legible `SystemExit` naming the `[cuda-8bit]` extra rather than a bare `ModuleNotFoundError`
+or (worse) a silent 32-bit fallback. `tests/test_import_guard.py`'s `FORBIDDEN_ROOTS` proves
+the import itself stays lazy (bitsandbytes never lands in `sys.modules` from importing
+`src.model.backend` alone).
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.backend import get_backend
+from src.model.blocks import MambaConfig, load_config
+from src.model.cuda_backend import CUDAMambaModel
+
+
+def _cfg(**over):
+    base = dict(d_model=64, n_layers=2, head_dim=16, d_state=16, vocab_size=256,
+                seq_len=32, precision="fp32")
+    base.update(over)
+    return MambaConfig(**base)
+
+
+# --------------------------------------------------------------------------- #
+# Config surface
+# --------------------------------------------------------------------------- #
+def test_optimizer_8bit_defaults_off():
+    cfg = _cfg()
+    assert cfg.optimizer_8bit is False
+    cfg.validate()                                  # must not raise
+
+
+def test_optimizer_8bit_composes_with_muon():
+    """Orthogonal axis, not a third `optimizer` enum value — `optimizer_8bit=True` must
+    validate cleanly alongside `optimizer: muon` (the plan's stated composition point;
+    the doc pass notes the memory payoff is small there, but it must still validate)."""
+    cfg = _cfg(optimizer="muon", optimizer_8bit=True)
+    cfg.validate()
+
+
+def test_toy_moe_8bit_fixture_loads_and_validates():
+    cfg = load_config("config/toy-moe-8bit.yaml")
+    assert cfg.optimizer == "adamw"
+    assert cfg.optimizer_8bit is True
+
+
+# --------------------------------------------------------------------------- #
+# Sizing-table consequence (#214's `optimizer_sizing_key` property)
+# --------------------------------------------------------------------------- #
+def test_optimizer_sizing_key_reflects_8bit():
+    assert _cfg(optimizer_8bit=False).optimizer_sizing_key == "adamw_fp32"
+    assert _cfg(optimizer_8bit=True).optimizer_sizing_key == "adam8bit_fp32"
+
+
+# --------------------------------------------------------------------------- #
+# MLX rejection — mirrors the existing Muon raise (backend.py::_mlx_backend)
+# --------------------------------------------------------------------------- #
+def test_mlx_backend_raises_on_optimizer_8bit():
+    pytest.importorskip("mlx")
+    cfg = _cfg(optimizer_8bit=True)
+    backend = get_backend("mlx")
+    model = backend.model_cls(cfg)
+    with pytest.raises(NotImplementedError):
+        backend.make_optimizer(model, 1e-3)
+
+
+# --------------------------------------------------------------------------- #
+# CUDA: legible SystemExit when bitsandbytes is absent (the box this suite runs on)
+# --------------------------------------------------------------------------- #
+def test_cuda_backend_raises_legible_systemexit_without_bitsandbytes():
+    pytest.importorskip("torch")
+    if _bitsandbytes_available():
+        pytest.skip("bitsandbytes IS installed here — the absent-dependency path is "
+                     "untestable on this box; see the manual pod checklist instead.")
+    cfg = _cfg(optimizer_8bit=True)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    backend = get_backend("cuda")
+    with pytest.raises(SystemExit, match=r"cuda-8bit"):
+        backend.make_optimizer(model, 1e-3)
+
+
+def test_cuda_backend_adamw_muon_hybrid_also_raises_without_bitsandbytes():
+    """The `_adamw` helper is shared by both the `adamw` branch AND the `muon` branch's
+    AdamW remainder side — this pins that the switch fires on the muon path too, not
+    just the pure-adamw one (the whole point of factoring it into one helper)."""
+    pytest.importorskip("torch")
+    if _bitsandbytes_available():
+        pytest.skip("bitsandbytes IS installed here — see the manual pod checklist instead.")
+    cfg = _cfg(optimizer="muon", optimizer_8bit=True)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    backend = get_backend("cuda")
+    with pytest.raises(SystemExit, match=r"cuda-8bit"):
+        backend.make_optimizer(model, 1e-3)
+
+
+def _bitsandbytes_available() -> bool:
+    import importlib.util
+    return importlib.util.find_spec("bitsandbytes") is not None

--- a/tests/test_cuda_fp8.py
+++ b/tests/test_cuda_fp8.py
@@ -1,33 +1,42 @@
-"""fp8 MoE-expert linears via NVIDIA Transformer Engine (#240, DESIGN-ONLY).
+"""fp8 MoE-expert linears via NVIDIA Transformer Engine (#214/#240, LIVE).
 
-#240 is blocked on #214 (CUDA MoE backend — no `_Expert`/`MoEBlock` exists in
-`cuda_backend.py` yet), so only the pieces that don't need a CUDA MoE expert are
-tested live here: the `_te_linear_cls()` capability probe and the `fp8_experts`
-config-validation rules. The bf16-vs-fp8 forward-equivalence + finite-grad-under-
-checkpoint acceptance tests (the real #240 payoff) are recorded as skipped
-placeholders so the intent survives to the #214 landing, when they get un-skipped
-and filled in against the real CUDA `_Expert`.
-
-This whole module SKIPS its Hopper/TE-specific tests on the non-Hopper Mac/CI box
-(no CUDA, no `transformer_engine` installed) — only the probe/validate tests run
-there, and they must PASS everywhere (they assert graceful absence, not presence).
+The `_te_linear_cls()` capability probe and the `fp8_experts` config-validation rules
+are plain-CPU testable and run everywhere. The bf16-vs-fp8 forward-equivalence +
+finite-grad-under-checkpoint acceptance tests need real Hopper+ hardware with
+`transformer_engine` installed (the `cuda-fp8` extra) — they build a real CUDA MoE
+model via `_Expert`/`MoEBlock` (#214) and exercise the fp8 GEMM/checkpoint wiring, so
+they stay GPU-gated behind the `_hopper` fixture and SKIP everywhere else, including
+CI's `cuda-cpu` job (CPU torch, no CUDA device at all).
 """
 
+import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")
+import torch.nn.functional as F  # noqa: E402
 
-from src.model.blocks import load_config
-from src.model.cuda_backend import _te_linear_cls, fp8_status
+from src.model.blocks import MambaConfig, load_config  # noqa: E402
+from src.model.cuda_backend import (CUDAMambaModel, MoEBlock, _te_linear_cls,  # noqa: E402
+                                    fp8_status)
 
 
 @pytest.fixture(scope="module")
 def _hopper():
-    """Skip if there's no Hopper+ (sm_90) CUDA device — mirrors `_compile_works` in
-    test_cuda_compile.py. TE-specific acceptance tests build on this; the probe test
-    below does NOT use this fixture, since it must run (and pass) on the Mac box too."""
-    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 9:
-        pytest.skip("no Hopper+ (sm_90) CUDA device here")
+    """Skip unless BOTH a Hopper+ (sm_90) CUDA device AND `transformer_engine` are
+    present — `fp8_status()` is exactly that combined probe (mirrors `_compile_works`
+    in test_cuda_compile.py). Building an fp8 model without this fixture would just
+    silently fall back to bf16 `nn.Linear`, defeating the point of these tests. The
+    probe/validate tests above do NOT use this fixture, since they must run (and
+    pass) on the non-Hopper Mac/CI box too."""
+    if not fp8_status():
+        pytest.skip("no Hopper+ (sm_90) CUDA device with transformer_engine installed here")
+
+
+def _moe_config(**over):
+    base = dict(d_model=64, n_layers=4, head_dim=16, d_state=16, vocab_size=256,
+                seq_len=32, precision="bf16", moe_every=2, n_experts=4, top_k=2)
+    base.update(over)
+    return MambaConfig(**base)
 
 
 def test_te_linear_cls_returns_none_without_crashing():
@@ -74,21 +83,94 @@ def test_fp8_experts_default_off_is_unaffected():
     cfg.validate()
 
 
-@pytest.mark.skip(reason="BLOCKED-ON-#214: no CUDA MoE _Expert/MoEBlock to build fp8 "
-                          "linears against yet; un-skip once #214 lands.")
 def test_fp8_expert_forward_matches_bf16(_hopper):
-    """Acceptance (deferred): a fp8-expert MoE forward should match the bf16-expert
-    forward within an fp8-appropriate tolerance (NOT the 1e-4 fp32 parity bar — fp8
-    e4m3 has ~2 decimal digits; expect ~1e-1 rel or a loss-delta bound). Needs #214's
-    CUDA `_Expert`/`MoEBlock` to exist before this can build a model."""
-    raise NotImplementedError
+    """An fp8-expert MoE forward should be CLOSE to (not equal to) its bf16-expert
+    twin, both built from the same weights so the only difference under test is the
+    expert GEMM precision:
+      * finite logits — fp8 GEMMs aren't a NaN factory
+      * ROUTING bit-identical at ZERO tolerance — the router is a plain `nn.Linear`
+        that always routes in fp32 (`MoEBlock._fp8_ctx` wraps the expert GEMMs only,
+        never the router), so fp8 must not leak into the routing DECISION even though
+        the expert VALUES it dispatches to differ
+      * an fp8-honest logit bound (~10% of the logit scale, NOT the usual 1e-4 fp32
+        parity bar — e4m3 has only 3 mantissa bits)
+      * loss agreement within ~5% — the hard gate
+    """
+    cfg_bf16 = _moe_config()
+    cfg_fp8 = _moe_config(fp8_experts=True)
+    cfg_bf16.validate()
+    cfg_fp8.validate()
+
+    torch.manual_seed(0)
+    model_bf16 = CUDAMambaModel(cfg_bf16, device="cuda")
+    model_fp8 = CUDAMambaModel(cfg_fp8, device="cuda")
+    # Same weights for both — an fp8 vs bf16 GEMM is the only variable under test; a
+    # different random init would confound the comparison.
+    model_fp8.load_state_dict(model_bf16.state_dict(), strict=True)
+    model_bf16.eval()
+    model_fp8.eval()
+    model_bf16.set_moe_load_counting(True)
+    model_fp8.set_moe_load_counting(True)
+
+    tokens = np.random.default_rng(0).integers(
+        0, cfg_bf16.vocab_size, size=(2, 32)).astype(np.int32)
+    with torch.no_grad():
+        logits_bf16 = model_bf16.forward(tokens)
+        logits_fp8 = model_fp8.forward(tokens)
+
+    assert torch.isfinite(logits_fp8).all()
+
+    loads_bf16 = model_bf16.pop_moe_load()
+    loads_fp8 = model_fp8.pop_moe_load()
+    assert loads_fp8 == loads_bf16, (loads_fp8, loads_bf16)   # zero-tolerance routing identity
+
+    scale = logits_bf16.abs().mean().item()
+    max_diff = (logits_fp8 - logits_bf16).abs().max().item()
+    assert max_diff < 0.10 * scale, (max_diff, scale)
+
+    targets = torch.as_tensor(
+        np.random.default_rng(1).integers(0, cfg_bf16.vocab_size, size=(2, 32)),
+        dtype=torch.long, device=logits_bf16.device)
+    loss_bf16 = F.cross_entropy(logits_bf16.reshape(-1, cfg_bf16.vocab_size), targets.reshape(-1))
+    loss_fp8 = F.cross_entropy(logits_fp8.reshape(-1, cfg_bf16.vocab_size), targets.reshape(-1))
+    assert abs(loss_fp8.item() - loss_bf16.item()) < 0.05 * abs(loss_bf16.item())
 
 
-@pytest.mark.skip(reason="BLOCKED-ON-#214: no CUDA MoE _Expert/MoEBlock to build fp8 "
-                          "linears against yet; un-skip once #214 lands.")
-def test_fp8_expert_checkpoint_backward_finite_grads(_hopper):
-    """Acceptance (deferred): fp8 experts under grad-checkpoint (using
-    `transformer_engine.pytorch.checkpoint`, not `torch.utils.checkpoint` — see the
-    `# BLOCKED-ON-#214` note in cuda_backend.py) should backprop to finite grads.
-    Needs #214's CUDA `_Expert`/`MoEBlock` to exist before this can build a model."""
-    raise NotImplementedError
+def test_fp8_expert_checkpoint_backward_finite_grads(_hopper, monkeypatch):
+    """fp8 experts under grad-checkpoint must use `transformer_engine.pytorch.
+    checkpoint`, NOT `torch.utils.checkpoint` (plain checkpoint's recompute pass
+    double-updates the fp8 amax history TE uses to calibrate its scale). "Grads are
+    finite" alone would also pass with the WRONG checkpoint function, so this also
+    monkeypatches `te.checkpoint` with a call counter to prove it was actually
+    selected — the sharp assertion this test exists for."""
+    import transformer_engine.pytorch as te
+    calls = {"n": 0}
+    real_checkpoint = te.checkpoint
+
+    def _counting_checkpoint(*args, **kwargs):
+        calls["n"] += 1
+        return real_checkpoint(*args, **kwargs)
+
+    monkeypatch.setattr(te, "checkpoint", _counting_checkpoint)
+
+    cfg = _moe_config(fp8_experts=True, grad_checkpoint=True)
+    cfg.validate()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg, device="cuda")
+    model.train()
+
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(2, 32)).astype(np.int32)
+    logits = model.forward(tokens)
+    logits.float().sum().backward()
+
+    assert calls["n"] > 0, "te.checkpoint was never called — wrong checkpoint fn selected"
+
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    any_nonzero = False
+    for expert in block.experts:
+        for p in expert.parameters():
+            assert p.grad is not None, "expert param has no grad (no-continue invariant broken)"
+            assert torch.isfinite(p.grad).all()
+            if torch.any(p.grad != 0):
+                any_nonzero = True
+    assert any_nonzero, "no routed expert received a non-zero grad"

--- a/tests/test_cuda_moe.py
+++ b/tests/test_cuda_moe.py
@@ -1,0 +1,212 @@
+"""CUDA/PyTorch twin of tests/test_moe.py (#214): the CUDA MoE block, mirroring the MLX
+dense reference plus the new grouped-gather routing.
+
+Skipped where torch is unavailable (runs on CPU — no GPU needed, like the rest of the
+`test_cuda_*` suite).
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+import torch.nn.functional as F  # noqa: E402
+
+from src.model.blocks import MambaConfig  # noqa: E402
+from src.model.cuda_backend import CUDAMambaModel, MambaBlock, MoEBlock  # noqa: E402
+
+
+def _cfg(**over):
+    base = dict(d_model=64, n_layers=4, head_dim=16, d_state=16, vocab_size=256,
+                seq_len=32, precision="fp32", moe_every=2, n_experts=4, top_k=2)
+    base.update(over)
+    return MambaConfig(**base)
+
+
+def _np(a):
+    return a.detach().cpu().numpy()
+
+
+def _moe_block(model):
+    return next(l for l in model.layers if isinstance(l, MoEBlock))
+
+
+# --------------------------------------------------------------------------- #
+# Block types + param accounting
+# --------------------------------------------------------------------------- #
+def test_moe_model_builds_with_expected_block_types():
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    types = [type(l).__name__ for l in model.layers]
+    assert types == ["MambaBlock", "MoEBlock", "MambaBlock", "MoEBlock"]
+
+
+def test_moe_param_count_matches_formula():
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    actual = sum(int(v.size) for v in model._portable_state_dict().values())
+    assert cfg.num_parameters() == actual
+
+
+def test_moe_shared_expert_param_count_matches_formula():
+    cfg = _cfg(n_shared_experts=1)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    block = _moe_block(model)
+    assert len(block.shared_experts) == 1
+    actual = sum(int(v.size) for v in model._portable_state_dict().values())
+    assert cfg.num_parameters() == actual
+
+
+# --------------------------------------------------------------------------- #
+# forward/step parity (MoE is pointwise -> trivially exact, but pinned anyway)
+# --------------------------------------------------------------------------- #
+def test_moe_forward_step_parity():
+    from src.conformance.forward_step_parity import check_forward_step_parity
+
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(2, 32)).astype(np.int32)
+    with torch.no_grad():
+        result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
+    assert result["ok"], result
+
+
+@pytest.mark.parametrize("impl", ["dense", "gather"])
+def test_moe_forward_step_parity_both_impls(impl):
+    from src.conformance.forward_step_parity import check_forward_step_parity
+
+    cfg = _cfg(moe_impl=impl)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    tokens = np.random.default_rng(1).integers(0, cfg.vocab_size, size=(2, 32)).astype(np.int32)
+    with torch.no_grad():
+        result = check_forward_step_parity(model, tokens, to_numpy=_np, rtol=1e-4, atol=1e-5)
+    assert result["ok"], result
+
+
+# --------------------------------------------------------------------------- #
+# init_state / forward_prefill / clone_state: the (B,0) placeholder round-trip
+# --------------------------------------------------------------------------- #
+def test_moe_state_placeholder_round_trip():
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    moe_idx = 1
+    assert cfg.is_moe_layer(moe_idx)
+
+    state = model.init_state(2)
+    conv, ssm = state[moe_idx]
+    assert conv.shape == (2, 0) and ssm.shape == (2, 0)
+
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(2, 16)).astype(np.int32)
+    with torch.no_grad():
+        _, pf_state = model.prefill(tokens)
+    pconv, pssm = pf_state[moe_idx]
+    assert pconv.shape == (2, 0) and pssm.shape == (2, 0)
+
+    cloned = model.clone_state(state)
+    cconv, cssm = cloned[moe_idx]
+    assert cconv.shape == (2, 0) and cssm.shape == (2, 0)
+    assert cconv is not conv and cssm is not ssm     # independent snapshot, not aliased
+
+
+# --------------------------------------------------------------------------- #
+# mixing_matrices: MoE layers (like attention) are skipped -- no mixing_matrix exists
+# --------------------------------------------------------------------------- #
+def test_mixing_matrices_skips_moe_layers():
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    tokens = np.random.default_rng(0).integers(0, cfg.vocab_size, size=(2, 16)).astype(np.int32)
+    with torch.no_grad():
+        out = model.mixing_matrices(tokens)
+    indices = [i for i, _ in out]
+    assert indices == [0, 2]                          # the Mamba layers only (1, 3 are MoE)
+    for i, m in out:
+        assert torch.isfinite(m).all()
+
+
+# --------------------------------------------------------------------------- #
+# Routing correctness
+# --------------------------------------------------------------------------- #
+def test_router_top_k_one_equals_argmax_expert():
+    cfg = _cfg(top_k=1)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    block = _moe_block(model)
+    xn = torch.randn(5, cfg.d_model)
+    cd = torch.float32
+    with torch.no_grad():
+        logits = _np(block.router(xn))
+        chosen = logits.argmax(axis=-1)
+        combined = _np(block._moe(xn))
+        expert_outs = np.stack([_np(e(xn, cd)) for e in block.experts], axis=1)  # (5,E,d)
+    for i, e in enumerate(chosen):
+        assert np.allclose(combined[i], expert_outs[i, e], atol=1e-5)
+
+
+@pytest.mark.parametrize("impl", ["dense", "gather"])
+def test_router_keeps_exactly_k_on_ties(impl):
+    """A zeroed router makes all experts tie; exactly top_k must be kept (ranks break
+    ties by index), for BOTH compute strategies — the whole point of the gather kernel
+    is to reproduce the dense reference's decision, not just its logits."""
+    cfg = _cfg(moe_impl=impl)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    block = _moe_block(model)
+    with torch.no_grad():
+        block.router.weight.zero_()
+    xn = torch.randn(3, cfg.d_model)
+    cd = torch.float32
+    with torch.no_grad():
+        combined = _np(block._moe(xn))
+        expert_outs = np.stack([_np(e(xn, cd)) for e in block.experts], axis=1)  # (3,E,d)
+    mean_first_k = expert_outs[:, :cfg.top_k, :].mean(axis=1)   # ranks break ties by index
+    assert np.allclose(combined, mean_first_k, atol=1e-5)
+    assert not np.allclose(combined, expert_outs.mean(axis=1), atol=1e-5)   # NOT all E
+
+
+def test_moe_degenerate_single_expert_equals_hand_computed_swiglu():
+    """E=1 (the dense-upcycle source, #214): softmax over a single logit is exactly 1.0
+    in fp32, so the block's output must equal the raw SwiGLU computation bit-for-bit."""
+    cfg = _cfg(n_experts=1, top_k=1)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    block = _moe_block(model)
+    xn = torch.randn(4, cfg.d_model)
+    with torch.no_grad():
+        combined = block._moe(xn)
+        e = block.experts[0]
+        g = xn @ e.gate.weight.t()
+        u = xn @ e.up.weight.t()
+        expected = (F.silu(g) * u) @ e.down.weight.t()
+    assert torch.equal(combined, expected)
+
+
+# --------------------------------------------------------------------------- #
+# torch.topk is DISQUALIFIED (plan finding #1) -- a permanent negative test so a future
+# "optimization" can't silently swap the selection primitive back in.
+# --------------------------------------------------------------------------- #
+def test_torch_topk_diverges_from_double_argsort_on_ties():
+    sel = torch.tensor([1., 1., 1., 0., 0., 2., 2., 0.])
+    k = 3
+    topk_ids = set(torch.topk(sel, k).indices.tolist())
+    order = torch.argsort(-sel, stable=True)
+    double_argsort_ids = set(order[:k].tolist())
+    assert double_argsort_ids == {0, 5, 6}
+    assert topk_ids != double_argsort_ids, (
+        "torch.topk must NOT match the double-argsort tie-break MLX/the CUDA block use "
+        "-- if this now passes, topk's tie-break semantics changed and MoEBlock._moe's "
+        "selection code (which deliberately avoids topk) should be revisited, not this "
+        "test loosened."
+    )

--- a/tests/test_cuda_moe.py
+++ b/tests/test_cuda_moe.py
@@ -194,19 +194,48 @@ def test_moe_degenerate_single_expert_equals_hand_computed_swiglu():
 
 
 # --------------------------------------------------------------------------- #
-# torch.topk is DISQUALIFIED (plan finding #1) -- a permanent negative test so a future
-# "optimization" can't silently swap the selection primitive back in.
+# Tie-break contract (#214).
+#
+# MLX, Swift and this backend all rank with `argsort(argsort(-sel))`, whose ties break by
+# ASCENDING EXPERT INDEX. `MoEBlock._moe` deliberately does not use `torch.topk`, whose
+# tie order torch does not specify and which is observably platform-dependent: on the tie
+# vector below, torch 2.12.0 returns {2,5,6} on macOS/arm64 but {0,5,6} on Linux/x86_64.
+# That is WHY topk is avoided -- but it is rationale, not an invariant, and asserting
+# `topk != reference` asserts on behaviour torch never promised (it fails whenever topk
+# happens to coincide, which says nothing about this code). So the assertions below pin
+# the two things that ARE contractual: the reference semantics, and the block obeying them.
 # --------------------------------------------------------------------------- #
-def test_torch_topk_diverges_from_double_argsort_on_ties():
+def test_double_argsort_breaks_ties_by_ascending_index():
+    """The primitive MLX/Swift/CUDA all agree on. Ties -> lowest expert index wins."""
     sel = torch.tensor([1., 1., 1., 0., 0., 2., 2., 0.])
-    k = 3
-    topk_ids = set(torch.topk(sel, k).indices.tolist())
     order = torch.argsort(-sel, stable=True)
-    double_argsort_ids = set(order[:k].tolist())
-    assert double_argsort_ids == {0, 5, 6}
-    assert topk_ids != double_argsort_ids, (
-        "torch.topk must NOT match the double-argsort tie-break MLX/the CUDA block use "
-        "-- if this now passes, topk's tie-break semantics changed and MoEBlock._moe's "
-        "selection code (which deliberately avoids topk) should be revisited, not this "
-        "test loosened."
-    )
+    assert set(order[:3].tolist()) == {0, 5, 6}
+    # stable=True is the whole contract; without it the tie order is unspecified.
+    assert order[:3].tolist() == [5, 6, 0]
+
+
+@pytest.mark.parametrize("impl", ["dense", "gather"])
+def test_moe_block_selection_obeys_double_argsort_tie_break(impl):
+    """The real routing path, on a deliberate all-ties fixture.
+
+    A zeroed router makes every logit 0, so `sel` is exactly the route bias and the
+    top-k choice is decided purely by the tie-break. Both impls must land on {0,5,6}
+    -- ascending index among equals -- for every token.
+    """
+    cfg = _cfg(n_experts=8, top_k=3, moe_impl=impl)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    block = _moe_block(model)
+    with torch.no_grad():
+        block.router.weight.zero_()
+    block.set_route_bias([1., 1., 1., 0., 0., 2., 2., 0.])
+    block.set_load_counting(True)
+
+    x = torch.randn(2, 5, cfg.d_model)
+    with torch.no_grad():
+        block.forward_seq(x)
+
+    loads = block.pop_load()
+    n_tokens = 2 * 5
+    assert [i for i, c in enumerate(loads) if c > 0] == [0, 5, 6]
+    assert all(loads[i] == n_tokens for i in (0, 5, 6))

--- a/tests/test_cuda_moe_balance.py
+++ b/tests/test_cuda_moe_balance.py
@@ -1,0 +1,301 @@
+"""CUDA/PyTorch twin of tests/test_moe_balance_mlx.py: Loss-Free-Balancing (#213/#214)
+on the torch backend -- the buffer-not-parameter contract, the bias-steers-selection-
+not-gate invariant, the portable round-trip, and the driver-facing plumbing.
+
+Skipped where torch is unavailable (CPU-only, no GPU needed).
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import MambaConfig  # noqa: E402
+from src.model.cuda_backend import CUDAMambaModel, MoEBlock  # noqa: E402
+from src.model.cuda_train_step import make_train_step  # noqa: E402
+from src.train.moe_balance import MoEBalancer, balancer_for_config  # noqa: E402
+
+
+def _cfg(**over):
+    base = dict(d_model=32, n_layers=2, head_dim=8, d_state=8, vocab_size=32,
+                seq_len=16, precision="fp32", moe_every=1, n_experts=8, top_k=2,
+                moe_d_ff=32)
+    base.update(over)
+    return MambaConfig(**base)
+
+
+def _np(a):
+    return a.detach().cpu().numpy()
+
+
+# --------------------------------------------------------------------------- #
+# D1 -- the bias is NOT a trained parameter
+# --------------------------------------------------------------------------- #
+def test_route_bias_and_load_counts_absent_from_named_parameters_and_state_dict():
+    torch.manual_seed(0)
+    model = CUDAMambaModel(_cfg(moe_balance_rate=0.05))
+    model.set_moe_biases([[0.5] * 8, [-0.5] * 8])
+
+    param_keys = [k for k, _ in model.named_parameters()]
+    assert not any("_route_bias" in k for k in param_keys), param_keys
+    assert not any("_load_counts" in k for k in param_keys), param_keys
+
+    sd_keys = list(model.state_dict().keys())
+    assert not any("_route_bias" in k for k in sd_keys), sd_keys
+    assert not any("_load_counts" in k for k in sd_keys), sd_keys
+
+    # ...and only the two D3-explicit portable keys, never a raw module-attribute leak.
+    portable_keys = list(model._portable_state_dict())
+    assert sorted(k for k in portable_keys if "route_bias" in k) == \
+        ["moe_route_bias.0", "moe_route_bias.1"]
+
+
+def test_load_state_dict_strict_succeeds_without_the_buffers():
+    """`load_state_dict(strict=True)` must not demand `_route_bias`/`_load_counts` -- the
+    whole point of `persistent=False`."""
+    torch.manual_seed(0)
+    model = CUDAMambaModel(_cfg(moe_balance_rate=0.05))
+    model.set_moe_biases([[0.1] * 8, [-0.1] * 8])
+    sd = model.state_dict()
+    assert not any("_route_bias" in k or "_load_counts" in k for k in sd)
+
+    torch.manual_seed(1)
+    fresh = CUDAMambaModel(_cfg(moe_balance_rate=0.05))
+    fresh.load_state_dict(sd, strict=True)      # must not raise
+
+
+def test_buffers_are_moved_by_to():
+    """A plain attribute would NOT be moved by `.to()`; `register_buffer` is what makes
+    this work -- verified on CPU-\"device\" (a real device move needs CUDA hardware, but
+    `.to()` on the same device still exercises the buffer machinery: it is a genuine
+    `nn.Module._apply` traversal, not a no-op skip)."""
+    torch.manual_seed(0)
+    model = CUDAMambaModel(_cfg(moe_balance_rate=0.05))
+    block = model.moe_blocks()[0]
+    before = block._route_bias.data_ptr()
+    model.to(torch.device("cpu"))
+    # After `.to()` the buffer must still be the tensor `nn.Module._apply` produced --
+    # i.e. it really participated in the traversal (a plain attribute would be
+    # untouched and this assertion would still trivially "pass" for the wrong reason,
+    # so the real guarantee here is the earlier persistent=False tests: this one just
+    # documents that `.to()` does not error or silently drop the buffer).
+    assert block._route_bias.shape == (8,)
+    assert block._route_bias.data_ptr() is not None
+
+
+def test_optimizer_step_leaves_the_bias_bit_identical():
+    torch.manual_seed(0)
+    model = CUDAMambaModel(_cfg(moe_balance_rate=0.05))
+    model.set_moe_biases([[0.1 * i for i in range(8)], [-0.1 * i for i in range(8)]])
+    before = model.moe_biases()
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-2)
+    step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=None)
+
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, 32, size=(4, 17))
+    for _ in range(3):
+        step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-2)
+    assert model.moe_biases() == before
+
+
+def test_balancer_moves_the_bias_by_exactly_rate_per_step():
+    cfg = _cfg(moe_balance_rate=0.25)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    balancer = balancer_for_config(cfg)
+    step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=balancer)
+    from src.train.moe_balance import attach_balancer
+    attach_balancer(balancer, model)
+
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, 32, size=(4, 17))
+    out = step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+    assert "moe_util_var" in out
+    got = model.moe_biases()
+    for layer_bias in got:
+        assert set(layer_bias) <= {-0.25, 0.0, 0.25}, layer_bias
+    assert got == balancer.biases()
+
+
+# --------------------------------------------------------------------------- #
+# D2 -- the bias steers SELECTION only; gates stay the unbiased softmax
+# --------------------------------------------------------------------------- #
+def _reference_moe(block, xn, bias=None):
+    with torch.no_grad():
+        logits = _np(block.router(xn).float())
+    probs = np.exp(logits - logits.max(-1, keepdims=True))
+    probs /= probs.sum(-1, keepdims=True)
+    k = block.config.top_k
+    sel = logits + np.asarray(bias) if bias is not None else probs
+    keep = np.argsort(np.argsort(-sel, axis=-1), axis=-1) < k
+    gate = np.where(keep, probs, 0.0)
+    gate = gate / gate.sum(-1, keepdims=True)
+    return keep, gate
+
+
+def _combine(block, xn, gate):
+    cd = torch.float32
+    with torch.no_grad():
+        outs = np.stack([_np(e(xn, cd)) for e in block.experts], axis=-2)
+    return (np.asarray(gate)[..., None] * outs).sum(-2)
+
+
+def test_bias_changes_selection_but_not_gate_values():
+    cfg = _cfg(moe_balance_rate=0.05)
+    torch.manual_seed(0)
+    block = MoEBlock(cfg, "cpu")
+    xn = torch.randn(3, cfg.seq_len, cfg.d_model)
+
+    keep_off, gate_off = _reference_moe(block, xn)
+    with torch.no_grad():
+        y_off = _np(block._moe(xn))
+
+    bias = [-50.0] + [0.0] * 6 + [50.0]
+    block.set_route_bias(bias)
+    keep_on, gate_on = _reference_moe(block, xn, bias)
+    with torch.no_grad():
+        y_on = _np(block._moe(xn))
+
+    assert keep_on[..., 7].all() and not keep_on[..., 0].any()
+    assert not np.array_equal(keep_off, keep_on)
+
+    both = keep_off & keep_on
+    ratio_off = np.where(both, gate_off, np.nan)
+    ratio_on = np.where(both, gate_on, np.nan)
+    scale = np.nansum(ratio_on, -1, keepdims=True) / np.nansum(ratio_off, -1, keepdims=True)
+    assert np.allclose(ratio_on[both], (ratio_off * scale)[both], atol=1e-5)
+
+    assert np.allclose(y_off, _combine(block, xn, gate_off), atol=1e-4)
+    assert np.allclose(y_on, _combine(block, xn, gate_on), atol=1e-4)
+
+
+def test_exactly_top_k_experts_survive_on_a_tie_under_bias():
+    cfg = _cfg(moe_balance_rate=0.05)
+    torch.manual_seed(0)
+    block = MoEBlock(cfg, "cpu")
+    with torch.no_grad():
+        block.router.weight.zero_()
+    block.set_route_bias([0.0] * cfg.n_experts)
+    block.set_load_counting(True)
+    xn = torch.randn(2, cfg.seq_len, cfg.d_model)
+    with torch.no_grad():
+        block._moe(xn)
+    assert sum(block.pop_load()) == 2 * cfg.seq_len * cfg.top_k
+
+
+# --------------------------------------------------------------------------- #
+# Plumbing -- the accessors the drivers use
+# --------------------------------------------------------------------------- #
+def test_set_moe_biases_raises_on_a_shape_mismatch():
+    torch.manual_seed(0)
+    model = CUDAMambaModel(_cfg(moe_balance_rate=0.05))
+    with pytest.raises(ValueError, match="1 bias vectors for 2 MoE layers"):
+        model.set_moe_biases([[0.0] * 8])
+    with pytest.raises(ValueError, match="route bias has 3 entries"):
+        model.set_moe_biases([[0.0] * 3, [0.0] * 3])
+    assert all(not b._bias_active for b in model.moe_blocks())
+
+
+def test_loading_a_bias_for_a_non_moe_layer_raises_clearly(tmp_path):
+    from src.train.checkpoint import load_weights_dict, save_weights
+
+    torch.manual_seed(0)
+    model = CUDAMambaModel(_cfg(moe_balance_rate=0.05))
+    model.set_moe_biases([[0.1] * 8, [0.2] * 8])
+    path = str(tmp_path / "weights.safetensors")
+    model.save(path)
+
+    weights = load_weights_dict(path)
+    weights["moe_route_bias.7"] = weights.pop("moe_route_bias.1")   # no layer 7 here
+    bad = str(tmp_path / "bad.safetensors")
+    save_weights(weights, bad, config=model.config)
+
+    torch.manual_seed(1)
+    fresh = CUDAMambaModel(_cfg(moe_balance_rate=0.05))
+    with pytest.raises(ValueError, match="layer 7 of this config is not an MoE layer"):
+        fresh.load(bad)
+
+
+def test_pop_moe_load_is_empty_for_a_dense_model():
+    torch.manual_seed(0)
+    model = CUDAMambaModel(_cfg(moe_every=None, n_experts=0, moe_d_ff=None))
+    assert model.moe_blocks() == []
+    assert model.pop_moe_load() == []
+    assert model.moe_biases() == []
+
+
+# --------------------------------------------------------------------------- #
+# D3 -- the bias round-trips through the PORTABLE safetensors
+# --------------------------------------------------------------------------- #
+def test_route_bias_round_trips_through_portable_weights(tmp_path):
+    cfg = _cfg(moe_balance_rate=0.05)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    bias = [[0.1 * i for i in range(8)], [-0.05 * i for i in range(8)]]
+    model.set_moe_biases(bias)
+
+    path = str(tmp_path / "weights.safetensors")
+    keys = model._portable_state_dict()
+    assert sorted(k for k in keys if k.startswith("moe_route_bias.")) == \
+        ["moe_route_bias.0", "moe_route_bias.1"]
+    model.save(path)
+
+    torch.manual_seed(1)
+    fresh = CUDAMambaModel(cfg)
+    assert fresh.moe_biases() == [[], []]
+    fresh.load(path)
+    assert fresh.moe_biases() == model.moe_biases()
+    assert np.allclose(np.array(fresh.moe_biases()), np.array(bias), atol=1e-6)
+    assert all(b._bias_active for b in fresh.moe_blocks())
+
+    tokens = np.arange(2 * cfg.seq_len).reshape(2, cfg.seq_len) % cfg.vocab_size
+    with torch.no_grad():
+        y1 = _np(model.forward(tokens))
+        y2 = _np(fresh.forward(tokens))
+    assert np.allclose(y1, y2)
+
+
+def test_portable_key_set_unchanged_when_the_bias_is_inactive():
+    for cfg in (_cfg(moe_balance_rate=None), _cfg(moe_balance_rate=0.05)):
+        torch.manual_seed(0)
+        model = CUDAMambaModel(cfg)          # constructed, never activated
+        sd = model._portable_state_dict()
+        assert not any(k.startswith("moe_route_bias.") for k in sd), list(sd)
+        assert sum(int(v.size) for v in sd.values()) == cfg.num_parameters()
+
+
+def test_loading_a_pre_213_checkpoint_leaves_the_bias_inactive(tmp_path):
+    cfg = _cfg(moe_balance_rate=0.05)
+    torch.manual_seed(0)
+    old = CUDAMambaModel(cfg)                # bias never activated
+    path = str(tmp_path / "weights.safetensors")
+    old.save(path)
+
+    torch.manual_seed(1)
+    fresh = CUDAMambaModel(cfg)
+    fresh.load(path)
+    assert all(not b._bias_active for b in fresh.moe_blocks())
+    assert fresh.moe_biases() == [[], []]
+
+
+# --------------------------------------------------------------------------- #
+# D5 -- grad_checkpoint doubles the counts and changes nothing else
+# --------------------------------------------------------------------------- #
+def test_grad_checkpoint_doubles_the_counts_and_changes_nothing_else():
+    def counts(grad_checkpoint):
+        cfg = _cfg(moe_balance_rate=0.05, grad_checkpoint=grad_checkpoint)
+        torch.manual_seed(0)
+        model = CUDAMambaModel(cfg)
+        opt = torch.optim.AdamW(model.parameters(), lr=1e-3)
+        step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=None)
+        model.set_moe_load_counting(True)
+        rng = np.random.default_rng(0)
+        tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
+        step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+        return model.pop_moe_load()
+
+    plain, checkpointed = counts(False), counts(True)
+    assert checkpointed == [[2 * c for c in layer] for layer in plain]
+    assert MoEBalancer.utilization_variance(plain) == \
+        MoEBalancer.utilization_variance(checkpointed)

--- a/tests/test_cuda_moe_fixture_parity.py
+++ b/tests/test_cuda_moe_fixture_parity.py
@@ -1,0 +1,118 @@
+"""The cross-backend gate for CUDA MoE (#214): the checked-in Swift/MLX parity fixtures
+(`swift/engine/Fixtures/toy-moe*/`) are a frozen MLX oracle -- self-describing weights +
+tokens + reference logits/hidden-states. This is the torch-only half of the #166 harness:
+no CI job has BOTH mlx and torch, so this is the only place MLX<->CUDA MoE numerics are
+actually gated. See `swift/engine/Fixtures/README.md`.
+
+Parameterized over {toy-moe, toy-moe-biased} x {dense, gather}: the reconstructed
+`MambaConfig` from each fixture's `.config.json` sidecar predates #214 (no `moe_impl`
+key), so both compute strategies are exercised explicitly by overriding it, rather than
+relying on whatever "auto" happens to resolve to.
+
+Skipped where torch is unavailable (CPU-only, no GPU needed).
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from safetensors.numpy import load_file  # noqa: E402
+
+from src.model.blocks import MambaConfig  # noqa: E402
+from src.model.cuda_backend import CUDAMambaModel  # noqa: E402
+from src.train.checkpoint import load_weights  # noqa: E402
+
+FIXTURES = Path(__file__).resolve().parents[1] / "swift" / "engine" / "Fixtures"
+RTOL, ATOL = 1e-4, 1e-5
+
+
+def _load_fixture(name: str, moe_impl: str):
+    fdir = FIXTURES / name
+    raw = __import__("json").loads((fdir / "weights.safetensors.config.json").read_text())
+    raw = {**raw, "moe_impl": moe_impl}       # pre-#214 sidecar has no moe_impl key
+    cfg = MambaConfig(**raw)
+    cfg.validate()
+
+    model = CUDAMambaModel(cfg)
+    model.eval()
+    load_weights(model, str(fdir / "weights.safetensors"))
+
+    tokens = load_file(str(fdir / "inputs.safetensors"))["tokens"]
+    ref = load_file(str(fdir / "reference.safetensors"))
+    meta = __import__("json").loads((fdir / "meta.json").read_text())
+    return model, tokens, ref, meta
+
+
+@pytest.mark.parametrize("fixture", ["toy-moe", "toy-moe-biased"])
+@pytest.mark.parametrize("moe_impl", ["dense", "gather"])
+def test_cuda_matches_mlx_reference_forward_and_step(fixture, moe_impl):
+    model, tokens, ref, meta = _load_fixture(fixture, moe_impl)
+    assert meta["precision"] == "fp32", (
+        "the fixture must stay fp32 -- a future regeneration at fp16/bf16 would "
+        "silently loosen this gate's precision without anyone noticing"
+    )
+
+    with torch.no_grad():
+        forward_logits = model.forward(tokens).detach().cpu().numpy()
+
+        state = model.init_state(tokens.shape[0])
+        steps = []
+        for t in range(tokens.shape[1]):
+            logits_t, state = model.step(tokens[:, t], state)
+            steps.append(logits_t.detach().cpu().numpy())
+        step_logits = np.stack(steps, axis=1)
+
+    fwd_diff = float(np.abs(forward_logits.astype(np.float64)
+                            - ref["forward_logits"].astype(np.float64)).max())
+    assert np.allclose(forward_logits, ref["forward_logits"], rtol=RTOL, atol=ATOL), (
+        f"{fixture}/{moe_impl}: forward_logits max|diff|={fwd_diff:.3e}"
+    )
+
+    step_diff = float(np.abs(step_logits.astype(np.float64)
+                             - ref["step_logits"].astype(np.float64)).max())
+    assert np.allclose(step_logits, ref["step_logits"], rtol=RTOL, atol=ATOL), (
+        f"{fixture}/{moe_impl}: step_logits max|diff|={step_diff:.3e}"
+    )
+
+
+@pytest.mark.parametrize("fixture", ["toy-moe", "toy-moe-biased"])
+@pytest.mark.parametrize("moe_impl", ["dense", "gather"])
+def test_cuda_matches_mlx_reference_hidden_states(fixture, moe_impl):
+    """Per-layer localization: if the whole-model logits ever mismatch, this pins which
+    layer diverged first instead of a week of manual bisection (the same reasoning as
+    `scripts/export_parity_fixture.py`'s own comment on why `hidden.{i}` is worth the
+    ~200 KB)."""
+    model, tokens, ref, _ = _load_fixture(fixture, moe_impl)
+    with torch.no_grad():
+        hidden = model.hidden_states(tokens)
+    n_layers = model.config.n_layers
+    assert len(hidden) == n_layers + 1
+    for i, h in enumerate(hidden):
+        h_np = h.detach().cpu().numpy()
+        ref_h = ref[f"hidden.{i}"]
+        diff = float(np.abs(h_np.astype(np.float64) - ref_h.astype(np.float64)).max())
+        assert np.allclose(h_np, ref_h, rtol=RTOL, atol=ATOL), (
+            f"{fixture}/{moe_impl}: hidden.{i} first diverges here, max|diff|={diff:.3e}"
+        )
+
+
+def test_biased_fixture_bias_values_match():
+    """The biased fixture's `moe_route_bias.*` load must reproduce as the SAME numbers
+    `model.moe_biases()` reports -- the D3 portable round-trip, exercised end-to-end
+    against a real cross-backend (MLX-written) checkpoint rather than a CUDA-written one."""
+    model, _, _, _ = _load_fixture("toy-moe-biased", "dense")
+    fdir = FIXTURES / "toy-moe-biased"
+    weights = load_file(str(fdir / "weights.safetensors"))
+    expected = {
+        int(k[len("moe_route_bias."):]): weights[k].tolist()
+        for k in weights if k.startswith("moe_route_bias.")
+    }
+    moe_layer_indices = [i for i in range(model.config.n_layers) if model.config.is_moe_layer(i)]
+    got = model.moe_biases()
+    assert len(got) == len(moe_layer_indices)
+    for pos, layer_idx in enumerate(moe_layer_indices):
+        assert layer_idx in expected, (layer_idx, expected)
+        assert np.allclose(got[pos], expected[layer_idx], atol=1e-6)

--- a/tests/test_cuda_moe_gather.py
+++ b/tests/test_cuda_moe_gather.py
@@ -1,0 +1,212 @@
+"""Dense vs. grouped-gather routing (#214): the two `MoEBlock` compute strategies must
+describe the SAME function -- same selection, same gate values, same logits, same load
+counts, same gradients -- differing only in how many GEMMs they issue.
+
+Skipped where torch is unavailable (CPU-only, no GPU needed).
+"""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from src.model.blocks import MambaConfig  # noqa: E402
+from src.model.cuda_backend import CUDAMambaModel, MoEBlock  # noqa: E402
+from src.model.cuda_train_step import _global_grad_norm  # noqa: E402
+
+
+def _cfg(**over):
+    base = dict(d_model=64, n_layers=4, head_dim=16, d_state=16, vocab_size=256,
+                seq_len=32, precision="fp32", moe_every=2, n_experts=4, top_k=2)
+    base.update(over)
+    return MambaConfig(**base)
+
+
+def _np(a):
+    return a.detach().cpu().numpy()
+
+
+def _built_pair(**cfg_over):
+    """Two models, identically seeded, differing only in `moe_impl`."""
+    cfg_d = _cfg(moe_impl="dense", **cfg_over)
+    torch.manual_seed(0)
+    m_dense = CUDAMambaModel(cfg_d)
+    m_dense.eval()
+
+    cfg_g = _cfg(moe_impl="gather", **cfg_over)
+    torch.manual_seed(0)
+    m_gather = CUDAMambaModel(cfg_g)
+    m_gather.eval()
+    return m_dense, m_gather
+
+
+def _built_block_pair(**cfg_over):
+    """Two bare MoEBlocks, identically seeded, differing only in `moe_impl` -- isolates
+    the dispatch kernel from the rest of the architecture (embedding, Mamba layers, LM
+    head), which is what the tight rtol=1e-6/atol=1e-6 tolerance below is actually about:
+    dense and gather are two summation ORDERS of the same computation, and floating-point
+    addition is not associative, so a whole-MODEL comparison compounds that reordering
+    noise across every layer and the wide-vocab head matmul -- see
+    `test_dense_vs_gather_full_model_logits_allclose` for that (looser-tolerance) check."""
+    cfg_d = _cfg(moe_impl="dense", **cfg_over)
+    torch.manual_seed(0)
+    bd = MoEBlock(cfg_d, "cpu")
+    cfg_g = _cfg(moe_impl="gather", **cfg_over)
+    torch.manual_seed(0)
+    bg = MoEBlock(cfg_g, "cpu")
+    return bd, bg
+
+
+# --------------------------------------------------------------------------- #
+# Logit agreement
+# --------------------------------------------------------------------------- #
+def test_dense_vs_gather_logits_allclose():
+    bd, bg = _built_block_pair()
+    xn = torch.randn(3, 17, bd.config.d_model)
+    with torch.no_grad():
+        yd = _np(bd._moe(xn))
+        yg = _np(bg._moe(xn))
+    assert np.allclose(yd, yg, rtol=1e-6, atol=1e-6)
+
+
+def test_dense_vs_gather_logits_allclose_with_bias():
+    bd, bg = _built_block_pair()
+    bias = [0.5, -1.0, 1.5, -2.0]
+    bd.set_route_bias(bias)
+    bg.set_route_bias(bias)
+    xn = torch.randn(4, 37, bd.config.d_model)
+    with torch.no_grad():
+        yd = _np(bd._moe(xn))
+        yg = _np(bg._moe(xn))
+    assert np.allclose(yd, yg, rtol=1e-6, atol=1e-6)
+
+
+def test_dense_vs_gather_full_model_logits_allclose():
+    """Same claim as above, but end-to-end through the whole 4-layer model + LM head.
+    The standard project cross-implementation tolerance (rtol=1e-4, atol=1e-5, same as
+    `forward_step_parity`/`backend_parity`) applies here rather than the tight
+    block-level bound above: reordered floating-point sums compound across 3 more
+    layers and a 256-wide softmax, which can amplify to a large RELATIVE error at a
+    near-zero logit entry even though the underlying computation is unchanged."""
+    m_dense, m_gather = _built_pair()
+    tokens = np.random.default_rng(0).integers(0, 256, size=(2, 32)).astype(np.int32)
+    with torch.no_grad():
+        y_dense = _np(m_dense.forward(tokens))
+        y_gather = _np(m_gather.forward(tokens))
+    assert np.allclose(y_dense, y_gather, rtol=1e-4, atol=1e-5)
+
+
+# --------------------------------------------------------------------------- #
+# Selection equivalence at ZERO tolerance: the dense mask and the gather ids must
+# describe the exact same kept set, over random / all-tie / biased logits.
+# --------------------------------------------------------------------------- #
+def _dense_kept_set(block, xn):
+    """The dense mask's kept expert-index set per row, read straight out of `_moe`'s
+    own selection code path (not re-derived) so this is a faithful probe."""
+    E, k = block.config.n_experts, block.config.top_k
+    with torch.no_grad():
+        logits = block.router(xn).float()
+        sel = (logits + block._route_bias) if block._bias_active else \
+            torch.softmax(logits, dim=-1)
+        order = torch.argsort(-sel, dim=-1, stable=True)
+        topk_ids, _ = torch.sort(order[..., :k], dim=-1)
+    return topk_ids
+
+
+@pytest.mark.parametrize("case", ["random", "all_tie", "biased"])
+def test_selection_ids_identical_dense_vs_gather(case):
+    m_dense, m_gather = _built_pair()
+    xn = torch.randn(3, 17, m_dense.config.d_model)
+
+    if case == "all_tie":
+        for m in (m_dense, m_gather):
+            for block in m.moe_blocks():
+                with torch.no_grad():
+                    block.router.weight.zero_()
+    elif case == "biased":
+        bias = [0.5, -1.0, 1.5, -2.0]
+        for m in (m_dense, m_gather):
+            for block in m.moe_blocks():
+                block.set_route_bias(bias)
+
+    bd = m_dense.moe_blocks()[0]
+    bg = m_gather.moe_blocks()[0]
+    ids_dense = _dense_kept_set(bd, xn)
+    ids_gather = _dense_kept_set(bg, xn)     # same selection code both blocks share
+    # Compare as SETS per row (order-independent) at zero tolerance -- this is an
+    # integer-index comparison, not a float comparison, so atol/rtol don't apply.
+    sd = ids_dense.sort(dim=-1).values
+    sg = ids_gather.sort(dim=-1).values
+    assert torch.equal(sd, sg)
+
+
+# --------------------------------------------------------------------------- #
+# pop_moe_load(): exactly equal between impls
+# --------------------------------------------------------------------------- #
+def test_pop_moe_load_exactly_equal_between_impls():
+    m_dense, m_gather = _built_pair()
+    m_dense.set_moe_load_counting(True)
+    m_gather.set_moe_load_counting(True)
+    tokens = np.random.default_rng(2).integers(0, 256, size=(3, 32)).astype(np.int32)
+    with torch.no_grad():
+        m_dense.forward(tokens)
+        m_gather.forward(tokens)
+    loads_dense = m_dense.pop_moe_load()
+    loads_gather = m_gather.pop_moe_load()
+    assert loads_dense == loads_gather
+    assert sum(sum(layer) for layer in loads_dense) == 3 * 32 * m_dense.config.top_k * \
+        m_dense.config.n_moe_layers
+
+
+# --------------------------------------------------------------------------- #
+# Empty-expert-group case: forward finite, that expert's grad is not None and exactly
+# 0.0, and the accumulated global grad norm stays finite.
+# --------------------------------------------------------------------------- #
+def test_empty_expert_group_yields_zero_finite_grad_not_none():
+    cfg = _cfg(moe_impl="gather")
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    with torch.no_grad():
+        # Force ALL tokens to rank experts [0, 1] first (ties broken by index), so
+        # experts 2 and 3 route zero tokens -- the empty-group path (#214 finding 2).
+        block.router.weight.zero_()
+
+    tokens = np.random.default_rng(0).integers(0, 256, size=(2, 32)).astype(np.int32)
+    out = model.forward(tokens)
+    assert torch.isfinite(out).all()
+    loss = out.float().sum()
+    loss.backward()
+
+    empty_expert = block.experts[3]      # never selected: top_k=2 keeps [0, 1] on every tie
+    for p in empty_expert.parameters():
+        assert p.grad is not None
+        assert torch.all(p.grad == 0.0)
+        assert torch.isfinite(p.grad).all()
+
+    norm = _global_grad_norm(list(model.parameters()))
+    assert torch.isfinite(norm)
+
+
+# --------------------------------------------------------------------------- #
+# Dense vs. gather expert-weight GRADIENT agreement (not just forward logits)
+# --------------------------------------------------------------------------- #
+def test_dense_vs_gather_expert_grad_agreement():
+    m_dense, m_gather = _built_pair()
+    tokens = np.random.default_rng(3).integers(0, 256, size=(2, 32)).astype(np.int32)
+
+    for m in (m_dense, m_gather):
+        m.zero_grad(set_to_none=True)
+        out = m.forward(tokens)
+        loss = out.float().sum()
+        loss.backward()
+
+    for (name_d, p_d), (name_g, p_g) in zip(m_dense.named_parameters(),
+                                             m_gather.named_parameters()):
+        assert name_d == name_g
+        if p_d.grad is None and p_g.grad is None:
+            continue
+        assert p_d.grad is not None and p_g.grad is not None, name_d
+        max_abs = float((p_d.grad - p_g.grad).abs().max())
+        assert torch.allclose(p_d.grad, p_g.grad, rtol=1e-5, atol=1e-5), \
+            f"{name_d}: max|grad diff|={max_abs:.3e}"

--- a/tests/test_cuda_muon.py
+++ b/tests/test_cuda_muon.py
@@ -165,10 +165,17 @@ def test_hybrid_optimizer_tolerates_empty_side():
     hybrid.load_state_dict(sd)                       # no-op on the muon side, must not raise
 
 
-def test_backend_partitions_real_model_params_via_is_muon_param():
+@pytest.mark.parametrize("cfg_path", [
+    TOY_MUON_CFG,
+    "config/toy-moe-muon.yaml",   # #214: covers MoE expert gate/up/down (Muon) + router (AdamW)
+])
+def test_backend_partitions_real_model_params_via_is_muon_param(cfg_path):
     """End-to-end: `get_backend("cuda").make_optimizer` on a `optimizer: muon` config
-    partitions the real CUDA model's named_parameters() exactly per `is_muon_param`."""
-    cfg = load_config(TOY_MUON_CFG)
+    partitions the real CUDA model's named_parameters() exactly per `is_muon_param`.
+    Parametrized over a plain hybrid config and an MoE one (#214) — the MoE case
+    additionally proves expert gate/up/down matrices land on Muon while the router
+    (also 2D, but excluded by `is_muon_param`'s router carve-out) stays on AdamW."""
+    cfg = load_config(cfg_path)
     assert cfg.optimizer == "muon"
     torch.manual_seed(0)
     model = CUDAMambaModel(cfg)

--- a/tests/test_cuda_train_step.py
+++ b/tests/test_cuda_train_step.py
@@ -13,12 +13,15 @@ import pytest
 
 torch = pytest.importorskip("torch")
 
-from src.model.blocks import load_config
+from src.model.blocks import MambaConfig, load_config
 from src.model.cuda_backend import CUDAMambaModel
-from src.model.cuda_train_step import make_train_step, save_optimizer, load_optimizer
+from src.model.cuda_train_step import (make_train_step, make_sft_train_step,
+                                       make_dpo_train_step, make_grpo_train_step,
+                                       save_optimizer, load_optimizer)
 from src.train.loss_scale import DynamicLossScaler
 from src.train.loop import TrainConfig, train
 from src.train.checkpoint import CheckpointStore
+from src.train.moe_balance import balancer_for_config, attach_balancer
 from src.data.pack import pack_ids
 from src.data.loader import PackedLoader
 
@@ -165,3 +168,143 @@ def test_save_kill_resume_exact(tmp_path):
 
     max_diff = max(abs(ref[s] - res[s]) for s in range(half, N))
     assert max_diff < 1e-4, f"resume not exact: max|diff|={max_diff:.3e}"
+
+
+# --------------------------------------------------------------------------- #
+# Loss-Free-Balancing threading (#213/#214): all four factories accept `balancer=`,
+# the overflow-skip/pop ordering, and grad-accum count accumulation.
+# --------------------------------------------------------------------------- #
+def _moe_cfg(**over):
+    base = dict(d_model=32, n_layers=2, head_dim=8, d_state=8, vocab_size=32,
+                seq_len=16, precision="fp32", moe_every=1, n_experts=8, top_k=2,
+                moe_d_ff=32, moe_balance_rate=0.05)
+    base.update(over)
+    return MambaConfig(**base)
+
+
+def _pretrain_mb(cfg, B=4, L=16, seed=0):
+    rng = np.random.default_rng(seed)
+    tokens = rng.integers(0, cfg.vocab_size, size=(B, L + 1))
+    return tokens[:, :-1], tokens[:, 1:]
+
+
+def _masked_mb(cfg, B=4, L=16, seed=0):
+    rng = np.random.default_rng(seed)
+    inp = rng.integers(0, cfg.vocab_size, size=(B, L))
+    tgt = rng.integers(0, cfg.vocab_size, size=(B, L))
+    mask = np.ones((B, L), dtype=np.float32)
+    return inp, tgt, mask
+
+
+def test_make_train_step_accepts_balancer_and_emits_util_var():
+    cfg = _moe_cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    balancer = balancer_for_config(cfg)
+    step = make_train_step(model, _adam(model), grad_clip=1.0, scaler=None, balancer=balancer)
+    attach_balancer(balancer, model)
+
+    inp, tgt = _pretrain_mb(cfg)
+    out = step(model, [(inp, tgt)], 1e-3)
+    assert "moe_util_var" in out
+
+
+def test_make_sft_train_step_accepts_balancer_and_emits_util_var():
+    cfg = _moe_cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    balancer = balancer_for_config(cfg)
+    step = make_sft_train_step(model, _adam(model), grad_clip=1.0, scaler=None,
+                               balancer=balancer)
+    attach_balancer(balancer, model)
+
+    mb = _masked_mb(cfg)
+    out = step(model, [mb], 1e-3)
+    assert "moe_util_var" in out
+
+
+def test_make_dpo_train_step_accepts_balancer_and_targets_policy_not_ref():
+    cfg = _moe_cfg()
+    torch.manual_seed(0)
+    policy = CUDAMambaModel(cfg)
+    torch.manual_seed(1)
+    ref = CUDAMambaModel(cfg)
+    balancer = balancer_for_config(cfg)
+    step = make_dpo_train_step(policy, ref, _adam(policy), grad_clip=1.0, scaler=None,
+                               balancer=balancer)
+    attach_balancer(balancer, policy)
+
+    c_in, c_tgt, c_mask = _masked_mb(cfg, seed=0)
+    r_in, r_tgt, r_mask = _masked_mb(cfg, seed=1)
+    out = step(policy, [(c_in, c_tgt, c_mask, r_in, r_tgt, r_mask)], 1e-3)
+    assert "moe_util_var" in out
+    # The balancer's pop/push must target the POLICY only -- the frozen reference is
+    # never wired to it, so its bias stays exactly whatever it started with (inactive).
+    assert ref.moe_biases() == [[], []]
+    assert policy.moe_biases() != [[], []]
+
+
+def test_make_grpo_train_step_accepts_balancer_and_emits_util_var():
+    cfg = _moe_cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    balancer = balancer_for_config(cfg)
+    step = make_grpo_train_step(model, _adam(model), grad_clip=1.0, scaler=None,
+                                balancer=balancer)
+    attach_balancer(balancer, model)
+
+    inp, tgt, mask = _masked_mb(cfg)
+    adv = np.random.default_rng(0).normal(size=(inp.shape[0],)).astype(np.float32)
+    out = step(model, [(inp, tgt, mask, adv)], 1e-3)
+    assert "moe_util_var" in out
+
+
+def test_overflow_skip_does_not_pop_moe_load_counts():
+    """The balancer hook runs AFTER the fp16 overflow early-return, so a skipped step's
+    routed-token counts are NOT popped -- they must survive into the next pop
+    (mirrors `mlx_backend.py:717-720`'s documented, intentional behavior)."""
+    cfg = _moe_cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    balancer = balancer_for_config(cfg)
+    # A scale above fp32-max forces loss*scale -> inf -> non-finite grads (robust trigger,
+    # same recipe as test_fp16_overflow_skips_update_and_backs_off above).
+    scaler = DynamicLossScaler(init_scale=1e40, backoff=0.5, min_scale=1.0)
+    step = make_train_step(model, _adam(model), grad_clip=1.0, scaler=scaler,
+                           balancer=balancer)
+    attach_balancer(balancer, model)          # turns load counting ON
+
+    inp, tgt = _pretrain_mb(cfg)
+    out = step(model, [(inp, tgt)], 1e-3)
+    assert out["skipped"] is True
+    assert "moe_util_var" not in out
+
+    # The forward pass ran (and counted) before overflow was detected in backward; since
+    # the balancer hook never ran, those counts were never popped -- a fresh pop must
+    # still see them.
+    survived = model.pop_moe_load()
+    assert sum(sum(layer) for layer in survived) > 0
+
+
+def test_grad_accum_two_microbatches_accumulates_moe_load_counts():
+    """Grad accumulation sums counts across BOTH micro-batches, not just the last one."""
+    cfg = _moe_cfg(moe_balance_rate=None)     # counting only, no balancer consuming it
+    inp, tgt = _pretrain_mb(cfg)
+
+    torch.manual_seed(0)
+    model1 = CUDAMambaModel(cfg)
+    step1 = make_train_step(model1, _adam(model1), grad_clip=1.0, scaler=None, balancer=None)
+    model1.set_moe_load_counting(True)
+    step1(model1, [(inp, tgt)], 1e-3)
+    single = model1.pop_moe_load()
+
+    torch.manual_seed(0)                      # identical fresh weights, pre-optimizer-step
+    model2 = CUDAMambaModel(cfg)
+    step2 = make_train_step(model2, _adam(model2), grad_clip=1.0, scaler=None, balancer=None)
+    model2.set_moe_load_counting(True)
+    step2(model2, [(inp, tgt), (inp, tgt)], 1e-3)
+    double = model2.pop_moe_load()
+
+    assert sum(sum(l) for l in single) > 0     # sanity: routing actually happened
+    for s_layer, d_layer in zip(single, double):
+        assert d_layer == [2 * c for c in s_layer]

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -113,7 +113,7 @@ PORTABLE_MODULES = [
     "src.serve.spec_decode",
 ]
 
-FORBIDDEN_ROOTS = ("mlx", "torch")
+FORBIDDEN_ROOTS = ("mlx", "torch", "bitsandbytes")
 
 
 def _run_guard(modules):

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -70,6 +70,7 @@ PORTABLE_MODULES = [
     "src.train.checkpoint",
     "src.train.loss_scale",
     "src.train.moe_balance",
+    "src.train.upcycle",
     "src.train.loop",
     "src.train.curriculum",
     "src.train.stream",

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -64,13 +64,54 @@ def test_active_params_below_total_and_matches_top_k():
 
 
 def test_moe_validation():
-    with pytest.raises(ValueError, match="n_experts"):
-        _cfg(moe_every=2, n_experts=1, top_k=1).validate()
     with pytest.raises(ValueError, match="top_k"):
         _cfg(moe_every=2, n_experts=4, top_k=5).validate()
     with pytest.raises(ValueError, match="moe_every"):
         _cfg(moe_every=0, n_experts=4, top_k=2).validate()
     _cfg(moe_every=2, n_experts=4, top_k=2).validate()           # valid: no raise
+
+
+def test_moe_degenerate_single_expert_valid():
+    # #214: n_experts=1 is now valid (the dense-upcycle source) provided top_k=1 and
+    # balancing is off — the degenerate block IS a plain SwiGLU FFN.
+    _cfg(moe_every=2, n_experts=1, top_k=1).validate()           # no raise
+
+
+def test_moe_single_expert_requires_top_k_one():
+    with pytest.raises(ValueError, match="top_k"):
+        _cfg(moe_every=2, n_experts=1, top_k=2).validate()
+
+
+def test_moe_single_expert_rejects_balance_rate():
+    with pytest.raises(ValueError, match="moe_balance_rate"):
+        _cfg(moe_every=2, n_experts=1, top_k=1, moe_balance_rate=0.01).validate()
+
+
+def test_moe_bad_moe_impl_rejected():
+    with pytest.raises(ValueError, match="moe_impl"):
+        _cfg(moe_every=2, n_experts=4, top_k=2, moe_impl="bogus").validate()
+    for ok in ("auto", "dense", "gather"):
+        _cfg(moe_every=2, n_experts=4, top_k=2, moe_impl=ok).validate()   # no raise
+
+
+def test_moe_shared_experts_negative_rejected():
+    with pytest.raises(ValueError, match="n_shared_experts"):
+        _cfg(moe_every=2, n_experts=4, top_k=2, n_shared_experts=-1).validate()
+
+
+def test_moe_shared_experts_require_moe():
+    with pytest.raises(ValueError, match="n_shared_experts"):
+        _cfg(n_shared_experts=1).validate()                      # moe_every unset
+
+
+def test_moe_shared_experts_add_capacity():
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2, n_shared_experts=1)
+    bd = cfg.parameter_breakdown()
+    assert cfg.num_parameters() == sum(bd.values())
+    plain = _cfg(moe_every=2, n_experts=4, top_k=2, n_shared_experts=0)
+    assert cfg.num_parameters() > plain.num_parameters()
+    # Shared experts are always fully active (every token), so active params grow too.
+    assert cfg.active_num_parameters() > plain.active_num_parameters()
 
 
 # --------------------------------------------------------------------------- #
@@ -152,6 +193,103 @@ def test_router_selects_top_k():
     expert_outs = np.stack([np.array(e(xn, cd)) for e in block.experts], axis=1)  # (5,E,d)
     for i, e in enumerate(chosen):
         assert np.allclose(combined[i], expert_outs[i, e], atol=1e-5)
+
+
+@requires_mlx
+def test_shared_expert_param_count_exact():
+    """n_shared_experts=1: the closed-form param count must exactly match the built
+    model's real tensors, same invariant as the no-shared-expert case above."""
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2, n_shared_experts=1)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    assert len(block.shared_experts) == 1
+    actual = sum(int(v.size) for v in model._portable_state_dict().values())
+    assert cfg.num_parameters() == actual
+
+
+@requires_mlx
+def test_shared_expert_forward_step_parity():
+    """Shared-expert MoE is still pointwise -> forward/step must agree."""
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2, n_shared_experts=1)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    tokens = np.arange(32).reshape(1, 32) % 256
+
+    seq = np.array(model.forward(mx.array(tokens)))[0]
+    state = model.init_state(1)
+    step = []
+    for t in range(tokens.shape[1]):
+        logit, state = model.step(mx.array(tokens[:, t]), state)
+        step.append(np.array(logit)[0])
+    step = np.stack(step)
+    rel = np.abs(seq - step).max() / (np.abs(seq).max() + 1e-6)
+    assert rel < 1e-4
+
+
+@requires_mlx
+def test_shared_expert_output_equals_shared_plus_routed():
+    """The block output must equal shared(xn) + the routed top_k combination, computed
+    by hand — additive, outside the router softmax/renormalization."""
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2, n_shared_experts=2)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    xn = mx.random.normal((5, cfg.d_model))
+    cd = mx.float32
+
+    combined = np.array(block._moe(xn))
+
+    logits = np.array(block.router(xn))
+    probs = np.exp(logits - logits.max(axis=-1, keepdims=True))
+    probs = probs / probs.sum(axis=-1, keepdims=True)
+    ranks = (-probs).argsort(axis=-1).argsort(axis=-1)
+    mask = ranks < cfg.top_k
+    gate = np.where(mask, probs, 0.0)
+    gate = gate / gate.sum(axis=-1, keepdims=True)
+    expert_outs = np.stack([np.array(e(xn, cd)) for e in block.experts], axis=1)  # (5,E,d)
+    routed = (gate[..., None] * expert_outs).sum(axis=1)
+    shared = sum(np.array(se(xn, cd)) for se in block.shared_experts)
+    expected = routed + shared
+    assert np.allclose(combined, expected, atol=1e-4)
+
+
+@requires_mlx
+def test_shared_experts_zero_is_byte_identical():
+    """n_shared_experts=0 must take the exact pre-#214 path (empty-generator guard)."""
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    assert cfg.n_shared_experts == 0
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    assert block.shared_experts == []
+    xn = mx.random.normal((3, cfg.d_model))
+    y = np.array(block._moe(xn))
+    assert np.all(np.isfinite(y))
+
+
+@requires_mlx
+def test_moe_impl_gather_raises_on_mlx():
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2, moe_impl="gather")
+    with pytest.raises(NotImplementedError):
+        MLXMambaModel(cfg)
+
+
+@requires_mlx
+def test_moe_impl_auto_and_dense_unchanged():
+    from src.model.mlx_backend import MLXMambaModel
+    for impl in ("auto", "dense"):
+        cfg = _cfg(moe_every=2, n_experts=4, top_k=2, moe_impl=impl)
+        mx.random.seed(0)
+        model = MLXMambaModel(cfg)
+        tokens = mx.array(np.arange(32).reshape(1, 32) % 256)
+        y = np.array(model.forward(tokens))
+        assert np.all(np.isfinite(y))
 
 
 @requires_mlx

--- a/tests/test_muon_taxonomy.py
+++ b/tests/test_muon_taxonomy.py
@@ -22,6 +22,10 @@ MUON_TRUE = [
     ("layers.1.experts.0.gate.weight", 2),
     ("layers.1.experts.0.up.weight", 2),
     ("layers.1.experts.0.down.weight", 2),
+    # Shared experts (#214): 2D, unexcluded -> Muon, same as routed experts.
+    ("layers.1.shared_experts.0.gate.weight", 2),
+    ("layers.1.shared_experts.0.up.weight", 2),
+    ("layers.1.shared_experts.0.down.weight", 2),
 ]
 
 MUON_FALSE = [

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -121,6 +121,18 @@ def test_grad_checkpoint_cuts_activations():
     assert a_on < a_off
 
 
+def test_optimizer_sizing_key_covers_every_config():
+    # #214: every config's `optimizer_sizing_key` must resolve to a real
+    # `OPTIMIZER_BYTES_PER_PARAM` entry, so `sizing.training_bytes` never KeyErrors on a
+    # real config even though its default caller-facing `optimizer=` param is different.
+    for path in sorted(CONFIG_DIR.glob("*.yaml")):
+        cfg = load_config(path)
+        assert cfg.optimizer_sizing_key in sizing.OPTIMIZER_BYTES_PER_PARAM, (
+            f"{path.name}: optimizer_sizing_key={cfg.optimizer_sizing_key!r} not in "
+            f"{list(sizing.OPTIMIZER_BYTES_PER_PARAM)}"
+        )
+
+
 def test_family_table_renders_all_tiers():
     table = sizing.format_family_table(sizing.load_family(CONFIG_DIR))
     for name, _ in FAMILY:

--- a/tests/test_upcycle.py
+++ b/tests/test_upcycle.py
@@ -1,0 +1,449 @@
+"""Tests for sparse upcycle (#214): `src/train/upcycle.py` (portable) plus the
+`check_weight_keys` / `load_config_sidecar` checkpoint helpers it depends on, plus a
+focused test of `scripts/train.py`'s `--resume` > `--init` precedence.
+
+Portable tests need no backend. The step-0 exactness tests (the #214 acceptance
+criterion — "upcycled init matches the dense forward at step 0") are backend-guarded:
+one on MLX, one on CUDA/torch (CPU-only torch is fine; no GPU needed).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+from src.data.pack import pack_ids
+from src.model.blocks import MambaConfig, load_config
+from src.train.checkpoint import (
+    check_weight_keys, load_config_sidecar, load_weights_dict, save_weights,
+)
+from src.train.upcycle import (
+    UpcycleError, _expected_keys, check_upcycle_compatible, upcycle_dense_to_moe,
+    upcycle_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _dense_cfg(**over):
+    base = dict(d_model=32, n_layers=2, head_dim=8, d_state=8, vocab_size=64, seq_len=16,
+                precision="fp32", moe_every=2, n_experts=1, top_k=1, moe_d_ff=8)
+    base.update(over)
+    return MambaConfig(**base)
+
+
+def _fine_cfg(**over):
+    base = dict(d_model=32, n_layers=2, head_dim=8, d_state=8, vocab_size=64, seq_len=16,
+                precision="fp32", moe_every=2, n_experts=6, top_k=2, moe_d_ff=8)
+    base.update(over)
+    return MambaConfig(**base)
+
+
+def _fake_weights(cfg, seed=0):
+    """A synthetic-but-shape-correct portable weight dict for `cfg`, without needing a
+    backend — built straight off `_expected_keys`."""
+    rng = np.random.default_rng(seed)
+    return {k: rng.standard_normal(shp).astype(np.float32)
+            for k, shp in _expected_keys(cfg).items()}
+
+
+try:
+    import mlx.core as mx
+    HAVE_MLX = True
+except ImportError:
+    HAVE_MLX = False
+requires_mlx = pytest.mark.skipif(not HAVE_MLX, reason="requires mlx (Apple Silicon)")
+
+
+# --------------------------------------------------------------------------- #
+# check_upcycle_compatible
+# --------------------------------------------------------------------------- #
+def test_check_upcycle_compatible_accepts_dense_fine_pair():
+    check_upcycle_compatible(_dense_cfg(), _fine_cfg())     # no raise
+
+
+def test_check_upcycle_compatible_accepts_the_real_toy_fixtures():
+    src_cfg = load_config(str(REPO_ROOT / "config/toy-moe-dense.yaml"))
+    dst_cfg = load_config(str(REPO_ROOT / "config/toy-moe-fine.yaml"))
+    check_upcycle_compatible(src_cfg, dst_cfg)              # no raise
+
+
+def test_check_upcycle_compatible_rejects_already_moe_source():
+    with pytest.raises(UpcycleError, match="degenerate n_experts=1"):
+        check_upcycle_compatible(_fine_cfg(), _fine_cfg())  # src has n_experts=6
+
+
+def test_check_upcycle_compatible_rejects_d_model_mismatch_names_223():
+    dst = _fine_cfg(d_model=64)
+    with pytest.raises(UpcycleError, match="#223") as exc:
+        check_upcycle_compatible(_dense_cfg(), dst)
+    assert "d_model" in str(exc.value)
+    assert "widen" in str(exc.value) or "Net2Net" in str(exc.value)
+
+
+def test_check_upcycle_compatible_reports_multiple_mismatches_together():
+    dst = _fine_cfg(d_state=4, vocab_size=128)
+    with pytest.raises(UpcycleError) as exc:
+        check_upcycle_compatible(_dense_cfg(), dst)
+    msg = str(exc.value)
+    # BOTH mismatches must be visible in ONE raise, not the first one only.
+    assert "d_state" in msg
+    assert "vocab_size" in msg
+
+
+def test_check_upcycle_compatible_rejects_moe_layer_index_mismatch():
+    dst = _fine_cfg(moe_every=1)                            # different interleave
+    with pytest.raises(UpcycleError, match="moe_every|moe_layer_indices"):
+        check_upcycle_compatible(_dense_cfg(), dst)
+
+
+# --------------------------------------------------------------------------- #
+# upcycle_dense_to_moe: the transform itself (portable, synthetic weights)
+# --------------------------------------------------------------------------- #
+def test_upcycle_output_key_set_and_shapes_match_dst():
+    src_cfg, dst_cfg = _dense_cfg(), _fine_cfg()
+    weights = _fake_weights(src_cfg, seed=1)
+    out = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=2)
+    expected = _expected_keys(dst_cfg)
+    assert set(out) == set(expected)
+    for k, shp in expected.items():
+        assert tuple(out[k].shape) == shp, k
+
+
+def test_upcycle_experts_are_independent_copies_of_source():
+    src_cfg, dst_cfg = _dense_cfg(), _fine_cfg()
+    weights = _fake_weights(src_cfg, seed=1)
+    out = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=2)
+    src_gate = weights["layers.1.experts.0.gate.weight"]
+    for j in range(dst_cfg.n_experts):
+        assert np.array_equal(out[f"layers.1.experts.{j}.gate.weight"], src_gate)
+    # Mutating one expert's array must not affect any other (independent .copy()s, not
+    # the same array aliased n_experts times).
+    out["layers.1.experts.0.gate.weight"][0, 0] += 1000.0
+    assert not np.array_equal(out["layers.1.experts.0.gate.weight"],
+                              out["layers.1.experts.1.gate.weight"])
+    for j in range(2, dst_cfg.n_experts):
+        assert np.array_equal(out[f"layers.1.experts.{j}.gate.weight"], src_gate)
+
+
+def test_upcycle_router_shape_and_seed_reproducible():
+    src_cfg, dst_cfg = _dense_cfg(), _fine_cfg()
+    weights = _fake_weights(src_cfg, seed=1)
+    router_key = "layers.1.router.weight"
+
+    out1 = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=42)
+    assert out1[router_key].shape == (dst_cfg.n_experts, dst_cfg.d_model)
+
+    out2 = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=42)
+    assert np.array_equal(out1[router_key], out2[router_key])       # same seed -> identical
+
+    out3 = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=43)
+    assert not np.array_equal(out1[router_key], out3[router_key])   # different seed -> different
+
+
+def test_upcycle_drops_moe_route_bias_keys():
+    src_cfg, dst_cfg = _dense_cfg(), _fine_cfg()
+    weights = _fake_weights(src_cfg, seed=1)
+    weights["moe_route_bias.1"] = np.zeros((1,), dtype=np.float32)   # E=1 -> length-1 bias
+    out = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=2)
+    assert not any(k.startswith("moe_route_bias.") for k in out)
+
+
+def test_upcycle_total_size_matches_dst_num_parameters():
+    src_cfg, dst_cfg = _dense_cfg(), _fine_cfg()
+    weights = _fake_weights(src_cfg, seed=1)
+    out = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=2)
+    assert sum(v.size for v in out.values()) == dst_cfg.num_parameters()
+
+
+def test_upcycle_shared_expert_zero_down_default():
+    src_cfg = _dense_cfg()
+    dst_cfg = _fine_cfg(n_shared_experts=1)
+    weights = _fake_weights(src_cfg, seed=1)
+    out = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=2)
+    down = out["layers.1.shared_experts.0.down.weight"]
+    assert np.array_equal(down, np.zeros_like(down))
+    gate = out["layers.1.shared_experts.0.gate.weight"]
+    assert not np.all(gate == 0.0)                        # fresh random, not degenerate
+
+
+def test_upcycle_shared_expert_forbid_raises_on_new_expert():
+    src_cfg = _dense_cfg()
+    dst_cfg = _fine_cfg(n_shared_experts=1)
+    weights = _fake_weights(src_cfg, seed=1)
+    with pytest.raises(UpcycleError, match="forbid"):
+        upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=2, shared_expert_init="forbid")
+
+
+def test_upcycle_rejects_unknown_shared_expert_init():
+    src_cfg, dst_cfg = _dense_cfg(), _fine_cfg()
+    weights = _fake_weights(src_cfg, seed=1)
+    with pytest.raises(UpcycleError, match="shared_expert_init"):
+        upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=2, shared_expert_init="bogus")
+
+
+def test_upcycle_raises_on_missing_source_expert_key():
+    src_cfg, dst_cfg = _dense_cfg(), _fine_cfg()
+    weights = _fake_weights(src_cfg, seed=1)
+    del weights["layers.1.experts.0.gate.weight"]
+    with pytest.raises(UpcycleError, match="experts.0.gate.weight"):
+        upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=2)
+
+
+def test_upcycle_manifest_contents():
+    src_cfg, dst_cfg = _dense_cfg(), _fine_cfg()
+    m = upcycle_manifest(src="a.safetensors", src_sha256="deadbeef", seed=7,
+                         router_init_scale=1.0, shared_expert_init="zero_down",
+                         src_cfg=src_cfg, dst_cfg=dst_cfg)
+    assert m["src"] == "a.safetensors"
+    assert m["src_sha256"] == "deadbeef"
+    assert m["seed"] == 7
+    assert m["n_experts_src"] == 1
+    assert m["n_experts_dst"] == 6
+    assert m["moe_layers"] == [1]
+
+
+# --------------------------------------------------------------------------- #
+# _expected_keys cross-checked against a real backend model (portable mirror must not
+# silently drift from the real thing)
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_expected_keys_matches_real_mlx_model():
+    from src.model.mlx_backend import MLXMambaModel
+    cfg = _fine_cfg(n_shared_experts=1, attn_every=None)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    real = {k: tuple(v.shape) for k, v in model._portable_state_dict().items()}
+    assert real == _expected_keys(cfg)
+
+
+# --------------------------------------------------------------------------- #
+# check_weight_keys
+# --------------------------------------------------------------------------- #
+def test_check_weight_keys_passes_on_exact_match():
+    expected = {"a": (2, 3), "b": (4,)}
+    weights = {"a": np.zeros((2, 3)), "b": np.zeros((4,))}
+    check_weight_keys(weights, expected, where="unit-test")   # no raise
+
+
+def test_check_weight_keys_reports_missing_unexpected_mismatched_together():
+    expected = {"a": (2, 3), "b": (4,), "c": (1,)}
+    weights = {"a": np.zeros((2, 3)), "b": np.zeros((5,)), "d": np.zeros((1,))}
+    with pytest.raises(ValueError) as exc:
+        check_weight_keys(weights, expected, where="unit-test")
+    msg = str(exc.value)
+    assert "missing" in msg and "c" in msg
+    assert "unexpected" in msg and "d" in msg
+    assert "mis-shaped" in msg and "b" in msg
+
+
+def test_check_weight_keys_ignores_moe_route_bias():
+    expected = {"a": (2,)}
+    weights = {"a": np.zeros((2,)), "moe_route_bias.0": np.zeros((1,))}
+    check_weight_keys(weights, expected, where="unit-test")   # no raise: bias not checked
+
+
+# --------------------------------------------------------------------------- #
+# load_config_sidecar
+# --------------------------------------------------------------------------- #
+def test_load_config_sidecar_round_trip(tmp_path):
+    cfg = _dense_cfg()
+    path = tmp_path / "weights.safetensors"
+    save_weights({"a": np.zeros((2,), dtype=np.float32)}, str(path), config=cfg)
+    loaded = load_config_sidecar(str(path))
+    assert loaded is not None
+    assert loaded.d_model == cfg.d_model
+    assert loaded.n_experts == cfg.n_experts
+    assert loaded.moe_d_ff == cfg.moe_d_ff
+
+
+def test_load_config_sidecar_returns_none_when_absent(tmp_path):
+    path = tmp_path / "weights.safetensors"
+    save_weights({"a": np.zeros((2,), dtype=np.float32)}, str(path))   # no config=
+    assert load_config_sidecar(str(path)) is None
+
+
+def test_load_config_sidecar_drops_unknown_fields(tmp_path, capsys):
+    cfg = _dense_cfg()
+    d = cfg.to_dict()
+    d["totally_unknown_field_from_the_future"] = 123
+    (tmp_path / "weights.safetensors.config.json").write_text(json.dumps(d))
+    loaded = load_config_sidecar(str(tmp_path / "weights.safetensors"))
+    assert loaded is not None
+    assert not hasattr(loaded, "totally_unknown_field_from_the_future")
+    assert "dropping fields unknown" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# Step-0 exactness (#214's stated acceptance criterion) — real backend models, the
+# checked-in toy-moe-dense/fine.yaml fixture pair.
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_mlx_step0_exactness_and_zero_router_grad():
+    import mlx.nn as nn
+    from mlx.utils import tree_flatten
+    from src.model.mlx_backend import MLXMambaModel
+
+    src_cfg = load_config(str(REPO_ROOT / "config/toy-moe-dense.yaml"))
+    dst_cfg = load_config(str(REPO_ROOT / "config/toy-moe-fine.yaml"))
+
+    mx.random.seed(0)
+    dense_model = MLXMambaModel(src_cfg)
+    tokens = np.arange(2 * src_cfg.seq_len).reshape(2, src_cfg.seq_len) % src_cfg.vocab_size
+    dense_logits = np.array(dense_model.forward(mx.array(tokens)))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wpath = Path(tmp) / "dense.safetensors"
+        dense_model.save(str(wpath))
+        weights = load_weights_dict(str(wpath))
+        upcycled = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=214)
+
+    mx.random.seed(0)
+    fine_model = MLXMambaModel(dst_cfg)
+    fine_model._load_portable(upcycled)
+    fine_logits = np.array(fine_model.forward(mx.array(tokens)))
+
+    max_diff = float(np.abs(dense_logits - fine_logits).max())
+    print(f"[test_mlx_step0_exactness] max|logits_dense - logits_upcycled| = {max_diff:.3e}")
+    assert max_diff < 1e-4
+
+    # router.weight.grad == 0 at step 0: gate weights always sum to 1 no matter what the
+    # router says, and every expert computes the IDENTICAL function (copied from the same
+    # source expert) -- so the combined output (and hence the loss) does not depend on the
+    # router's value at all. Expected, documented behavior, not a bug.
+    def loss_fn(model, x):
+        return model.forward(x).astype(mx.float32).sum()
+
+    value_and_grad = nn.value_and_grad(fine_model, loss_fn)
+    _, grads = value_and_grad(fine_model, mx.array(tokens))
+    flat = dict(tree_flatten(grads))
+    router_grad_keys = [k for k in flat if k.endswith("router.weight")]
+    assert router_grad_keys
+    for k in router_grad_keys:
+        g = np.array(flat[k])
+        assert np.abs(g).max() < 1e-5, f"{k}: max|grad|={np.abs(g).max():.3e}"
+
+
+@requires_mlx
+def test_mlx_step0_exactness_with_shared_expert():
+    from src.model.mlx_backend import MLXMambaModel
+
+    src_cfg = load_config(str(REPO_ROOT / "config/toy-moe-dense.yaml"))
+    dst_cfg = MambaConfig(**{**load_config(str(REPO_ROOT / "config/toy-moe-fine.yaml")).to_dict(),
+                             "n_shared_experts": 1})
+    dst_cfg.validate()
+
+    mx.random.seed(0)
+    dense_model = MLXMambaModel(src_cfg)
+    tokens = np.arange(2 * src_cfg.seq_len).reshape(2, src_cfg.seq_len) % src_cfg.vocab_size
+    dense_logits = np.array(dense_model.forward(mx.array(tokens)))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wpath = Path(tmp) / "dense.safetensors"
+        dense_model.save(str(wpath))
+        weights = load_weights_dict(str(wpath))
+        upcycled = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=214)
+
+    mx.random.seed(0)
+    fine_model = MLXMambaModel(dst_cfg)
+    fine_model._load_portable(upcycled)
+    fine_logits = np.array(fine_model.forward(mx.array(tokens)))
+
+    max_diff = float(np.abs(dense_logits - fine_logits).max())
+    print(f"[test_mlx_step0_exactness_with_shared_expert] max|diff| = {max_diff:.3e}")
+    assert max_diff < 1e-4
+
+
+def test_cuda_step0_exactness_and_zero_router_grad():
+    torch = pytest.importorskip("torch")
+    from src.model.cuda_backend import CUDAMambaModel
+
+    src_cfg = load_config(str(REPO_ROOT / "config/toy-moe-dense.yaml"))
+    dst_cfg = load_config(str(REPO_ROOT / "config/toy-moe-fine.yaml"))
+
+    torch.manual_seed(0)
+    dense_model = CUDAMambaModel(src_cfg)
+    tokens = np.arange(2 * src_cfg.seq_len).reshape(2, src_cfg.seq_len) % src_cfg.vocab_size
+    with torch.no_grad():
+        dense_logits = dense_model.forward(tokens).detach().cpu().numpy()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wpath = Path(tmp) / "dense.safetensors"
+        dense_model.save(str(wpath))
+        weights = load_weights_dict(str(wpath))
+        upcycled = upcycle_dense_to_moe(weights, src_cfg, dst_cfg, seed=214)
+
+    torch.manual_seed(0)
+    fine_model = CUDAMambaModel(dst_cfg)
+    fine_model._load_portable(upcycled)
+    with torch.no_grad():
+        fine_logits = fine_model.forward(tokens).detach().cpu().numpy()
+
+    max_diff = float(np.abs(dense_logits - fine_logits).max())
+    print(f"[test_cuda_step0_exactness] max|logits_dense - logits_upcycled| = {max_diff:.3e}")
+    assert max_diff < 1e-4
+
+    from src.model.cuda_backend import MoEBlock
+    block = next(l for l in fine_model.layers if isinstance(l, MoEBlock))
+    loss = fine_model.forward(tokens).float().sum()
+    loss.backward()
+    g = block.router.weight.grad
+    assert g is not None
+    assert float(g.abs().max()) < 1e-5
+
+
+# --------------------------------------------------------------------------- #
+# --resume beats --init on scripts/train.py (focused test of that branch)
+# --------------------------------------------------------------------------- #
+def _load_train_module():
+    spec = importlib.util.spec_from_file_location("_scripts_train_for_upcycle_test",
+                                                   REPO_ROOT / "scripts/train.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO_ROOT))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.pop(0)
+    return mod
+
+
+@requires_mlx
+def test_resume_beats_init(tmp_path, monkeypatch, capsys):
+    tiny = dict(d_model=16, n_layers=1, head_dim=4, d_state=4, expand=2, d_conv=2,
+               dt_rank="auto", vocab_size=32, seq_len=8, tie_embeddings=True,
+               precision="fp32", chunk_size=None, grad_checkpoint=False,
+               dt_min=0.001, dt_max=0.1, dt_init_floor=0.0001)
+    cfg_path = tmp_path / "tiny.yaml"
+    cfg_path.write_text(yaml.safe_dump(tiny))
+
+    data_dir = tmp_path / "data"
+    pack_ids(np.arange(300, dtype=np.uint16) % 32, data_dir / "train.bin", dtype=np.uint16)
+    pack_ids(np.arange(100, dtype=np.uint16) % 32, data_dir / "val.bin", dtype=np.uint16)
+    out_dir = tmp_path / "out"
+
+    mod = _load_train_module()
+    common = ["--config", str(cfg_path), "--data", str(data_dir), "--out", str(out_dir),
+              "--batch-size", "2", "--grad-accum", "1", "--ckpt-every", "1",
+              "--eval-every", "1000000", "--log-every", "1000000", "--backend", "mlx"]
+
+    monkeypatch.setattr(sys, "argv", ["train.py", *common, "--total-steps", "1"])
+    mod.main()
+    capsys.readouterr()   # discard first run's output
+
+    bogus_init = tmp_path / "does-not-exist.safetensors"
+    monkeypatch.setattr(sys, "argv",
+                        ["train.py", *common, "--total-steps", "2",
+                         "--init", str(bogus_init)])
+    mod.main()            # must NOT raise: a real --resume checkpoint exists under out_dir,
+                           # so --resume wins and --init (pointing at a NONEXISTENT file) is
+                           # never read.
+    out = capsys.readouterr().out
+    assert "[init] IGNORED" in out
+    assert "[resume] from step 1" in out


### PR DESCRIPTION
Closes #214

`cuda_backend.py` raised `NotImplementedError` for any config with MoE layers, and RunPod is CUDA — so the whole M12 spine downstream of it was blocked (#240 fp8, #222 small run, #223 Large A). This lands the port plus the pieces #213 deliberately left out.

## Summary

- **CUDA `MoEBlock`** — mirrors the MLX reference name-for-name, so `named_parameters()` emits the identical portable key set. `_route_bias`/`_load_counts` are `register_buffer(persistent=False)`: invisible to `named_parameters()` *and* `state_dict()`, but still moved by `.to()`. `moe_route_bias.*` is emitted only when the bias is active and popped before `load_state_dict(strict=True)`, so an MLX-trained checkpoint loads into CUDA and routes identically (#213 D3).
- **Grouped-gather (dropless) routing** — cost scales with `top_k`, not `n_experts`. Selectable via a new `moe_impl: auto|dense|gather`; the dense path stays as the parity oracle.
- **Shared expert** (`n_shared_experts`, default 0) on both backends — additive, outside the router softmax and the top-k renormalization.
- **Balancer threading** through all four CUDA train-step factories, reusing `src/train/moe_balance.py` unchanged, as #213 promised.
- **Sparse-upcycle init** — `src/train/upcycle.py` (portable, numpy-only) + `scripts/upcycle.py`. A dense `n_experts: 1` checkpoint's expert is replicated into N slots with a fresh seeded router. `validate()` relaxed to admit E=1, which is exactly a SwiGLU FFN.
- **`--init` on `scripts/train.py`** — also the missing half of the WSD trunk-re-decay lever (#238); nothing in the tree could start a run from a foreign checkpoint before.
- **8-bit optimizer** (`optimizer_8bit`) and **fp8 expert linears** wired; four config fixtures; a new `cuda-cpu` CI job.

## Deliberately not here

**FSDP/ZeRO-2 + in-node expert parallel** → **#271**. No multi-GPU pod exists to validate it, no design record specifies it, and it has no acceptance criterion in this issue. It blocks #223 but not #222. The issue title says "FSDP"; this PR does not deliver it, and the title was changed rather than overstate.

Also filed **#272**: the design record names #200 (`d_model 768`) as the single upcycle source for both MoE runs, but Large A is `1536` and expert replication cannot widen tensors. `upcycle_dense_to_moe` raises rather than papering over it.

## Verification

Both acceptance criteria, measured:

| Check | Result |
|---|---|
| MoE trains on CUDA, bit-exact resume | smoke gate passes on `toy-moe.yaml`, `--moe-impl` both `dense` and `gather` |
| Balanced routing de-collapses | util-variance **11.7x** lower (64 experts, top-6); #213 measured 17.5x on MLX |
| Upcycled init vs dense forward at step 0 | **1.19e-06** (MLX), **2.38e-06** (CUDA), fp32 |
| CUDA vs frozen MLX fixtures | **2.86e-06** / **3.34e-06** (Swift's own accepted figure is 2.38e-06) |
| dense vs gather | numerically identical |

Suite: **1230 passed, 13 skipped** (was 1144 on `main`).

Two implementation details are load-bearing and were established empirically, not assumed:

- **`torch.topk` is disqualified** — it diverges from MLX's `argsort(argsort(-x)) < k` on ties (e.g. `[1,1,1,0,0,2,2,0]`, k=3: topk picks `{6,5,2}`, double-argsort `{0,5,6}`). Selection uses `torch.argsort(..., stable=True)`. A logit comparison at 1e-4 cannot see a tie-break flip, so there is also an integer load-vector gate at `atol=0` and an explicit `topk` negative test.
- **Empty expert groups stay in the graph.** `if count == 0: continue` would leave `p.grad is None`, and `Muon.step` then skips that expert's momentum decay while the dense path decays it — a silent, impl-dependent divergence. A zero-row GEMM matches dense exactly.

The gather dispatch deliberately uses a two-step `expand` + `index_select` rather than the one-shot form, whose `index_add_` backward is an atomic reduction with run-varying summation order — that would have broken the smoke gate's bit-exact resume. It doesn't: resume diff is `0.000e+00`.

## Not verified anywhere

Honest list — none of this has executed:

- **fp8 numerics** — tests are un-skipped but gated on compute capability >= 9 (Hopper). #240 stays open.
- **8-bit optimizer numerics and resume fidelity** — bitsandbytes ships CUDA-only wheels; only the config surface, the seam guard, the failure message and the MLX rejection are tested.
- **`torch.compile` x grad-checkpoint x gather** — the gather kernel's host sync is a guaranteed graph break; mitigation is in place but untested on a GPU.
- **`argsort(stable=True)` on CUDA's radix sort** — verified on CPU across every tie pattern tried. **The entire routing contract rests on this**, so it is worth confirming on a real GPU before this is relied on at scale.

`scripts/smoke_test.py`'s `n_moe_layers == 0` assert was **removed**, not merely re-commented: its stated reason ("MoE is MLX-only") is now false, and the gather path was built deterministic specifically so routing stays inside the bit-exact-resume contract rather than needing a carve-out from it.

## Testing

- [x] Tests added/updated — 6 new modules, +86 tests
- [x] All tests passing — 1230 passed, 13 skipped
- [x] Manual testing completed — smoke gate on MLX, CUDA dense, and CUDA MoE (both impls); upcycle exercised end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K3gzzSsE7RJjyNp4QUQff
