### PR TITLE
feat: [M12] LSP oracle service (multi-op: definition/references/completions/quickinfo)

### DIFF
--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -699,6 +699,78 @@ risk for a *different* server or config that front-loads a syntactic-only push �
 retained so it can be re-run if the pinned toolchain changes — but it is not a live bug, and **#211 is
 closed** on this evidence.
 
+## The multi-op LSP service and its measured throughput ceiling (#220)
+
+`TsLspOracle` (above) is deliberately **one-shot**: a fresh, never-reused `cand_{n}.ts` URI per
+call, single-file, no `didChange`, no version counter, no cross-file program. That contract is
+load-bearing for the #194/#211 harness path this whole document is about, but two M12 consumers
+need the *opposite* shape and cannot be served from it: **#226** completion-list logit masking
+needs a per-decode-step `textDocument/completion` against a **warm, multi-file program** (one edit
+plus one query per generated token), and the code eval suite's cross-file/type-aware arm needs
+`definition`/`references`/`documentSymbol` over a real multi-file project. `src/lsp/ts_service.py`
+adds `TsLspService` as a **new, separate** class for exactly this — stable URIs, monotonically
+versioned `didChange` edits, lazy `didOpen` (only *diagnostics* need a document open at all; the
+tsconfig's directory-wide `include` already puts every file in the program, so cross-file
+`definition`/`references` resolve without any file being open). `ts_lsp.py` and `oracle.py` are
+**untouched** — both classes share only the already op-agnostic `jsonrpc.py`.
+
+**No settle window, by design.** `TsLspService.diagnostics()` is first-push-wins, same as
+`TsLspOracle`, citing the #211 evidence directly above in this document: the pinned
+`typescript-language-server` 5.3.0's first `publishDiagnostics` push is semantically complete (0/97
+disagreed), so a settle/quiescence window (`opengrep.py`'s `_SETTLE_S`) would put a floor of
+*seconds* on every call and make the throughput this section measures structurally unreachable.
+That divergence from `opengrep.py` — which settles deliberately, for a *different* server with a
+confirmed stale-generation race — is intentional; it is not something to "fix" to match. 5.3.0 also
+advertises no `capabilities.diagnosticProvider`, confirmed again below, so LSP 3.17 pull diagnostics
+remain unavailable on this pin — version/seq-gated push-and-wait is the only option.
+
+### Measured (`scripts/bench_ts_lsp.py --n-files 5000 --warmup 20 --iters 200`, seed 0)
+
+A deterministic synthetic 5000-file TypeScript project (one `hub.ts` exporting widely-used
+`Vec`/`scale`, every other module importing it plus 1–3 acyclic imports from lower-indexed
+modules), opened once as a warm program. The BLIND-guarded sanity probe passed every check (a real
+`definition` into hub, `references` fan-in across ≥2 files, `completions` containing `"x"`, non-empty
+`quickinfo`/`document_symbols`, and a deliberately broken `v.gorblak` edit correctly detected and
+cleared) — the numbers below are real measurements, not an empty-and-fast run:
+
+| op | median | p95 | calls/s | non-empty rate |
+|---|---:|---:|---:|---:|
+| `diagnostics` (edit→re-check, the #226 shape) | **378.1 ms** | 383.0 ms | 3.1 | 0% (benign edits — expected; correctness is what the sanity probe checks) |
+| `diagnostics_cached` (unchanged-document cache hit — **not** the SLA number) | 0.007 ms | 0.017 ms | 112,110 | 0% |
+| `definition` | 1.74 ms | 2.17 ms | 595 | 100% |
+| `references` | 506.0 ms | 523.3 ms | 2.0 | 100% |
+| `completions` | 0.38 ms | 0.45 ms | **2,629** | 100% |
+| `quickinfo` | 0.31 ms | 0.39 ms | 3,102 | 100% |
+| `document_symbols` | 0.42 ms | 0.54 ms | 2,332 | 100% |
+
+Cold `open_project` load: **1.23 s**. `server_sync_kind = 2` (Incremental). `diagnosticProvider =
+null` (pull diagnostics confirmed unavailable on this pin, consistent with the #211 finding above).
+`n_restarts = 0`, `n_timeouts = 0` — a clean run, not one papered over by the reliability counters.
+
+### Verdict: WARN
+
+Per the issue's two gates — latency (`diagnostics` edit→re-check median < 50 ms) for the type-aware
+eval arm, throughput (`completions` ≥ 200 calls/s) for #226's per-decode-step masking — this run is
+**WARN**: the throughput gate clears comfortably (2,629 calls/s, 13× the bar), but the latency gate
+misses by nearly 8× (378 ms vs. the 50 ms bar). Per-request `completions`/`quickinfo`/
+`document_symbols`/`definition` are all sub-millisecond-to-low-single-digit-ms at 5000 files — the
+cost is concentrated in whatever `diagnostics()` and `references()` do at this project size (both
+in the several-hundred-ms range), consistent with tsserver doing real whole-program semantic work
+proportional to project size for those two operations, not with a broken or degraded measurement
+(the sanity probe and the 100% non-empty rates on every op rule that out).
+
+**Consequence for #226:** completion-list logit masking is throughput-clear on its own gate, so a
+decode loop that queries `completions()` once per generated token is not structurally blocked by
+this measurement. The **type-aware eval arm**, which is what actually drives the `diagnostics`
+number measured here (an edit-then-recheck cycle per candidate), is the one that misses its latency
+bar at this project size — a consumer needing sub-50ms diagnostics against a 5000-file warm program
+should budget for ~378ms per check, or reduce project scope, rather than assume the number in the
+issue's accept criterion. This is a measured finding, not a to-do to "fix" this module — the
+mechanism is behaving correctly (see the sanity probe and the zero-timeout, zero-restart run); the
+cost is inherent to whole-program semantic analysis at this scale.
+
+See `scripts/bench_ts_lsp.py` and the full per-op breakdown in `results/ts_lsp_bench.json`.
+
 ## Verdict
 
 The persistent-LSP swap is **not a free upgrade over batch `tsc`**: it trades the slow loop's

--- a/results/ts_lsp_bench.json
+++ b/results/ts_lsp_bench.json
@@ -1,0 +1,106 @@
+{
+  "ops": {
+    "completions": {
+      "calls_per_s": 2629.4,
+      "iters": 200,
+      "mean_ms": 0.38,
+      "median_ms": 0.378,
+      "min_ms": 0.299,
+      "n_nonempty": 200,
+      "nonempty_rate": 1.0,
+      "op": "completions",
+      "p95_ms": 0.447
+    },
+    "definition": {
+      "calls_per_s": 595.19,
+      "iters": 200,
+      "mean_ms": 1.68,
+      "median_ms": 1.744,
+      "min_ms": 0.377,
+      "n_nonempty": 200,
+      "nonempty_rate": 1.0,
+      "op": "definition",
+      "p95_ms": 2.172
+    },
+    "diagnostics": {
+      "calls_per_s": 3.09,
+      "iters": 200,
+      "mean_ms": 324.144,
+      "median_ms": 378.11,
+      "min_ms": 0.292,
+      "n_nonempty": 0,
+      "nonempty_rate": 0.0,
+      "op": "diagnostics",
+      "p95_ms": 383.041
+    },
+    "diagnostics_cached": {
+      "calls_per_s": 112110.38,
+      "iters": 200,
+      "mean_ms": 0.009,
+      "median_ms": 0.007,
+      "min_ms": 0.006,
+      "n_nonempty": 0,
+      "nonempty_rate": 0.0,
+      "op": "diagnostics_cached",
+      "p95_ms": 0.017
+    },
+    "document_symbols": {
+      "calls_per_s": 2331.87,
+      "iters": 200,
+      "mean_ms": 0.429,
+      "median_ms": 0.42,
+      "min_ms": 0.301,
+      "n_nonempty": 200,
+      "nonempty_rate": 1.0,
+      "op": "document_symbols",
+      "p95_ms": 0.538
+    },
+    "quickinfo": {
+      "calls_per_s": 3102.3,
+      "iters": 200,
+      "mean_ms": 0.322,
+      "median_ms": 0.314,
+      "min_ms": 0.261,
+      "n_nonempty": 200,
+      "nonempty_rate": 1.0,
+      "op": "quickinfo",
+      "p95_ms": 0.389
+    },
+    "references": {
+      "calls_per_s": 1.98,
+      "iters": 200,
+      "mean_ms": 505.144,
+      "median_ms": 505.993,
+      "min_ms": 467.505,
+      "n_nonempty": 200,
+      "nonempty_rate": 1.0,
+      "op": "references",
+      "p95_ms": 523.29
+    }
+  },
+  "summary": {
+    "cold_load_s": 1.2276767080184072,
+    "diagnostic_provider": null,
+    "iters": 200,
+    "n_files": 5000,
+    "n_restarts": 0,
+    "n_timeouts": 0,
+    "sanity_probe": {
+      "checks": {
+        "completions_contains_x": true,
+        "definition_resolves_to_hub": true,
+        "diagnostics_clean_after_revert": true,
+        "diagnostics_detects_break": true,
+        "document_symbols_nonempty": true,
+        "quickinfo_nonempty": true,
+        "references_fan_in": true
+      },
+      "failed": [],
+      "ok": true
+    },
+    "seed": 0,
+    "server_sync_kind": 2,
+    "verdict": "WARN",
+    "warmup": 20
+  }
+}

--- a/scripts/bench_ts_lsp.py
+++ b/scripts/bench_ts_lsp.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""SLA harness for `src/lsp/ts_service.py`'s `TsLspService` (#220) -- the issue's
+accept/kill criterion for whether a warm, multi-op `typescript-language-server`
+process can sustain the throughput #226's decode-time completion-list masking
+needs, and the latency the code eval suite's cross-file arm needs.
+
+Generates a deterministic synthetic N-file TypeScript project (`_generate_project`,
+`random.Random(seed)` only -- never eval transcripts, the `opengrep_soak.py`
+contamination discipline), opens it once as a warm `TsLspService` program, runs a
+BLIND-guarded sanity probe against KNOWN targets, then measures per-op
+median/mean/min/p95 latency and calls/s for `diagnostics`, `definition`,
+`references`, `completions`, `quickinfo`, `document_symbols`.
+
+    # Fast smoke first, to shake out protocol shape before the 5k run:
+    .venv/bin/python scripts/bench_ts_lsp.py --n-files 50 --warmup 3 --iters 20
+
+    # The real run:
+    .venv/bin/python scripts/bench_ts_lsp.py --n-files 5000 --warmup 20 --iters 200
+
+**BLIND guard.** A project too large for the server, a bad tsconfig, or a
+semantic-features-disabled tsserver makes every op return empty results very
+FAST, which reads as a spectacular PASS. `_sanity_probe` confirms real,
+known-answer results on every op BEFORE any timing starts; any failure prints
+the failing checks, writes `{"verdict": "BLIND", ...}` to `--out`, and exits 2.
+An empty measurement is never reported as a pass.
+
+**Verdict**, keyed to the issue's two consumers:
+  - `PASS`  -- median warm `diagnostics` (edit->re-check) < 50ms AND
+               `completions` >= 200 calls/s.
+  - `WARN`  -- between the two bars (either gate missed but completions >= 20/s).
+  - `KILL`  -- completions < ~20 calls/s -> #226 decode-time masking rescopes
+               to offline.
+  - `BLIND` -- the sanity probe failed; nothing was measured.
+
+If the bench lands in WARN or KILL, that is a real, reportable result -- record
+the numbers and the #226 consequence in `docs/design/12-lsp-in-the-loop.md`.
+Do NOT tune the harness or loosen a threshold until it passes.
+
+Exits cleanly (0) with no traceback when no `typescript-language-server`
+toolchain is resolvable (`opengrep_soak.py:80-84` style). Always tears down the
+service and cleans its scratch dir in a `finally` unless `--keep-scratch`.
+
+Stdlib + above-the-seam repo imports only (no mlx/torch).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Dict, List, Tuple
+
+# Repo root on sys.path so `src.lsp.*` imports resolve when run as a script.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.lsp.tsc import SET_DIR  # noqa: E402
+from src.lsp.ts_lsp import resolve_ts_lsp  # noqa: E402
+from src.lsp.ts_service import TsLspService  # noqa: E402
+
+_HUB_PATH = "src/hub.ts"
+_IMPORT_RE = re.compile(r'import\s*\{[^}]*\}\s*from\s*"\./([A-Za-z0-9_]+)"')
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic project generator
+# --------------------------------------------------------------------------- #
+
+def _mod_path(i: int) -> str:
+    return f"src/mod_{i:04d}.ts"
+
+
+def _module_index(path: str) -> int:
+    """`src/hub.ts` -> 0; `src/mod_0007.ts` -> 7."""
+    stem = Path(path).stem
+    if stem == "hub":
+        return 0
+    return int(stem.split("_")[1])
+
+
+def _resolve_import(path: str, target_rel: str) -> str:
+    """`target_rel` is the bare module name from an `import ... from "./X"` --
+    `"hub"` or `"mod_0007"`. `path` (the importer) is unused; kept for a
+    stable, obvious call signature at the two call sites (bench + test)."""
+    return f"src/{target_rel}.ts"
+
+
+def _generate_project(n_files: int, seed: int) -> Dict[str, str]:
+    """Deterministic synthetic TypeScript project: `src/hub.ts` (index 0,
+    widely-imported -- the `references` fan-in target) plus
+    `src/mod_0001.ts` .. `src/mod_{n_files-1:04d}.ts`. Every mod
+    unconditionally imports `{ Vec, scale }` from hub, plus 1-3 seeded imports
+    from LOWER-indexed mods only (acyclic by construction -- every import
+    resolves, no TS2307 noise), and exports a function/interface that
+    genuinely uses the imported symbols (mirrors
+    `eval_sets/code_recall/fixture_repo.jsonl`'s import/export shape, scaled
+    up). `random.Random(seed)` only -- no global RNG -- so the same
+    `(n_files, seed)` is byte-identical every time."""
+    if n_files < 2:
+        raise ValueError("n_files must be >= 2")
+    rng = random.Random(seed)
+    files: Dict[str, str] = {
+        _HUB_PATH: (
+            "export interface Vec { x: number; y: number }\n\n"
+            "export function scale(v: Vec, k: number): Vec {\n"
+            "  return { x: v.x * k, y: v.y * k };\n"
+            "}\n\n"
+            "export const ORIGIN: Vec = { x: 0, y: 0 };\n"
+        ),
+    }
+
+    for i in range(1, n_files):
+        lower_mods = list(range(1, i))   # other mods only -- hub is handled separately below
+        k = rng.randint(1, min(3, len(lower_mods))) if lower_mods else 0
+        chosen = sorted(rng.sample(lower_mods, k)) if k else []
+
+        import_lines = ['import { Vec, scale } from "./hub";']
+        uses = ["scale(v, 2)"]
+        for idx in chosen:
+            import_lines.append(f'import {{ f{idx} }} from "./{Path(_mod_path(idx)).stem}";')
+            uses.append(f"f{idx}(v)")
+
+        body_uses = "\n  ".join(f"const u{j} = {u};" for j, u in enumerate(uses))
+        files[_mod_path(i)] = (
+            "\n".join(import_lines) + "\n\n"
+            f"export function f{i}(v: Vec): Vec {{\n"
+            f"  {body_uses}\n"
+            f"  const vx = v.x;\n"
+            f"  return scale(v, 1);\n"
+            f"}}\n\n"
+            f"export interface T{i} {{ v: Vec; tag: number }}\n"
+        )
+
+    return files
+
+
+# --------------------------------------------------------------------------- #
+# BLIND guard
+# --------------------------------------------------------------------------- #
+
+def _sanity_probe(service: TsLspService, files: Dict[str, str]) -> dict:
+    """Confirm real, known-answer results on every op against a known target
+    in the generated project, BEFORE any timing starts. Never trust an empty
+    result as "the server has nothing to say" -- an empty-but-fast run is
+    indistinguishable from a broken one unless something here fails loudly."""
+    target = _mod_path(1)
+    mod_text = files[target]
+    hub_text = files[_HUB_PATH]
+    checks: Dict[str, bool] = {}
+
+    call_offset = mod_text.index("scale(")
+    defs = service.definition(target, call_offset)
+    checks["definition_resolves_to_hub"] = any(d.path == _HUB_PATH for d in defs)
+
+    vec_offset = hub_text.index("interface Vec") + len("interface ")
+    refs = service.references(_HUB_PATH, vec_offset, include_declaration=True)
+    checks["references_fan_in"] = len(refs) > 1 and len({r.path for r in refs}) >= 2
+
+    dot_offset = mod_text.index("v.x") + 2
+    completions = service.completions(target, dot_offset)
+    checks["completions_contains_x"] = any(c.label == "x" for c in completions)
+
+    info = service.quickinfo(target, call_offset)
+    checks["quickinfo_nonempty"] = bool(info)
+
+    symbols = service.document_symbols(target)
+    checks["document_symbols_nonempty"] = bool(symbols)
+
+    broken = mod_text.replace("v.x", "v.gorblak", 1)
+    service.update(target, broken)
+    broken_diags = service.diagnostics(target)
+    checks["diagnostics_detects_break"] = any(d.code == "TS2339" for d in broken_diags)
+    service.update(target, mod_text)   # revert
+    clean_diags = service.diagnostics(target)
+    checks["diagnostics_clean_after_revert"] = clean_diags == []
+
+    failed = sorted(k for k, v in checks.items() if not v)
+    return {"ok": not failed, "checks": checks, "failed": failed}
+
+
+# --------------------------------------------------------------------------- #
+# Measurement
+# --------------------------------------------------------------------------- #
+
+def _is_nonempty(x) -> bool:
+    if x is None:
+        return False
+    if isinstance(x, str):
+        return bool(x)
+    try:
+        return len(x) > 0
+    except TypeError:
+        return bool(x)
+
+
+def _summarize(op_name: str, samples_s: List[float], n_nonempty: int, iters: int) -> dict:
+    ms = sorted(s * 1000.0 for s in samples_s)
+    n = len(ms)
+    mean_ms = sum(ms) / n if n else 0.0
+    median_ms = ms[n // 2] if n else 0.0
+    min_ms = ms[0] if n else 0.0
+    p95_ms = ms[min(n - 1, int(round(0.95 * (n - 1))))] if n else 0.0
+    total_s = sum(samples_s)
+    calls_per_s = iters / total_s if total_s > 0 else 0.0
+    return {
+        "op": op_name, "iters": iters,
+        "mean_ms": round(mean_ms, 3), "median_ms": round(median_ms, 3),
+        "min_ms": round(min_ms, 3), "p95_ms": round(p95_ms, 3),
+        "calls_per_s": round(calls_per_s, 2),
+        "n_nonempty": n_nonempty,
+        "nonempty_rate": round(n_nonempty / iters, 3) if iters else 0.0,
+    }
+
+
+def _measure_op(op_name: str, fn: Callable, targets: List[Tuple], *,
+                warmup: int, iters: int) -> dict:
+    n = len(targets)
+    if n == 0:
+        raise RuntimeError(f"{op_name}: no targets generated -- project too small?")
+    for w in range(warmup):
+        fn(*targets[w % n])
+    samples_s: List[float] = []
+    n_nonempty = 0
+    for it in range(iters):
+        args = targets[it % n]
+        t0 = time.perf_counter()
+        result = fn(*args)
+        samples_s.append(time.perf_counter() - t0)
+        if _is_nonempty(result):
+            n_nonempty += 1
+    return _summarize(op_name, samples_s, n_nonempty, iters)
+
+
+def _run_measurements(service: TsLspService, files: Dict[str, str], args) -> Dict[str, dict]:
+    mod_paths = [_mod_path(i) for i in range(1, args.n_files)]
+    hub_text = files[_HUB_PATH]
+
+    # Rotating position/file per op so the server can't serve one hot cache
+    # entry forever.
+    scale_call_targets = [(p, files[p].index("scale(")) for p in mod_paths]
+    completion_targets = [(p, files[p].index("v.x") + 2) for p in mod_paths]
+    symbol_targets = [(p,) for p in mod_paths]
+    reference_targets = [
+        (_HUB_PATH, hub_text.index("interface Vec") + len("interface ")),
+        (_HUB_PATH, hub_text.index("function scale") + len("function ")),
+    ]
+
+    ops: Dict[str, dict] = {}
+    ops["definition"] = _measure_op(
+        "definition", lambda path, off: service.definition(path, off),
+        scale_call_targets, warmup=args.warmup, iters=args.iters)
+    ops["references"] = _measure_op(
+        "references", lambda path, off: service.references(path, off, include_declaration=True),
+        reference_targets, warmup=args.warmup, iters=args.iters)
+    ops["completions"] = _measure_op(
+        "completions", lambda path, off: service.completions(path, off),
+        completion_targets, warmup=args.warmup, iters=args.iters)
+    ops["quickinfo"] = _measure_op(
+        "quickinfo", lambda path, off: service.quickinfo(path, off),
+        scale_call_targets, warmup=args.warmup, iters=args.iters)
+    ops["document_symbols"] = _measure_op(
+        "document_symbols", lambda path: service.document_symbols(path),
+        symbol_targets, warmup=args.warmup, iters=args.iters)
+
+    # diagnostics: an EDIT -> RE-CHECK cycle, timed TOGETHER -- the shape
+    # #226's consumer actually has (one edit per generated token). Timing a
+    # cache hit and calling it a re-check would be the same BLIND failure in
+    # a different coat.
+    counter = [0]
+
+    def _edit_and_check(path):
+        counter[0] += 1
+        service.update(path, files[path] + f"\n// bench edit {counter[0]}\n")
+        return service.diagnostics(path)
+
+    ops["diagnostics"] = _measure_op(
+        "diagnostics", _edit_and_check, [(p,) for p in mod_paths],
+        warmup=args.warmup, iters=args.iters)
+
+    # diagnostics_cached: pure cache-hit path (unchanged document), reported
+    # SEPARATELY -- explicitly NOT the SLA number.
+    ops["diagnostics_cached"] = _measure_op(
+        "diagnostics_cached", lambda path: service.diagnostics(path),
+        [(p,) for p in mod_paths], warmup=args.warmup, iters=args.iters)
+
+    return ops
+
+
+def _verdict(diag_median_ms: float, completions_calls_per_s: float) -> str:
+    if completions_calls_per_s < 20:
+        return "KILL"
+    if diag_median_ms < 50 and completions_calls_per_s >= 200:
+        return "PASS"
+    return "WARN"
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+
+def _write_results(out_path: Path, result: dict) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"[bench_ts_lsp] wrote {out_path}")
+
+
+def _print_report(summary: dict, ops: Dict[str, dict]) -> None:
+    print("=" * 72)
+    print("TS-LSP multi-op service bench (#220)")
+    print("=" * 72)
+    print(f"n_files={summary['n_files']}  cold_load_s={summary['cold_load_s']:.3f}  "
+          f"server_sync_kind={summary['server_sync_kind']}  "
+          f"diagnosticProvider={summary['diagnostic_provider']!r}")
+    print("-" * 72)
+    print(f"{'op':<20}{'median_ms':>12}{'p95_ms':>10}{'calls/s':>10}{'nonempty%':>11}")
+    for name, s in ops.items():
+        print(f"{name:<20}{s['median_ms']:>12.2f}{s['p95_ms']:>10.2f}"
+              f"{s['calls_per_s']:>10.1f}{s['nonempty_rate'] * 100:>10.1f}%")
+    print("-" * 72)
+    print(f"n_restarts={summary['n_restarts']}  n_timeouts={summary['n_timeouts']}")
+    print(f"VERDICT: {summary['verdict']}")
+    if summary["verdict"] in ("WARN", "KILL"):
+        print("  -> #226 decode-time completion-list masking rescopes to OFFLINE "
+              "if this holds (throughput gate: completions >= 200 calls/s).")
+    print("=" * 72)
+
+
+# --------------------------------------------------------------------------- #
+# Driver
+# --------------------------------------------------------------------------- #
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--n-files", type=int, default=5000, help="project size")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--warmup", type=int, default=20, help="untimed ops per kind")
+    ap.add_argument("--iters", type=int, default=200, help="timed ops per kind")
+    ap.add_argument("--timeout-s", type=float, default=10.0)
+    ap.add_argument("--out", type=str, default="results/ts_lsp_bench.json")
+    ap.add_argument("--keep-scratch", action="store_true",
+                    help="leave the generated project on disk for inspection")
+    ap.add_argument("--max-server-memory", type=int, default=None,
+                    help="initializationOptions.maxTsServerMemory (MB) -- raise this if a "
+                         "large project silently disables semantic features (edge case: "
+                         "tsserver project-size/memory limits)")
+    args = ap.parse_args()
+    if args.n_files < 2:
+        ap.error("--n-files must be >= 2")
+    if args.iters < 1:
+        ap.error("--iters must be >= 1")
+    if args.warmup < 0:
+        ap.error("--warmup must be >= 0")
+    return args
+
+
+def main() -> int:
+    args = _parse_args()
+
+    argv = resolve_ts_lsp()
+    if argv is None:
+        print("SKIP: no typescript-language-server toolchain resolvable "
+              f"(need `npm i -D typescript-language-server` in {SET_DIR}).")
+        return 0
+
+    out_path = Path(args.out)
+    if not out_path.is_absolute():
+        out_path = _REPO_ROOT / out_path
+
+    print(f"[bench_ts_lsp] n_files={args.n_files} seed={args.seed} "
+          f"warmup={args.warmup} iters={args.iters} timeout_s={args.timeout_s}")
+    files = _generate_project(args.n_files, args.seed)
+
+    init_options = {}
+    if args.max_server_memory is not None:
+        init_options["maxTsServerMemory"] = args.max_server_memory
+
+    service = TsLspService(timeout_s=args.timeout_s, initialization_options=init_options)
+    try:
+        service.open_project(files)
+        print(f"[bench_ts_lsp] cold load: {service.cold_load_s:.3f}s  "
+              f"server_sync_kind={service.server_sync_kind}  "
+              f"diagnosticProvider={service.server_capabilities.get('diagnosticProvider')!r}")
+
+        probe = _sanity_probe(service, files)
+        if not probe["ok"]:
+            print("BLIND: sanity probe failed -- nothing was measured.")
+            for name, ok in probe["checks"].items():
+                print(f"  {name}: {'OK' if ok else 'FAILED'}")
+            _write_results(out_path, {"summary": {"verdict": "BLIND", "sanity_probe": probe},
+                                      "ops": {}})
+            raise SystemExit(2)
+
+        ops = _run_measurements(service, files, args)
+        verdict = _verdict(ops["diagnostics"]["median_ms"], ops["completions"]["calls_per_s"])
+        summary = {
+            "verdict": verdict,
+            "n_files": args.n_files, "seed": args.seed,
+            "warmup": args.warmup, "iters": args.iters,
+            "cold_load_s": service.cold_load_s,
+            "server_sync_kind": service.server_sync_kind,
+            "diagnostic_provider": service.server_capabilities.get("diagnosticProvider"),
+            "sanity_probe": probe,
+            "n_restarts": service.n_restarts, "n_timeouts": service.n_timeouts,
+        }
+        _write_results(out_path, {"summary": summary, "ops": ops})
+        _print_report(summary, ops)
+    finally:
+        if args.keep_scratch:
+            # Detach TemporaryDirectory's finalizer so it survives process exit.
+            service._tmpdir_obj._finalizer.detach()
+            service._teardown_process()
+            print(f"[bench_ts_lsp] scratch dir kept at {service.scratch_dir}")
+        else:
+            service.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval_code_suite.py
+++ b/scripts/eval_code_suite.py
@@ -356,7 +356,7 @@ def _run_tsc(args):
         n_clean = 0
         for row in rows:
             artifact = row["prompt"] + row.get("gold_completion", "")
-            codes = [d.code for d in oracle.diagnose(artifact)]
+            codes = [d.code for d in oracle.diagnostics(artifact)]
             clean = not codes
             n_clean += int(clean)
             records.append(make_record(

--- a/src/lsp/diagnostics.py
+++ b/src/lsp/diagnostics.py
@@ -23,6 +23,7 @@ ABOVE THE SEAM — stdlib only. No `mlx`/`torch` import anywhere in this module
 
 from __future__ import annotations
 
+import bisect
 import re
 from dataclasses import dataclass, replace
 from typing import Callable, Iterator, List, Optional, Sequence, Tuple
@@ -176,6 +177,39 @@ def line_col_to_offset(source: str, line: int, col: int) -> int:
     starts = _line_start_offsets(source)
     line_text = source.split("\n")[line - 1]
     return starts[line - 1] + _utf16_col_to_char_index(line_text, col)
+
+
+def _char_index_to_utf16_col(line: str, index: int) -> int:
+    """0-indexed Python `str` character index within `line` -> 1-indexed UTF-16-
+    code-unit column. Exact inverse of `_utf16_col_to_char_index` on every index
+    that is not inside a surrogate pair (a Python `str` index never is)."""
+    units = 0
+    for ch in line[:index]:
+        units += 2 if ord(ch) > 0xFFFF else 1
+    return units + 1
+
+
+def offset_to_lsp_position(source: str, offset: int) -> dict:
+    """0-indexed character offset into `source` -> an LSP `Position`
+    (`{"line": l0, "character": c0}`, BOTH 0-indexed, `character` in UTF-16 code
+    units). The inverse of `line_col_to_offset`, which is 1-indexed on both axes
+    because that is `tsc`'s reporting convention; LSP's wire format is 0-indexed on
+    both, so the conversion happens here once rather than at each call site.
+
+    Raises `ValueError` on `offset < 0` or `offset > len(source)` -- silently
+    clamping an out-of-range offset would hand the server a plausible-but-wrong
+    position and get back confidently wrong completions, which is exactly the
+    BLIND failure mode this module exists to prevent. `offset == len(source)`
+    (EOF) is legal and must work -- it is the decode-frontier position #226 uses.
+    """
+    if offset < 0 or offset > len(source):
+        raise ValueError(f"offset {offset} out of range for source of length {len(source)}")
+    starts = _line_start_offsets(source)
+    line0 = bisect.bisect_right(starts, offset) - 1
+    line_text = source.split("\n")[line0]
+    char_index = offset - starts[line0]
+    character0 = _char_index_to_utf16_col(line_text, char_index) - 1
+    return {"line": line0, "character": character0}
 
 
 def parse_tsc_output(output: str, source: str) -> List[Diagnostic]:

--- a/src/lsp/diagnostics.py
+++ b/src/lsp/diagnostics.py
@@ -153,6 +153,17 @@ def _line_start_offsets(source: str) -> List[int]:
     return starts
 
 
+def _line_text(source: str, starts: List[int], line0: int) -> str:
+    """Slice out 0-indexed line `line0` using already-computed line-start
+    offsets `starts` (from `_line_start_offsets`) -- O(length of the line),
+    not O(len(source)): avoids `source.split("\\n")`'s full-list allocation on
+    every call, which dominates cost for high-frequency ops like #226's
+    per-token completions."""
+    start = starts[line0]
+    end = starts[line0 + 1] - 1 if line0 + 1 < len(starts) else len(source)
+    return source[start:end]
+
+
 def _utf16_col_to_char_index(line: str, col: int) -> int:
     """1-indexed UTF-16-code-unit column -> 0-indexed Python `str` character index
     within `line`. Most characters are 1 UTF-16 unit; astral-plane characters
@@ -175,7 +186,7 @@ def _utf16_col_to_char_index(line: str, col: int) -> int:
 def line_col_to_offset(source: str, line: int, col: int) -> int:
     """1-indexed (line, col) -> 0-indexed character offset into `source`."""
     starts = _line_start_offsets(source)
-    line_text = source.split("\n")[line - 1]
+    line_text = _line_text(source, starts, line - 1)
     return starts[line - 1] + _utf16_col_to_char_index(line_text, col)
 
 
@@ -206,7 +217,7 @@ def offset_to_lsp_position(source: str, offset: int) -> dict:
         raise ValueError(f"offset {offset} out of range for source of length {len(source)}")
     starts = _line_start_offsets(source)
     line0 = bisect.bisect_right(starts, offset) - 1
-    line_text = source.split("\n")[line0]
+    line_text = _line_text(source, starts, line0)
     char_index = offset - starts[line0]
     character0 = _char_index_to_utf16_col(line_text, char_index) - 1
     return {"line": line0, "character": character0}

--- a/src/lsp/ts_service.py
+++ b/src/lsp/ts_service.py
@@ -1,0 +1,698 @@
+"""Warm, multi-op `typescript-language-server` client -- the counterpart to
+`ts_lsp.py`'s `TsLspOracle` for two M12 consumers that need the OPPOSITE shape:
+
+  - **#226 completion-list logit masking** needs a per-decode-step
+    `textDocument/completion` against a warm, multi-file program -- one edit
+    plus one query per generated token.
+  - **The code eval suite's cross-file / type-aware arm** needs
+    `definition`/`references`/`documentSymbol` over a real multi-file project.
+
+`TsLspOracle` is deliberately **one-shot**: a fresh, never-reused `cand_{n}.ts`
+URI per call, single-file, no `didChange`, no version counter, no cross-file
+program (`ts_lsp.py:85-88`) -- that contract is load-bearing for the #194/#211
+harness path and every `CompositeOracle` consumer (`oracle.py`). `TsLspService`
+does not share it: it opens ONE project once, keeps documents open with
+monotonically versioned `didChange` edits, and answers five more LSP ops in
+addition to diagnostics. `ts_lsp.py` and `oracle.py` are UNTOUCHED by this
+module -- both new and old share only the already fully op-agnostic
+`jsonrpc.py`.
+
+**No settle window on `diagnostics()`.** #211 established
+(`docs/design/12-lsp-in-the-loop.md:664-700`) that on the pinned
+`typescript-language-server` **5.3.0** the FIRST `publishDiagnostics` push is
+semantically complete -- 0/97 #194 candidates disagreed between their first
+push and the union of all pushes, and a crafted candidate carrying both a
+syntactic and a distinct semantic defect coalesced into **one** push. The
+server does publish up to 3 idempotent re-publishes ~1.2s apart, but the first
+is already the answer. A settle/quiescence window (`opengrep.py`'s
+`_SETTLE_S`) puts a floor of *seconds* on every call, which makes >=200
+calls/s structurally unreachable -- so `diagnostics()` below is first-push-wins,
+same as `TsLspOracle`. `opengrep.py:288-323` settles deliberately, for a
+*different* server with a confirmed stale-generation race (its own module
+docstring) -- that divergence is intentional. **Do not "fix" this module to
+settle like opengrep.py; it would defeat the reason this class exists.**
+
+5.3.0 also advertises **no** `capabilities.diagnosticProvider` in its
+`initialize` result, so LSP 3.17 *pull* diagnostics (`textDocument/diagnostic`)
+are not available on this pin -- push-and-wait, gated by version/seq (see
+`diagnostics()`), is the only option.
+
+Not safe for concurrent use -- one service instance == one sequential
+open/edit/query stream, matching `TsLspOracle`'s contract.
+
+ABOVE THE SEAM -- stdlib only. No `mlx`/`torch` import anywhere in this module
+(guarded by `tests/test_import_guard.py`).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, List, Mapping, Optional, Set
+from urllib.parse import unquote, urlparse
+
+from .diagnostics import Diagnostic, line_col_to_offset, offset_to_lsp_position
+from .jsonrpc import JsonRpcEndpoint, spawn
+from .ts_lsp import resolve_ts_lsp
+from .tsc import DEFAULT_TSCONFIG_PATH, SET_DIR
+
+_DEFAULT_TIMEOUT_S = 10.0
+_TEARDOWN_TIMEOUT_S = 5.0
+
+
+# --------------------------------------------------------------------------- #
+# Result types
+# --------------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class Location:
+    uri: str
+    path: str          # project-relative, for readable assertions/reports
+    line: int           # 1-indexed, matching Diagnostic's convention
+    col: int             # 1-indexed UTF-16 column, matching Diagnostic's convention
+    end_line: int
+    end_col: int
+
+
+@dataclass(frozen=True)
+class CompletionItem:
+    label: str
+    kind: Optional[int] = None
+    detail: Optional[str] = None
+    insert_text: Optional[str] = None
+    sort_text: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Symbol:
+    name: str
+    kind: int
+    line: int
+    col: int
+    container: Optional[str] = None
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers -- no I/O, this is what the mechanism tests exercise directly
+# --------------------------------------------------------------------------- #
+
+def _content_changes(text: str, change_range: Optional[dict] = None) -> List[dict]:
+    """Full-text change by default (`contentChanges: [{"text": text}]`, no
+    `range` key) -- valid under sync kind Full (1) *and* Incremental (2) alike
+    (a change event with no `range` means whole-document replacement).
+    Structured so a *ranged* change is a drop-in later."""
+    if change_range is None:
+        return [{"text": text}]
+    return [{"range": change_range, "text": text}]
+
+
+def _did_change_params(uri: str, version: int, text: str) -> dict:
+    return {"textDocument": {"uri": uri, "version": version},
+            "contentChanges": _content_changes(text)}
+
+
+def _text_document_position(uri: str, position: dict) -> dict:
+    return {"textDocument": {"uri": uri}, "position": position}
+
+
+def _references_params(uri: str, position: dict, include_declaration: bool) -> dict:
+    params = _text_document_position(uri, position)
+    params["context"] = {"includeDeclaration": include_declaration}
+    return params
+
+
+def _uri_to_relpath(uri: str, root: Path) -> str:
+    """Inverse of `Path.as_uri()`, resolved relative to `root` (the scratch
+    dir) for readable assertions/reports. Falls back to the absolute path if
+    `uri` doesn't sit under `root` (shouldn't happen for this class -- every
+    file lives in the scratch dir -- but never raise over it)."""
+    parsed = urlparse(uri)
+    p = Path(unquote(parsed.path))
+    try:
+        return p.relative_to(root).as_posix()
+    except ValueError:
+        return p.as_posix()
+
+
+def _map_location(raw, root: Path) -> List[Location]:
+    """Normalize a `textDocument/definition` or `textDocument/references`
+    result -- `null`, a single `Location` (`uri` + `range`), a single
+    `LocationLink` (`targetUri` + `targetSelectionRange`/`targetRange`), or a
+    list of either -- into `List[Location]`. We request `linkSupport: False`
+    so a plain `Location` is expected, but map defensively regardless."""
+    if raw is None:
+        items = []
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        items = [raw]
+
+    out: List[Location] = []
+    for item in items:
+        if "targetUri" in item:   # LocationLink
+            uri = item["targetUri"]
+            rng = item.get("targetSelectionRange") or item["targetRange"]
+        else:                      # Location
+            uri = item["uri"]
+            rng = item["range"]
+        start, end = rng["start"], rng["end"]
+        out.append(Location(
+            uri=uri, path=_uri_to_relpath(uri, root),
+            line=start["line"] + 1, col=start["character"] + 1,
+            end_line=end["line"] + 1, end_col=end["character"] + 1,
+        ))
+    return out
+
+
+def _map_completion_items(raw) -> List[CompletionItem]:
+    """`textDocument/completion` result is `CompletionItem[] | CompletionList
+    {isIncomplete, items} | null` -- normalize all three. `isIncomplete` is not
+    representable in a bare list, so the caller (`TsLspService.completions`)
+    records it separately on `self.last_completion_incomplete` rather than
+    silently treating a truncated list as complete."""
+    if raw is None:
+        return []
+    items = raw.get("items", []) if isinstance(raw, dict) else raw
+    out = []
+    for it in items:
+        out.append(CompletionItem(
+            label=it.get("label", ""), kind=it.get("kind"),
+            detail=it.get("detail"), insert_text=it.get("insertText"),
+            sort_text=it.get("sortText"),
+        ))
+    return out
+
+
+def _map_hover(contents) -> Optional[str]:
+    """Normalize an LSP `Hover.contents` value -- `MarkupContent`
+    (`{"kind","value"}`), a bare string, `MarkedString` (`{"language","value"}`),
+    or a list of any of those -- to one string (list entries joined with
+    `"\\n"`). `None` in (a `null` hover, or a hover with no contents) -> `None`
+    out."""
+    if contents is None:
+        return None
+    if isinstance(contents, str):
+        return contents
+    if isinstance(contents, dict):
+        return contents.get("value")
+    if isinstance(contents, list):
+        parts = []
+        for item in contents:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and item.get("value"):
+                parts.append(item["value"])
+        return "\n".join(parts) if parts else None
+    return None
+
+
+def _map_symbols(raw) -> List[Symbol]:
+    """`textDocument/documentSymbol` result is `DocumentSymbol[]` (hierarchical
+    -- has `children` + `selectionRange`) *or* `SymbolInformation[]` (flat --
+    has `location` + `containerName`), or `null`. `DocumentSymbol` trees are
+    flattened depth-first, carrying the parent's `name` as `container`."""
+    if not raw:
+        return []
+    out: List[Symbol] = []
+
+    def _flatten(items, container: Optional[str]) -> None:
+        for it in items:
+            if "selectionRange" in it:   # DocumentSymbol
+                pos = it["selectionRange"]["start"]
+                out.append(Symbol(name=it["name"], kind=it["kind"],
+                                   line=pos["line"] + 1, col=pos["character"] + 1,
+                                   container=container))
+                children = it.get("children") or []
+                if children:
+                    _flatten(children, it["name"])
+            else:                          # SymbolInformation
+                loc = it["location"]
+                pos = loc["range"]["start"]
+                out.append(Symbol(name=it["name"], kind=it["kind"],
+                                   line=pos["line"] + 1, col=pos["character"] + 1,
+                                   container=it.get("containerName")))
+
+    _flatten(raw, None)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Client capabilities
+# --------------------------------------------------------------------------- #
+
+_CLIENT_CAPABILITIES = {
+    "textDocument": {
+        # Sync KIND is a SERVER capability (reported in the initialize result); the
+        # client only declares these flags. didChange payloads below are full-text,
+        # which is valid under Full (1) and Incremental (2) sync alike.
+        "synchronization": {"dynamicRegistration": False, "willSave": False,
+                            "willSaveWaitUntil": False, "didSave": True},
+        # versionSupport asks the server to stamp publishDiagnostics with the
+        # document version -- how diagnostics() tells a post-edit push from a
+        # stale pre-edit one. Optional in LSP 3.16; there is a seq-based fallback.
+        "publishDiagnostics": {"relatedInformation": False, "versionSupport": True},
+        "definition": {"dynamicRegistration": False, "linkSupport": False},
+        "references": {"dynamicRegistration": False},
+        "completion": {
+            "dynamicRegistration": False,
+            "contextSupport": True,
+            "completionItem": {"snippetSupport": False,
+                               "documentationFormat": ["plaintext"]},
+        },
+        "hover": {"dynamicRegistration": False,
+                  "contentFormat": ["plaintext", "markdown"]},
+        "documentSymbol": {"dynamicRegistration": False,
+                           "hierarchicalDocumentSymbolSupport": True},
+    },
+    "workspace": {"workspaceFolders": True},
+}
+
+
+# --------------------------------------------------------------------------- #
+# TsLspService
+# --------------------------------------------------------------------------- #
+
+class TsLspService:
+    """One persistent `typescript-language-server --stdio` process carrying a
+    warm, multi-file program: stable URIs, monotonically versioned
+    `didChange` edits, and `definition`/`references`/`completions`/
+    `quickinfo`/`document_symbols` in addition to `diagnostics`. See the
+    module docstring for why this is a NEW class rather than an extension of
+    `TsLspOracle`.
+
+    Lazy `didOpen`: `open_project` materializes every file on disk (so the
+    tsconfig's whole-directory `include` puts every file in the *program*,
+    letting cross-file `definition`/`references` resolve without any file
+    being open) but only `didOpen`s the warm-up file. Every other document is
+    opened lazily by `_ensure_open` the first time an op touches it -- only
+    *diagnostics* need a document to be open at all (servers publish
+    diagnostics for open documents only), so this is the difference between a
+    bench that measures a warm program and one that measures 5000 didOpens.
+
+    Not safe for concurrent use.
+    """
+
+    def __init__(self, *, timeout_s: float = _DEFAULT_TIMEOUT_S,
+                 tsconfig: Path = DEFAULT_TSCONFIG_PATH,
+                 scratch_parent: Path = SET_DIR,
+                 initialization_options: Optional[dict] = None,
+                 argv: Optional[List[str]] = None) -> None:
+        self.argv = argv if argv is not None else resolve_ts_lsp()
+        if self.argv is None:
+            raise RuntimeError("no typescript-language-server toolchain resolvable "
+                                f"(run `npm i -D typescript-language-server` in {scratch_parent})")
+        self.timeout_s = timeout_s
+        self.tsconfig = tsconfig
+        self.initialization_options = initialization_options or {}
+
+        self.n_calls = 0
+        self.wall_s = 0.0
+        self.n_timeouts = 0
+        self.n_restarts = 0
+        self.op_counts: Dict[str, int] = {}
+        self.op_wall_s: Dict[str, float] = {}
+        self.cold_load_s: Optional[float] = None
+        self.last_completion_incomplete: Optional[bool] = None
+
+        # Nesting under `scratch_parent` (default `SET_DIR`) is load-bearing --
+        # see ts_lsp.py:79-83: TypeScript's default `typeRoots` walk needs to
+        # find `SET_DIR/node_modules/@types/node` from wherever the scratch dir
+        # sits. `.gitignore`'s `lsp_scratch_*` already covers the prefix.
+        self._tmpdir_obj = tempfile.TemporaryDirectory(dir=str(scratch_parent), prefix="lsp_scratch_")
+        self.scratch_dir = Path(self._tmpdir_obj.name)
+        # The pinned tsconfig has no include/files, so it picks up every .ts
+        # under the scratch dir recursively -- what makes a warm multi-file
+        # program work with zero extra config.
+        (self.scratch_dir / "tsconfig.json").write_text(
+            tsconfig.read_text(encoding="utf-8"), encoding="utf-8")
+
+        self._project_opened = False
+        self._files: Dict[str, str] = {}          # project-relative path -> text
+        self._versions: Dict[str, int] = {}        # project-relative path -> version
+        self._open: Set[str] = set()               # project-relative paths, didOpen'd
+
+        self._diag_lock = threading.Lock()
+        self._diag_events: Dict[str, threading.Event] = {}
+        self._diag_state: Dict[str, dict] = {}      # uri -> {"seq", "version", "payload"}
+        self._diag_seq_counter = 0
+        self._update_marker: Dict[str, int] = {}    # uri -> seq counter as-of last edit/open
+
+        self.server_sync_kind: Optional[int] = None
+        self.server_capabilities: dict = {}
+
+        self._proc: Optional[subprocess.Popen] = None
+        self._endpoint: Optional[JsonRpcEndpoint] = None
+        self._start_server()
+
+    # ----------------------------------------------------------------- #
+    # path/uri helpers
+    # ----------------------------------------------------------------- #
+
+    def _abs_path(self, path: str) -> Path:
+        return self.scratch_dir / path
+
+    def _uri(self, path: str) -> str:
+        return self._abs_path(path).as_uri()
+
+    # ----------------------------------------------------------------- #
+    # server lifecycle
+    # ----------------------------------------------------------------- #
+
+    def _on_notification(self, msg: dict) -> None:
+        if msg.get("method") != "textDocument/publishDiagnostics":
+            return
+        params = msg.get("params") or {}
+        uri = params.get("uri")
+        if uri is None:
+            return
+        with self._diag_lock:
+            self._diag_seq_counter += 1
+            self._diag_state[uri] = {
+                "seq": self._diag_seq_counter,
+                "version": params.get("version"),
+                "payload": params.get("diagnostics", []),
+            }
+            event = self._diag_events.get(uri)
+            if event is not None:
+                event.set()
+
+    def _start_server(self) -> None:
+        self._proc, self._endpoint = spawn(
+            self.argv + ["--stdio"], cwd=str(self.scratch_dir),
+            on_notification=self._on_notification)
+        result = self._endpoint.request("initialize", {
+            "processId": os.getpid(),
+            "rootUri": self.scratch_dir.as_uri(),
+            "capabilities": _CLIENT_CAPABILITIES,
+            "initializationOptions": self.initialization_options,
+        }, timeout=self.timeout_s)
+        self._endpoint.notify("initialized", {})
+
+        self.server_capabilities = (result or {}).get("capabilities", {})
+        sync = self.server_capabilities.get("textDocumentSync")
+        if isinstance(sync, dict):
+            self.server_sync_kind = sync.get("change")
+        elif isinstance(sync, int):
+            self.server_sync_kind = sync
+        else:
+            self.server_sync_kind = None
+
+    def _ensure_alive(self) -> None:
+        if self._proc is not None and self._proc.poll() is None:
+            return
+        self._restart()
+
+    def _restart(self) -> None:
+        """Restart lost the warm program (every open document + the server's
+        project state); files are already on disk (both `open_project` and
+        `update` write through), so re-`didOpen` every previously-open path at
+        its CURRENT version -- version counters stay monotonic across restarts
+        (LSP requires per-document monotonicity; reusing 1 after an edit would
+        let a stale push masquerade as current). `_diag_state` is cleared so no
+        pre-restart push is mistaken for a post-restart one."""
+        self.n_restarts += 1
+        open_paths = list(self._open)
+        self._teardown_process()
+        with self._diag_lock:
+            self._diag_state.clear()
+            self._diag_events.clear()
+            self._update_marker.clear()
+        self._open.clear()
+        self._start_server()
+        for path in open_paths:
+            self._ensure_open(path)
+
+    def _teardown_process(self) -> None:
+        if self._endpoint is not None:
+            self._endpoint.close()
+            self._endpoint = None
+        if self._proc is not None:
+            try:
+                self._proc.terminate()
+                self._proc.wait(timeout=_TEARDOWN_TIMEOUT_S)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=_TEARDOWN_TIMEOUT_S)
+            except OSError:
+                pass  # already dead
+            self._proc = None
+
+    # ----------------------------------------------------------------- #
+    # project / document lifecycle
+    # ----------------------------------------------------------------- #
+
+    def open_project(self, files: Mapping[str, str], *, warm_path: Optional[str] = None) -> None:
+        """Materialize `files` (project-relative path -> text) on disk, then
+        `didOpen` exactly one (the first key, or `warm_path`) to force
+        tsserver to load the configured project, blocking on its first
+        `publishDiagnostics` (bounded by `timeout_s`, counted as a timeout,
+        never a hang). Records `self.cold_load_s`. One service instance ==
+        one project -- calling this twice is a `RuntimeError`."""
+        if self._project_opened:
+            raise RuntimeError("open_project called twice -- one TsLspService "
+                                "instance == one project")
+        if not files:
+            raise RuntimeError("open_project requires at least one file")
+        self._ensure_alive()
+
+        for rel, text in files.items():
+            abs_path = self._abs_path(rel)
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            abs_path.write_text(text, encoding="utf-8")
+            self._files[rel] = text
+            self._versions[rel] = 1
+        self._project_opened = True
+
+        warm = warm_path if warm_path is not None else next(iter(files))
+        uri = self._uri(warm)
+        t0 = time.monotonic()
+        with self._diag_lock:
+            event = threading.Event()
+            self._diag_events[uri] = event
+        self._ensure_open(warm)
+        got = event.wait(self.timeout_s)
+        with self._diag_lock:
+            self._diag_events.pop(uri, None)
+        self.cold_load_s = time.monotonic() - t0
+        if not got:
+            self.n_timeouts += 1
+
+    def _ensure_open(self, path: str) -> None:
+        if path in self._open:
+            return
+        uri = self._uri(path)
+        text = self._files[path]
+        with self._diag_lock:
+            self._update_marker.setdefault(uri, self._diag_seq_counter)
+        self._endpoint.notify("textDocument/didOpen", {
+            "textDocument": {"uri": uri, "languageId": "typescript",
+                              "version": self._versions[path], "text": text},
+        })
+        self._open.add(path)
+
+    def update(self, path: str, text: str) -> int:
+        """`_ensure_open(path)`, write `text` through to disk (so a restart
+        can recover it and tsserver's on-disk view stays consistent), bump the
+        version, and send `textDocument/didChange` (full-text). Returns the
+        new version."""
+        self._ensure_alive()
+        self._ensure_open(path)
+        uri = self._uri(path)
+        self._abs_path(path).write_text(text, encoding="utf-8")
+        self._files[path] = text
+        self._versions[path] += 1
+        version = self._versions[path]
+        with self._diag_lock:
+            self._update_marker[uri] = self._diag_seq_counter
+        self._endpoint.notify("textDocument/didChange", _did_change_params(uri, version, text))
+        return version
+
+    # ----------------------------------------------------------------- #
+    # diagnostics -- version-aware first-push-wins
+    # ----------------------------------------------------------------- #
+
+    def _push_is_current(self, state: dict, want_version: int, marker: int) -> bool:
+        version = state.get("version")
+        if version is not None:
+            return version == want_version
+        # Server omits `version` (optional even with versionSupport: True) --
+        # fall back to seq-vs-last-edit comparison. Never assume a push is
+        # current just because it's the latest one seen.
+        return state["seq"] > marker
+
+    def diagnostics(self, path: str) -> List[Diagnostic]:
+        """Return every `severity == 1` diagnostic for `path`'s CURRENT
+        version. **Version-aware first-push-wins, no settle window** (see the
+        module docstring's #211 evidence). If a push already recorded for this
+        document matches the current version (or, when the server omits
+        `version`, post-dates the last `update()`/open), it is returned
+        immediately from a cache -- the honest fast path for "diagnose the
+        same unchanged document again", NOT a re-check. Otherwise waits up to
+        `timeout_s` for a matching push. Never raises on timeout or a dead
+        server -- returns `[]` and counts it (`n_timeouts`), `TsLspOracle`'s
+        contract."""
+        self._ensure_alive()
+        self._ensure_open(path)
+        uri = self._uri(path)
+        want_version = self._versions[path]
+
+        t0 = time.monotonic()
+        with self._diag_lock:
+            state = self._diag_state.get(uri)
+            marker = self._update_marker.get(uri, 0)
+            if state is not None and self._push_is_current(state, want_version, marker):
+                payload = list(state["payload"])
+                self._record_op("diagnostics", time.monotonic() - t0)
+                return self._filter_diagnostics_payload(payload, self._files[path])
+            event = threading.Event()
+            self._diag_events[uri] = event
+
+        # No settle window -- see module docstring. The pinned
+        # typescript-language-server 5.3.0's FIRST publishDiagnostics push for
+        # a document is already semantically complete; waiting for quiescence
+        # here (opengrep.py's _SETTLE_S idiom) would put a floor of seconds on
+        # every call and make >=200 calls/s structurally unreachable. Do not
+        # "fix" this to settle like opengrep.py -- that divergence is
+        # intentional (see the module docstring).
+        got = event.wait(self.timeout_s)
+        with self._diag_lock:
+            self._diag_events.pop(uri, None)
+            state = self._diag_state.get(uri)
+            marker = self._update_marker.get(uri, 0)
+
+        self._record_op("diagnostics", time.monotonic() - t0)
+
+        if not got or state is None or not self._push_is_current(state, want_version, marker):
+            self.n_timeouts += 1
+            return []
+        return self._filter_diagnostics_payload(list(state["payload"]), self._files[path])
+
+    def _filter_diagnostics_payload(self, payload: List[dict], text: str) -> List[Diagnostic]:
+        # Re-expressed (NOT imported) from ts_lsp.py:65's `_map_diagnostic` --
+        # that helper is private and takes the source text positionally.
+        # Trap A: LSP's integer `code` must become f"TS{code}" or
+        # `is_incomplete` breaks. Trap B: only severity == 1 (Error) survives,
+        # or tsserver's hints inflate the set (ts_lsp.py:16-24). Pinned
+        # independently for this class in tests/test_ts_service_mechanism.py.
+        out = []
+        for d in payload:
+            if d.get("severity", 1) != 1:
+                continue
+            start = d["range"]["start"]
+            line, col = start["line"] + 1, start["character"] + 1
+            out.append(Diagnostic(
+                code=f"TS{d['code']}", line=line, col=col, message=d["message"],
+                offset=line_col_to_offset(text, line, col),
+                source="ts", severity=d.get("severity", 1),
+            ))
+        return out
+
+    # ----------------------------------------------------------------- #
+    # the other four ops
+    # ----------------------------------------------------------------- #
+
+    def _record_op(self, op_name: str, elapsed: float) -> None:
+        self.wall_s += elapsed
+        self.n_calls += 1
+        self.op_counts[op_name] = self.op_counts.get(op_name, 0) + 1
+        self.op_wall_s[op_name] = self.op_wall_s.get(op_name, 0.0) + elapsed
+
+    def _timed_request(self, op_name: str, fn: Callable[[], object], *, empty):
+        """`_ensure_alive()`, run `fn()`, record cost. A `TimeoutError` or
+        `ConnectionError` is counted (`n_timeouts`) and returns `empty` --
+        never raises. A JSON-RPC `error` reply (`RuntimeError` from
+        `jsonrpc.py:210`) is RE-RAISED, not swallowed: a server that rejects
+        our params is a bug in us, and hiding it as "no completions" would be
+        exactly the BLIND failure mode this repo guards hardest."""
+        self._ensure_alive()
+        t0 = time.monotonic()
+        try:
+            result = fn()
+        except (TimeoutError, ConnectionError):
+            self.n_timeouts += 1
+            result = empty
+        finally:
+            self._record_op(op_name, time.monotonic() - t0)
+        return result
+
+    def definition(self, path: str, offset: int) -> List[Location]:
+        def _op():
+            self._ensure_open(path)
+            uri = self._uri(path)
+            pos = offset_to_lsp_position(self._files[path], offset)
+            raw = self._endpoint.request("textDocument/definition",
+                                         _text_document_position(uri, pos),
+                                         timeout=self.timeout_s)
+            return _map_location(raw, self.scratch_dir)
+        return self._timed_request("definition", _op, empty=[])
+
+    def references(self, path: str, offset: int, *,
+                    include_declaration: bool = False) -> List[Location]:
+        def _op():
+            self._ensure_open(path)
+            uri = self._uri(path)
+            pos = offset_to_lsp_position(self._files[path], offset)
+            raw = self._endpoint.request(
+                "textDocument/references",
+                _references_params(uri, pos, include_declaration),
+                timeout=self.timeout_s)
+            return _map_location(raw, self.scratch_dir)
+        return self._timed_request("references", _op, empty=[])
+
+    def completions(self, path: str, offset: int) -> List[CompletionItem]:
+        def _op():
+            self._ensure_open(path)
+            uri = self._uri(path)
+            pos = offset_to_lsp_position(self._files[path], offset)
+            raw = self._endpoint.request("textDocument/completion",
+                                         _text_document_position(uri, pos),
+                                         timeout=self.timeout_s)
+            self.last_completion_incomplete = (
+                bool(raw.get("isIncomplete")) if isinstance(raw, dict) else False)
+            return _map_completion_items(raw)
+        return self._timed_request("completions", _op, empty=[])
+
+    def quickinfo(self, path: str, offset: int) -> Optional[str]:
+        def _op():
+            self._ensure_open(path)
+            uri = self._uri(path)
+            pos = offset_to_lsp_position(self._files[path], offset)
+            raw = self._endpoint.request("textDocument/hover",
+                                         _text_document_position(uri, pos),
+                                         timeout=self.timeout_s)
+            contents = raw.get("contents") if raw is not None else None
+            return _map_hover(contents)
+        return self._timed_request("quickinfo", _op, empty=None)
+
+    def document_symbols(self, path: str) -> List[Symbol]:
+        def _op():
+            self._ensure_open(path)
+            uri = self._uri(path)
+            raw = self._endpoint.request("textDocument/documentSymbol",
+                                         {"textDocument": {"uri": uri}},
+                                         timeout=self.timeout_s)
+            return _map_symbols(raw)
+        return self._timed_request("document_symbols", _op, empty=[])
+
+    # ----------------------------------------------------------------- #
+    # misc
+    # ----------------------------------------------------------------- #
+
+    @property
+    def calls_per_s(self) -> float:
+        return self.n_calls / self.wall_s if self.wall_s else 0.0
+
+    def close(self) -> None:
+        self._teardown_process()
+        self._tmpdir_obj.cleanup()
+
+    def __enter__(self) -> "TsLspService":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()

--- a/src/lsp/ts_service.py
+++ b/src/lsp/ts_service.py
@@ -482,6 +482,19 @@ class TsLspService:
         if not got:
             self.n_timeouts += 1
 
+    def _notify_retrying(self, method: str, params: dict) -> None:
+        """`self._endpoint.notify(...)`, retried once after `_restart()` if the
+        write itself raises `OSError` (e.g. `BrokenPipeError` -- the server died
+        in the narrow window between `_ensure_alive()`'s `poll()` and this
+        write). Without this, that race would surface as an unhandled
+        exception from `_ensure_open`/`update`, breaking `diagnostics()`'s
+        documented "never raises on a dead server" contract two frames up."""
+        try:
+            self._endpoint.notify(method, params)
+        except OSError:
+            self._restart()
+            self._endpoint.notify(method, params)
+
     def _ensure_open(self, path: str) -> None:
         if path in self._open:
             return
@@ -489,7 +502,7 @@ class TsLspService:
         text = self._files[path]
         with self._diag_lock:
             self._update_marker.setdefault(uri, self._diag_seq_counter)
-        self._endpoint.notify("textDocument/didOpen", {
+        self._notify_retrying("textDocument/didOpen", {
             "textDocument": {"uri": uri, "languageId": "typescript",
                               "version": self._versions[path], "text": text},
         })
@@ -509,7 +522,7 @@ class TsLspService:
         version = self._versions[path]
         with self._diag_lock:
             self._update_marker[uri] = self._diag_seq_counter
-        self._endpoint.notify("textDocument/didChange", _did_change_params(uri, version, text))
+        self._notify_retrying("textDocument/didChange", _did_change_params(uri, version, text))
         return version
 
     # ----------------------------------------------------------------- #
@@ -605,10 +618,14 @@ class TsLspService:
     def _timed_request(self, op_name: str, fn: Callable[[], object], *, empty):
         """`_ensure_alive()`, run `fn()`, record cost. A `TimeoutError` or
         `ConnectionError` is counted (`n_timeouts`) and returns `empty` --
-        never raises. A JSON-RPC `error` reply (`RuntimeError` from
-        `jsonrpc.py:210`) is RE-RAISED, not swallowed: a server that rejects
-        our params is a bug in us, and hiding it as "no completions" would be
-        exactly the BLIND failure mode this repo guards hardest."""
+        never raises. `ConnectionError` already covers the write-side dead-
+        server case (`BrokenPipeError` etc. are `ConnectionError` subclasses
+        in the stdlib, unlike the bare `notify()` calls in `_ensure_open`/
+        `update` -- see `_notify_retrying` -- those had no handler at all). A
+        JSON-RPC `error` reply (`RuntimeError` from `jsonrpc.py:210`) is
+        RE-RAISED, not swallowed: a server that rejects our params is a bug in
+        us, and hiding it as "no completions" would be exactly the BLIND
+        failure mode this repo guards hardest."""
         self._ensure_alive()
         t0 = time.monotonic()
         try:

--- a/tests/test_eval_code_suite.py
+++ b/tests/test_eval_code_suite.py
@@ -12,6 +12,8 @@ The driver runs with `--stub-model --byte-tokenizer`, so no backend, no checkpoi
 network are involved.
 """
 
+import argparse
+import importlib.util
 import json
 import subprocess
 import sys
@@ -21,6 +23,20 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts/eval_code_suite.py"
+
+
+def _script_module():
+    """Import `scripts/eval_code_suite.py` as a module without running it --
+    the `tests/test_build_domain_val_sets.py:22-29` idiom -- so `_run_tsc` can
+    be called directly with a monkeypatched oracle, no subprocess."""
+    spec = importlib.util.spec_from_file_location("eval_code_suite", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO_ROOT))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.pop(0)
+    return mod
 
 OFFLINE = ("--stub-model", "--byte-tokenizer", "--context-lens", "512",
            "--depths", "0.0,0.5,1.0", "--batch-size", "4")
@@ -155,3 +171,67 @@ def test_a_tokenizer_must_be_chosen(tmp_path):
                          cwd=REPO_ROOT, capture_output=True, text=True)
     assert res.returncode != 0
     assert "--byte-tokenizer" in res.stderr
+
+
+# --------------------------------------------------------------------------------------- #
+# Regression: `_run_tsc` must call the oracle by its REAL method name (#220).
+#
+# scripts/eval_code_suite.py:359 called `oracle.diagnose(artifact)` -- `CompositeOracle`
+# (src/lsp/oracle.py) has never had a `diagnose` method, only `diagnostics`. That is the
+# ONLY `.diagnose(` call site in the repo, so `--suites tsc` raised AttributeError on its
+# very first row. This pins the fix by monkeypatching in a stub oracle with no `diagnose`
+# method at all, so the pre-fix code fails loudly and the fixed code passes -- no node
+# toolchain needed, so it runs in CI.
+# --------------------------------------------------------------------------------------- #
+
+class _StubOracle:
+    """Minimal stand-in for `CompositeOracle`: only what `_run_tsc` actually
+    uses (`diagnostics`, `close`, `sources_active`, `n_calls`, `wall_s`) --
+    deliberately NO `diagnose` method, so calling that name raises
+    `AttributeError` exactly as it would against the real class."""
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        self.sources_active = ["ts"]
+        self.n_calls = 0
+        self.wall_s = 0.0
+
+    def diagnostics(self, source: str):
+        from src.lsp.diagnostics import Diagnostic
+        self.n_calls += 1
+        if "gorblak" in source:
+            return [Diagnostic(code="TS2339", line=1, col=1, message="stub finding", offset=0)]
+        return []
+
+    def close(self) -> None:
+        pass
+
+
+def test_run_tsc_calls_the_oracle_by_its_real_method_name(monkeypatch, tmp_path):
+    mod = _script_module()
+    monkeypatch.setattr("src.lsp.oracle.resolve_oracle", lambda kind: True)
+    monkeypatch.setattr("src.lsp.oracle.CompositeOracle", _StubOracle)
+
+    tsc_set = tmp_path / "tsc_set.jsonl"
+    rows = [
+        {"id": "clean-1", "prompt": "const x = 1;\n", "gold_completion": "",
+         "error_class": "none", "expected_diagnostic": None},
+        {"id": "error-1", "prompt": "console.log(u.", "gold_completion": "gorblak);\n",
+         "error_class": "unfamiliar_member_access", "expected_diagnostic": "TS2339"},
+    ]
+    with open(tsc_set, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+    args = argparse.Namespace(tsc_set=tsc_set, limit=None)
+    result, src = mod._run_tsc(args)
+
+    assert result["summary"]["n"] == 2
+    assert result["summary"]["clean_rate"] == 0.5   # one clean, one flagged
+    assert src["sources_active"] == ["ts"]
+
+
+def test_composite_oracle_has_no_diagnose_method():
+    from src.lsp.oracle import CompositeOracle
+
+    assert not hasattr(CompositeOracle, "diagnose")

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -100,6 +100,7 @@ PORTABLE_MODULES = [
     "src.lsp.execute",
     "src.lsp.jsonrpc",
     "src.lsp.ts_lsp",
+    "src.lsp.ts_service",
     "src.lsp.opengrep",
     "src.lsp.oracle",
     "src.lsp.ts_boundaries",

--- a/tests/test_lsp_diagnostics.py
+++ b/tests/test_lsp_diagnostics.py
@@ -6,11 +6,14 @@ Real-compiler format pinning lives in `test_lsp_tsc.py`; this file only exercise
 
 from __future__ import annotations
 
+import pytest
+
 from src.lsp.diagnostics import (Diagnostic, FORWARD_RESOLVABLE_CODES,
                                   MODULE_RESOLUTION_CODES, SUPPRESSION_RE,
                                   close_open_delimiters, drop_codes, filter_diagnostics,
                                   is_incomplete, is_source_balanced, line_col_to_offset,
-                                  parse_tsc_output, statement_boundary, strip_suggestion)
+                                  offset_to_lsp_position, parse_tsc_output,
+                                  statement_boundary, strip_suggestion)
 
 
 # --------------------------------------------------------------------------- #
@@ -339,3 +342,59 @@ def test_drop_codes_passes_everything_through_when_no_match():
     diags = [Diagnostic(code="TS2339", line=1, col=1, message="x", offset=0)]
     wrapped = drop_codes(lambda src: list(diags), MODULE_RESOLUTION_CODES)
     assert [d.code for d in wrapped("s")] == ["TS2339"]
+
+
+# --------------------------------------------------------------------------- #
+# offset_to_lsp_position — the inverse of line_col_to_offset (#220)
+# --------------------------------------------------------------------------- #
+
+def test_offset_to_lsp_position_first_char():
+    source = "abc\ndef\nghi"
+    assert offset_to_lsp_position(source, 0) == {"line": 0, "character": 0}
+
+
+def test_offset_to_lsp_position_mid_line():
+    source = "abc\ndef\nghi"
+    # 'e' in "def" -- second line, second character.
+    assert offset_to_lsp_position(source, source.index("e")) == {"line": 1, "character": 1}
+
+
+def test_offset_to_lsp_position_line_start():
+    source = "abc\ndef\nghi"
+    assert offset_to_lsp_position(source, source.index("g")) == {"line": 2, "character": 0}
+
+
+def test_offset_to_lsp_position_end_of_source_is_legal():
+    # The decode-frontier position (#226's use case) -- EOF, not out of range.
+    source = "abc\ndef\nghi"
+    pos = offset_to_lsp_position(source, len(source))
+    assert pos == {"line": 2, "character": 3}
+
+
+def test_offset_to_lsp_position_round_trips_against_line_col_to_offset():
+    source = "const é = 1;\nconst y = 2;\nfunction f() {\n  return y;\n}\n"
+    for offset in range(len(source) + 1):
+        pos = offset_to_lsp_position(source, offset)
+        back = line_col_to_offset(source, pos["line"] + 1, pos["character"] + 1)
+        assert back == offset, (offset, pos, back)
+
+
+def test_offset_to_lsp_position_round_trips_astral_surrogate_pair():
+    # Mirrors test_line_col_to_offset_astral_surrogate_pair: an emoji outside the
+    # BMP is 1 Python str character but a 2-unit UTF-16 surrogate pair.
+    source = "const s = \"\U0001F600\"; const after = 1;"
+    after_idx = source.index("after")
+    pos = offset_to_lsp_position(source, after_idx)
+    back = line_col_to_offset(source, pos["line"] + 1, pos["character"] + 1)
+    assert back == after_idx
+
+
+def test_offset_to_lsp_position_rejects_negative_offset():
+    with pytest.raises(ValueError):
+        offset_to_lsp_position("abc", -1)
+
+
+def test_offset_to_lsp_position_rejects_offset_past_end():
+    source = "abc"
+    with pytest.raises(ValueError):
+        offset_to_lsp_position(source, len(source) + 1)

--- a/tests/test_ts_service.py
+++ b/tests/test_ts_service.py
@@ -1,0 +1,178 @@
+"""Real-`typescript-language-server` tests for `src/lsp/ts_service.py`'s
+`TsLspService` -- the warm, multi-op counterpart to `test_ts_lsp.py`. Skipped
+wholesale on a host without the toolchain installed (`npm i -D
+typescript-language-server` in `eval_sets/ts_error_injection`), mirroring
+`tests/test_ts_lsp.py`'s `resolve_ts_lsp() is None` idiom. The binary-free
+mechanism tests that gate this class in CI live in
+`tests/test_ts_service_mechanism.py`.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.lsp.diagnostics import Diagnostic
+from src.lsp.ts_lsp import TsLspOracle, resolve_ts_lsp
+from src.lsp.ts_service import Location, Symbol, TsLspService
+
+pytestmark = pytest.mark.skipif(resolve_ts_lsp() is None,
+                                reason="no typescript-language-server toolchain on this host")
+
+_HUB_TS = (
+    "export interface Vec { x: number; y: number }\n\n"
+    "export function scale(v: Vec, k: number): Vec {\n"
+    "  return { x: v.x * k, y: v.y * k };\n"
+    "}\n"
+)
+_USES_HUB_TS = (
+    'import { Vec, scale } from "./hub";\n\n'
+    "export function double(v: Vec): Vec {\n"
+    "  return scale(v, 2);\n"
+    "}\n"
+)
+_OTHER_TS = "export function noop(): void {}\n"
+_BROKEN_TS = (
+    'import { Vec } from "./hub";\n\n'
+    "export function touch(v: Vec): number {\n"
+    "  return v.x;\n"
+    "}\n"
+)
+
+_FIXTURE_FILES = {
+    "src/hub.ts": _HUB_TS,
+    "src/uses_hub.ts": _USES_HUB_TS,
+    "src/other.ts": _OTHER_TS,
+    "src/broken.ts": _BROKEN_TS,
+}
+
+
+@pytest.fixture(scope="module")
+def service():
+    svc = TsLspService(timeout_s=10.0)
+    svc.open_project(dict(_FIXTURE_FILES), warm_path="src/hub.ts")
+    yield svc
+    svc.close()
+
+
+# --------------------------------------------------------------------------- #
+# cross-file definition / references / completions / quickinfo / symbols
+# --------------------------------------------------------------------------- #
+
+def test_cross_file_definition_lands_in_hub(service: TsLspService):
+    call_offset = _USES_HUB_TS.index("scale(")
+    defs = service.definition("src/uses_hub.ts", call_offset)
+    assert defs, "expected at least one definition location"
+    assert all(isinstance(d, Location) for d in defs)
+    assert any(d.path == "src/hub.ts" for d in defs)
+    hub_decl_line = _HUB_TS.splitlines().index(
+        "export function scale(v: Vec, k: number): Vec {") + 1
+    assert any(d.path == "src/hub.ts" and d.line == hub_decl_line for d in defs)
+
+
+def test_references_on_hub_symbol_spans_at_least_two_files(service: TsLspService):
+    scale_offset = _HUB_TS.index("function scale") + len("function ")
+    refs = service.references("src/hub.ts", scale_offset, include_declaration=True)
+    assert refs
+    assert len({r.path for r in refs}) >= 2
+
+
+def test_completions_after_dot_contains_x(service: TsLspService):
+    dot_offset = _BROKEN_TS.index("v.x") + 2
+    items = service.completions("src/broken.ts", dot_offset)
+    assert any(item.label == "x" for item in items)
+
+
+def test_quickinfo_on_hub_function_is_nonempty_and_names_it(service: TsLspService):
+    call_offset = _USES_HUB_TS.index("scale(")
+    info = service.quickinfo("src/uses_hub.ts", call_offset)
+    assert info
+    assert "scale" in info
+
+
+def test_document_symbols_on_hub_contains_exported_names(service: TsLspService):
+    symbols = service.document_symbols("src/hub.ts")
+    assert symbols
+    assert all(isinstance(s, Symbol) for s in symbols)
+    names = {s.name for s in symbols}
+    assert "Vec" in names and "scale" in names
+
+
+# --------------------------------------------------------------------------- #
+# version-aware diagnostics: edit -> error, revert -> clean
+# --------------------------------------------------------------------------- #
+
+def test_update_then_diagnostics_detects_and_clears_a_break(service: TsLspService):
+    broken = _BROKEN_TS.replace("v.x", "v.gorblak", 1)
+    v_after_break = service.update("src/broken.ts", broken)
+    diags = service.diagnostics("src/broken.ts")
+    assert any(d.code == "TS2339" for d in diags), \
+        f"expected TS2339 among {[d.code for d in diags]}"
+
+    v_after_revert = service.update("src/broken.ts", _BROKEN_TS)
+    assert v_after_revert == v_after_break + 1
+    clean = service.diagnostics("src/broken.ts")
+    assert clean == [], f"expected clean after revert, got {clean}"
+
+
+def test_version_counter_is_strictly_increasing(service: TsLspService):
+    v1 = service.update("src/other.ts", _OTHER_TS + "// edit 1\n")
+    v2 = service.update("src/other.ts", _OTHER_TS + "// edit 2\n")
+    v3 = service.update("src/other.ts", _OTHER_TS + "// edit 3\n")
+    assert v1 < v2 < v3
+
+
+# --------------------------------------------------------------------------- #
+# resilience: dead server restarts and restores the warm program
+# --------------------------------------------------------------------------- #
+
+def test_killed_server_restarts_and_reopens_documents(service: TsLspService):
+    assert service.n_restarts == 0
+
+    service._proc.kill()
+    service._proc.wait(timeout=5.0)
+
+    call_offset = _USES_HUB_TS.index("scale(")
+    defs = service.definition("src/uses_hub.ts", call_offset)
+    assert any(d.path == "src/hub.ts" for d in defs), \
+        "definition did not recover a real result after the server was killed"
+    assert service.n_restarts == 1
+
+
+def test_no_orphan_process_after_close():
+    svc = TsLspService(timeout_s=10.0)
+    proc = svc._proc
+    pid = proc.pid
+    svc.close()
+    assert proc.poll() is not None, "child process was not reaped by close()"
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)
+
+
+# --------------------------------------------------------------------------- #
+# parity: TsLspService agrees with the validated TsLspOracle on a #194 record
+# --------------------------------------------------------------------------- #
+
+def test_parity_with_ts_lsp_oracle_on_194_member_access_001():
+    prompt = "interface User { name: string; age: number; }\nconst u: User = { name: \"Ada\", age: 32 };\nconsole.log(u."
+    error_completion = "gorblak);\n"
+    source = prompt + error_completion
+
+    oracle = TsLspOracle(timeout_s=10.0)
+    svc = TsLspService(timeout_s=10.0)
+    try:
+        oracle_diags = oracle.diagnostics(source)
+        svc.open_project({"src/single.ts": source})
+        svc_diags = svc.diagnostics("src/single.ts")
+
+        oracle_codes = {d.code for d in oracle_diags}
+        svc_codes = {d.code for d in svc_diags}
+        assert "TS2339" in oracle_codes, "TsLspOracle lost its own label"
+        assert "TS2339" in svc_codes, \
+            f"TsLspService did not reproduce TsLspOracle's TS2339 finding: {svc_codes}"
+        for d in svc_diags:
+            assert isinstance(d, Diagnostic)
+    finally:
+        oracle.close()
+        svc.close()

--- a/tests/test_ts_service_mechanism.py
+++ b/tests/test_ts_service_mechanism.py
@@ -1,0 +1,548 @@
+"""Binary-free mechanism tests for `src/lsp/ts_service.py`'s `TsLspService` --
+the CI gate for this class (no `typescript-language-server` needed; the live
+correctness tests are in `tests/test_ts_service.py`, skipped without the
+toolchain).
+
+Built on `tests/test_jsonrpc.py`'s `os.pipe()` fake-transport pattern (a
+`_ScriptedServer` here plays the "other side of the wire" and auto-replies
+per a canned table) plus `tests/test_opengrep_oracle.py`'s "subclass and
+bypass `__init__`" precedent (`_FakeService`), so the class's own logic --
+version-aware diagnostics gating, lazy `didOpen`, timeout/error handling,
+restart bookkeeping, and every result-mapping helper -- runs unchanged
+against a scripted server, with no subprocess anywhere.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import BinaryIO, Dict, List, Tuple
+
+import pytest
+
+from src.lsp.jsonrpc import JsonRpcEndpoint, encode_message, read_message
+from src.lsp.ts_service import (
+    CompletionItem, Location, Symbol, TsLspService,
+    _content_changes, _did_change_params, _map_completion_items, _map_hover,
+    _map_location, _map_symbols, _references_params, _text_document_position,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_TIMEOUT = 5.0
+
+
+def _pipe_files() -> Tuple[BinaryIO, BinaryIO]:
+    r_fd, w_fd = os.pipe()
+    return os.fdopen(r_fd, "rb", buffering=0), os.fdopen(w_fd, "wb", buffering=0)
+
+
+def _wait_until(cond, timeout: float = 2.0, interval: float = 0.01) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if cond():
+            return True
+        time.sleep(interval)
+    return False
+
+
+class _RpcError:
+    """Sentinel telling `_ScriptedServer` to reply with a JSON-RPC `error`
+    instead of a `result`."""
+
+    def __init__(self, message: str = "scripted failure") -> None:
+        self.message = message
+
+
+def _raw_diag(code: int, line0: int = 0, char0: int = 0, message: str = "msg",
+              severity: int = 1) -> dict:
+    return {"range": {"start": {"line": line0, "character": char0},
+                       "end": {"line": line0, "character": char0 + 1}},
+            "code": code, "message": message, "severity": severity}
+
+
+class _ScriptedServer:
+    """The "other side" of the wire: two `os.pipe()` pairs plus a daemon
+    thread that reads client->server frames and replies per `responses`
+    (method -> value, or a `value(request) -> value` callable, or an
+    `_RpcError`), recording every request/notification it saw. Methods listed
+    in `pending` are deliberately never answered (exercises the timeout
+    path)."""
+
+    def __init__(self, responses=None, pending=()) -> None:
+        self.to_client_r, self.to_client_w = _pipe_files()   # server writes here
+        self.to_server_r, self.to_server_w = _pipe_files()   # endpoint writes here
+        self.responses: Dict[str, object] = dict(responses or {})
+        self.pending = set(pending)
+        self.seen: List[dict] = []
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        while True:
+            msg = read_message(self.to_server_r)
+            if msg is None:
+                return
+            with self._lock:
+                self.seen.append(msg)
+            if "id" not in msg:
+                continue   # a notification -- no reply
+            method = msg.get("method")
+            if method in self.pending:
+                continue   # deliberately unanswered
+            value = self.responses.get(method, {})
+            if callable(value):
+                value = value(msg)
+            if isinstance(value, _RpcError):
+                self._send({"jsonrpc": "2.0", "id": msg["id"],
+                           "error": {"code": -32000, "message": value.message}})
+            else:
+                self._send({"jsonrpc": "2.0", "id": msg["id"], "result": value})
+
+    def _send(self, obj: dict) -> None:
+        self.to_client_w.write(encode_message(obj))
+
+    def push_diagnostics(self, uri: str, diagnostics: List[dict], version=None) -> None:
+        params = {"uri": uri, "diagnostics": diagnostics}
+        if version is not None:
+            params["version"] = version
+        self._send({"jsonrpc": "2.0", "method": "textDocument/publishDiagnostics",
+                   "params": params})
+
+    def requests_for(self, method: str) -> List[dict]:
+        with self._lock:
+            return [m for m in self.seen if m.get("method") == method]
+
+    def notifications_for(self, method: str) -> List[dict]:
+        return [m for m in self.requests_for(method) if "id" not in m]
+
+    def close(self) -> None:
+        for f in (self.to_client_r, self.to_client_w, self.to_server_r, self.to_server_w):
+            try:
+                f.close()
+            except (OSError, ValueError):
+                pass
+
+
+class _FakeService(TsLspService):
+    """A `TsLspService` whose subprocess-touching pieces are bypassed -- no
+    spawn, no `initialize` handshake -- wired instead to a `_ScriptedServer`'s
+    pipes. `_ensure_alive` is stubbed to a no-op (mirrors
+    `test_opengrep_oracle.py`'s `_FakeOracle`): there is no real process to
+    poll, and none of these tests exercise restart (the plan's restart-
+    recovery acceptance test needs a real process and lives in
+    `tests/test_ts_service.py`)."""
+
+    def __init__(self, scripted: _ScriptedServer, *, timeout_s: float, scratch_dir: Path) -> None:
+        # Deliberately bypass TsLspService.__init__ (no binary, no spawn, no
+        # tempdir).
+        self.timeout_s = timeout_s
+        self.tsconfig = None
+        self.initialization_options: dict = {}
+        self.n_calls = 0
+        self.wall_s = 0.0
+        self.n_timeouts = 0
+        self.n_restarts = 0
+        self.op_counts: Dict[str, int] = {}
+        self.op_wall_s: Dict[str, float] = {}
+        self.cold_load_s = None
+        self.last_completion_incomplete = None
+
+        self.scratch_dir = scratch_dir
+        self._project_opened = False
+        self._files: Dict[str, str] = {}
+        self._versions: Dict[str, int] = {}
+        self._open: set = set()
+
+        self._diag_lock = threading.Lock()
+        self._diag_events: Dict[str, threading.Event] = {}
+        self._diag_state: Dict[str, dict] = {}
+        self._diag_seq_counter = 0
+        self._update_marker: Dict[str, int] = {}
+
+        self.server_sync_kind = None
+        self.server_capabilities: dict = {}
+
+        self._proc = None
+        self._endpoint = JsonRpcEndpoint(scripted.to_client_r, scripted.to_server_w,
+                                         on_notification=self._on_notification)
+        self._endpoint.start()
+
+    def _ensure_alive(self) -> None:
+        pass  # no real process in the fake
+
+
+@pytest.fixture
+def scripted():
+    s = _ScriptedServer()
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def fake(scripted, tmp_path):
+    svc = _FakeService(scripted, timeout_s=0.3, scratch_dir=tmp_path)
+    yield svc, scripted
+    svc._endpoint.close()
+
+
+def _seed_open_file(svc: TsLspService, path: str, text: str, *, version: int = 1) -> str:
+    """Register `path` as if `open_project` had materialized it, WITHOUT
+    sending a real `didOpen` -- the test decides when that happens."""
+    (svc.scratch_dir / path).parent.mkdir(parents=True, exist_ok=True)
+    (svc.scratch_dir / path).write_text(text, encoding="utf-8")
+    svc._files[path] = text
+    svc._versions[path] = version
+    return svc._uri(path)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Pure helpers, no transport at all
+# --------------------------------------------------------------------------- #
+
+def test_did_change_params_shape():
+    params = _did_change_params("file:///a.ts", 3, "hello world")
+    assert params["textDocument"] == {"uri": "file:///a.ts", "version": 3}
+    assert params["contentChanges"] == [{"text": "hello world"}]
+    assert "range" not in params["contentChanges"][0]
+
+
+def test_content_changes_ranged_variant():
+    rng = {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}}
+    out = _content_changes("x", change_range=rng)
+    assert out == [{"range": rng, "text": "x"}]
+
+
+def test_text_document_position_shape():
+    pos = {"line": 2, "character": 5}
+    params = _text_document_position("file:///a.ts", pos)
+    assert params == {"textDocument": {"uri": "file:///a.ts"}, "position": pos}
+
+
+def test_references_params_carries_include_declaration():
+    pos = {"line": 0, "character": 0}
+    params = _references_params("file:///a.ts", pos, True)
+    assert params["context"] == {"includeDeclaration": True}
+    params_false = _references_params("file:///a.ts", pos, False)
+    assert params_false["context"] == {"includeDeclaration": False}
+
+
+# --------------------------------------------------------------------------- #
+# 2. Result mapping variants
+# --------------------------------------------------------------------------- #
+
+def test_map_location_plain_location(tmp_path):
+    raw = {"uri": (tmp_path / "src/a.ts").as_uri(),
+           "range": {"start": {"line": 1, "character": 2}, "end": {"line": 1, "character": 5}}}
+    out = _map_location(raw, tmp_path)
+    assert len(out) == 1
+    loc = out[0]
+    assert isinstance(loc, Location)
+    assert loc.path == "src/a.ts"
+    assert loc.line == 2 and loc.col == 3
+    assert loc.end_line == 2 and loc.end_col == 6
+
+
+def test_map_location_location_link(tmp_path):
+    raw = {"targetUri": (tmp_path / "src/b.ts").as_uri(),
+           "targetRange": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}},
+           "targetSelectionRange": {"start": {"line": 3, "character": 4},
+                                    "end": {"line": 3, "character": 7}}}
+    out = _map_location(raw, tmp_path)
+    assert len(out) == 1
+    # targetSelectionRange preferred over targetRange.
+    assert out[0].line == 4 and out[0].col == 5
+
+
+def test_map_location_none_is_empty_list(tmp_path):
+    assert _map_location(None, tmp_path) == []
+
+
+def test_map_location_bare_dict_vs_list(tmp_path):
+    raw_single = {"uri": (tmp_path / "a.ts").as_uri(),
+                  "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 1}}}
+    single = _map_location(raw_single, tmp_path)
+    assert len(single) == 1
+    as_list = _map_location([raw_single, raw_single], tmp_path)
+    assert len(as_list) == 2
+
+
+def test_map_completion_items_bare_array():
+    raw = [{"label": "x"}, {"label": "y", "kind": 5, "insertText": "y()"}]
+    items = _map_completion_items(raw)
+    assert [i.label for i in items] == ["x", "y"]
+    assert items[1].kind == 5 and items[1].insert_text == "y()"
+    assert isinstance(items[0], CompletionItem)
+
+
+def test_map_completion_items_completion_list():
+    raw = {"isIncomplete": True, "items": [{"label": "z"}]}
+    items = _map_completion_items(raw)
+    assert [i.label for i in items] == ["z"]
+
+
+def test_map_completion_items_none():
+    assert _map_completion_items(None) == []
+
+
+def test_map_hover_markup_content():
+    assert _map_hover({"kind": "markdown", "value": "**bold**"}) == "**bold**"
+
+
+def test_map_hover_bare_string():
+    assert _map_hover("plain hover text") == "plain hover text"
+
+
+def test_map_hover_list_of_marked_strings():
+    contents = ["first", {"language": "ts", "value": "const x = 1;"}]
+    assert _map_hover(contents) == "first\nconst x = 1;"
+
+
+def test_map_hover_none():
+    assert _map_hover(None) is None
+
+
+def test_map_symbols_nested_document_symbol():
+    raw = [{
+        "name": "Outer", "kind": 5,
+        "range": {"start": {"line": 0, "character": 0}, "end": {"line": 5, "character": 0}},
+        "selectionRange": {"start": {"line": 0, "character": 5}, "end": {"line": 0, "character": 10}},
+        "children": [{
+            "name": "inner", "kind": 6,
+            "range": {"start": {"line": 1, "character": 0}, "end": {"line": 2, "character": 0}},
+            "selectionRange": {"start": {"line": 1, "character": 2}, "end": {"line": 1, "character": 7}},
+        }],
+    }]
+    out = _map_symbols(raw)
+    assert [s.name for s in out] == ["Outer", "inner"]
+    assert out[0].container is None
+    assert out[1].container == "Outer"
+    assert out[1].line == 2 and out[1].col == 3
+
+
+def test_map_symbols_flat_symbol_information():
+    raw = [{
+        "name": "foo", "kind": 12, "containerName": "MyModule",
+        "location": {"uri": "file:///a.ts",
+                     "range": {"start": {"line": 2, "character": 0}, "end": {"line": 2, "character": 3}}},
+    }]
+    out = _map_symbols(raw)
+    assert len(out) == 1
+    assert out[0].name == "foo" and out[0].container == "MyModule"
+    assert out[0].line == 3
+
+
+def test_map_symbols_none():
+    assert _map_symbols(None) == []
+
+
+# --------------------------------------------------------------------------- #
+# 3. Version counter monotonicity
+# --------------------------------------------------------------------------- #
+
+def test_update_version_counter_is_monotonic_and_server_sees_it_in_order(fake):
+    svc, scripted = fake
+    _seed_open_file(svc, "a.ts", "v1")
+    svc._open.add("a.ts")   # already open -- update() must not re-didOpen
+
+    versions = [svc.update("a.ts", f"v{n}") for n in (2, 3, 4)]
+    assert versions == [2, 3, 4]
+
+    assert _wait_until(lambda: len(scripted.notifications_for("textDocument/didChange")) == 3)
+    changes = scripted.notifications_for("textDocument/didChange")
+    seen_versions = [c["params"]["textDocument"]["version"] for c in changes]
+    assert seen_versions == [2, 3, 4]
+    assert scripted.notifications_for("textDocument/didOpen") == []
+
+
+# --------------------------------------------------------------------------- #
+# 4. Lazy didOpen: exactly once per path; update() opens an untouched path
+# --------------------------------------------------------------------------- #
+
+def test_didopen_sent_exactly_once_across_repeated_ops(fake):
+    svc, scripted = fake
+    scripted.responses["textDocument/definition"] = []
+    _seed_open_file(svc, "a.ts", "const x = 1;\n")
+
+    svc.definition("a.ts", 0)
+    svc.definition("a.ts", 5)
+    assert _wait_until(lambda: len(scripted.requests_for("textDocument/definition")) == 2)
+    assert len(scripted.notifications_for("textDocument/didOpen")) == 1
+
+
+def test_update_on_untouched_path_opens_it_first(fake):
+    svc, scripted = fake
+    _seed_open_file(svc, "b.ts", "old text")
+    assert "b.ts" not in svc._open
+
+    version = svc.update("b.ts", "new text")
+    assert version == 2
+    assert _wait_until(lambda: len(scripted.notifications_for("textDocument/didChange")) == 1)
+    opens = scripted.notifications_for("textDocument/didOpen")
+    assert len(opens) == 1
+    assert opens[0]["params"]["textDocument"]["text"] == "old text"   # opened BEFORE the edit landed
+    assert opens[0]["params"]["textDocument"]["version"] == 1
+    changes = scripted.notifications_for("textDocument/didChange")
+    assert changes[0]["params"]["textDocument"]["version"] == 2
+    assert changes[0]["params"]["contentChanges"] == [{"text": "new text"}]
+
+
+# --------------------------------------------------------------------------- #
+# 5. Timeout is counted, not raised
+# --------------------------------------------------------------------------- #
+
+def test_completions_timeout_is_counted_not_raised(fake):
+    svc, scripted = fake
+    scripted.pending.add("textDocument/completion")
+    _seed_open_file(svc, "a.ts", "x.")
+
+    result = svc.completions("a.ts", 2)
+    assert result == []
+    assert svc.n_timeouts == 1
+
+
+def test_definition_timeout_returns_empty_list(fake):
+    svc, scripted = fake
+    scripted.pending.add("textDocument/definition")
+    _seed_open_file(svc, "a.ts", "x")
+
+    assert svc.definition("a.ts", 0) == []
+    assert svc.n_timeouts == 1
+
+
+def test_quickinfo_timeout_returns_none(fake):
+    svc, scripted = fake
+    scripted.pending.add("textDocument/hover")
+    _seed_open_file(svc, "a.ts", "x")
+
+    assert svc.quickinfo("a.ts", 0) is None
+    assert svc.n_timeouts == 1
+
+
+# --------------------------------------------------------------------------- #
+# 6. A JSON-RPC error reply propagates -- the deliberate asymmetry with timeouts
+# --------------------------------------------------------------------------- #
+
+def test_jsonrpc_error_reply_raises_runtime_error(fake):
+    svc, scripted = fake
+    scripted.responses["textDocument/definition"] = _RpcError("bad params")
+    _seed_open_file(svc, "a.ts", "x")
+
+    with pytest.raises(RuntimeError):
+        svc.definition("a.ts", 0)
+
+
+# --------------------------------------------------------------------------- #
+# 7. diagnostics() version gating
+# --------------------------------------------------------------------------- #
+
+def test_diagnostics_version_gating(fake):
+    svc, scripted = fake
+    uri = _seed_open_file(svc, "a.ts", "old text", version=1)
+    svc._open.add("a.ts")
+
+    # v1 push arrives -- the cache-hit fast path for "unchanged document".
+    scripted.push_diagnostics(uri, [_raw_diag(2339, message="old error")], version=1)
+    assert _wait_until(lambda: uri in svc._diag_state)
+    diags = svc.diagnostics("a.ts")
+    assert [d.code for d in diags] == ["TS2339"]
+    assert svc.n_timeouts == 0
+
+    # Edit -> version 2.
+    svc.update("a.ts", "new text")
+    assert svc._versions["a.ts"] == 2
+
+    # A STALE v1 push arrives AFTER the edit -- must not be mistaken for current.
+    scripted.push_diagnostics(uri, [_raw_diag(9999, message="stale")], version=1)
+    assert _wait_until(lambda: svc._diag_state[uri]["version"] == 1)
+    stale_result = svc.diagnostics("a.ts")   # times out -- no v2 push yet
+    assert stale_result == []
+    assert svc.n_timeouts == 1
+
+    # Now the real post-edit v2 push arrives.
+    scripted.push_diagnostics(uri, [_raw_diag(1234, message="new error")], version=2)
+    assert _wait_until(lambda: svc._diag_state[uri]["version"] == 2)
+    fresh = svc.diagnostics("a.ts")
+    assert [d.code for d in fresh] == ["TS1234"]
+
+
+def test_diagnostics_falls_back_to_seq_when_server_omits_version(fake):
+    svc, scripted = fake
+    uri = _seed_open_file(svc, "a.ts", "text", version=1)
+    svc._open.add("a.ts")
+    with svc._diag_lock:
+        marker_before = svc._diag_seq_counter
+
+    scripted.push_diagnostics(uri, [_raw_diag(2339)])   # no version field
+    assert _wait_until(lambda: uri in svc._diag_state)
+    with svc._diag_lock:
+        assert svc._diag_state[uri]["seq"] > marker_before
+    diags = svc.diagnostics("a.ts")
+    assert [d.code for d in diags] == ["TS2339"]
+
+
+# --------------------------------------------------------------------------- #
+# 8. Trap A / Trap B pinning on this class
+# --------------------------------------------------------------------------- #
+
+def test_trap_a_integer_code_becomes_ts_prefixed(fake):
+    svc, _ = fake
+    text = "const x: number = 'hi';\n"
+    payload = [_raw_diag(2339, message="bad")]
+    out = svc._filter_diagnostics_payload(payload, text)
+    assert [d.code for d in out] == ["TS2339"]
+
+
+def test_trap_b_severity_4_hint_is_dropped(fake):
+    svc, _ = fake
+    text = "const unused = 1;\n"
+    payload = [_raw_diag(6133, severity=4)]
+    assert svc._filter_diagnostics_payload(payload, text) == []
+
+
+# --------------------------------------------------------------------------- #
+# 9. _generate_project determinism (scripts/bench_ts_lsp.py)
+# --------------------------------------------------------------------------- #
+
+def _bench_module():
+    spec = importlib.util.spec_from_file_location(
+        "bench_ts_lsp", REPO_ROOT / "scripts" / "bench_ts_lsp.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(REPO_ROOT))
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        sys.path.pop(0)
+    return mod
+
+
+def test_generate_project_is_deterministic():
+    mod = _bench_module()
+    a = mod._generate_project(12, 0)
+    b = mod._generate_project(12, 0)
+    assert a == b
+
+
+def test_generate_project_different_seed_differs():
+    mod = _bench_module()
+    a = mod._generate_project(12, 0)
+    b = mod._generate_project(12, 1)
+    assert a != b
+
+
+def test_generate_project_imports_resolve_and_are_acyclic():
+    mod = _bench_module()
+    files = mod._generate_project(20, 0)
+    index_of = {path: i for i, path in enumerate(sorted(files, key=mod._module_index))}
+    for path, text in files.items():
+        my_idx = mod._module_index(path)
+        for m in mod._IMPORT_RE.finditer(text):
+            target_rel = m.group(1)
+            target_path = mod._resolve_import(path, target_rel)
+            assert target_path in files, f"{path} imports missing {target_path}"
+            assert mod._module_index(target_path) < my_idx or target_path == "src/hub.ts", (
+                f"{path} imports {target_path}, not lower-indexed -- would create a cycle")


### PR DESCRIPTION
Closes #220

## Summary
- Add `TsLspService` (`src/lsp/ts_service.py`) -- a NEW warm, multi-op `typescript-language-server` client alongside the untouched, one-shot `TsLspOracle` (`src/lsp/ts_lsp.py`) and `CompositeOracle` (`src/lsp/oracle.py`, both zero-diff). Stable URIs, monotonically versioned `didChange` edits, lazy `didOpen`, and `definition`/`references`/`completions`/`quickinfo`/`document_symbols` in addition to version-aware first-push-wins `diagnostics` (no settle window, per #211's confirmed single-push completeness on the pinned 5.3.0 server).
- `src/lsp/diagnostics.py`: add `offset_to_lsp_position` (+ `_char_index_to_utf16_col`), the LSP-position inverse of `line_col_to_offset`, needed so every op can be addressed by character offset.
- `scripts/bench_ts_lsp.py`: **new** SLA harness -- a deterministic N-file synthetic project generator, a BLIND-guarded sanity probe (known-answer checks on every op before any timing starts), and per-op median/mean/min/p95 latency + calls/s measurement.
- `scripts/eval_code_suite.py:359`: fix the live `oracle.diagnose(artifact)` -> `oracle.diagnostics(artifact)` `AttributeError` bug in `_run_tsc` (the only `.diagnose(` call site in the repo -- `--suites tsc` raised on its first row), with a regression test (`tests/test_eval_code_suite.py`) pinning the real method name via a stub oracle with no `diagnose` method.
- `tests/test_ts_service_mechanism.py`: **new**, binary-free `os.pipe()` scripted-server tests -- the actual CI gate for `TsLspService` (verified green with `PATH=/usr/bin:/bin`, no node toolchain).
- `tests/test_ts_service.py`: **new**, live `typescript-language-server` tests (cross-file definition/references fan-in, restart recovery, no-orphan-process, parity with `TsLspOracle` on a #194 record). Skips cleanly without the toolchain.
- `tests/test_lsp_diagnostics.py`: round-trip + edge-case tests for `offset_to_lsp_position`.
- `tests/test_import_guard.py`: `src.lsp.ts_service` added to `PORTABLE_MODULES`.

## Measured SLA result (real numbers, not tuned to pass)
`scripts/bench_ts_lsp.py --n-files 5000 --warmup 20 --iters 200` (seed 0), sanity probe passed on every check:

| op | median | calls/s |
|---|---:|---:|
| `diagnostics` (edit->re-check, the #226 shape) | 378.1 ms | 3.1 |
| `completions` | 0.38 ms | **2,629** |
| `definition` | 1.74 ms | 595 |
| `references` | 506.0 ms | 2.0 |
| `quickinfo` | 0.31 ms | 3,102 |
| `document_symbols` | 0.42 ms | 2,332 |

**Verdict: WARN.** The throughput gate (`completions` >= 200 calls/s, #226's decode-time masking) clears comfortably at 13x the bar. The latency gate (`diagnostics` median < 50ms, the type-aware eval arm) misses by ~8x at 5000 files -- a real, measured finding recorded in `docs/design/12-lsp-in-the-loop.md` and `results/ts_lsp_bench.json`, not a harness tuned until it passed. `n_restarts=0`, `n_timeouts=0`, 100% non-empty rate on every op except the (expected-clean) benign-edit `diagnostics` loop -- the sanity probe rules out a BLIND/empty-and-fast measurement.

## Testing
- [x] Tests added/updated
- [x] All tests passing (`pytest -q -rs`: 1327 passed, 13 skipped -- all pre-existing/unrelated)
- [x] `tests/test_import_guard.py` green with `src.lsp.ts_service` listed
- [x] `git diff --stat` confirms zero diff on `src/lsp/ts_lsp.py` and `src/lsp/oracle.py`
- [x] `scripts/eval_code_suite.py --suites tsc` completes instead of raising `AttributeError`
- [x] Mechanism tests verified green with no node toolchain on `PATH` (the real CI gate)
- [x] Live tests (`tests/test_ts_service.py`, 10 tests) pass against the pinned local `typescript-language-server` 5.3.0
- [x] `scripts/bench_ts_lsp.py` produced a real verdict (WARN, not BLIND)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019K3gzzSsE7RJjyNp4QUQff