### PR TITLE
docs: reconcile the M12 record with what #214 actually settled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ The smoke gate stresses exactly this round-trip.
   aux-loss-free MoE router #213 **— done** → CUDA MoE backend #214 **— done: dropless
   grouped-gather routing, shared expert, `src/train/upcycle.py` sparse-upcycle init; fp8
   expert GEMMs (#240) and 8-bit AdamW moments wired but hardware-unverified; FSDP/ZeRO-2 +
-  expert parallel split into a follow-up issue that blocks #223, not #222** →
+  expert parallel split out to **#271**, which blocks #223, not #222** →
   FIM/curriculum/eval build → ablation sweep #219 → small full run #222 → sparse-upcycled
   large run #223), with **SSI**
   (structural-signal integration) as a secondary

--- a/README.md
+++ b/README.md
@@ -119,8 +119,10 @@ docs/usage.md              usage guide   docs/infrastructure.md  cloud runbook  
 
 ## Status
 
-The POC core is **implemented and verified on Apple Silicon**, and the **CUDA backend is now
-done and verified on a rented A40** (full suite green on both). The active program is **M12 — the
+The POC core is **implemented and verified on Apple Silicon**, and the **CUDA backend is done and
+was verified on a rented A40** at M8 (full suite green on both). Note the A40 run predates the M12
+MoE work: the CUDA MoE block, fp8 experts and 8-bit optimizer paths added since have **not** been
+exercised on that hardware — see `docs/infrastructure.md`'s manual-verification checklist. The active program is **M12 — the
 from-scratch Mamba-2 hybrid MoE code model**
 ([issue #198](https://github.com/travisgalloway/monica/issues/198)); the M1–M8 core was tracked in
 [issue #2](https://github.com/travisgalloway/monica/issues/2). The earlier M10 distillation program
@@ -136,18 +138,22 @@ from-scratch Mamba-2 hybrid MoE code model**
 | 5 POC scale run           | infra done; ~1.9B-token Qwen2.5 corpus built → R2; ~205M `poc-qwen` run on RunPod; prior OLMo run hit val-ppl ~77 |
 | 6 OLMES / lm-eval         | done — loglikelihood + generative (`generate_until`) tasks                        |
 | 7 Serving + chat + rewind | done — CLI generate/chat over `SessionStore` + `RewindTree`                       |
-| 8 CUDA backend            | **done** — pure-PyTorch Mamba-2/SSD + optional mamba-ssm fast paths; A40-verified |
+| 8 CUDA backend            | **done** — pure-PyTorch Mamba-2/SSD + optional mamba-ssm fast paths; A40-verified as of M8 |
 | 9 Post-training           | **done** — SFT / DPO / GRPO machinery on MLX (+ CUDA step-factory parity)         |
 | 10 Distillation           | machinery **built, then dropped** 2026-07-19 (reserve; see `docs/reserve/`)        |
-| 12 MoE code model         | **active** — MoE build (#213/#214) is the net-new work; SSI signal secondary       |
+| 12 MoE code model         | **active** — MoE build **done on both backends** (#213/#214); next: corpus #252, sweep #219 |
 
 **M12 — the active program.** A from-scratch **TypeScript-first Mamba-2 hybrid MoE code model**
 (tracker [#198](https://github.com/travisgalloway/monica/issues/198); design record
 [`docs/design/13-code-model-moe.md`](docs/design/13-code-model-moe.md)). The spine: own byte-level
-BPE (#191 — **done: native Swift, #245**) → Essential-Web + Stack-v2 corpus (#193) → aux-loss-free MoE router (#213) → CUDA MoE
-backend (#214) → FIM / length curriculum / evals → ablation sweep (#219) → small full run (#222) →
-sparse-upcycled large run (#223). The bulk of the net-new work is the MoE build — MoE is
-MLX-toy-only today. A **secondary axis (SSI)** studies language-server / static-analysis signal:
+BPE (#191 — **done: native Swift, #245**) → Essential-Web + Stack-v2 corpus (pipeline #193 done;
+the corpus build itself is #252, the current blocker) → aux-loss-free MoE router (#213 — **done**)
+→ CUDA MoE backend (#214 — **done**) → FIM / length curriculum / evals (#215/#216/#221 — **done**)
+→ ablation sweep (#219) → small full run (#222) → sparse-upcycled large run (#223). **MoE now runs
+on both backends**: MLX keeps the dense-evaluation reference, and CUDA adds grouped-gather dispatch,
+a shared expert and a sparse-upcycle init path. The net-new work remaining ahead of the runs is the
+corpus (#252), multi-GPU sharding (#271, which blocks #223 but not #222), and resolving #200's
+`d_model` conflict with Large A (#272). A **secondary axis (SSI)** studies language-server / static-analysis signal:
 a validated clean-rate tool with a found functional ceiling (#225/#226/#227/#230).
 
 **Reserve — M10 distillation (dropped 2026-07-19; code removed #189).** The frozen-teacher

--- a/docs/design/05-training.md
+++ b/docs/design/05-training.md
@@ -184,8 +184,11 @@ block reproduces the dense forward exactly at step 0 regardless of the combinati
 formula. `check_upcycle_compatible(src_cfg, dst_cfg)` reports **every** dimension mismatch
 at once (not one-at-a-time raises, which is how a run ends up mis-dimensioned) and hard-
 `UpcycleError`s on any `d_model` mismatch — expert replication can copy a tensor, not widen
-it; see [13-code-model-moe.md](13-code-model-moe.md#the-ssi-fold-structural-signal-integration--secondary)'s
-"Open (#223)" note for why that is a live constraint, not a hypothetical one.
+it; see [13-code-model-moe.md](13-code-model-moe.md#the-mhm-spine-the-programs-phases)'s "Open (#223)" note (and
+#272) for why that is a live constraint, not a hypothetical one. The same note records the
+rest of the source shape: #200 is trained as a degenerate `n_experts: 1, top_k: 1` MoE with
+`moe_d_ff ≈ d_inner/8`, and `_MUST_MATCH` (`src/train/upcycle.py:48-52`) lists all 15 fields
+source and target must agree on.
 `scripts/upcycle.py` runs this offline as an explicit, one-shot CLI (never implicitly
 inside `train.py` — a mistyped `--init` reshaping instead of erroring would burn a whole
 run on a wrong init that still produces a plausible-looking loss curve), writing one
@@ -272,6 +275,14 @@ mamba-ssm kernels, grad checkpointing), so these are the net-new ones.
 | **`torch.compile`** default-on for real CUDA runs | #239 / `7a71073` | `src/model/cuda_backend.py` | **landed** |
 | **fp8** MoE-expert linears (Transformer Engine, Hopper) | #240, landed with #214 | `src/model/cuda_backend.py` (`_te_linear_cls`, `MoEBlock._fp8_ctx`, `_layer_forward`'s TE-checkpoint branch) | **wired**, hardware-unverified (no Hopper CI runner) |
 | **8-bit AdamW moments** (bitsandbytes) | #214 | `src/model/backend.py` (`_cuda_backend._make_optimizer`'s `_adamw` helper) | **wired**, hardware-unverified (no CUDA CI runner) |
+| **FSDP/ZeRO-2 + in-node expert parallel** | #271 (split from #214) | — nothing in the tree; `torch.distributed` is not imported anywhere | **not built** — blocks #223, not #222 |
+
+The last row is the one to watch. Everything above it is a *throughput or memory* lever on a
+single card; #271 is the difference between "#223 can run" and "#223 cannot run at all". At
+~700M-active/3.5B-total with fp32 master weights, grads and AdamW moments, model + optimizer
+state alone exceeds one 80GB card before activations. The small MoE run (#222, ~700M total)
+fits one GPU, which is why it is not gated on this. See `docs/infrastructure.md` — the pod
+recipes there are all single-GPU today.
 
 Two details worth carrying:
 

--- a/docs/design/07-configs-and-decisions.md
+++ b/docs/design/07-configs-and-decisions.md
@@ -36,12 +36,25 @@ scale run) — but they are no longer the whole surface.
 
 The M12 code model's own configs (small ~120M-active/700M-total, "Large A"
 ~700M-active/3.5B-total) do **not** exist yet — they arrive with #200/#219. See
-[13-code-model-moe.md](13-code-model-moe.md). **Note (#200):** whatever `d_model` #200
-lands at, Large A's sparse-upcycle source must match it exactly — `src/train/upcycle.py`
-hard-raises `UpcycleError` on any `d_model` mismatch (expert replication copies a tensor,
-it cannot widen one). #200's currently-assumed `d_model 768` does not match Large A's
-current default of `d_model 1536`; see [13-code-model-moe.md](13-code-model-moe.md)'s
-"Open (#223)" note and its follow-up issue before dimensioning #200.
+[13-code-model-moe.md](13-code-model-moe.md).
+
+**Note (#200) — the sparse-upcycle source is a specific shape, not just a matching width.**
+Three things must hold, and only the first is about `d_model`:
+
+- **`d_model` must match the target exactly.** `src/train/upcycle.py` hard-raises
+  `UpcycleError` on a mismatch (expert replication copies a tensor, it cannot widen one).
+  #200's currently-assumed `d_model 768` does **not** match Large A's current default of
+  `d_model 1536` — see [13-code-model-moe.md](13-code-model-moe.md)'s "Open (#223)" note and
+  **#272** before dimensioning #200.
+- **…and so must 14 other fields.** `_MUST_MATCH` (`src/train/upcycle.py:48-52`) is the
+  authority: `moe_every`, `moe_d_ff_resolved`, `attn_every`, `n_attn_heads_resolved`,
+  `vocab_size`, `tie_embeddings` and the rest of the backbone. Matching only the non-expert
+  dims is necessary but not sufficient.
+- **#200 is trained as a degenerate `n_experts: 1, top_k: 1` MoE with `moe_d_ff ≈ d_inner/8`**,
+  not as a plain dense config — a plain dense model has no `experts.0.*` keys to replicate, and
+  the narrow `moe_d_ff` is what makes 64 fine-grained experts fit Large A's budget. The
+  `toy-moe-dense.yaml` / `toy-moe-fine.yaml` pair above is the worked example;
+  `scripts/upcycle.py --dry-run` checks a real pair in seconds.
 
 ## `config/toy.yaml`
 

--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -197,8 +197,9 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
 > *Architectural consequence — configuration guidance, not a validator rule.* In PSM the suffix is
 > consumed **before** the middle is generated, so every middle token depends on recalling the suffix
 > out of state — the fixed-width-state bottleneck the hybrid exists to patch. Therefore **the final
-> block should be an attention block**: `n_layers % attn_every == 0`, from `layer i is attention iff
-> (i+1) % attn_every == 0` (`src/model/blocks.py:211`). `config/toy-hybrid.yaml` satisfies it
+> block should be an attention block**: `n_layers % attn_every == 0`, from
+> `MambaConfig.is_attention_layer` (`src/model/blocks.py`) — `(i + 1) % attn_every == 0`.
+> `config/toy-hybrid.yaml` satisfies it
 > (4 layers, `attn_every 2` → `[Mamba, Attn, Mamba, Attn]`); `config/student-1b.yaml` (28 layers,
 > `attn_every 8` → attention at 7/15/23, top block Mamba) does **not**, so a future MHM config must
 > not copy that shape. This is deliberately *not* a `MambaConfig.validate()` rule — that validator

--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -10,10 +10,14 @@ from-scratch code model, described below.
 
 ## What this is
 
-> **Read this section as the target design, not as shipped state.** As of 2026-08-07 the MHM
-> components that are **built** are the tokenizer (MHM-P1b, #191/#245), aux-loss-free load
-> balancing (MHM-P2-T0, #213, portable — shared by both backends), and the **CUDA MoE backend**
-> (MHM-P2-T1, #214). `MambaConfig` carries the MoE and hybrid-attention knobs (`moe_every`,
+> **Read this section as the target design, not as shipped state.** As of 2026-08-08 the MHM
+> components that are **built** are the tokenizer (MHM-P1b, #191/#245), the ratified vocab
+> (#251, 49152), aux-loss-free load balancing (MHM-P2-T0, #213, portable — shared by both
+> backends), the **CUDA MoE backend** (MHM-P2-T1, #214), FIM training (#215), the length
+> curriculum + dataloader-state resume (#216), the code eval suite (#221), the pure-PyTorch
+> Mamba-2 reference (#218), and the three training-efficiency levers — hybrid Muon+AdamW (#237),
+> the WSD schedule (#238), and `torch.compile` default-on (#239). `MambaConfig` carries the MoE
+> and hybrid-attention knobs (`moe_every`,
 > `n_experts`, `top_k`, `n_shared_experts`, `moe_impl`, `attn_every`, `fp8_experts`,
 > `optimizer_8bit`, `moe_balance_rate`). Both the MLX and CUDA `MoEBlock`s now have a shared
 > expert (DeepSeek-V2/V3 form, additive, outside the router softmax/top-k renormalization) and
@@ -28,9 +32,11 @@ from-scratch code model, described below.
 > 8-bit AdamW-moments switch (bitsandbytes) are wired but **hardware-unverified** — see
 > docs/infrastructure.md's manual-verification checklist. `src/train/upcycle.py` +
 > `scripts/upcycle.py` (#214) turn a dense (degenerate `n_experts: 1`) checkpoint into a sparse-MoE
-> init that matches the dense forward at step 0. FIM, the Essential-Web + Stack-v2 mixture, and
-> repo-context packing described below are **designed, not implemented**. Per-item status is in
-> the MHM-P# list that follows; when the two disagree, the P# list wins.
+> init that matches the dense forward at step 0. What is **designed, not implemented** is the
+> Essential-Web + Stack-v2 mixture and repo-context packing described below — the pipeline is
+> #193 (closed) but the corpus itself is #252, and nothing has been built from it yet. (FIM used
+> to be listed here as unimplemented; it shipped with #215.) Per-item status is in the MHM-P#
+> list that follows; when the two disagree, the P# list wins.
 
 A from-scratch, **TypeScript-first Mamba-2 hybrid Mixture-of-Experts (MoE) code model**. The
 backbone is mostly Mamba-2/SSD state-space layers with a **minority (~12.5%) of full-attention
@@ -142,7 +148,7 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
   or ported checkpoint routes as trained) → CUDA MoE backend (#214, **done** — dropless
   grouped-gather routing, shared expert, `src/train/upcycle.py` sparse-upcycle init, 8-bit AdamW
   moments and fp8 expert GEMMs wired but hardware-unverified; **FSDP/ZeRO-2 + expert parallel
-  split out to #271, blocking #223 but not #222) → FIM (#215, **done** — see the
+  split out to #271, blocking #223 but not #222**) → FIM (#215, **done** — see the
   resolved note below), length curriculum + dataloader-state resume
   (#216, **done** — `--curriculum "0.25:2048,0.5:4096,1.0:16384"` on `scripts/train.py`, plus
   explicit `MicroBatchStream` state committed inside the checkpoint slot; see
@@ -192,7 +198,7 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
 > consumed **before** the middle is generated, so every middle token depends on recalling the suffix
 > out of state — the fixed-width-state bottleneck the hybrid exists to patch. Therefore **the final
 > block should be an attention block**: `n_layers % attn_every == 0`, from `layer i is attention iff
-> (i+1) % attn_every == 0` (`src/model/blocks.py:192`). `config/toy-hybrid.yaml` satisfies it
+> (i+1) % attn_every == 0` (`src/model/blocks.py:211`). `config/toy-hybrid.yaml` satisfies it
 > (4 layers, `attn_every 2` → `[Mamba, Attn, Mamba, Attn]`); `config/student-1b.yaml` (28 layers,
 > `attn_every 8` → attention at 7/15/23, top block Mamba) does **not**, so a future MHM config must
 > not copy that shape. This is deliberately *not* a `MambaConfig.validate()` rule — that validator
@@ -262,9 +268,36 @@ Namespaced **MHM-P#** to avoid colliding with backlog priority tiers (P0/P1/P2):
 > | **#223** | **Large A** (~700M-active/3.5B-total), upcycled from **#200** | the headline model |
 >
 > This costs one extra dense run but buys the thing that matters: the MoE machinery is proven at
-> ~$100s rather than first being exercised on the ~$1.2k large run. It also means **#200 must be
-> re-dimensioned** off `poc-small.yaml`'s 97M shape to match the small rung's non-expert backbone
-> — otherwise the upcycle won't line up.
+> ~$100s rather than first being exercised on the ~$1.2k large run.
+
+> **What shape the "dense checkpoint" actually has (#214).** "Dense" here is a statement about
+> routing, not about block type, and reading it as "a plain non-MoE config" produces a checkpoint
+> the upcycle cannot use. Three constraints, all enforced in code:
+>
+> 1. **#200 is trained as a degenerate `n_experts: 1, top_k: 1` MoE**, not as a `poc-small.yaml`-shaped
+>    dense model. `scripts/upcycle.py` replicates `layers.{i}.experts.0.{gate,up,down}` into the
+>    target's expert slots, and only a one-expert MoE block has those keys — a plain dense model has
+>    nothing to copy. At E=1 the router's softmax over a single logit is exactly `1.0` and
+>    `MoEBlock._moe` takes the `k == E` branch, so the block *is* a plain SwiGLU FFN: same math, right
+>    key layout. `MambaConfig.validate()` carries an explicit carve-out for E=1 (and requires
+>    `moe_balance_rate: null` there, since balancing one expert is `sign(0) == 0` forever).
+> 2. **`moe_d_ff` must be the fine-grained per-expert width (~`d_inner/8`), not the `null → d_inner`
+>    default.** This is the constraint most likely to be missed, because a dense config would normally
+>    leave it null. Fine-grained MoE means *many narrow* experts, not a few wide ones: at Large A's
+>    scale (`d_model 1536`, `d_inner 3072`), 64 full-width experts would cost **~906M params per MoE
+>    layer**, which the ~3.5B total budget cannot absorb at any useful depth. The target therefore
+>    sizes each expert at `d_inner/8`, and since `moe_d_ff_resolved` is one of the fields that must
+>    match, **#200's dense FFN blocks are deliberately narrow**.
+> 3. **Matching the non-expert backbone is necessary but NOT sufficient.**
+>    `src/train/upcycle.py:48-52` (`_MUST_MATCH`) is the authority — **15 fields** must agree,
+>    including `moe_every`, `moe_d_ff_resolved`, `attn_every` and `n_attn_heads_resolved`, not just
+>    `d_model`. `check_upcycle_compatible` reports every mismatch at once and refuses to transform.
+>    Treat that tuple as the spec rather than re-deriving the list here, where it would drift.
+>
+> Consequence for #200: it must be **re-dimensioned** off `poc-small.yaml`'s 97M shape to match the
+> small rung's non-expert backbone *and* carry the source shape above. `config/toy-moe-dense.yaml`
+> and `config/toy-moe-fine.yaml` are the worked source/target pair; `scripts/upcycle.py --dry-run`
+> checks compatibility in seconds, which is the cheap way to find this out rather than after a run.
 
 > **Open (#223) — #200's `d_model` doesn't match Large A.** The table above names #200
 > (`d_model 768`, the small rung) as *the single upcycle source for both MoE runs*, but Large A's

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2,7 +2,8 @@
 
 Why the Mamba-2 Hybrid POC is built the way it is. These files explain the **design
 choices and their rationale** — the *what* and *why*. The POC core (M1–M7), the **CUDA
-backend (M8, A40-verified)**, and the **post-training machinery (M9, SFT/DPO/GRPO)** are
+backend (M8, A40-verified — that run predates the M12 MoE/fp8/8-bit paths, which have not
+been exercised on it)**, and the **post-training machinery (M9, SFT/DPO/GRPO)** are
 implemented and verified; the M1–M8 milestones were tracked in
 [issue #2](https://github.com/travisgalloway/monica/issues/2). The **active program is M12 — the
 from-scratch Mamba-2 hybrid MoE code model** ([issue #198](https://github.com/travisgalloway/monica/issues/198));
@@ -50,9 +51,11 @@ Every claim here is sourced from a docstring or config comment in the code, with
     clean-rate tool (0.887→0.962) that leaves functional pass@1 flat (0.503) — the recorded
     rationale for demoting the LSP signal to secondary.
 13. **[The M12 code model — Mamba-2 hybrid MoE + SSI](13-code-model-moe.md)** — the **live
-    program** (#198): the MHM spine (own BPE — **native Swift**, #191/#245 → Essential-Web + Stack-v2 → aux-loss-free MoE →
-    CUDA MoE backend → FIM/curriculum/evals → ablation sweep → sparse-upcycled large run) and the
-    secondary SSI structural-signal fold (#225/#226/#227/#230).
+    program** (#198): the MHM spine (own BPE — **native Swift**, #191/#245 **done** →
+    Essential-Web + Stack-v2 corpus, #252 **the current blocker** → aux-loss-free MoE, #213
+    **done** → CUDA MoE backend, #214 **done** → FIM/curriculum/evals, #215/#216/#221 **done** →
+    ablation sweep #219 → small full run #222 → sparse-upcycled large run #223, **blocked on #271
+    and #272**) and the secondary SSI structural-signal fold (#225/#226/#227/#230).
 14. [The native inference + training engine (Swift + MLX)](14-inference-engine.md) — the M13
     engine (#163): prefill-via-scan, quantization, speculative decoding, the Swift train step +
     checkpoint I/O, and the B1–B4 investigation behind **Swift/MLX, Mac-first**.
@@ -87,7 +90,7 @@ Every claim here is sourced from a docstring or config comment in the code, with
 | OLMES / lm-eval | implemented (Tier-2); scores near chance at POC scale | loglikelihood + generative tasks run end-to-end | `src/eval/olmes_adapter.py` |
 | Build method (M12) | **from-scratch** Mamba-2 hybrid **MoE** code model (not distillation) | model quality is the primary axis; MoE = capability per active param | `docs/design/13-code-model-moe.md` |
 | Tokenizer (M12) | **own byte-level BPE — native Swift** (`swift/MonicaTokenizer`, #191/#245) | cross-platform (macOS + Linux/CUDA), bit-identical; own tiktoken-style format; o200k-style pretokenizer (digit-split ≤3, indentation merge); uint16; **MLX deliberately not used** (BPE is CPU/integer work). Python code-path retired | `docs/design/13-code-model-moe.md` (MHM-P1b) |
-| Model sizes (M12) | small ~120M-act/700M-tot; large "Large A" ~700M-act/3.5B-tot | large is **sparse-upcycled** from the small dense ckpt; ablation sweep picks the layout (#219) | `docs/design/13-code-model-moe.md` |
+| Model sizes (M12) | small ~120M-act/700M-tot; large "Large A" ~700M-act/3.5B-tot | large is **sparse-upcycled** from the small dense ckpt (#200); ablation sweep picks the layout (#219). **⚠️ Open (#272):** #200 is `d_model 768` and Large A defaults to `1536` — replication cannot widen a tensor, so as currently dimensioned this does **not** work. Also **#271** (FSDP/expert-parallel) is unbuilt and blocks the large run | `docs/design/13-code-model-moe.md` |
 | Structural signal (M12, secondary) | LSP/opengrep as measurement + training signal (SSI) | validated clean-rate tool, functional ceiling found; #225/#226/#227/#230 | `docs/design/13-code-model-moe.md` |
 | Data framework | `datatrove` + R2 + RunPod | builds the M12 corpus (Essential-Web + Stack-v2, #193) + reserve data. For the M12 code corpus, Python **cleans** (→ `cleaned.jsonl`); the native Swift `monica-tokenize pack` **tokenizes+packs** | `docs/design/08-corpus-pipeline.md` |
 | Native engine (M13) | **Swift + MLX, Mac-first** (B1); ggml/llama.cpp port deferred | reuses our MLX numerics/weights/quant and the native `swift/MonicaTokenizer`; parity-checkable against the Python seam at fp32 ~1e-4. Not Mac-locked (mlx-swift#320 CUDA build) but Apple Silicon first; ggml is gated on arch freeze + MoE-Mamba support and has no training path | `docs/design/14-inference-engine.md` |

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -195,7 +195,9 @@ RunPod provides the on-demand compute. Two roles, kept separate:
 RunPod network volumes are **region-locked** and cannot be moved once created — every later pod
 that needs the corpus + checkpoints must be schedulable in that same region, so the pin is
 effectively permanent. Choose the region by **where the card you will actually train on has
-capacity** — H100 for the M12 large run (#223) — not by proximity to R2. R2 has no egress fee
+capacity** — H100 for the M12 large run (#223; but see the single-GPU warning under "GPU pod"
+below — #223 also needs **#271** built and **#272** resolved before it is runnable at all) — not
+by proximity to R2. R2 has no egress fee
 (above), so "network-close to R2" is a *latency*, not a *cost*, consideration: worth weighing once
 the H100-capacity region is chosen, but subordinate to it.
 
@@ -339,8 +341,22 @@ python scripts/train.py --backend cuda --config config/<student-or-poc>.yaml \
 ```
 
 Bring the pod up **in that order** so a config or throughput problem surfaces *before* the long
-run. The CUDA backend is already done and A40-verified (the full suite is green on a rented
-A40); the fused kernels auto-detect at runtime and degrade gracefully when absent.
+run. The CUDA backend is done and was A40-verified **at M8** (the full suite was green on a rented
+A40); the fused kernels auto-detect at runtime and degrade gracefully when absent. That run
+predates the M12 MoE work — the CUDA MoE block, fp8 experts and the 8-bit optimizer have **not**
+been exercised on that or any other GPU; see the manual-verification checklist below.
+
+> **⚠️ Every pod recipe in this document is single-GPU, and that is a real ceiling, not an
+> omission.** Multi-GPU sharding (FSDP/ZeRO-2 + in-node expert parallel) is **#271 — not built**.
+> Nothing in the tree imports `torch.distributed`. Practically:
+> - **#222** (small MoE, ~700M total) fits one card and is runnable on these recipes today.
+> - **#223** (Large A, ~700M-active/3.5B-total) does **not**. Model + optimizer state alone
+>   exceeds one 80GB card before activations. Renting an H100 for #223 today buys a pod that
+>   cannot run the job.
+>
+> #223 is additionally blocked on **#272** (#200 is `d_model 768`, Large A defaults to `1536`, and
+> sparse-upcycle replication cannot widen a tensor). Settle both before committing to a region or
+> a reservation.
 
 ### Manual verification: 8-bit optimizer + fp8 experts (#214)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ cuda-fast = ["torch>=2.0", "mamba-ssm>=2.0", "causal-conv1d>=1.0"]
 # TE is Hopper-only (sm_90+) and a heavy dependency, and fp8 applies only to the expert
 # GEMMs (gate/up/down), not the whole model. Auto-detected at runtime by
 # `cuda_backend._te_linear_cls()` and degrades to bf16/fp16 `nn.Linear` when absent or
-# pre-Hopper. DESIGN-ONLY today (blocked on #214's CUDA MoE experts).
+# pre-Hopper. Wired by #214, but hardware-unverified: the acceptance tests are sm_90-gated
+# and have never executed, so #240 stays open until they run on a Hopper pod.
 cuda-fp8 = ["torch>=2.0", "transformer-engine>=1.0"]
 # 8-bit AdamW optimizer states (#214) via bitsandbytes, a SEPARATE extra from
 # `cuda`/`cuda-fast`/`cuda-fp8`: bitsandbytes ships CUDA-only prebuilt wheels (no

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -161,9 +161,10 @@ class MambaConfig:
     # `cuda_backend._expert_linear` builds the TE linears, `MoEBlock._fp8_ctx` wraps the
     # expert-compute region in `fp8_autocast`, and `_layer_forward` routes MoE layers
     # through `transformer_engine.pytorch.checkpoint` (plain checkpoint double-updates the
-    # fp8 amax history). The acceptance tests at `tests/test_cuda_fp8.py:77-93` are
-    # un-skipped but gated on sm_90+, so they have never executed — #240 stays open until
-    # they run green on a Hopper pod.
+    # fp8 amax history). The acceptance tests — `test_fp8_expert_forward_matches_bf16` and
+    # `test_fp8_expert_checkpoint_backward_finite_grads` in `tests/test_cuda_fp8.py` — are
+    # un-skipped but gated on the `_hopper` fixture (sm_90+), so they have never executed —
+    # #240 stays open until they run green on a Hopper pod.
     fp8_experts: bool = False
 
     # --- training-free long-context extension (#54) ---

--- a/src/model/blocks.py
+++ b/src/model/blocks.py
@@ -157,9 +157,13 @@ class MambaConfig:
     # (gate/up/down), not the whole model — everything else stays at `precision`. A no-op
     # on MLX and on non-Hopper CUDA (the `cuda_backend._te_linear_cls()` probe falls back
     # to a plain bf16/fp16 `nn.Linear` when TE is absent or the device is pre-sm_90).
-    # DESIGN-ONLY today: #240 is blocked on #214 (no CUDA MoE experts exist yet to attach
-    # fp8 to) — this field and its validate() rule land now so #214 can wire fp8 in
-    # mechanically. See `cuda_backend.py`'s `# BLOCKED-ON-#214` block.
+    # WIRED but HARDWARE-UNVERIFIED (#214 landed the CUDA experts this attaches to):
+    # `cuda_backend._expert_linear` builds the TE linears, `MoEBlock._fp8_ctx` wraps the
+    # expert-compute region in `fp8_autocast`, and `_layer_forward` routes MoE layers
+    # through `transformer_engine.pytorch.checkpoint` (plain checkpoint double-updates the
+    # fp8 amax history). The acceptance tests at `tests/test_cuda_fp8.py:77-93` are
+    # un-skipped but gated on sm_90+, so they have never executed — #240 stays open until
+    # they run green on a Hopper pod.
     fp8_experts: bool = False
 
     # --- training-free long-context extension (#54) ---


### PR DESCRIPTION
Refs #198. Follow-up to #214 / PR #273 — no behaviour change, docs and comments only.

#214 settled several things that were not in the plan of record and invalidated several that were. Its own doc pass covered part of that; this closes the rest. The backlog half of the reconciliation is already applied directly to the issues (see below).

## The part that matters

**A load-bearing decision existed only in a config comment.** The sparse-upcycle source — #200, which seeds *both* #222 and #223 — must be trained as a degenerate `n_experts: 1, top_k: 1` MoE with `moe_d_ff ≈ d_inner/8`. Not a plain dense config: a plain dense model has no `experts.0.{gate,up,down}` keys for `scripts/upcycle.py` to replicate, and the narrow width is what lets 64 fine-grained experts fit Large A's budget (64 full-width experts ≈ **906M params per MoE layer**).

`docs/design/13-code-model-moe.md` never mentioned `moe_d_ff` at all and described the source only as "#200's **dense** checkpoint" — which reads as `poc-small.yaml`-shaped. `config/toy-moe-dense.yaml:14-16` admitted the gap in its own comment: *"that extra constraint is not written down anywhere else in the design docs."*

Related half-truth fixed: `07-configs` said only `d_model` had to match. `_MUST_MATCH` (`src/train/upcycle.py:48-52`) requires **15 fields**. Both docs now cite that tuple as the authority instead of restating a list that would drift.

## Claims that were flatly false

- `README.md` — "MoE is **MLX-toy-only today**". Untrue since #214.
- `13:31` — FIM "designed, not implemented", while `13:145` in the same file said done.
- `13`'s built-list omitted #215/#216/#218/#221/#237/#238/#239.
- `blocks.py` and `pyproject.toml` pointed at a `BLOCKED-ON-#214` marker that **no longer exists anywhere in the tree**.
- "A40-verified" (4 places) → "A40-verified **at M8**". That run predates the MoE/fp8/8-bit paths, none of which have executed on any GPU.

## Two gaps in the docs read at decision time

- **`05-training.md`** owns the training-lever record and had **no distributed story at all** (`grep -i fsdp` → nothing) while listing fp8 and 8-bit with status columns. Adds an FSDP/ZeRO-2 row for #271, marked not-built.
- **`docs/infrastructure.md`** is read at *rental time* and never mentioned #271, while its region-pin advice still said "H100 for the M12 large run (#223)". **Renting an H100 for #223 today buys a pod that cannot run the job** — ~3.5B total exceeds one 80GB card before activations. Adds an explicit single-GPU ceiling note and cross-references #272.

Plus a broken anchor, a stale line ref (`blocks.py:192` → `:211`), and an unclosed bold run in 13's P2 spine that bled emphasis into the FIM entry.

## Backlog changes (already applied, not part of this PR)

- **#240 reopened** — a `Closes #240` keyword in a #273 branch commit closed it on merge. fp8 is wired but its sm_90-gated tests have never executed.
- **#198** — ticked six boxes whose issues were already closed (#251, #215, #216, #218, #221, #224); added #230 (an open M12 issue absent from the checklist); recorded that **#272 gates #200's dimensions**, not just #223's budget.
- **#200** — added the upcycle-source shape and the #272 block; removed the demoted Branch-Train-Mix rationale; repointed corpus #193 → #252; corrected vocab 16k → 49152 (#251).
- **#222** — removed "Produces the dense checkpoint that the large run sparse-upcycles from", which contradicted both #198 and #272.
- **#223** — resolved the `#H` placeholder → #200; named #271 and #272 as blockers.
- **#217** (#193 → #252), **#227** (`#K` → #225), **#252** (given the M12 milestone and labels it lacked despite being the declared critical path).

Each edited issue carries a comment recording what changed and why.

## Testing

- [x] Tests added/updated — n/a, docs and comments only
- [x] All tests passing — **1232 passed, 13 skipped**, unchanged
- [x] Manual testing completed — verification greps confirm the false claims are gone, the `moe_d_ff` constraint is now findable in both design docs, and #271 reaches `05-training.md`, `infrastructure.md` and `design/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K3gzzSsE7RJjyNp4QUQff