### PR TITLE
feat: [M12] MoE routing diagnostics + mid-training kill-criterion

### DIFF
--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -326,6 +326,47 @@ builds dropless grouped-gather MoE with a shared expert and a sparse-upcycle ini
 remains before a real RunPod run is FSDP/ZeRO-2 + expert parallel (#271, blocking #223 but not
 #222) and resolving the `d_model` conflict above (#272).
 
+### #217 — routing diagnostics + kill-criterion
+
+Before #217 the only routing signal reaching `metrics.jsonl` was `moe_util_var` (a single scalar,
+`max` over layers), and only when a `MoEBalancer` is attached (`moe_balance_rate` set) — which is
+`null` in every config in the tree. There was no way to tell mid-run whether the router was
+*specializing*, the thing the #222/#223 runs turn on. #217 adds three signals, all keyed off the
+same per-block `_count_loads` gate the balancer already uses:
+
+- **`moe_router_entropy`** (+ `moe_router_entropy_per_layer`) — mean per-token entropy (nats) of
+  the UNBIASED gate distribution, accumulated in `MoEBlock._moe` on both backends, **outside** the
+  `top_k < n_experts` guard (loads are meaningless at `top_k == n_experts`, but the gate
+  distribution is still real). `MoEBlock.pop_routing_stats()` / the model-level
+  `pop_moe_routing_stats()` drain both the entropy accumulator and the load counter in ONE pop —
+  the train step (`_accumulate_and_step`, both backends) calls it exactly once per step and shares
+  the result between the balancer and the diagnostics, which are no longer gated on
+  `balancer is not None`.
+- **`moe_util_var`** (+ `moe_util_var_per_layer`) — unchanged key/meaning, now reported on every
+  step that observed any routed load, independent of whether a balancer is attached.
+- **Per-domain expert histograms** (`src/eval/moe_routing.py`) — a periodic diagnostic eval pass
+  (`--moe-diag-every`) over the per-domain val sets `scripts/build_domain_val_sets.py` builds (the
+  same `domains.json` input `src/eval/domain_bpb.py` consumes). **Packed training shards carry no
+  domain tag** (documented at `src/eval/domain_bpb.py:15-31`; #252, which would add one, is open
+  and blocked on #251), so this measures expert usage on held-out samples *drawn from* each
+  domain, not over the live training mix. `histogram_overlap` / `specialization_report` compute
+  pairwise routing overlap (`1 - TV`, 1.0 = identical routing) across every measured domain pair,
+  written to `metrics.jsonl` as `moe_domain_overlap` (mean), `moe_domain_overlap_max`, and the raw
+  `moe_expert_hist`.
+
+**The kill-criterion (`kill_check`) reports; it does not abort.** `--moe-kill-pair` /
+`--moe-kill-overlap` (default 0.90) name two domains and a routing-overlap threshold; when the
+measured overlap is `>= threshold` the run prints a loud `[moe-kill]` line and a `moe_kill` event
+in `metrics.jsonl` (`moe_kill_triggered`, echoed live), but **never stops the run** — killing a
+multi-day run from a threshold is the operator's call, not this module's. Early in training
+routing is near-uniform by construction, so a high overlap there is *expected*, not evidence of a
+broken router; a threshold crossed at step 50 does not mean what the same crossing means at step
+50,000.
+
+Standing repo rule applied throughout: a check that cannot observe its target reports BLIND,
+never healthy. An unmeasured domain, an all-zero histogram, or counting-off entropy never reads
+as "the router is fine" — each case raises or is recorded as an explicit `None`.
+
 ## The SSI fold (structural signal integration — secondary)
 
 "Does feeding language-server / static-analysis signal into the model help?" — retained as a

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -29,6 +29,7 @@ imports stay behind `src.model.backend.get_backend`, so the module stays importa
 from __future__ import annotations
 
 import argparse
+import math
 from pathlib import Path
 
 
@@ -137,9 +138,17 @@ def main() -> None:
         raise SystemExit(f"[moe-diag] {args.config} has no MoE layers (moe_every is "
                          "unset) — there is no router to diagnose.")
     if args.moe_diag_every and args.moe_diag_every % args.log_every != 0:
-        print(f"[moe-diag] WARNING: --moe-diag-every={args.moe_diag_every} does not "
-              f"divide --log-every={args.log_every} — the diagnostic pass will silently "
-              "never fire (it only runs on steps that are also log_every steps).")
+        # The diagnostic is nested inside the log_every block (as `val_eval`/`eval_every`
+        # already is), so it fires only on steps that are multiples of BOTH — i.e. every
+        # lcm(log_every, moe_diag_every), NOT every moe_diag_every. It does still fire;
+        # the cadence is just coarser than asked for. Say which, so a run that logs a
+        # diagnostic every 200 steps when 15 was requested is not read as a bug.
+        effective = math.lcm(args.moe_diag_every, args.log_every)
+        print(f"[moe-diag] WARNING: --moe-diag-every={args.moe_diag_every} is not a "
+              f"multiple of --log-every={args.log_every} — the diagnostic pass only runs "
+              f"on steps that are also log steps, so its EFFECTIVE cadence is every "
+              f"{effective} steps, not {args.moe_diag_every}. Make it a multiple of "
+              f"--log-every to get the cadence you asked for.")
 
     tokens_per_step = args.batch_size * cfg.seq_len * args.grad_accum
     # Length curriculum (#216): the stage allocation, not the fixed shape, decides how

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -58,6 +58,26 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--ckpt-every", type=int, default=500)
     ap.add_argument("--eval-batches", type=int, default=50,
                     help="cap val batches per eval (None-like 0 = full val set)")
+    ap.add_argument("--moe-diag-every", type=int, default=0,
+                    help="#217: steps between MoE routing diagnostic passes (0 = off). "
+                         "Only fires on steps that are also --log-every steps, so use a "
+                         "multiple of it.")
+    ap.add_argument("--moe-diag-domains", type=Path, default=None,
+                    help="domains.json from scripts/build_domain_val_sets.py — the "
+                         "per-domain val sets the expert histograms are measured over. "
+                         "Packed training shards carry no domain tag (#252), so this is "
+                         "usage on held-out samples DRAWN FROM each domain, not over the "
+                         "live training mix.")
+    ap.add_argument("--moe-kill-pair", type=str, default="typescript,math",
+                    help="two domain names from domains.json whose expert histograms the "
+                         "kill-criterion compares.")
+    ap.add_argument("--moe-kill-overlap", type=float, default=0.90,
+                    help="routing overlap at or above which the pair is NOT specializing. "
+                         "Early in training routing is near-uniform by construction and "
+                         "overlap is legitimately ~1.0 — this REPORTS, it never aborts.")
+    ap.add_argument("--moe-diag-batches", type=int, default=8,
+                    help="cap batches per domain in a diagnostic pass (this is a probe, "
+                         "not an eval — keep it small).")
     ap.add_argument("--init-loss-scale", type=float, default=2.0 ** 13)
     ap.add_argument("--resume", type=Path, default=None,
                     help="resume bundle dir; if omitted, auto-detects <out>/resume")
@@ -103,6 +123,23 @@ def main() -> None:
     backend = get_backend(args.backend)
 
     cfg = load_config(str(args.config))                 # validates (vocab < 2**32, head_dim | d_inner, ...)
+
+    # #217: fail fast, before the model is built where possible — a bad routing-diagnostic
+    # flag should not surface 200 steps into a multi-day run.
+    if args.moe_diag_every and args.moe_diag_domains is None:
+        raise SystemExit("--moe-diag-every > 0 requires --moe-diag-domains "
+                         "(domains.json from scripts/build_domain_val_sets.py)")
+    moe_kill_pair = tuple(s.strip() for s in args.moe_kill_pair.split(","))
+    if len(moe_kill_pair) != 2:
+        raise SystemExit(f"--moe-kill-pair must be exactly two comma-separated domain "
+                         f"names, got {args.moe_kill_pair!r}")
+    if args.moe_diag_every and cfg.n_moe_layers == 0:
+        raise SystemExit(f"[moe-diag] {args.config} has no MoE layers (moe_every is "
+                         "unset) — there is no router to diagnose.")
+    if args.moe_diag_every and args.moe_diag_every % args.log_every != 0:
+        print(f"[moe-diag] WARNING: --moe-diag-every={args.moe_diag_every} does not "
+              f"divide --log-every={args.log_every} — the diagnostic pass will silently "
+              "never fire (it only runs on steps that are also log_every steps).")
 
     tokens_per_step = args.batch_size * cfg.seq_len * args.grad_accum
     # Length curriculum (#216): the stage allocation, not the fixed shape, decides how
@@ -174,6 +211,44 @@ def main() -> None:
     max_b = args.eval_batches or None
     val_eval = lambda m: evaluate(m, val_loader, max_batches=max_b, to_numpy=np_to)
 
+    moe_diag = None
+    if args.moe_diag_every:
+        from src.eval.moe_routing import (expert_histograms, format_routing_report,
+                                          kill_check, specialization_report)
+        from src.eval.domain_bpb import load_domain_index
+        diag_index = load_domain_index(args.moe_diag_domains)      # raises early if bad
+        diag_domains = {n: e["packed"] for n, e in diag_index.items()}
+
+        def moe_diag(m):
+            hists = expert_histograms(m, diag_domains, batch_size=args.batch_size,
+                                      seq_len=cfg.seq_len,
+                                      max_batches=args.moe_diag_batches, to_numpy=np_to)
+            report = specialization_report(hists)
+            kill = kill_check(report, pair=moe_kill_pair, threshold=args.moe_kill_overlap)
+            if kill["triggered"]:
+                # Loud, and a machine-readable event line of its own — it does NOT abort
+                # the run (that is the user's call; see --moe-kill-overlap's help). No
+                # "step" key: the loop owns the step number and the payload this function
+                # returns lands on the logged step anyway — this event line is the loud
+                # one, the flat moe_kill_* fields below are the durable record. `logger`
+                # is defined further down in main(); this closure only runs once training
+                # starts, by which point it is bound in the enclosing scope.
+                print(f"[moe-kill] {kill['pair']} routing overlap "
+                      f"{kill['overlap']:.4f} >= {args.moe_kill_overlap:.4f}: the router "
+                      f"is NOT specializing between these domains. Reporting only — the "
+                      f"run continues. Early in training this is expected.")
+                print(format_routing_report(report, kill))
+                logger({"event": "moe_kill", "moe_kill_pair": kill["pair"],
+                       "moe_kill_overlap": kill["overlap"],
+                       "moe_kill_threshold": kill["threshold"],
+                       "moe_kill_triggered": kill["triggered"]})
+            return {"moe_domain_overlap": report["mean_overlap"],
+                    "moe_domain_overlap_max": report["max_overlap"],
+                    "moe_kill_pair": kill["pair"],
+                    "moe_kill_overlap": kill["overlap"],
+                    "moe_kill_triggered": kill["triggered"],
+                    "moe_expert_hist": hists}
+
     # --- resume (double-buffered, crash-safe checkpoint store) -----------------
     out = args.out
     out.mkdir(parents=True, exist_ok=True)
@@ -219,6 +294,12 @@ def main() -> None:
     # counting. No-op when balancing is off. `CheckpointStore.save` is unchanged — there
     # is deliberately no second copy of the bias in the resume bundle.
     attach_balancer(balancer, model)
+    # #217: routing diagnostics are DECOUPLED from balancing. `attach_balancer` turns
+    # counting on only when a balancer exists (moe_balance.py:171), and moe_balance_rate is
+    # null in every config in the tree — so without this the diagnostics would observe
+    # nothing and report a uniform, blind zero.
+    if args.moe_diag_every:
+        model.set_moe_load_counting(True)
 
     logger = JsonlLogger(str(out / "metrics.jsonl"), append=resuming)
 
@@ -237,6 +318,7 @@ def main() -> None:
         log_every=args.log_every, eval_every=args.eval_every,
         ckpt_every=args.ckpt_every, out_dir=str(out), seed=args.seed,
         lr_schedule=args.lr_schedule, decay_frac=args.decay_frac,
+        moe_diag_every=args.moe_diag_every,
     )
 
     n_params = sum(int(np.asarray(v).size) for _, v in model._portable_state_dict().items())
@@ -264,7 +346,8 @@ def main() -> None:
                   "line in metrics.jsonl.")
 
     result = train(model, train_loader, tcfg, train_step,
-                   val_eval=val_eval, logger=logger, on_checkpoint=on_checkpoint,
+                   val_eval=val_eval, moe_diag=moe_diag, logger=logger,
+                   on_checkpoint=on_checkpoint,
                    start_step=start_step, curriculum=curriculum,
                    loader_factory=loader_factory if curriculum is not None else None,
                    start_data_state=start_data_state,

--- a/src/eval/moe_routing.py
+++ b/src/eval/moe_routing.py
@@ -1,0 +1,254 @@
+"""MoE routing diagnostics: per-domain expert histograms + a mid-training kill-criterion
+(#217).
+
+ABOVE THE SEAM. Pure numpy + stdlib; touches a model only through the duck-typed
+`ModelInterface.forward` plus the MoE accessors `set_moe_load_counting` / `pop_moe_load`
+(both backends already expose these for Loss-Free-Balancing, #213/#214) — no `mlx` or
+`torch` import here, ever.
+
+What this measures, and what it is NOT
+---------------------------------------
+The question this module answers is: does the router send different domains (say,
+TypeScript vs math) to different experts, or has it collapsed onto one shared set? That
+would be the earliest, cheapest signal that MoE capacity is buying nothing.
+
+Packed training shards carry no domain tag — `src/data/shard.py`'s manifest is
+`{seq_len, dtype, tokenizer, n_documents, n_sequences, n_tokens, shards}`, and the Swift
+packer (`swift/Sources/MonicaTokenizer/Packing.swift`) writes the identical shape; the
+per-record `source`/`lang` that exist at the cleaned-Parquet stage are dropped by the time
+tokens are packed (documented at `src/eval/domain_bpb.py:15-31`). #252, which would add a
+`.domains` sidecar carrying that tag through packing, is open and blocked on #251. So —
+exactly like `domain_bpb.py` — this reads the purpose-built per-domain val sets built by
+`scripts/build_domain_val_sets.py` (`domains.json`, the same input `load_domain_index`
+already parses). **This measures expert usage on held-out samples drawn from each domain,
+not over the live training mix.** No `.domains` sidecar, no re-pack, no Swift packer
+change, no dependency on #252.
+
+The BLIND rule
+---------------
+A check that cannot observe its target must report loudly, never healthily. An empty
+histogram, an unmeasured domain, or a missing kill-criterion input must never silently
+read as "the router is fine" / "the router is specializing" — every such case here raises
+or is recorded as an explicit `None`, never a zero or a default verdict.
+
+The kill-criterion REPORTS, it does not abort
+-----------------------------------------------
+`kill_check` below is a diagnostic, not a control-flow decision: it never raises a
+training run's abort signal. Killing a multi-day run from a threshold is the operator's
+call, not this module's. And **early in training, routing is near-uniform by
+construction**, so a high overlap between any two domains is *expected*, not evidence of
+a broken router — a threshold crossed at step 50 is not the same event as one crossed at
+step 50,000. Callers must read the verdict in that light.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+import numpy as np
+
+from ..data.loader import PackedLoader
+
+
+def expert_histograms(model, domains: Dict[str, str], *, batch_size: int = 4,
+                      seq_len: int = 512, max_batches: Optional[int] = 8,
+                      to_numpy=np.asarray) -> Dict[str, Optional[list]]:
+    """Per-domain, per-MoE-layer expert token counts from a forward-only pass.
+
+    `domains` maps a domain name to its packed `.bin` (exactly `load_domain_index`'s
+    `{name: entry["packed"]}` projection). Each domain is read `shuffle=False,
+    drop_last=False` so the histogram is a deterministic function of
+    `(seq_len, batch_size, max_batches)`.
+
+    Returns `{domain: [[count per expert] per MoE layer]}`, or `None` for a domain whose
+    val file is too small for one chunk (the `domain_bpb`/`long_context` convention —
+    explicitly unmeasured, never a zero histogram).
+
+    Mutates model state: turns per-expert load counting on (if it was not already) and
+    drains the accumulators, both before measuring the first domain and after each one.
+    """
+    if not domains:
+        raise ValueError("expert_histograms(): no domains — an empty report is a failure, "
+                         "not a perfect score")
+
+    model.set_moe_load_counting(True)
+    # The training step drains the counters every step, but an fp16-overflow-skipped step
+    # deliberately leaves its counts behind (`cuda_train_step.py:95-97`); discarding them
+    # here keeps training tokens out of a domain histogram. The cost is that one skipped
+    # step's counts never reach the balancer, which is noise under a sign-based update.
+    if not model.pop_moe_load():
+        raise ValueError(
+            "expert_histograms(): model has no MoE layers — an expert histogram cannot "
+            "be measured, and an empty report must not read as 'the router is fine'"
+        )
+
+    out: Dict[str, Optional[list]] = {}
+    for name in sorted(domains):
+        packed_path = Path(domains[name])
+        if not packed_path.exists():
+            raise FileNotFoundError(f"domain {name!r}: packed val file {packed_path} "
+                                    "does not exist")
+        try:
+            loader = PackedLoader(packed_path, seq_len=seq_len, batch_size=batch_size,
+                                  shuffle=False, drop_last=False)
+        except ValueError:
+            # Too small for even one (seq_len + 1) chunk. Explicitly unmeasured, not zero.
+            out[name] = None
+            continue
+
+        for i, (inputs, _targets) in enumerate(loader.epoch()):
+            if max_batches is not None and i >= max_batches:
+                break
+            # The forward output is discarded — this is a routing probe, not a loss eval
+            # — but `to_numpy` is still called so the MLX lazy graph is forced exactly as
+            # `val_loss.evaluate` does it (otherwise the router calls would never run).
+            to_numpy(model.forward(inputs))
+
+        hist = model.pop_moe_load()
+        if sum(sum(layer) for layer in hist) <= 0:
+            raise ValueError(
+                f"domain {name!r}: every expert count is zero — the router was not "
+                "observed (load counting off, or top_k == n_experts). A zero histogram "
+                "must not be reported as a routing measurement."
+            )
+        out[name] = hist
+
+    if all(v is None for v in out.values()):
+        raise ValueError(
+            "expert_histograms(): every domain was too small to score — no routing was "
+            "measured"
+        )
+    return out
+
+
+def histogram_overlap(h_a: list, h_b: list) -> dict:
+    """Per-layer routing overlap between two per-layer expert histograms.
+
+    `1 - TV` between the two L1-normalized distributions, i.e.
+    `sum_e min(p_e, q_e)`: **1.0 = identical routing (no specialization)**, 0.0 = disjoint.
+    Returns `{"per_layer": [float], "mean": float}`.
+
+    Raises on a layer-count or expert-count mismatch, and on a layer whose total is zero in
+    either histogram — an unnormalizable layer has no overlap, and defaulting it to 0.0
+    would fabricate perfect specialization.
+    """
+    if len(h_a) != len(h_b):
+        raise ValueError(f"histogram_overlap(): {len(h_a)} layers vs {len(h_b)} layers")
+    per_layer = []
+    for i, (a, b) in enumerate(zip(h_a, h_b)):
+        if len(a) != len(b):
+            raise ValueError(
+                f"histogram_overlap(): layer {i} has {len(a)} experts vs {len(b)}"
+            )
+        total_a, total_b = sum(a), sum(b)
+        if total_a <= 0 or total_b <= 0:
+            raise ValueError(
+                f"histogram_overlap(): layer {i} has a zero-total histogram "
+                f"(total_a={total_a}, total_b={total_b}) — unnormalizable, not 0.0 overlap"
+            )
+        pa = [x / total_a for x in a]
+        pb = [x / total_b for x in b]
+        per_layer.append(sum(min(x, y) for x, y in zip(pa, pb)))
+    mean = sum(per_layer) / len(per_layer) if per_layer else 0.0
+    return {"per_layer": per_layer, "mean": mean}
+
+
+def specialization_report(hists: Dict[str, list]) -> dict:
+    """Pairwise `histogram_overlap` across every measured domain pair.
+
+    Returns
+      {"domains": [sorted measured names],
+       "by_pair": {"a|b": {"per_layer": [...], "mean": float}},   # a < b, sorted key
+       "mean_overlap": float,          # mean over pairs
+       "max_overlap": float, "max_pair": "a|b",
+       "unmeasured_domains": [...]}    # the `None` entries from expert_histograms
+
+    Raises when fewer than two domains were measured — one domain yields no pair, and an
+    empty `by_pair` must not read as "well separated".
+    """
+    unmeasured = sorted(n for n, v in hists.items() if v is None)
+    measured = sorted(n for n, v in hists.items() if v is not None)
+    if len(measured) < 2:
+        raise ValueError(
+            f"specialization_report(): only {len(measured)} domain(s) measured "
+            f"({measured}) — need at least 2 to report an overlap, an empty result must "
+            "not read as 'well separated'"
+        )
+
+    by_pair: Dict[str, dict] = {}
+    for i, a in enumerate(measured):
+        for b in measured[i + 1:]:
+            key = "|".join(sorted((a, b)))
+            by_pair[key] = histogram_overlap(hists[a], hists[b])
+
+    mean_overlap = sum(v["mean"] for v in by_pair.values()) / len(by_pair)
+    max_pair = max(by_pair, key=lambda k: by_pair[k]["mean"])
+    return {
+        "domains": measured,
+        "by_pair": by_pair,
+        "mean_overlap": mean_overlap,
+        "max_overlap": by_pair[max_pair]["mean"],
+        "max_pair": max_pair,
+        "unmeasured_domains": unmeasured,
+    }
+
+
+def kill_check(report: dict, *, pair=("typescript", "math"), threshold: float = 0.90) -> dict:
+    """The #217 mid-training kill-criterion: do two domains hit the same experts?
+
+    Returns `{"pair": "a|b", "overlap": float, "per_layer": [...], "threshold": float,
+              "specializing": bool, "triggered": bool}` where
+    `triggered = overlap >= threshold` (i.e. NOT specializing) and
+    `specializing = not triggered`.
+
+    REPORTS ONLY — nothing here aborts a run (see the module docstring).
+
+    Raises when either named domain is absent from the report, or was unmeasured: a
+    kill-criterion that cannot see its two domains has no verdict, and returning
+    `specializing=True` there would be exactly the BLIND failure it exists to prevent.
+    """
+    a, b = pair
+    key = "|".join(sorted((a, b)))
+    domains = set(report.get("domains", []))
+    unmeasured = set(report.get("unmeasured_domains", []))
+    for name in (a, b):
+        if name in unmeasured:
+            raise ValueError(
+                f"kill_check(): domain {name!r} was unmeasured (val set too small) — the "
+                "kill-criterion cannot see it, and reporting a verdict anyway would be "
+                "the BLIND failure it exists to prevent"
+            )
+        if name not in domains:
+            raise ValueError(
+                f"kill_check(): domain {name!r} is not in the report ({sorted(domains)}) "
+                "— the kill-criterion cannot see it, and reporting a verdict anyway would "
+                "be the BLIND failure it exists to prevent"
+            )
+    entry = report["by_pair"][key]
+    triggered = entry["mean"] >= threshold
+    return {
+        "pair": key,
+        "overlap": entry["mean"],
+        "per_layer": entry["per_layer"],
+        "threshold": threshold,
+        "specializing": not triggered,
+        "triggered": triggered,
+    }
+
+
+def format_routing_report(report: dict, kill: Optional[dict] = None) -> str:
+    """Human table — one line per domain pair + the kill verdict, in
+    `domain_bpb.format_domain_bpb_table`'s style."""
+    lines = ["MoE routing overlap by domain pair (1.0 = identical routing, 0.0 = disjoint):"]
+    for key, entry in sorted(report["by_pair"].items()):
+        lines.append(f"  {key:<32} overlap={entry['mean']:.4f}")
+    lines.append(f"  {'mean':<32} overlap={report['mean_overlap']:.4f}")
+    lines.append(f"  {'max (' + report['max_pair'] + ')':<32} overlap={report['max_overlap']:.4f}")
+    if report["unmeasured_domains"]:
+        lines.append(f"  unmeasured: {', '.join(report['unmeasured_domains'])}")
+    if kill is not None:
+        verdict = "NOT specializing (>= threshold)" if kill["triggered"] else "specializing"
+        lines.append(f"  kill-check {kill['pair']}: overlap={kill['overlap']:.4f} "
+                     f"threshold={kill['threshold']:.4f} -> {verdict}")
+    return "\n".join(lines)

--- a/src/model/cuda_backend.py
+++ b/src/model/cuda_backend.py
@@ -724,6 +724,11 @@ class AttentionBlock(nn.Module):
 # port of mlx_backend's MoE block, now with a real gathered-dispatch kernel alongside
 # the dense evaluate-every-expert reference.
 # --------------------------------------------------------------------------- #
+_ROUTE_EPS = 1e-9      # #217: log-guard for the router-entropy diagnostic. Must be
+                       # IDENTICAL to mlx_backend.py's — the two backends' entropies are
+                       # compared at fp32 ~1e-4 by the parity test.
+
+
 class _Expert(nn.Module):
     """A SwiGLU FFN expert: down(silu(gate(x)) * up(x)). Bias-free. Torch port of
     `mlx_backend._Expert`, built via `_expert_linear`: a plain `nn.Linear` unless
@@ -811,6 +816,10 @@ class MoEBlock(nn.Module):
         self._bias_active = False
         self._count_loads = False
         self.register_buffer("_load_counts", torch.zeros(E), persistent=False)
+        # #217 routing diagnostics, torch mirror of mlx_backend.MoEBlock. `persistent=False`
+        # for the same reason as `_load_counts`: absent from `state_dict()`, moved by `.to()`.
+        self.register_buffer("_entropy_sum", torch.zeros(()), persistent=False)
+        self._n_routed = 0
 
     def set_route_bias(self, vec) -> None:
         """Set the per-expert selection bias (#213) — `vec` a `list[float]` of length
@@ -836,6 +845,19 @@ class MoEBlock(nn.Module):
         counts = self._load_counts.clone()
         self._load_counts.zero_()
         return [float(c) for c in counts.tolist()]
+
+    def pop_routing_stats(self) -> dict:
+        """This block's routing diagnostics since the last pop, then reset. Torch mirror
+        of `mlx_backend.MoEBlock.pop_routing_stats` — see there for the full contract.
+
+        DRAINS the load accumulator too (calls `pop_load()`), so a caller must use either
+        this or `pop_load()` for a given step, never both (#217)."""
+        load = self.pop_load()
+        n = self._n_routed
+        total = float(self._entropy_sum.item()) if n else 0.0
+        self._entropy_sum.zero_()
+        self._n_routed = 0
+        return {"load": load, "entropy": (total / n) if n else None, "n_tokens": int(n)}
 
     def _fp8_ctx(self):
         """Context manager for the expert-compute region (#214/#240). A `te.Linear`
@@ -913,6 +935,16 @@ class MoEBlock(nn.Module):
         E, k = self.config.n_experts, self.config.top_k
         logits = _f32(_linear(self.router, xn, cd))          # (..., E) — route in fp32
         probs = F.softmax(logits, dim=-1)                    # UNBIASED — always the gate weight
+
+        if self._count_loads:
+            # #217 — see mlx_backend.MoEBlock._moe for the full rationale (outside the
+            # k<E guard; gated by _count_loads; grad_checkpoint doubles numerator AND
+            # denominator so the ratio is exact). Kept literally in step with MLX: the
+            # two entropies are compared at fp32 ~1e-4 in tests.
+            with torch.no_grad():
+                ent = -(probs * torch.log(probs + _ROUTE_EPS)).sum(dim=-1)
+                self._entropy_sum += ent.sum()
+                self._n_routed += int(probs.numel() // E)
 
         if k < E:                                             # keep EXACTLY top_k per token
             # Loss-Free-Balancing (#213 D2): when active, rank by the BIASED selection
@@ -1170,6 +1202,13 @@ class CUDAMambaModel(ModelInterface, nn.Module):
 
     def pop_moe_load(self) -> List[List[float]]:
         return [block.pop_load() for block in self.moe_blocks()]
+
+    def pop_moe_routing_stats(self) -> List[dict]:
+        """Per-MoE-layer routing diagnostics since the last pop, in layer order (#217).
+        Torch mirror of `MLXMambaModel.pop_moe_routing_stats` — see there for the
+        contract. This is the ONLY pop the train step performs; `pop_moe_load()` must
+        not also be called for the same step."""
+        return [block.pop_routing_stats() for block in self.moe_blocks()]
 
     def init_state(self, batch_size: int) -> State:
         c = self.config

--- a/src/model/cuda_train_step.py
+++ b/src/model/cuda_train_step.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from ..train.moe_balance import MoEBalancer
+from ..train.moe_balance import moe_routing_metrics
 
 
 def _global_grad_norm(params) -> torch.Tensor:
@@ -88,18 +88,25 @@ def _accumulate_and_step(model, optimizer, params, loss_fn, micro_batches, lr,
     if scaler:
         out["loss_scale"] = scaler.scale
         out["skipped"] = False
-    if balancer is not None:
-        # Loss-Free-Balancing (#213/#214): update the bias from this step's routed-token
-        # counts, OUTSIDE the gradient, then push the new biases back into the model for
-        # the next forward. `pop_moe_load` returns `[]` for a model with no MoE layers.
-        # Placed at the VERY END, after `out` is assembled — i.e. AFTER the fp16 overflow
-        # early-return above, so a skipped step does NOT pop the counters (intentional,
-        # mirrors `mlx_backend.py:717-720` — do not "fix" with a `finally`).
-        loads = model.pop_moe_load()
-        if loads:
-            balancer.update(loads)
-            model.set_moe_biases(balancer.biases())
-            out["moe_util_var"] = max(MoEBalancer.utilization_variance(loads))
+    # --- MoE routing diagnostics + Loss-Free-Balancing (#213/#214/#217) -------
+    # ONE pop per step, shared: `pop_moe_routing_stats` drains the load counters too, so
+    # calling `pop_moe_load()` here as well would zero them and hand the balancer nothing.
+    # Placed at the VERY END, after `out` is assembled — i.e. AFTER the fp16 overflow
+    # early-return above, so a skipped step does NOT pop the counters (intentional,
+    # mirrors `mlx_backend.py:717-720` — do not "fix" with a `finally`). NOT gated on
+    # `balancer is not None`: diagnostics must work with `moe_balance_rate: null`, which
+    # is every config in the tree (#217). `model` here is the same model the caller
+    # passed to `_accumulate_and_step` — for DPO that is always `policy_model`, never
+    # `ref_model` (see `make_dpo_train_step`).
+    pop = getattr(model, "pop_moe_routing_stats", None)
+    if pop is not None:
+        stats = pop()
+        if stats:
+            loads = [s["load"] for s in stats]
+            if balancer is not None:
+                balancer.update(loads)
+                model.set_moe_biases(balancer.biases())
+            out.update(moe_routing_metrics(stats))
     return out
 
 

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -575,6 +575,11 @@ class AttentionBlock(nn.Module):
 # --------------------------------------------------------------------------- #
 # Sparse Mixture-of-Experts FFN block (#53)
 # --------------------------------------------------------------------------- #
+_ROUTE_EPS = 1e-9      # #217: log-guard for the router-entropy diagnostic. Must be
+                       # IDENTICAL in cuda_backend.py — the two backends' entropies are
+                       # compared at fp32 ~1e-4 by the parity test.
+
+
 class _Expert(nn.Module):
     """A SwiGLU FFN expert: down(silu(gate(x)) * up(x)). Bias-free, matmuls in `cd`."""
 
@@ -649,6 +654,12 @@ class MoEBlock(nn.Module):
         # training wiring flips this on exactly when a balancer exists.
         self._count_loads = False
         self._load_counts = mx.zeros((config.n_experts,))
+        # #217 routing diagnostics. Same leading-underscore rule as `_load_counts`: an
+        # mx.array under a `_`-prefixed attribute is excluded from `parameters()` by
+        # `nn.Module.valid_parameter_filter`, so it can never be differentiated or
+        # stepped. Gated by the SAME `_count_loads` flag, for the same lazy-graph reason.
+        self._entropy_sum = mx.zeros(())
+        self._n_routed = 0            # plain int: a static shape count, no graph
 
     def set_route_bias(self, vec) -> None:
         """Set the per-expert selection bias (Loss-Free-Balancing, #213) — `vec` a
@@ -688,11 +699,48 @@ class MoEBlock(nn.Module):
         self._load_counts = mx.zeros_like(counts)
         return [float(c) for c in counts.tolist()]
 
+    def pop_routing_stats(self) -> dict:
+        """This block's routing diagnostics since the last pop, then reset.
+
+        Returns `{"load": list[float], "entropy": float | None, "n_tokens": int}`.
+        `entropy` is the MEAN per-token entropy (nats) of the UNBIASED router
+        distribution — `None` when nothing was observed (counting off), never `0.0`,
+        which would read as "perfectly one-hot / fully specialized".
+
+        This DRAINS the load accumulator too (it calls `pop_load()`), so a caller must
+        use either this or `pop_load()` for a given step, never both — the train step
+        pops here exactly once and shares the result (#217).
+        """
+        load = self.pop_load()
+        n = self._n_routed
+        total = float(self._entropy_sum.item()) if n else 0.0
+        self._entropy_sum = mx.zeros(())
+        self._n_routed = 0
+        return {"load": load, "entropy": (total / n) if n else None, "n_tokens": int(n)}
+
     def _moe(self, xn: Array) -> Array:
         cd = _DTYPES[self.config.precision]
         E, k = self.config.n_experts, self.config.top_k
         logits = _f32(_linear(self.router, xn, cd))          # (..., E) — route in fp32
         probs = mx.softmax(logits, axis=-1)                  # UNBIASED — always the gate weight
+        if self._count_loads:
+            # #217: mean per-token entropy of the UNBIASED gate distribution, the
+            # specialization signal. Deliberately OUTSIDE the `k < E` guard below:
+            # loads are meaningless at k == E (no mask exists, balancing is vacuous),
+            # but the gate distribution is still real, and an entropy that silently
+            # reported 0.0 there would read as "fully specialized" — the BLIND failure
+            # this repo forbids. Detached (`stop_gradient`): a diagnostic must never
+            # become a training signal. Gated by `_count_loads` for the same
+            # lazy-graph reason as the load counter (:646-649) — nothing would ever
+            # pop it on an un-instrumented run.
+            #
+            # With `grad_checkpoint: true` the layer's forward is RECOMPUTED in
+            # backward, so `_entropy_sum` AND `_n_routed` both double (#213 D5). The
+            # reported value is their RATIO, so it is exact — the same argument that
+            # makes the doubled load counts harmless.
+            ent = -mx.sum(probs * mx.log(probs + _ROUTE_EPS), axis=-1)   # (...,) nats
+            self._entropy_sum = self._entropy_sum + mx.stop_gradient(mx.sum(ent))
+            self._n_routed += int(probs.size // E)
         if k < E:                                            # keep EXACTLY top_k per token
             # Loss-Free-Balancing (#213 D2): when active, rank by the BIASED selection
             # score `logits + route_bias`; the gate weight below stays `probs` (unbiased).
@@ -941,6 +989,15 @@ class MLXMambaModel(ModelInterface, nn.Module):
         order), resetting each block's accumulator. `[]` when the model has no MoE
         layers (dense / hybrid-only models)."""
         return [block.pop_load() for block in self.moe_blocks()]
+
+    def pop_moe_routing_stats(self) -> List[dict]:
+        """Per-MoE-layer routing diagnostics since the last pop, in layer order (#217).
+
+        Each entry is `MoEBlock.pop_routing_stats()`'s dict. `[]` for a model with no MoE
+        layers. This is the ONLY pop the train step performs — it drains the load counters
+        as well, so `pop_moe_load()` must not also be called for the same step.
+        """
+        return [block.pop_routing_stats() for block in self.moe_blocks()]
 
     def init_state(self, batch_size: int) -> State:
         c = self.config

--- a/src/model/mlx_train_step.py
+++ b/src/model/mlx_train_step.py
@@ -15,7 +15,7 @@ import mlx.nn as nn
 import mlx.optimizers as optim
 from mlx.utils import tree_flatten, tree_unflatten
 
-from ..train.moe_balance import MoEBalancer
+from ..train.moe_balance import moe_routing_metrics
 
 
 def _global_grad_norm(grads) -> mx.array:
@@ -78,15 +78,22 @@ def _accumulate_and_step(model, optimizer, loss_and_grad, micro_batches, lr,
     if scaler:
         out["loss_scale"] = scaler.scale
         out["skipped"] = False
-    if balancer is not None:
-        # Loss-Free-Balancing (#213): update the bias from this step's routed-token
-        # counts, OUTSIDE the gradient, then push the new biases back into the model for
-        # the next forward. `pop_moe_load` returns `[]` for a model with no MoE layers.
-        loads = model.pop_moe_load()
-        if loads:
-            balancer.update(loads)
-            model.set_moe_biases(balancer.biases())
-            out["moe_util_var"] = max(MoEBalancer.utilization_variance(loads))
+    # --- MoE routing diagnostics + Loss-Free-Balancing (#213/#217) ------------
+    # ONE pop per step, shared: `pop_moe_routing_stats` drains the load counters too, so
+    # calling `pop_moe_load()` here as well would zero them and hand the balancer nothing.
+    # Placed at the VERY END, after the fp16 overflow early-return above, so a skipped
+    # step does NOT pop the counters (intentional — do not "fix" with a `finally`).
+    # NOT gated on `balancer is not None`: diagnostics must work with
+    # `moe_balance_rate: null`, which is every config in the tree (#217).
+    pop = getattr(model, "pop_moe_routing_stats", None)
+    if pop is not None:
+        stats = pop()
+        if stats:
+            loads = [s["load"] for s in stats]
+            if balancer is not None:
+                balancer.update(loads)
+                model.set_moe_biases(balancer.biases())
+            out.update(moe_routing_metrics(stats))
     return out
 
 

--- a/src/train/logging.py
+++ b/src/train/logging.py
@@ -26,8 +26,12 @@ class JsonlLogger:
             # `event`/`seq_len` make a #216 length-curriculum stage change visible in the
             # terminal — otherwise a boundary (and the CUDA recompile that follows it)
             # looks like an unexplained stall.
+            # #217 — the routing signal has to be visible live, not only in
+            # metrics.jsonl; `moe_kill_triggered` is a bool and formats through the
+            # non-float branch below.
             keys = ("event", "step", "seq_len", "lr", "loss", "grad_norm",
-                    "val_loss", "val_perplexity")
+                    "val_loss", "val_perplexity", "moe_util_var", "moe_router_entropy",
+                    "moe_domain_overlap", "moe_kill_triggered")
             parts = [f"{k}={payload[k]:.4g}" if isinstance(payload.get(k), float)
                      else f"{k}={payload[k]}" for k in keys if k in payload]
             print("  ".join(parts))

--- a/src/train/loop.py
+++ b/src/train/loop.py
@@ -42,6 +42,9 @@ class TrainConfig:
     seed: int = 0
     lr_schedule: str = "cosine"
     decay_frac: float = 0.2
+    moe_diag_every: int = 0  # #217: steps between MoE routing diagnostic passes, 0 = off.
+                              # Like eval_every, only fires on a step that is also a
+                              # log_every step — pick a multiple of log_every.
 
 
 # A backend-provided step: (model, micro_batches, lr) -> dict(loss=, grad_norm=, ...).
@@ -73,6 +76,7 @@ def train(
     train_step: TrainStepFn,
     *,
     val_eval: Optional[Callable[[ModelInterface], dict]] = None,
+    moe_diag: Optional[Callable[[ModelInterface], dict]] = None,
     logger: Optional[Callable[[dict], None]] = None,
     on_checkpoint: Optional[Callable[[int, Any], None]] = None,
     start_step: int = 0,
@@ -88,7 +92,9 @@ def train(
     + a within-backend resume bundle) are injected so this stays backend-free. Resume is
     driven by `start_step` plus, since #216, an explicit `start_data_state`.
     `val_eval(model)` returns a metrics dict (e.g. {val_loss, val_perplexity}) merged into
-    the logged payload.
+    the logged payload. `moe_diag(model)` (#217) is the same shape — a periodic MoE
+    routing-diagnostic pass (per-domain expert histograms + the kill-criterion) — merged
+    in on its own `cfg.moe_diag_every` cadence.
 
     Length curriculum (#216). Pass a `LengthCurriculum` plus a
     `loader_factory(seq_len, batch_size) -> loader` to ramp `seq_len` (and shrink
@@ -173,6 +179,8 @@ def train(
                        "tokens": tokens_seen}
             if val_eval and step % cfg.eval_every == 0:
                 payload.update(val_eval(model))
+            if moe_diag and cfg.moe_diag_every and step % cfg.moe_diag_every == 0:
+                payload.update(moe_diag(model))
             log(payload)
             t0 = time.perf_counter()
             tokens_since_log = 0

--- a/src/train/moe_balance.py
+++ b/src/train/moe_balance.py
@@ -127,6 +127,36 @@ class MoEBalancer:
         self.bias = [list(row) if row else [0.0] * self.n_experts for row in rows]
 
 
+def moe_routing_metrics(stats: list) -> dict:
+    """Flat, JSON-serializable per-step routing metrics from `pop_moe_routing_stats()` (#217).
+
+    `stats` is one dict per MoE layer: `{"load", "entropy", "n_tokens"}`. Emits
+
+      moe_util_var                 max over layers  (UNCHANGED key + meaning)
+      moe_util_var_per_layer       list[float]
+      moe_router_entropy           mean over layers (nats)
+      moe_router_entropy_per_layer list[float]
+
+    Each pair is emitted ONLY when it was actually observed — a layer set with zero total
+    routed load reports NO `moe_util_var` (0.0 would read as "perfectly balanced" rather
+    than "no signal", the BLIND failure), and layers with `entropy is None` (counting off,
+    or k==E with counting off) contribute no entropy key. So an un-instrumented step emits
+    exactly what it emits today: nothing.
+    """
+    out: dict = {}
+    loads = [s["load"] for s in stats]
+    if any(sum(layer_loads) > 0 for layer_loads in loads):
+        var_per_layer = MoEBalancer.utilization_variance(loads)
+        out["moe_util_var"] = max(var_per_layer)
+        out["moe_util_var_per_layer"] = var_per_layer
+    entropies = [s["entropy"] for s in stats]
+    observed = [e for e in entropies if e is not None]
+    if observed:
+        out["moe_router_entropy"] = sum(observed) / len(observed)
+        out["moe_router_entropy_per_layer"] = entropies
+    return out
+
+
 def balancer_for_config(cfg) -> "MoEBalancer | None":
     """Map a `MambaConfig` to the `MoEBalancer` its training driver needs, or `None`.
 

--- a/tests/test_backend_parity.py
+++ b/tests/test_backend_parity.py
@@ -165,6 +165,43 @@ def test_portable_weights_roundtrip_both_directions(tmp_path):
     assert np.allclose(before, after, rtol=1e-4, atol=1e-5), f"round-trip drift {max_abs:.3e}"
 
 
+@pytest.mark.skipif(not (HAVE_MLX and HAVE_TORCH),
+                    reason="needs both mlx and torch (run on a Mac)")
+def test_moe_routing_entropy_parity_mlx_vs_torch(tmp_path):
+    """#217: the two backends' routing-entropy diagnostic must agree, not just the
+    logits. Identical portable weights, identical input, load counting on in both --
+    per-layer mean entropy compared at fp32 ~1e-4 (same tolerance as the logits parity
+    tests above)."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.cuda_backend import CUDAMambaModel
+
+    cfg = load_config("config/toy-moe.yaml")
+    torch.manual_seed(0)
+    src = CUDAMambaModel(cfg)
+    path = str(tmp_path / "weights.safetensors")
+    src.save(path)
+
+    mlx_m = MLXMambaModel(cfg)
+    mlx_m.load(path)
+    cuda_m = CUDAMambaModel(cfg)
+    cuda_m.load(path)
+    mlx_m.set_moe_load_counting(True)
+    cuda_m.set_moe_load_counting(True)
+
+    tokens = _tokens(cfg)
+    mlx_m.forward(tokens)
+    with torch.no_grad():
+        cuda_m.forward(tokens)
+    mlx_stats = mlx_m.pop_moe_routing_stats()
+    cuda_stats = cuda_m.pop_moe_routing_stats()
+
+    assert len(mlx_stats) == len(cuda_stats) == cfg.n_moe_layers > 0
+    for a, b in zip(mlx_stats, cuda_stats):
+        assert a["entropy"] is not None and b["entropy"] is not None
+        assert a["entropy"] == pytest.approx(b["entropy"], rel=1e-4, abs=1e-5)
+        assert a["n_tokens"] == b["n_tokens"]
+
+
 @pytest.mark.skipif(not HAVE_TORCH, reason="needs torch")
 def test_parity_harness_torch_self(tmp_path):
     """Runnable without mlx: identical weights in two torch instances pass the parity

--- a/tests/test_cuda_moe.py
+++ b/tests/test_cuda_moe.py
@@ -194,6 +194,139 @@ def test_moe_degenerate_single_expert_equals_hand_computed_swiglu():
 
 
 # --------------------------------------------------------------------------- #
+# #217 routing-entropy diagnostics — torch mirror of tests/test_moe.py
+# --------------------------------------------------------------------------- #
+def test_entropy_uniform_routing_approaches_log_n_experts():
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    block = _moe_block(model)
+    with torch.no_grad():
+        block.router.weight.zero_()
+    block.set_load_counting(True)
+    xn = torch.randn(5, cfg.d_model)
+    with torch.no_grad():
+        block._moe(xn)
+    stats = block.pop_routing_stats()
+    assert stats["entropy"] == pytest.approx(np.log(cfg.n_experts), abs=1e-4)
+    assert stats["n_tokens"] == 5
+
+
+def test_entropy_near_zero_when_router_is_sharply_one_hot():
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    block = _moe_block(model)
+    with torch.no_grad():
+        block.router.weight.fill_(-10.0)
+        block.router.weight[0, :] = 10.0
+    block.set_load_counting(True)
+    xn = torch.ones(5, cfg.d_model)
+    with torch.no_grad():
+        block._moe(xn)
+    stats = block.pop_routing_stats()
+    assert stats["entropy"] < 1e-3
+
+
+def test_entropy_reported_at_top_k_equals_n_experts_while_load_is_zero():
+    cfg = _cfg(top_k=4)   # n_experts=4 (the _cfg default) -> k == E, no mask exists
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    block = _moe_block(model)
+    block.set_load_counting(True)
+    xn = torch.randn(5, cfg.d_model)
+    with torch.no_grad():
+        block._moe(xn)
+    stats = block.pop_routing_stats()
+    assert stats["entropy"] is not None
+    assert all(c == 0.0 for c in stats["load"])
+
+
+def test_pop_routing_stats_resets_the_accumulator():
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    block = _moe_block(model)
+    block.set_load_counting(True)
+    xn = torch.randn(5, cfg.d_model)
+    with torch.no_grad():
+        block._moe(xn)
+    block.pop_routing_stats()
+    second = block.pop_routing_stats()
+    assert second["entropy"] is None
+    assert second["n_tokens"] == 0
+    assert second["load"] == [0.0] * cfg.n_experts
+
+
+def test_entropy_grad_checkpoint_ratio_invariant():
+    """`cuda_backend` has no grad-checkpoint concept identical to MLX's `mx.checkpoint`
+    wrapper for this toy path, but the entropy accumulation itself is checkpoint-agnostic
+    (it just sums whatever forward calls happen); pinned here at the block level: TWO
+    forward calls through the same accumulator must double both entropy_sum and
+    n_routed, leaving the reported MEAN unchanged (mirrors mlx_backend's D5 argument)."""
+    cfg = _cfg()
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    block = _moe_block(model)
+    block.set_load_counting(True)
+    xn = torch.randn(5, cfg.d_model)
+    with torch.no_grad():
+        block._moe(xn)
+    once = block.pop_routing_stats()
+
+    torch.manual_seed(0)
+    model2 = CUDAMambaModel(cfg)
+    block2 = _moe_block(model2)
+    block2.set_load_counting(True)
+    with torch.no_grad():
+        block2._moe(xn)
+        block2._moe(xn)
+    twice = block2.pop_routing_stats()
+
+    assert once["entropy"] == pytest.approx(twice["entropy"], abs=1e-5)
+    assert twice["n_tokens"] == 2 * once["n_tokens"]
+
+
+def test_no_balancer_path_still_emits_routing_metrics():
+    """Diagnostics must work with `moe_balance_rate: null` (#217) -- decoupled from
+    `balancer is not None`."""
+    from src.model.cuda_train_step import make_train_step
+
+    cfg = _cfg(moe_balance_rate=None)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=None)
+    model.set_moe_load_counting(True)
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
+    out = step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+    for key in ("moe_router_entropy", "moe_router_entropy_per_layer",
+               "moe_util_var", "moe_util_var_per_layer"):
+        assert key in out
+
+
+def test_pop_once_balancer_gets_the_counts_and_they_are_not_popped_twice():
+    from src.model.cuda_train_step import make_train_step
+    from src.train.moe_balance import attach_balancer, balancer_for_config
+
+    cfg = _cfg(moe_balance_rate=0.1)
+    torch.manual_seed(0)
+    model = CUDAMambaModel(cfg)
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    balancer = balancer_for_config(cfg)
+    step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=balancer)
+    attach_balancer(balancer, model)
+
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
+    step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+
+    assert model.pop_moe_load() == [[0.0] * cfg.n_experts for _ in range(cfg.n_moe_layers)]
+    assert any(any(v != 0.0 for v in layer) for layer in balancer.biases())
+
+
+# --------------------------------------------------------------------------- #
 # Tie-break contract (#214).
 #
 # MLX, Swift and this backend all rank with `argsort(argsort(-sel))`, whose ties break by

--- a/tests/test_cuda_moe_balance.py
+++ b/tests/test_cuda_moe_balance.py
@@ -28,6 +28,25 @@ def _np(a):
     return a.detach().cpu().numpy()
 
 
+def _capture_loads_during_step(model, step, micro_batches, lr):
+    """Run one train step, capturing the per-expert load counts at the moment #217's
+    routing-diagnostics pop drains them (`pop_moe_routing_stats`, called unconditionally
+    now — even with `balancer=None`). Reading `model.pop_moe_load()` AFTER the step
+    would see an already-drained (all-zero) accumulator, since the diagnostics pop is
+    no longer gated on a balancer being attached."""
+    captured = {}
+    orig = model.pop_moe_routing_stats
+
+    def spy():
+        stats = orig()
+        captured["stats"] = stats
+        return stats
+
+    model.pop_moe_routing_stats = spy
+    step(model, micro_batches, lr)
+    return [s["load"] for s in captured["stats"]]
+
+
 # --------------------------------------------------------------------------- #
 # D1 -- the bias is NOT a trained parameter
 # --------------------------------------------------------------------------- #
@@ -292,8 +311,8 @@ def test_grad_checkpoint_doubles_the_counts_and_changes_nothing_else():
         model.set_moe_load_counting(True)
         rng = np.random.default_rng(0)
         tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
-        step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
-        return model.pop_moe_load()
+        return _capture_loads_during_step(
+            model, step, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
 
     plain, checkpointed = counts(False), counts(True)
     assert checkpointed == [[2 * c for c in layer] for layer in plain]

--- a/tests/test_cuda_train_step.py
+++ b/tests/test_cuda_train_step.py
@@ -286,6 +286,25 @@ def test_overflow_skip_does_not_pop_moe_load_counts():
     assert sum(sum(layer) for layer in survived) > 0
 
 
+def _capture_loads_during_step(model, step, micro_batches, lr):
+    """Run one train step, capturing the per-expert load counts at the moment #217's
+    routing-diagnostics pop drains them (`pop_moe_routing_stats`, called unconditionally
+    now — even with `balancer=None`). Reading `model.pop_moe_load()` AFTER the step
+    would see an already-drained (all-zero) accumulator, since the diagnostics pop is
+    no longer gated on a balancer being attached."""
+    captured = {}
+    orig = model.pop_moe_routing_stats
+
+    def spy():
+        stats = orig()
+        captured["stats"] = stats
+        return stats
+
+    model.pop_moe_routing_stats = spy
+    step(model, micro_batches, lr)
+    return [s["load"] for s in captured["stats"]]
+
+
 def test_grad_accum_two_microbatches_accumulates_moe_load_counts():
     """Grad accumulation sums counts across BOTH micro-batches, not just the last one."""
     cfg = _moe_cfg(moe_balance_rate=None)     # counting only, no balancer consuming it
@@ -295,15 +314,13 @@ def test_grad_accum_two_microbatches_accumulates_moe_load_counts():
     model1 = CUDAMambaModel(cfg)
     step1 = make_train_step(model1, _adam(model1), grad_clip=1.0, scaler=None, balancer=None)
     model1.set_moe_load_counting(True)
-    step1(model1, [(inp, tgt)], 1e-3)
-    single = model1.pop_moe_load()
+    single = _capture_loads_during_step(model1, step1, [(inp, tgt)], 1e-3)
 
     torch.manual_seed(0)                      # identical fresh weights, pre-optimizer-step
     model2 = CUDAMambaModel(cfg)
     step2 = make_train_step(model2, _adam(model2), grad_clip=1.0, scaler=None, balancer=None)
     model2.set_moe_load_counting(True)
-    step2(model2, [(inp, tgt), (inp, tgt)], 1e-3)
-    double = model2.pop_moe_load()
+    double = _capture_loads_during_step(model2, step2, [(inp, tgt), (inp, tgt)], 1e-3)
 
     assert sum(sum(l) for l in single) > 0     # sanity: routing actually happened
     for s_layer, d_layer in zip(single, double):

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -83,6 +83,7 @@ PORTABLE_MODULES = [
     "src.eval.code_recall",
     "src.eval.code_needle",
     "src.eval.domain_bpb",
+    "src.eval.moe_routing",
     "src.eval.external_sets",
     "src.eval.olmes_adapter",
     "src.eval.bfcl_adapter",

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -292,6 +292,154 @@ def test_moe_impl_auto_and_dense_unchanged():
         assert np.all(np.isfinite(y))
 
 
+# --------------------------------------------------------------------------- #
+# #217 routing-entropy diagnostics
+# --------------------------------------------------------------------------- #
+@requires_mlx
+def test_entropy_uniform_routing_approaches_log_n_experts():
+    """A zeroed router makes the gate distribution exactly uniform -> entropy == ln(E)."""
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    block.router.weight = mx.zeros_like(block.router.weight)
+    block.set_load_counting(True)
+    xn = mx.random.normal((5, cfg.d_model))
+    block._moe(xn)
+    stats = block.pop_routing_stats()
+    assert stats["entropy"] == pytest.approx(np.log(cfg.n_experts), abs=1e-4)
+    assert stats["n_tokens"] == 5
+
+
+@requires_mlx
+def test_entropy_near_zero_when_router_is_sharply_one_hot():
+    """Large logit magnitude on one expert -> softmax collapses -> entropy ~ 0."""
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    # A fixed all-ones input with expert 0's row strongly positive and every other row
+    # strongly negative -> logit0 >> logit_i for i>0 regardless of any input scale noise,
+    # so softmax collapses onto expert 0 by construction (not by luck of a random xn).
+    w = np.full((cfg.n_experts, cfg.d_model), -10.0, dtype=np.float32)
+    w[0, :] = 10.0
+    block.router.weight = mx.array(w)
+    block.set_load_counting(True)
+    xn = mx.ones((5, cfg.d_model))
+    block._moe(xn)
+    stats = block.pop_routing_stats()
+    assert stats["entropy"] < 1e-3
+
+
+@requires_mlx
+def test_entropy_reported_at_top_k_equals_n_experts_while_load_is_zero():
+    """The key case the placement OUTSIDE the `k < E` guard exists for: at top_k==E there
+    is no mask (no load), but the gate distribution is still real and must be measured."""
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=4)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    block.set_load_counting(True)
+    xn = mx.random.normal((5, cfg.d_model))
+    block._moe(xn)
+    stats = block.pop_routing_stats()
+    assert stats["entropy"] is not None
+    assert all(c == 0.0 for c in stats["load"])
+
+
+@requires_mlx
+def test_pop_routing_stats_resets_the_accumulator():
+    from src.model.mlx_backend import MLXMambaModel, MoEBlock
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    block = next(l for l in model.layers if isinstance(l, MoEBlock))
+    block.set_load_counting(True)
+    xn = mx.random.normal((5, cfg.d_model))
+    block._moe(xn)
+    block.pop_routing_stats()
+    second = block.pop_routing_stats()
+    assert second["entropy"] is None
+    assert second["n_tokens"] == 0
+    assert second["load"] == [0.0] * cfg.n_experts
+
+
+@requires_mlx
+def test_entropy_grad_checkpoint_ratio_invariant():
+    """`grad_checkpoint` doubles BOTH the entropy sum and the token count (the layer's
+    forward is recomputed in backward); the reported MEAN must be exactly the ratio, so
+    it agrees between checkpointed and non-checkpointed runs, while n_tokens doubles."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    import mlx.optimizers as optim
+
+    def run(grad_checkpoint):
+        cfg = _cfg(moe_every=2, n_experts=4, top_k=2, grad_checkpoint=grad_checkpoint)
+        mx.random.seed(0)
+        model = MLXMambaModel(cfg)
+        opt = optim.AdamW(learning_rate=1e-3)
+        step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=None)
+        model.set_moe_load_counting(True)
+        rng = np.random.default_rng(0)
+        tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
+        out = step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+        return out["moe_router_entropy"]
+
+    plain, checkpointed = run(False), run(True)
+    assert plain == pytest.approx(checkpointed, abs=1e-5)
+
+
+@requires_mlx
+def test_no_balancer_path_still_emits_routing_metrics():
+    """Diagnostics must work with `moe_balance_rate: null` (every config in the tree,
+    #217) — the whole point of decoupling the pop from `balancer is not None`."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    import mlx.optimizers as optim
+
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2, moe_balance_rate=None)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    opt = optim.AdamW(learning_rate=1e-3)
+    step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=None)
+    model.set_moe_load_counting(True)     # normally attach_balancer's job; no balancer here
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
+    out = step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+    for key in ("moe_router_entropy", "moe_router_entropy_per_layer",
+               "moe_util_var", "moe_util_var_per_layer"):
+        assert key in out
+
+
+@requires_mlx
+def test_pop_once_balancer_gets_the_counts_and_they_are_not_popped_twice():
+    """After one train step with a balancer attached, a fresh `pop_moe_load()` sees an
+    already-drained (all-zero) accumulator, AND the balancer's biases moved off zero --
+    i.e. the balancer consumed the same pop the diagnostics did, not a second one."""
+    from src.model.mlx_backend import MLXMambaModel
+    from src.model.mlx_train_step import make_train_step
+    from src.train.moe_balance import attach_balancer, balancer_for_config
+    import mlx.optimizers as optim
+
+    cfg = _cfg(moe_every=2, n_experts=4, top_k=2, moe_balance_rate=0.1)
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    opt = optim.AdamW(learning_rate=1e-3)
+    balancer = balancer_for_config(cfg)
+    step = make_train_step(model, opt, grad_clip=1.0, scaler=None, balancer=balancer)
+    attach_balancer(balancer, model)
+
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
+    step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
+
+    assert model.pop_moe_load() == [[0.0] * cfg.n_experts for _ in range(cfg.n_moe_layers)]
+    assert any(any(v != 0.0 for v in layer) for layer in balancer.biases())
+
+
 @requires_mlx
 def test_router_keeps_exactly_k_on_ties():
     """A zeroed router makes all experts tie; exactly top_k must be kept (not all of

--- a/tests/test_moe_balance_mlx.py
+++ b/tests/test_moe_balance_mlx.py
@@ -41,6 +41,25 @@ def _cfg(**over):
     return MambaConfig(**base)
 
 
+def _capture_loads_during_step(model, step, micro_batches, lr):
+    """Run one train step, capturing the per-expert load counts at the moment #217's
+    routing-diagnostics pop drains them (`pop_moe_routing_stats`, called unconditionally
+    now — even with `balancer=None`). Reading `model.pop_moe_load()` AFTER the step
+    would see an already-drained (all-zero) accumulator, since the diagnostics pop is
+    no longer gated on a balancer being attached."""
+    captured = {}
+    orig = model.pop_moe_routing_stats
+
+    def spy():
+        stats = orig()
+        captured["stats"] = stats
+        return stats
+
+    model.pop_moe_routing_stats = spy
+    step(model, micro_batches, lr)
+    return [s["load"] for s in captured["stats"]]
+
+
 def _train_and_probe(cfg, seed=0, steps=400, lr=2e-3, batch=4):
     """Train `cfg`'s model for `steps` real train_steps on fresh random toy batches each
     step (sustained gradient signal — a single memorized batch saturates the loss too
@@ -462,8 +481,8 @@ def test_grad_checkpoint_doubles_the_counts_and_changes_nothing_else():
         model.set_moe_load_counting(True)
         rng = np.random.default_rng(0)
         tokens = rng.integers(0, cfg.vocab_size, size=(4, cfg.seq_len + 1))
-        step(model, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
-        return model.pop_moe_load()
+        return _capture_loads_during_step(
+            model, step, [(tokens[:, :-1], tokens[:, 1:])], 1e-3)
 
     plain, checkpointed = counts(False), counts(True)
     assert checkpointed == [[2 * c for c in layer] for layer in plain]

--- a/tests/test_moe_routing.py
+++ b/tests/test_moe_routing.py
@@ -1,0 +1,250 @@
+"""MoE routing diagnostics (#217): per-domain expert histograms + the mid-training
+kill-criterion. Portable — no backend; `expert_histograms` is exercised against a
+duck-typed fake model (the `tests/test_moe_balance.py:233` `_FakeModel` pattern) over
+tiny real packed files built with `src.data.pack.pack_ids` (the `tests/test_train_loop.py`
+precedent)."""
+
+import numpy as np
+import pytest
+
+from src.data.pack import pack_ids
+from src.eval.moe_routing import (expert_histograms, format_routing_report,
+                                  histogram_overlap, kill_check, specialization_report)
+
+
+# --------------------------------------------------------------------------- #
+# histogram_overlap
+# --------------------------------------------------------------------------- #
+def test_histogram_overlap_identical_histograms_is_one():
+    h = [[10.0, 20.0, 30.0], [5.0, 5.0]]
+    result = histogram_overlap(h, h)
+    assert result["mean"] == pytest.approx(1.0)
+    assert all(v == pytest.approx(1.0) for v in result["per_layer"])
+
+
+def test_histogram_overlap_disjoint_histograms_is_zero():
+    a = [[10.0, 0.0], [0.0, 10.0]]
+    b = [[0.0, 10.0], [10.0, 0.0]]
+    result = histogram_overlap(a, b)
+    assert result["mean"] == pytest.approx(0.0)
+    assert result["per_layer"] == [pytest.approx(0.0), pytest.approx(0.0)]
+
+
+def test_histogram_overlap_hand_worked_partial_case():
+    # Layer 0: p = [0.5, 0.5], q = [1.0, 0.0] -> overlap = min(.5,1) + min(.5,0) = 0.5.
+    a = [[5.0, 5.0]]
+    b = [[10.0, 0.0]]
+    result = histogram_overlap(a, b)
+    assert result["per_layer"] == [pytest.approx(0.5)]
+    assert result["mean"] == pytest.approx(0.5)
+
+
+def test_histogram_overlap_per_layer_values_differ_across_layers():
+    a = [[10.0, 0.0], [5.0, 5.0]]
+    b = [[10.0, 0.0], [10.0, 0.0]]
+    result = histogram_overlap(a, b)
+    assert result["per_layer"][0] == pytest.approx(1.0)   # layer 0 identical
+    assert result["per_layer"][1] == pytest.approx(0.5)   # layer 1 half-overlap
+    assert result["mean"] == pytest.approx(0.75)
+
+
+def test_histogram_overlap_layer_count_mismatch_raises():
+    with pytest.raises(ValueError, match="layers"):
+        histogram_overlap([[1.0, 2.0]], [[1.0, 2.0], [3.0, 4.0]])
+
+
+def test_histogram_overlap_expert_count_mismatch_raises():
+    with pytest.raises(ValueError, match="experts"):
+        histogram_overlap([[1.0, 2.0]], [[1.0, 2.0, 3.0]])
+
+
+def test_histogram_overlap_zero_total_layer_raises():
+    with pytest.raises(ValueError, match="zero-total"):
+        histogram_overlap([[0.0, 0.0]], [[1.0, 2.0]])
+
+
+# --------------------------------------------------------------------------- #
+# specialization_report
+# --------------------------------------------------------------------------- #
+def _hists_3domain():
+    return {
+        "a": [[10.0, 0.0]],
+        "b": [[10.0, 0.0]],       # identical to a
+        "c": [[0.0, 10.0]],       # disjoint from a and b
+    }
+
+
+def test_specialization_report_pair_keys_sorted():
+    report = specialization_report(_hists_3domain())
+    assert set(report["by_pair"]) == {"a|b", "a|c", "b|c"}
+
+
+def test_specialization_report_mean_max_pair_correct():
+    report = specialization_report(_hists_3domain())
+    assert report["by_pair"]["a|b"]["mean"] == pytest.approx(1.0)
+    assert report["by_pair"]["a|c"]["mean"] == pytest.approx(0.0)
+    assert report["by_pair"]["b|c"]["mean"] == pytest.approx(0.0)
+    assert report["mean_overlap"] == pytest.approx(1.0 / 3)
+    assert report["max_pair"] == "a|b"
+    assert report["max_overlap"] == pytest.approx(1.0)
+
+
+def test_specialization_report_carries_unmeasured_domains():
+    hists = {**_hists_3domain(), "d": None}
+    report = specialization_report(hists)
+    assert report["unmeasured_domains"] == ["d"]
+    assert report["domains"] == ["a", "b", "c"]
+    assert "d" not in report["by_pair"] and not any("d" in k for k in report["by_pair"])
+
+
+def test_specialization_report_fewer_than_two_measured_raises():
+    with pytest.raises(ValueError, match="at least 2"):
+        specialization_report({"a": [[10.0, 0.0]], "b": None})
+    with pytest.raises(ValueError, match="at least 2"):
+        specialization_report({"a": None, "b": None})
+
+
+# --------------------------------------------------------------------------- #
+# kill_check
+# --------------------------------------------------------------------------- #
+def test_kill_check_triggered_above_threshold():
+    report = specialization_report(_hists_3domain())
+    kill = kill_check(report, pair=("a", "b"), threshold=0.90)
+    assert kill["triggered"] is True
+    assert kill["specializing"] is False
+    assert kill["pair"] == "a|b"
+    assert kill["overlap"] == pytest.approx(1.0)
+
+
+def test_kill_check_not_triggered_below_threshold():
+    report = specialization_report(_hists_3domain())
+    kill = kill_check(report, pair=("a", "c"), threshold=0.90)
+    assert kill["triggered"] is False
+    assert kill["specializing"] is True
+
+
+def test_kill_check_boundary_is_greater_equal():
+    report = specialization_report(_hists_3domain())
+    kill = kill_check(report, pair=("a", "b"), threshold=1.0)   # overlap == 1.0 exactly
+    assert kill["triggered"] is True                            # >=, not >
+
+
+def test_kill_check_missing_domain_raises():
+    report = specialization_report(_hists_3domain())
+    with pytest.raises(ValueError, match="not in the report"):
+        kill_check(report, pair=("a", "nonexistent"))
+
+
+def test_kill_check_unmeasured_domain_raises():
+    hists = {**_hists_3domain(), "d": None}
+    report = specialization_report(hists)
+    with pytest.raises(ValueError, match="unmeasured"):
+        kill_check(report, pair=("a", "d"))
+
+
+def test_kill_check_specializing_is_not_triggered():
+    report = specialization_report(_hists_3domain())
+    for pair in (("a", "b"), ("a", "c")):
+        kill = kill_check(report, pair=pair, threshold=0.5)
+        assert kill["specializing"] == (not kill["triggered"])
+
+
+# --------------------------------------------------------------------------- #
+# format_routing_report
+# --------------------------------------------------------------------------- #
+def test_format_routing_report_names_every_pair_and_verdict():
+    report = specialization_report(_hists_3domain())
+    kill = kill_check(report, pair=("a", "b"), threshold=0.90)
+    text = format_routing_report(report, kill)
+    for key in report["by_pair"]:
+        assert key in text
+    assert "a|b" in text          # the kill verdict line
+
+
+# --------------------------------------------------------------------------- #
+# expert_histograms — duck-typed fake model + tiny real packed files
+# --------------------------------------------------------------------------- #
+class _FakeModel:
+    """The slice of the backend model `expert_histograms` touches: `set_moe_load_counting`,
+    `forward` (return value discarded, so any array works), and `pop_moe_load` — scripted
+    to return one histogram per call, in call order. The first call is always the
+    module's mandatory discard-pop before the first domain."""
+
+    def __init__(self, script):
+        self._script = list(script)
+        self.counting = False
+
+    def set_moe_load_counting(self, flag):
+        self.counting = bool(flag)
+
+    def forward(self, inputs):
+        return np.asarray(inputs)
+
+    def pop_moe_load(self):
+        if not self._script:
+            raise AssertionError("pop_moe_load() called more times than scripted")
+        return self._script.pop(0)
+
+
+def _packed(tmp_path, name, n_tokens, vocab=32, seed=0):
+    path = tmp_path / f"{name}.bin"
+    ids = np.random.default_rng(seed).integers(0, vocab, size=n_tokens)
+    pack_ids(ids, path)
+    return path
+
+
+def test_expert_histograms_empty_domains_raises(tmp_path):
+    model = _FakeModel([[[1.0]]])   # discard-pop only; never reached
+    with pytest.raises(ValueError, match="no domains"):
+        expert_histograms(model, {})
+
+
+def test_expert_histograms_missing_packed_path_raises(tmp_path):
+    model = _FakeModel([[[1.0, 1.0]]])   # non-empty discard-pop: model has MoE layers
+    domains = {"missing": str(tmp_path / "does_not_exist.bin")}
+    with pytest.raises(FileNotFoundError):
+        expert_histograms(model, domains)
+
+
+def test_expert_histograms_no_moe_model_raises(tmp_path):
+    packed = _packed(tmp_path, "d", n_tokens=200, vocab=32)
+    model = _FakeModel([[]])   # pop_moe_load() == [] -> no MoE layers
+    with pytest.raises(ValueError, match="no MoE layers"):
+        expert_histograms(model, {"d": str(packed)}, seq_len=8, batch_size=2)
+
+
+def test_expert_histograms_all_zero_histogram_raises(tmp_path):
+    packed = _packed(tmp_path, "d", n_tokens=200, vocab=32)
+    # discard-pop (non-empty), then the domain's own pop returns an all-zero histogram.
+    model = _FakeModel([[[1.0, 1.0]], [[0.0, 0.0], [0.0, 0.0]]])
+    with pytest.raises(ValueError, match="every expert count is zero"):
+        expert_histograms(model, {"d": str(packed)}, seq_len=8, batch_size=2)
+
+
+def test_expert_histograms_too_small_domain_records_none(tmp_path):
+    # seq_len=8 needs 9 tokens/chunk; 4 tokens is too small for even one chunk.
+    tiny = _packed(tmp_path, "tiny", n_tokens=4, vocab=32)
+    ok = _packed(tmp_path, "ok", n_tokens=200, vocab=32)
+    model = _FakeModel([[[1.0]], [[5.0, 3.0]]])   # discard-pop, then "ok" domain's pop
+    out = expert_histograms(model, {"tiny": str(tiny), "ok": str(ok)},
+                            seq_len=8, batch_size=2, max_batches=2)
+    assert out["tiny"] is None
+    assert out["ok"] == [[5.0, 3.0]]
+
+
+def test_expert_histograms_all_none_raises(tmp_path):
+    tiny_a = _packed(tmp_path, "a", n_tokens=4, vocab=32)
+    tiny_b = _packed(tmp_path, "b", n_tokens=4, vocab=32)
+    model = _FakeModel([[[1.0]]])   # discard-pop only; neither domain reaches a real pop
+    with pytest.raises(ValueError, match="too small to score"):
+        expert_histograms(model, {"a": str(tiny_a), "b": str(tiny_b)}, seq_len=8, batch_size=2)
+
+
+def test_expert_histograms_returns_scripted_hist_per_domain(tmp_path):
+    a = _packed(tmp_path, "a", n_tokens=200, vocab=32)
+    b = _packed(tmp_path, "b", n_tokens=200, vocab=32)
+    model = _FakeModel([[[1.0]], [[9.0, 1.0]], [[2.0, 8.0]]])
+    out = expert_histograms(model, {"a": str(a), "b": str(b)},
+                            seq_len=8, batch_size=2, max_batches=2)
+    assert out == {"a": [[9.0, 1.0]], "b": [[2.0, 8.0]]}
+    assert model.counting is True

--- a/tests/test_train_loop.py
+++ b/tests/test_train_loop.py
@@ -64,6 +64,59 @@ def test_val_dict_merged_and_tokens_per_sec_present():
     assert evald[0]["val_loss"] == 1.5
 
 
+def test_moe_diag_fires_only_on_its_cadence_and_merges_into_the_payload():
+    """#217: `moe_diag` is merged like `val_eval`, but on its own `moe_diag_every`
+    cadence (independent of `eval_every`)."""
+    def fake_step(model, micro, lr):
+        return {"loss": 1.0, "grad_norm": 0.5}
+
+    calls = []
+
+    def moe_diag(model):
+        calls.append(model)
+        return {"moe_domain_overlap": 0.5, "moe_kill_triggered": False}
+
+    loader = FakeLoader(n_batches=100)
+    cfg = TrainConfig(total_steps=6, grad_accum=1, warmup_steps=0, log_every=1,
+                      eval_every=100, ckpt_every=100, moe_diag_every=2)
+    logs = []
+    train("the-model", loader, cfg, fake_step, moe_diag=moe_diag, logger=logs.append)
+
+    diagged = [p for p in logs if "moe_domain_overlap" in p]
+    assert {p["step"] for p in diagged} == {0, 2, 4}
+    assert all(p["moe_kill_triggered"] is False for p in diagged)
+    assert calls == ["the-model"] * 3           # moe_diag(model) called with the real model
+
+
+def test_moe_diag_every_zero_never_fires_and_does_not_raise():
+    def fake_step(model, micro, lr):
+        return {"loss": 1.0, "grad_norm": 0.5}
+
+    def moe_diag(model):
+        raise AssertionError("moe_diag must not be called when moe_diag_every == 0")
+
+    loader = FakeLoader(n_batches=100)
+    cfg = TrainConfig(total_steps=4, grad_accum=1, warmup_steps=0, log_every=1,
+                      eval_every=100, ckpt_every=100, moe_diag_every=0)   # default: off
+    logs = []
+    train(None, loader, cfg, fake_step, moe_diag=moe_diag, logger=logs.append)   # no raise
+
+    assert not any("moe_domain_overlap" in p for p in logs)
+
+
+def test_moe_diag_none_with_nonzero_every_is_a_noop():
+    def fake_step(model, micro, lr):
+        return {"loss": 1.0, "grad_norm": 0.5}
+
+    loader = FakeLoader(n_batches=100)
+    cfg = TrainConfig(total_steps=4, grad_accum=1, warmup_steps=0, log_every=1,
+                      eval_every=100, ckpt_every=100, moe_diag_every=2)
+    logs = []
+    train(None, loader, cfg, fake_step, moe_diag=None, logger=logs.append)   # no raise
+
+    assert not any("moe_domain_overlap" in p for p in logs)
+
+
 def test_checkpoint_fires_at_interval():
     ckpts = []
 


### PR DESCRIPTION
Closes #217

## Summary
- Adds `moe_router_entropy` (+ per-layer) — mean per-token entropy (nats) of the unbiased
  router distribution, accumulated in `MoEBlock._moe` on both backends outside the
  `top_k < n_experts` guard, so it is measured even when `top_k == n_experts` (no load
  mask exists there, but the gate distribution is still real).
- `moe_util_var` (+ per-layer) is unchanged in key/meaning but is now reported whenever
  any load was observed, decoupled from `MoEBalancer` attachment — previously it only
  ever appeared when a balancer was attached (`moe_balance_rate` set), which is `null`
  in every config in the tree today, so this signal was effectively dead.
- New portable module `src/eval/moe_routing.py`: `expert_histograms` (a periodic
  diagnostic forward-only pass over the per-domain val sets from
  `scripts/build_domain_val_sets.py` — packed training shards carry no domain tag, so
  this measures usage on held-out samples *drawn from* each domain, not the live
  training mix), `histogram_overlap`/`specialization_report` (pairwise routing overlap),
  and `kill_check` — a mid-training kill-criterion that **reports loudly but never
  aborts the run** when two named domains' routing overlap crosses a threshold (killing
  a multi-day run from a threshold is the operator's call; early-training near-uniform
  routing makes a naive auto-abort a real risk of false positives).
- Both backends' `pop_moe_routing_stats()` drains load + entropy counters in ONE pop per
  step, shared between the balancer and the diagnostics (`_accumulate_and_step`, both
  backends) — the single most breakable contract in this change, pinned by dedicated
  pop-once tests on both backends.
- `scripts/train.py`: five new flags (`--moe-diag-every`, `--moe-diag-domains`,
  `--moe-kill-pair`, `--moe-kill-overlap`, `--moe-diag-batches`) with fail-fast
  validation; routing-diagnostic wiring is independent of the balancer wiring.
- `src/train/logging.py`'s console echo allowlist extended so the new signals are
  visible live, not only in `metrics.jsonl`.
- `docs/design/13-code-model-moe.md` gets a short "#217 — routing diagnostics +
  kill-criterion" subsection.

**Intentional behavior change** (called out per the plan): with a balancer attached and
`top_k == n_experts`, `moe_util_var` used to be emitted as `0.0`; it is now omitted
entirely, since no routed load exists to measure at `top_k == n_experts`. No test or
consumer depended on the old value.

**Pre-existing test fixups:** three tests (`test_cuda_train_step.py`,
`test_cuda_moe_balance.py`, `test_moe_balance_mlx.py`) assumed that with
`balancer=None`, `pop_moe_load()` was never called by the train step, so counts stayed
on the model for a direct post-step read. That assumption no longer holds now that
diagnostics pop unconditionally (decoupled from the balancer) — fixed by capturing the
counts at the moment `pop_moe_routing_stats()` drains them instead of reading
`pop_moe_load()` after the step.

## Testing
- [x] Tests added/updated — `tests/test_moe_routing.py` (new, portable), entropy tests
  in `tests/test_moe.py` / `tests/test_cuda_moe.py`, pop-once + no-balancer tests on both
  backends, a `moe_diag` cadence test in `tests/test_train_loop.py`, and a live
  MLX↔CUDA entropy parity test in `tests/test_backend_parity.py`.
- [x] All tests passing — full suite `1275 passed, 13 skipped` (skips are pre-existing
  environment gaps: no CUDA device, no Hopper+TE, no prettier toolchain, `torch.compile`
  unusable on this host's clang — unrelated to this change), plus
  `tests/test_import_guard.py` (the seam gate: `src/eval/moe_routing.py` is portable,
  numpy/stdlib only).
- [x] Manual testing completed — smoke gate (`scripts/smoke_test.py`) against a
  freshly-built toy split passed; ran an end-to-end `scripts/train.py` on
  `config/toy-moe.yaml` (`moe_balance_rate: null`, the previously-silent case) with
  `--moe-diag-every` wired to a 2-domain `domains.json` — confirmed
  `moe_router_entropy`/`moe_util_var` on every logged step, `moe_domain_overlap`/
  `moe_kill_triggered` only on the diagnostic-cadence steps, entropy starting near
  `ln(4)`, the kill-criterion firing loudly (console + a `moe_kill` event line) without
  stopping the run, and the CLI validation paths (missing `--moe-diag-domains`, a bad
  `--moe-kill-pair`, a non-MoE config, a `--moe-diag-every`/`--log-every` mismatch
  warning).
- CUDA-specific paths (`tests/test_cuda_*.py`) run and pass on this host's CPU-only
  torch; true CUDA hardware is gated in CI's `smoke-linux` job, which this PR does not
  have access to run directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K3gzzSsE7RJjyNp4QUQff