### PR TITLE
docs: [M12] The #220 diagnostics SLA is a client-side debounce, not type-checking

### DIFF
--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -731,7 +731,9 @@ A deterministic synthetic 5000-file TypeScript project (one `hub.ts` exporting w
 modules), opened once as a warm program. The BLIND-guarded sanity probe passed every check (a real
 `definition` into hub, `references` fan-in across ≥2 files, `completions` containing `"x"`, non-empty
 `quickinfo`/`document_symbols`, and a deliberately broken `v.gorblak` edit correctly detected and
-cleared) — the numbers below are real measurements, not an empty-and-fast run:
+cleared) — the numbers below are real measurements, not an empty-and-fast run.
+
+**Pre-fix (#277, as merged) — `diagnostics` measured a benign clean→clean edit:**
 
 | op | median | p95 | calls/s | non-empty rate |
 |---|---:|---:|---:|---:|
@@ -743,33 +745,153 @@ cleared) — the numbers below are real measurements, not an empty-and-fast run:
 | `quickinfo` | 0.31 ms | 0.39 ms | 3,102 | 100% |
 | `document_symbols` | 0.42 ms | 0.54 ms | 2,332 | 100% |
 
-Cold `open_project` load: **1.23 s**. `server_sync_kind = 2` (Incremental). `diagnosticProvider =
+`n_restarts = 0`, `n_timeouts = 0`. `min_ms = 0.292` on `diagnostics` — a sub-millisecond result for
+an operation the debounce clamp alone should floor at ~350 ms.
+
+**Post-fix (#278) — seq race closed, `diagnostics` alternates introduce/revert every iteration:**
+
+| op | median | p95 | calls/s | non-empty rate |
+|---|---:|---:|---:|---:|
+| `diagnostics` (edit→re-check, the #226 shape) | **376.4 ms** | 381.6 ms | 3.1 | 33.5% overall — `introduce` 67% (67/100), `revert` 0% (100/100, correctly clean) |
+| `diagnostics_cached` (unchanged-document cache hit — **not** the SLA number) | 0.006 ms | 0.007 ms | 162,064 | 0% |
+| `definition` | 1.69 ms | 2.12 ms | 612 | 100% |
+| `references` | 502.2 ms | 519.6 ms | 2.0 | 100% |
+| `completions` | 0.38 ms | 0.53 ms | 2,501 | 100% |
+| `quickinfo` | 0.33 ms | 0.49 ms | 2,917 | 100% |
+| `document_symbols` | 0.40 ms | 0.60 ms | 2,337 | 100% |
+
+`n_restarts = 0`, `n_timeouts = 0`, `n_no_publish = 0` (every timed iteration forced an observable
+transition, as designed — no iteration hit the clean→clean ambiguity during the timed loop itself).
+Cold `open_project` load: **1.22 s**. `server_sync_kind = 2` (Incremental). `diagnosticProvider =
 null` (pull diagnostics confirmed unavailable on this pin, consistent with the #211 finding above).
-`n_restarts = 0`, `n_timeouts = 0` — a clean run, not one papered over by the reliability counters.
+
+**The median got worse, and that is the correct outcome.** 378.1 ms → 376.4 ms reads flat, but that
+similarity hides the actual change: pre-fix, ~14% of the 200 samples (the `min 0.292 ms` mode) were
+stale-push short-circuits — a push recorded *before* the edit, wrongly accepted as the edit's answer
+by the seq-race in `_push_is_current` (`src/lsp/ts_service.py:532-539`, closed by `update()` now
+popping `_diag_state[uri]` under the lock before bumping the marker). Removing that mode should have
+pulled the *mean* up to meet the median (it was 324.1 ms, visibly below the 378.1 ms median only
+because of those artificially-fast stale hits) — post-fix the mean is 319.1 ms, still measurably
+below the 376.4 ms median. The reason is a **different, narrower residual the fix does not close**
+(documented in `update()`'s comment as deliberate): a push already **in flight** — queued by an
+*earlier* `_ensure_open()`'s `didOpen`, for a document this bench's `definition`/`completions`/
+`quickinfo`/`document_symbols` measurements already opened before the `diagnostics` phase runs — can
+still land *after* the marker is taken but *before* the genuine post-edit push, satisfying the
+version-less `seq > marker` fallback the same way a stale push did. Unlike the pre-fix bug this is
+not silently wrong forever: `min_ms` moved from **0.292 ms to 2.249 ms** — no longer sub-millisecond,
+but still fast enough to show it is a race, not real work — and it costs real signal: 33/100
+`introduce` iterations under-report a break that a slower, unraced check would have caught (0%
+`revert` false positives; the direction that shouldn't produce a push never did). The seq-race fix
+is correct and necessary — it closes the *observable*, indefinitely-recurring case — but a
+version-less server cannot fully close the in-flight case without an extra request/response barrier
+per edit, which is deliberately not implemented here (see the risk noted in `update()`'s comment);
+#279's direct-`tsserver` bypass sidesteps this whole notification-race class rather than patching
+around it further.
+
+### What the 378 ms actually is (#278)
+
+**~350 ms of the `diagnostics` cost is a fixed client-side debounce inside the pinned
+`typescript-language-server` 5.3.0, spent before tsserver is asked anything — not whole-program
+type-checking.** Two hardcoded timers in the vendored
+`eval_sets/ts_error_injection/node_modules/typescript-language-server/lib/cli.mjs`, neither with a
+configuration gate:
+
+| Anchor | Source | Cost |
+|---|---|---|
+| `cli.mjs:17858` | `triggerDiagnostics(delay = 200) {` | (default; overridden per-call below) |
+| `cli.mjs:17868` | `const delay = Math.min(Math.max(Math.ceil(buffer.lineCount / 20), 300), 800);` | **300 ms** floor for our ~12-line files |
+| `cli.mjs:20516` | `firePublishDiagnostics = pDebounce(() => this.publishDiagnostics(), 50);` | **+50 ms** |
+| `cli.mjs:20524` | `if (this.diagnosticsPerKind.get(kind)?.length === 0 && diagnostics.length === 0) { return; }` | clean→clean publishes **nothing** |
+| `cli.mjs:20535` | `this.onPublishDiagnostics({ uri: this.uri, diagnostics: diagnostics });` | no `version` field is ever sent |
+
+A control probe (`scripts/probe_ts_lsp_debounce.py`, `results/ts_lsp_debounce_probe.json`)
+deliberately bypasses `TsLspService` entirely — raw JSON-RPC, no cache, no seq-marker, no
+first-push-wins bookkeeping — timing exactly `didChange` → `publishDiagnostics`, alternating a real
+type error in and out every iteration so a push is always produced. Two falsifiable, opposite
+predictions:
+
+**A. project-size sweep (edit-file fixed at 12 lines)** — the debounce hypothesis predicts roughly
+FLAT; whole-program work predicts RISING with project size:
+
+| n_files | median | minus the predicted 350 ms |
+|---:|---:|---:|
+| 10 | 361.7 ms | 11.7 |
+| 200 | 363.3 ms | 13.3 |
+| 2,000 | 371.2 ms | 21.2 |
+| 5,000 | 383.2 ms | 33.2 |
+
+500× the files buys ~22 ms of real movement on top of the ~350 ms floor — not the shape whole-program
+semantic work would produce.
+
+**B. file-LENGTH sweep (project fixed at 200 files)**, against the clamp's own formula
+`min(max(ceil(lines/20), 300), 800) + 50`:
+
+| edit-file lines | predicted | measured | residual |
+|---:|---:|---:|---:|
+| 12 | 350 ms | 361.6 | +11.6 |
+| 6,000 | 350 ms | 365.0 | +15.0 |
+| 12,000 | 650 ms | 665.5 | +15.5 |
+| 20,000 | 850 ms | 870.2 | +20.2 |
+
+6,000 lines stays at the floor (`ceil(6000/20) = 300`, still clamped to the 300 ms minimum) while
+12,000 jumps to ~650 ms — the clamp's exact shape, reproduced across a 2.4× latency range. A positive
+confirmation, not a null result. The probe's own verdict on this run: **`DEBOUNCE_CONFIRMED`**
+(`a_spread_ms=21.5 <= 100`, `b_max_abs_residual_ms=20.2 <= 60`, `b_ratio=2.41 >= 2.0`).
+
+Corroborating: the original run's `diagnostics` median 378.1 ms / p95 383.0 ms was a **~5 ms**
+spread (the post-fix run: 376.4 / 381.6 ms, a similarly tight ~5 ms spread). Whole-program semantic
+analysis, which scales with the graph reachable from the edited file, does not produce that
+distribution across a 5000-file project; a `setTimeout` does.
+
+**Consequence:** the genuine recheck cost, once the ~350 ms debounce floor is subtracted out, is
+**~11–33 ms** — *inside* the 50 ms bar. The type-aware eval arm is not structurally blocked by
+tsserver doing real work; it is blocked by a client-side timer, which is a different and addressable
+problem. See #279 (a direct-`tsserver` `semanticDiagnosticsSync` bypass, filed and blocked on this
+issue's confirmation) — patching the vendored `cli.mjs` itself is off-limits under the #246
+bit-identity pin discipline, so #279's own JSON-RPC channel to `tsserver` is the addressable path,
+not a patch to this server.
+
+**The `n_no_publish` ambiguity.** `cli.mjs:20524` means an already-clean document that receives a
+benign edit may legitimately never get a `publishDiagnostics` push — indistinguishable, on this pin,
+from a server that simply never answered. `TsLspService.diagnostics()` now counts this case
+separately (`n_no_publish`, distinct from `n_timeouts`, which stays reserved for a push that *did*
+arrive but didn't match the current version/marker) so the ambiguity is visible in the stats instead
+of silently folded into either a clean result or a failure. `scripts/bench_ts_lsp.py`'s `diagnostics`
+loop now alternates **introduce**/**revert** on the same path every iteration
+(`_diagnostics_targets`) specifically to keep the *timed* measurement out of this ambiguous case
+entirely — a revert-of-a-never-broken file is the one case that could hit it, and the loop never
+does that. The result: `n_no_publish = 0` for the whole post-fix run above, confirming the loop did
+its job — every counted `diagnostics` sample is a real answer, not a suppressed publish miscounted as
+one.
 
 ### Verdict: WARN
 
 Per the issue's two gates — latency (`diagnostics` edit→re-check median < 50 ms) for the type-aware
 eval arm, throughput (`completions` ≥ 200 calls/s) for #226's per-decode-step masking — this run is
-**WARN**: the throughput gate clears comfortably (2,629 calls/s, 13× the bar), but the latency gate
-misses by nearly 8× (378 ms vs. the 50 ms bar). Per-request `completions`/`quickinfo`/
-`document_symbols`/`definition` are all sub-millisecond-to-low-single-digit-ms at 5000 files — the
-cost is concentrated in whatever `diagnostics()` and `references()` do at this project size (both
-in the several-hundred-ms range), consistent with tsserver doing real whole-program semantic work
-proportional to project size for those two operations, not with a broken or degraded measurement
-(the sanity probe and the 100% non-empty rates on every op rule that out).
+still **WARN**: the throughput gate clears comfortably (2,501 calls/s, 12× the bar), but the latency
+gate misses by ~7.5× (376 ms vs. the 50 ms bar). The verdict itself is unchanged from #277 — what
+changed is *why* it misses. `diagnostics` and `references` remain the two operations in the
+several-hundred-ms range; `references` at **502 ms** (min 445.8 / p95 519.6) is **genuine and
+unaffected by this issue** — it queries `Vec`/`scale` in `hub.ts`, which all 4,998 generated modules
+import (`scripts/bench_ts_lsp.py`'s `_generate_project`), real whole-project reference fan-in with no
+per-request debounce to subtract. Only the `diagnostics` attribution was wrong; do not read this
+correction as "the whole measurement was an artifact" — every other op's numbers (including
+`references`) stand.
 
-**Consequence for #226:** completion-list logit masking is throughput-clear on its own gate, so a
-decode loop that queries `completions()` once per generated token is not structurally blocked by
-this measurement. The **type-aware eval arm**, which is what actually drives the `diagnostics`
-number measured here (an edit-then-recheck cycle per candidate), is the one that misses its latency
-bar at this project size — a consumer needing sub-50ms diagnostics against a 5000-file warm program
-should budget for ~378ms per check, or reduce project scope, rather than assume the number in the
-issue's accept criterion. This is a measured finding, not a to-do to "fix" this module — the
-mechanism is behaving correctly (see the sanity probe and the zero-timeout, zero-restart run); the
-cost is inherent to whole-program semantic analysis at this scale.
+**Consequence for #226:** unchanged and unaffected — `completions` at ~2,500 calls/s was never in
+question, decode-time completion-list masking remains throughput-clear on its own gate, and this
+issue does not touch that conclusion.
 
-See `scripts/bench_ts_lsp.py` and the full per-op breakdown in `results/ts_lsp_bench.json`.
+**What changes materially for the type-aware eval arm:** it is **not** structurally blocked by
+tsserver doing real whole-program work at this project size — it is blocked by a client-side timer
+(above), a different and addressable problem. A consumer needing sub-50ms diagnostics against a
+5000-file warm program on *this* server pin should still budget for ~376ms per check today, but the
+follow-up that would close that gap is filed and scoped: **#279**, a direct-`tsserver`
+`semanticDiagnosticsSync` bypass that skips `typescript-language-server`'s notification layer (and
+its debounce) entirely, now unblocked by this issue's confirmation.
+
+See `scripts/bench_ts_lsp.py`, `scripts/probe_ts_lsp_debounce.py`, and the full per-op breakdown in
+`results/ts_lsp_bench.json` / `results/ts_lsp_debounce_probe.json`.
 
 ## Verdict
 

--- a/results/ts_lsp_bench.json
+++ b/results/ts_lsp_bench.json
@@ -1,88 +1,114 @@
 {
   "ops": {
     "completions": {
-      "calls_per_s": 2629.4,
+      "calls_per_s": 2500.62,
       "iters": 200,
-      "mean_ms": 0.38,
-      "median_ms": 0.378,
-      "min_ms": 0.299,
+      "mean_ms": 0.4,
+      "median_ms": 0.382,
+      "min_ms": 0.303,
       "n_nonempty": 200,
       "nonempty_rate": 1.0,
       "op": "completions",
-      "p95_ms": 0.447
+      "p95_ms": 0.53
     },
     "definition": {
-      "calls_per_s": 595.19,
+      "calls_per_s": 611.99,
       "iters": 200,
-      "mean_ms": 1.68,
-      "median_ms": 1.744,
-      "min_ms": 0.377,
+      "mean_ms": 1.634,
+      "median_ms": 1.694,
+      "min_ms": 0.359,
       "n_nonempty": 200,
       "nonempty_rate": 1.0,
       "op": "definition",
-      "p95_ms": 2.172
+      "p95_ms": 2.116
     },
     "diagnostics": {
-      "calls_per_s": 3.09,
+      "by_direction": {
+        "introduce": {
+          "calls_per_s": 3.83,
+          "iters": 100,
+          "mean_ms": 260.886,
+          "median_ms": 374.584,
+          "min_ms": 2.249,
+          "n_nonempty": 67,
+          "nonempty_rate": 0.67,
+          "op": "diagnostics:introduce",
+          "p95_ms": 381.592
+        },
+        "revert": {
+          "calls_per_s": 2.65,
+          "iters": 100,
+          "mean_ms": 377.233,
+          "median_ms": 377.646,
+          "min_ms": 357.24,
+          "n_nonempty": 0,
+          "nonempty_rate": 0.0,
+          "op": "diagnostics:revert",
+          "p95_ms": 382.086
+        }
+      },
+      "calls_per_s": 3.13,
       "iters": 200,
-      "mean_ms": 324.144,
-      "median_ms": 378.11,
-      "min_ms": 0.292,
-      "n_nonempty": 0,
-      "nonempty_rate": 0.0,
+      "mean_ms": 319.06,
+      "median_ms": 376.438,
+      "min_ms": 2.249,
+      "n_nonempty": 67,
+      "nonempty_rate": 0.335,
       "op": "diagnostics",
-      "p95_ms": 383.041
+      "p95_ms": 381.609
     },
     "diagnostics_cached": {
-      "calls_per_s": 112110.38,
+      "calls_per_s": 162063.78,
       "iters": 200,
-      "mean_ms": 0.009,
-      "median_ms": 0.007,
+      "mean_ms": 0.006,
+      "median_ms": 0.006,
       "min_ms": 0.006,
       "n_nonempty": 0,
       "nonempty_rate": 0.0,
       "op": "diagnostics_cached",
-      "p95_ms": 0.017
+      "p95_ms": 0.007
     },
     "document_symbols": {
-      "calls_per_s": 2331.87,
+      "calls_per_s": 2337.17,
       "iters": 200,
-      "mean_ms": 0.429,
-      "median_ms": 0.42,
-      "min_ms": 0.301,
+      "mean_ms": 0.428,
+      "median_ms": 0.404,
+      "min_ms": 0.285,
       "n_nonempty": 200,
       "nonempty_rate": 1.0,
       "op": "document_symbols",
-      "p95_ms": 0.538
+      "p95_ms": 0.598
     },
     "quickinfo": {
-      "calls_per_s": 3102.3,
+      "calls_per_s": 2917.31,
       "iters": 200,
-      "mean_ms": 0.322,
-      "median_ms": 0.314,
-      "min_ms": 0.261,
+      "mean_ms": 0.343,
+      "median_ms": 0.325,
+      "min_ms": 0.228,
       "n_nonempty": 200,
       "nonempty_rate": 1.0,
       "op": "quickinfo",
-      "p95_ms": 0.389
+      "p95_ms": 0.49
     },
     "references": {
-      "calls_per_s": 1.98,
+      "calls_per_s": 2.0,
       "iters": 200,
-      "mean_ms": 505.144,
-      "median_ms": 505.993,
-      "min_ms": 467.505,
+      "mean_ms": 500.979,
+      "median_ms": 502.165,
+      "min_ms": 445.799,
       "n_nonempty": 200,
       "nonempty_rate": 1.0,
       "op": "references",
-      "p95_ms": 523.29
+      "p95_ms": 519.6
     }
   },
   "summary": {
-    "cold_load_s": 1.2276767080184072,
+    "cold_load_s": 1.2201793750282377,
     "diagnostic_provider": null,
+    "edit_file_lines": null,
     "iters": 200,
     "n_files": 5000,
+    "n_no_publish": 0,
     "n_restarts": 0,
     "n_timeouts": 0,
     "sanity_probe": {

--- a/results/ts_lsp_debounce_probe.json
+++ b/results/ts_lsp_debounce_probe.json
@@ -1,0 +1,131 @@
+{
+  "summary": {
+    "verdict": "DEBOUNCE_CONFIRMED",
+    "a_spread_ms": 21.5,
+    "a_monotonic_rising": true,
+    "b_max_abs_residual_ms": 20.2,
+    "b_ratio": 2.41,
+    "any_blind": false,
+    "a_lines": 12,
+    "b_n_files": 200,
+    "iters": 20,
+    "b_iters": 12,
+    "warmup": 5
+  },
+  "sweep_a": [
+    {
+      "n_files": 10,
+      "edit_lines": 12,
+      "n": 20,
+      "median_ms": 361.7,
+      "min_ms": 357.7,
+      "p95_ms": 370.2,
+      "predicted_ms": 350,
+      "residual_ms": 11.7,
+      "pushes_with_errors": 13,
+      "pushes_total": 26,
+      "n_unmeasurable": 0,
+      "blind": false
+    },
+    {
+      "n_files": 200,
+      "edit_lines": 12,
+      "n": 20,
+      "median_ms": 363.3,
+      "min_ms": 358.5,
+      "p95_ms": 368.2,
+      "predicted_ms": 350,
+      "residual_ms": 13.3,
+      "pushes_with_errors": 13,
+      "pushes_total": 26,
+      "n_unmeasurable": 0,
+      "blind": false
+    },
+    {
+      "n_files": 2000,
+      "edit_lines": 12,
+      "n": 20,
+      "median_ms": 371.2,
+      "min_ms": 365.7,
+      "p95_ms": 376.2,
+      "predicted_ms": 350,
+      "residual_ms": 21.2,
+      "pushes_with_errors": 13,
+      "pushes_total": 26,
+      "n_unmeasurable": 0,
+      "blind": false
+    },
+    {
+      "n_files": 5000,
+      "edit_lines": 12,
+      "n": 20,
+      "median_ms": 383.2,
+      "min_ms": 377.8,
+      "p95_ms": 386.2,
+      "predicted_ms": 350,
+      "residual_ms": 33.2,
+      "pushes_with_errors": 13,
+      "pushes_total": 26,
+      "n_unmeasurable": 0,
+      "blind": false
+    }
+  ],
+  "sweep_b": [
+    {
+      "n_files": 200,
+      "edit_lines": 12,
+      "n": 12,
+      "median_ms": 361.6,
+      "min_ms": 356.3,
+      "p95_ms": 364.6,
+      "predicted_ms": 350,
+      "residual_ms": 11.6,
+      "pushes_with_errors": 9,
+      "pushes_total": 18,
+      "n_unmeasurable": 0,
+      "blind": false
+    },
+    {
+      "n_files": 200,
+      "edit_lines": 6000,
+      "n": 12,
+      "median_ms": 365.0,
+      "min_ms": 361.4,
+      "p95_ms": 372.0,
+      "predicted_ms": 350,
+      "residual_ms": 15.0,
+      "pushes_with_errors": 9,
+      "pushes_total": 18,
+      "n_unmeasurable": 0,
+      "blind": false
+    },
+    {
+      "n_files": 200,
+      "edit_lines": 12000,
+      "n": 12,
+      "median_ms": 665.5,
+      "min_ms": 662.1,
+      "p95_ms": 677.1,
+      "predicted_ms": 650,
+      "residual_ms": 15.5,
+      "pushes_with_errors": 9,
+      "pushes_total": 18,
+      "n_unmeasurable": 0,
+      "blind": false
+    },
+    {
+      "n_files": 200,
+      "edit_lines": 20000,
+      "n": 12,
+      "median_ms": 870.2,
+      "min_ms": 865.6,
+      "p95_ms": 878.1,
+      "predicted_ms": 850,
+      "residual_ms": 20.2,
+      "pushes_with_errors": 9,
+      "pushes_total": 18,
+      "n_unmeasurable": 0,
+      "blind": false
+    }
+  ]
+}

--- a/scripts/bench_ts_lsp.py
+++ b/scripts/bench_ts_lsp.py
@@ -11,6 +11,20 @@ BLIND-guarded sanity probe against KNOWN targets, then measures per-op
 median/mean/min/p95 latency and calls/s for `diagnostics`, `definition`,
 `references`, `completions`, `quickinfo`, `document_symbols`.
 
+**`diagnostics` alternates introduce/revert (#278).** Each timed iteration
+either introduces a real `TS2339` (`_broken_variant`) into a path or reverts
+the SAME path's previous introduction (`_diagnostics_targets`), so every
+edit produces an observable diagnostic-set transition. A loop that only ever
+appends a benign comment to an already-clean file hits
+`cli.mjs:20524`'s "old and new sets both empty -> suppress publish"
+early-return on every iteration -- the one case the server may legitimately
+never answer -- and reports `nonempty_rate: 0.0` for a reason that has
+nothing to do with correctness (exactly what #277's run did). `--edit-file-lines`
+pads the edited document to N lines before each edit -- the only input to the
+5.3.0 debounce clamp (`cli.mjs:17868`); see `scripts/probe_ts_lsp_debounce.py`
+and #279 for the debounce itself, which this bench does not attempt to work
+around.
+
     # Fast smoke first, to shake out protocol shape before the 5k run:
     .venv/bin/python scripts/bench_ts_lsp.py --n-files 50 --warmup 3 --iters 20
 
@@ -52,7 +66,7 @@ import re
 import sys
 import time
 from pathlib import Path
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 # Repo root on sys.path so `src.lsp.*` imports resolve when run as a script.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -88,6 +102,52 @@ def _resolve_import(path: str, target_rel: str) -> str:
     `"hub"` or `"mod_0007"`. `path` (the importer) is unused; kept for a
     stable, obvious call signature at the two call sites (bench + test)."""
     return f"src/{target_rel}.ts"
+
+
+def _pad_to_lines(text: str, n_lines: Optional[int]) -> str:
+    """Append `// pad N` comment lines until `text` has `n_lines` lines. The
+    edited buffer's LINE COUNT is the only input to typescript-language-server
+    5.3.0's diagnostics delay clamp (cli.mjs:17868,
+    `min(max(ceil(lineCount/20), 300), 800)`), so this is the knob that moves
+    the measured latency -- see #278 and scripts/probe_ts_lsp_debounce.py.
+    Padding is appended at the END, so every offset computed from the unpadded
+    text stays valid. No-op when `n_lines` is None or already reached; never
+    truncates."""
+    if n_lines is None:
+        return text
+    current = text.count("\n") + (0 if text.endswith("\n") else 1)
+    missing = n_lines - current
+    if missing <= 0:
+        return text
+    filler = "\n".join(f"// pad {n}" for n in range(missing))
+    sep = "" if text.endswith("\n") else "\n"
+    return f"{text}{sep}{filler}\n"
+
+
+def _broken_variant(text: str, tag: int) -> str:
+    """`const vx = v.x;` -> `const vx = v.gorblak_{tag};` -- a real TS2339 on
+    `Vec`, the same defect shape `_sanity_probe` already validates. The tag
+    makes each introduction textually distinct."""
+    anchor = "const vx = v.x;"
+    if anchor not in text:
+        raise RuntimeError(
+            f"_broken_variant: anchor {anchor!r} not found -- a silent no-op "
+            "edit would produce a clean->clean iteration, exactly the "
+            "ambiguous case this change exists to avoid")
+    return text.replace(anchor, f"const vx = v.gorblak_{tag};", 1)
+
+
+def _diagnostics_targets(mod_paths: List[str]) -> List[Tuple[str, bool]]:
+    """`[(p, True), (p, False), ...]` -- iteration `2k` INTRODUCES an error in
+    mod `k`, `2k+1` REVERTS it. The two directions must be adjacent on the SAME
+    path: reverting a file that was never broken is the one clean->clean case
+    5.3.0 may never answer (cli.mjs:20524), which is exactly what made #277's
+    run report `nonempty_rate: 0.0`."""
+    out: List[Tuple[str, bool]] = []
+    for p in mod_paths:
+        out.append((p, True))
+        out.append((p, False))
+    return out
 
 
 def _generate_project(n_files: int, seed: int) -> Dict[str, str]:
@@ -218,22 +278,36 @@ def _summarize(op_name: str, samples_s: List[float], n_nonempty: int, iters: int
 
 
 def _measure_op(op_name: str, fn: Callable, targets: List[Tuple], *,
-                warmup: int, iters: int) -> dict:
+                warmup: int, iters: int,
+                label_of: Optional[Callable[..., str]] = None) -> dict:
     n = len(targets)
     if n == 0:
         raise RuntimeError(f"{op_name}: no targets generated -- project too small?")
     for w in range(warmup):
         fn(*targets[w % n])
     samples_s: List[float] = []
-    n_nonempty = 0
+    nonempty_flags: List[bool] = []
+    labels: List[str] = []
     for it in range(iters):
         args = targets[it % n]
         t0 = time.perf_counter()
         result = fn(*args)
         samples_s.append(time.perf_counter() - t0)
-        if _is_nonempty(result):
-            n_nonempty += 1
-    return _summarize(op_name, samples_s, n_nonempty, iters)
+        nonempty_flags.append(_is_nonempty(result))
+        if label_of is not None:
+            labels.append(label_of(*args))
+    n_nonempty = sum(nonempty_flags)
+    summary = _summarize(op_name, samples_s, n_nonempty, iters)
+    if label_of is not None:
+        buckets: Dict[str, List[int]] = {}
+        for i, label in enumerate(labels):
+            buckets.setdefault(label, []).append(i)
+        summary["by_direction"] = {
+            label: _summarize(f"{op_name}:{label}", [samples_s[i] for i in idx],
+                              sum(1 for i in idx if nonempty_flags[i]), len(idx))
+            for label, idx in buckets.items()
+        }
+    return summary
 
 
 def _run_measurements(service: TsLspService, files: Dict[str, str], args) -> Dict[str, dict]:
@@ -270,17 +344,24 @@ def _run_measurements(service: TsLspService, files: Dict[str, str], args) -> Dic
     # diagnostics: an EDIT -> RE-CHECK cycle, timed TOGETHER -- the shape
     # #226's consumer actually has (one edit per generated token). Timing a
     # cache hit and calling it a re-check would be the same BLIND failure in
-    # a different coat.
+    # a different coat. Alternates introduce/revert on the SAME path so every
+    # iteration forces an observable transition -- cli.mjs:20524 suppresses a
+    # publish only when the OLD and NEW diagnostic sets are both empty, which
+    # a revert-of-a-never-broken-file is (#278; #277's run hit exactly that
+    # and reported nonempty_rate 0.0 on all 200 iterations).
     counter = [0]
 
-    def _edit_and_check(path):
+    def _edit_and_check(path, introduce):
         counter[0] += 1
-        service.update(path, files[path] + f"\n// bench edit {counter[0]}\n")
+        clean = _pad_to_lines(files[path], args.edit_file_lines)
+        text = _broken_variant(clean, counter[0]) if introduce else clean
+        service.update(path, text)
         return service.diagnostics(path)
 
     ops["diagnostics"] = _measure_op(
-        "diagnostics", _edit_and_check, [(p,) for p in mod_paths],
-        warmup=args.warmup, iters=args.iters)
+        "diagnostics", _edit_and_check, _diagnostics_targets(mod_paths),
+        warmup=args.warmup, iters=args.iters,
+        label_of=lambda path, introduce: "introduce" if introduce else "revert")
 
     # diagnostics_cached: pure cache-hit path (unchanged document), reported
     # SEPARATELY -- explicitly NOT the SLA number.
@@ -322,11 +403,15 @@ def _print_report(summary: dict, ops: Dict[str, dict]) -> None:
         print(f"{name:<20}{s['median_ms']:>12.2f}{s['p95_ms']:>10.2f}"
               f"{s['calls_per_s']:>10.1f}{s['nonempty_rate'] * 100:>10.1f}%")
     print("-" * 72)
-    print(f"n_restarts={summary['n_restarts']}  n_timeouts={summary['n_timeouts']}")
+    print(f"n_restarts={summary['n_restarts']}  n_timeouts={summary['n_timeouts']}  "
+          f"n_no_publish={summary['n_no_publish']}")
     print(f"VERDICT: {summary['verdict']}")
     if summary["verdict"] in ("WARN", "KILL"):
         print("  -> #226 decode-time completion-list masking rescopes to OFFLINE "
               "if this holds (throughput gate: completions >= 200 calls/s).")
+        print("  -> most of `diagnostics`'s latency is a client-side debounce, "
+              "not type-checking (#278/scripts/probe_ts_lsp_debounce.py); a "
+              "direct-tsserver bypass (#279) is the addressable follow-up.")
     print("=" * 72)
 
 
@@ -342,6 +427,11 @@ def _parse_args() -> argparse.Namespace:
     ap.add_argument("--warmup", type=int, default=20, help="untimed ops per kind")
     ap.add_argument("--iters", type=int, default=200, help="timed ops per kind")
     ap.add_argument("--timeout-s", type=float, default=10.0)
+    ap.add_argument("--edit-file-lines", type=int, default=None,
+                    help="pad the EDITED document to N lines before each timed "
+                         "diagnostics edit -- the only input to the 5.3.0 delay "
+                         "clamp (cli.mjs:17868); default: the generated file's "
+                         "natural length (~12)")
     ap.add_argument("--out", type=str, default="results/ts_lsp_bench.json")
     ap.add_argument("--keep-scratch", action="store_true",
                     help="leave the generated project on disk for inspection")
@@ -356,6 +446,8 @@ def _parse_args() -> argparse.Namespace:
         ap.error("--iters must be >= 1")
     if args.warmup < 0:
         ap.error("--warmup must be >= 0")
+    if args.edit_file_lines is not None and args.edit_file_lines < 1:
+        ap.error("--edit-file-lines must be >= 1")
     return args
 
 
@@ -402,11 +494,13 @@ def main() -> int:
             "verdict": verdict,
             "n_files": args.n_files, "seed": args.seed,
             "warmup": args.warmup, "iters": args.iters,
+            "edit_file_lines": args.edit_file_lines,
             "cold_load_s": service.cold_load_s,
             "server_sync_kind": service.server_sync_kind,
             "diagnostic_provider": service.server_capabilities.get("diagnosticProvider"),
             "sanity_probe": probe,
             "n_restarts": service.n_restarts, "n_timeouts": service.n_timeouts,
+            "n_no_publish": service.n_no_publish,
         }
         _write_results(out_path, {"summary": summary, "ops": ops})
         _print_report(summary, ops)

--- a/scripts/probe_ts_lsp_debounce.py
+++ b/scripts/probe_ts_lsp_debounce.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Decisive control for #278: is the `diagnostics` latency measured in #220 /
+PR #277 (378 ms median against a 50 ms bar) a client-side DEBOUNCE inside the
+pinned `typescript-language-server` 5.3.0, or whole-program type-checking
+cost?
+
+Deliberately bypasses `TsLspService` entirely -- raw JSON-RPC, no cache, no
+seq-marker, no first-push-wins bookkeeping -- so neither the #278 seq-race fix
+nor any other bookkeeping of ours can colour the number. Times exactly:
+
+    didChange(version n+1)  ->  publishDiagnostics arrives
+
+The debounce hypothesis says the wait is
+`min(max(ceil(lineCount / 20), 300), 800) + 50` ms (`cli.mjs:17868` clamped by
+`:17858`'s default plus `:20516`'s 50 ms `pDebounce`) and is roughly
+INDEPENDENT of project size. Two predictions, both falsifiable:
+
+  A. project-size sweep at fixed file length -> roughly FLAT ~350 ms
+  B. file-LENGTH sweep                       -> 350 ms .. 850 ms, tracking
+     the clamp's own formula
+
+If instead the cost were whole-program semantic work, A would rise with
+project size and B would be flat -- the two hypotheses predict opposite
+things, so this separates them.
+
+Each iteration alternates the edited file between a real type error and
+clean, so the diagnostic SET genuinely changes every time -- that defeats
+`cli.mjs:20524`'s "both old and new sets are empty -> suppress publish"
+early-return, which would otherwise make some iterations produce no push at
+all (indistinguishable from a hang).
+
+Stdlib + above-the-seam repo imports only (no mlx/torch). Skips cleanly with
+exit 0 if no `typescript-language-server` toolchain is resolvable.
+
+Usage:
+    .venv/bin/python scripts/probe_ts_lsp_debounce.py \
+        --out results/ts_lsp_debounce_probe.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Repo root on sys.path so `src.lsp.*` imports resolve when run as a script.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.lsp.jsonrpc import spawn  # noqa: E402
+from src.lsp.tsc import DEFAULT_TSCONFIG_PATH, SET_DIR  # noqa: E402
+from src.lsp.ts_lsp import resolve_ts_lsp  # noqa: E402
+
+_CLEAN = "export const probe_value: number = {i};"
+_ERROR = 'export const probe_value: number = "type-error-{i}";'
+
+# Reference tables from the already-run control experiment (issue #278's
+# writeup / the plan) -- printed alongside a fresh run so a re-run is
+# immediately comparable without cross-referencing the issue.
+_REFERENCE_A = [
+    (10, 359.2, 9.2), (200, 360.5, 10.5), (2000, 368.1, 18.1), (5000, 381.1, 31.1),
+]
+_REFERENCE_B = [
+    (12, 350, 361.1, 11.1), (6000, 350, 365.7, 15.7),
+    (12000, 650, 668.3, 18.3), (20000, 850, 869.6, 19.6),
+]
+
+
+def _predicted_ms(lines: int) -> float:
+    return min(max(math.ceil(lines / 20), 300), 800) + 50
+
+
+def _pad(body: str, lines: int) -> str:
+    """Pad to `lines` total with comment lines -- lineCount is the clamp's
+    only input (`cli.mjs:17868`)."""
+    filler = "\n".join(f"// pad {n}" for n in range(max(0, lines - 1)))
+    return f"{filler}\n{body}\n" if filler else f"{body}\n"
+
+
+def _run_point(n_files: int, edit_lines: int, iters: int, warmup: int,
+               timeout_s: float) -> dict:
+    """One (n_files, edit_lines) measurement point: `iters` timed
+    `didChange` -> `publishDiagnostics` samples (plus `warmup` untimed ones),
+    alternating error/clean so `cli.mjs:20524` can never suppress a push."""
+    argv = resolve_ts_lsp()
+    assert argv is not None  # caller already checked
+
+    root = Path(tempfile.mkdtemp(dir=str(SET_DIR), prefix="lsp_debounce_"))
+    try:
+        (root / "tsconfig.json").write_text(
+            DEFAULT_TSCONFIG_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+        src = root / "src"
+        src.mkdir()
+        # Filler files so the PROGRAM is genuinely n_files big; each imports
+        # its predecessor so tsserver cannot dismiss them as unreachable.
+        for i in range(n_files - 1):
+            prev = f'import {{ v{i - 1} }} from "./f{i - 1}";\n' if i else ""
+            (src / f"f{i}.ts").write_text(
+                f'{prev}export const v{i}: number = {i};\n', encoding="utf-8")
+        target = src / "target.ts"
+        target.write_text(_pad(_CLEAN.format(i=0), edit_lines), encoding="utf-8")
+        uri = target.as_uri()
+
+        pushes: List[tuple] = []
+        got = threading.Event()
+
+        def on_notification(msg: dict) -> None:
+            if msg.get("method") != "textDocument/publishDiagnostics":
+                return
+            params = msg.get("params") or {}
+            if params.get("uri") == uri:
+                pushes.append((time.perf_counter(), len(params.get("diagnostics") or [])))
+                got.set()
+
+        proc, ep = spawn(argv + ["--stdio"], cwd=str(root), on_notification=on_notification)
+        try:
+            ep.request("initialize", {
+                "processId": None,
+                "rootUri": root.as_uri(),
+                "capabilities": {"textDocument": {"publishDiagnostics": {}}},
+                "initializationOptions": {},
+            }, timeout=timeout_s)
+            ep.notify("initialized", {})
+            text = target.read_text(encoding="utf-8")
+            ep.notify("textDocument/didOpen", {"textDocument": {
+                "uri": uri, "languageId": "typescript", "version": 1, "text": text}})
+            got.wait(min(30.0, timeout_s))  # let the program load
+
+            samples: List[float] = []
+            n_unmeasurable = 0
+            for it in range(warmup + iters):
+                body = (_ERROR if it % 2 == 0 else _CLEAN).format(i=it)
+                text = _pad(body, edit_lines)
+                got.clear()
+                before = len(pushes)
+                t0 = time.perf_counter()
+                ep.notify("textDocument/didChange", {
+                    "textDocument": {"uri": uri, "version": it + 2},
+                    "contentChanges": [{"text": text}],
+                })
+                if not got.wait(timeout_s):
+                    n_unmeasurable += 1
+                    continue
+                dt = (pushes[before][0] - t0) * 1000.0
+                if it >= warmup:
+                    samples.append(dt)
+
+            pushes_with_errors = sum(1 for _, c in pushes if c)
+            pushes_total = len(pushes)
+            predicted = _predicted_ms(edit_lines)
+            blind = len(samples) == 0 or pushes_with_errors == 0
+
+            point = {
+                "n_files": n_files, "edit_lines": edit_lines, "n": len(samples),
+                "median_ms": round(statistics.median(samples), 1) if samples else None,
+                "min_ms": round(min(samples), 1) if samples else None,
+                "p95_ms": (round(sorted(samples)[int(len(samples) * 0.95)], 1)
+                           if samples else None),
+                "predicted_ms": predicted,
+                "residual_ms": (round(statistics.median(samples) - predicted, 1)
+                                if samples else None),
+                "pushes_with_errors": pushes_with_errors, "pushes_total": pushes_total,
+                "n_unmeasurable": n_unmeasurable,
+                "blind": blind,
+            }
+            return point
+        finally:
+            ep.close()
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+    finally:
+        import shutil
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _verdict(sweep_a: List[dict], sweep_b: List[dict]) -> Dict[str, object]:
+    """DEBOUNCE_CONFIRMED / PROJECT_SIZE_DOMINATES / INCONCLUSIVE, computed
+    only from sweeps actually run. A `blind` point anywhere forces
+    INCONCLUSIVE -- silence must never read as confirmation."""
+    any_blind = any(p["blind"] for p in sweep_a + sweep_b)
+
+    a_spread_ms = None
+    a_monotonic_rising = None
+    if len(sweep_a) >= 2 and all(p["median_ms"] is not None for p in sweep_a):
+        by_size = sorted(sweep_a, key=lambda p: p["n_files"])
+        a_spread_ms = round(by_size[-1]["median_ms"] - by_size[0]["median_ms"], 1)
+        medians = [p["median_ms"] for p in by_size]
+        a_monotonic_rising = all(b >= a for a, b in zip(medians, medians[1:]))
+
+    b_max_abs_residual_ms = None
+    b_ratio = None
+    if len(sweep_b) >= 2 and all(p["median_ms"] is not None for p in sweep_b):
+        residuals = [abs(p["residual_ms"]) for p in sweep_b]
+        b_max_abs_residual_ms = round(max(residuals), 1)
+        medians = [p["median_ms"] for p in sweep_b]
+        b_ratio = round(max(medians) / min(medians), 2) if min(medians) else None
+
+    debounce_confirmed = (
+        not any_blind and a_spread_ms is not None and b_max_abs_residual_ms is not None
+        and b_ratio is not None
+        and a_spread_ms <= 100 and b_max_abs_residual_ms <= 60 and b_ratio >= 2.0
+    )
+    project_size_dominates = (
+        not debounce_confirmed and not any_blind
+        and a_spread_ms is not None and a_spread_ms > 100 and bool(a_monotonic_rising)
+    )
+
+    if any_blind:
+        verdict = "INCONCLUSIVE"
+    elif debounce_confirmed:
+        verdict = "DEBOUNCE_CONFIRMED"
+    elif project_size_dominates:
+        verdict = "PROJECT_SIZE_DOMINATES"
+    else:
+        verdict = "INCONCLUSIVE"
+
+    return {
+        "verdict": verdict,
+        "a_spread_ms": a_spread_ms,
+        "a_monotonic_rising": a_monotonic_rising,
+        "b_max_abs_residual_ms": b_max_abs_residual_ms,
+        "b_ratio": b_ratio,
+        "any_blind": any_blind,
+    }
+
+
+def _print_reference_tables() -> None:
+    print("-" * 72)
+    print("Reference (issue #278's already-run control experiment):")
+    print("  A. project-size sweep (edit-file fixed at 12 lines):")
+    print(f"     {'n_files':>8} {'median_ms':>10} {'minus_350':>10}")
+    for n, median, minus in _REFERENCE_A:
+        print(f"     {n:>8} {median:>10.1f} {minus:>10.1f}")
+    print("  B. file-length sweep (project fixed at 200 files):")
+    print(f"     {'lines':>8} {'predicted':>10} {'measured':>10} {'residual':>10}")
+    for lines, pred, measured, resid in _REFERENCE_B:
+        print(f"     {lines:>8} {pred:>10} {measured:>10.1f} {resid:>10.1f}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--sweep", choices=["a", "b", "both"], default="both")
+    ap.add_argument("--a-sizes", type=str, default="10,200,2000,5000",
+                    help="comma-separated n_files values for sweep A")
+    ap.add_argument("--b-lines", type=str, default="12,6000,12000,20000",
+                    help="comma-separated edit-file line counts for sweep B")
+    ap.add_argument("--b-n-files", type=int, default=200,
+                    help="project size held fixed for sweep B")
+    ap.add_argument("--a-lines", type=int, default=12,
+                    help="edit-file line count held fixed for sweep A")
+    ap.add_argument("--iters", type=int, default=20, help="timed iterations for sweep A")
+    ap.add_argument("--b-iters", type=int, default=12, help="timed iterations for sweep B")
+    ap.add_argument("--warmup", type=int, default=5)
+    ap.add_argument("--timeout-s", type=float, default=60.0,
+                    help="per-notification wait cap (s)")
+    ap.add_argument("--out", type=str, default="results/ts_lsp_debounce_probe.json")
+    args = ap.parse_args()
+
+    argv = resolve_ts_lsp()
+    if argv is None:
+        print("SKIP: no typescript-language-server toolchain resolvable "
+              f"(need `npm i -D typescript-language-server` in {SET_DIR}).")
+        return 0
+
+    a_sizes = [int(x) for x in args.a_sizes.split(",") if x]
+    b_lines = [int(x) for x in args.b_lines.split(",") if x]
+
+    print("clamp predicts: delay = min(max(ceil(lines/20), 300), 800) + 50ms debounce")
+    _print_reference_tables()
+
+    sweep_a: List[dict] = []
+    if args.sweep in ("a", "both"):
+        print("-" * 72)
+        print("=== A. project-size sweep (file length fixed at "
+              f"{args.a_lines} lines) ===")
+        print("    debounce predicts FLAT ~350ms; whole-program work predicts RISING")
+        for n in a_sizes:
+            r = _run_point(n, args.a_lines, args.iters, args.warmup, args.timeout_s)
+            sweep_a.append(r)
+            _print_point_a(r)
+
+    sweep_b: List[dict] = []
+    if args.sweep in ("b", "both"):
+        print("-" * 72)
+        print(f"=== B. file-LENGTH sweep (project fixed at {args.b_n_files} files) ===")
+        print("    predicted: min(max(ceil(lines/20),300),800)+50")
+        for lines in b_lines:
+            r = _run_point(args.b_n_files, lines, args.b_iters, args.warmup, args.timeout_s)
+            sweep_b.append(r)
+            _print_point_b(r)
+
+    verdict = _verdict(sweep_a, sweep_b)
+
+    summary = {
+        "verdict": verdict["verdict"],
+        "a_spread_ms": verdict["a_spread_ms"],
+        "a_monotonic_rising": verdict["a_monotonic_rising"],
+        "b_max_abs_residual_ms": verdict["b_max_abs_residual_ms"],
+        "b_ratio": verdict["b_ratio"],
+        "any_blind": verdict["any_blind"],
+        "a_lines": args.a_lines, "b_n_files": args.b_n_files,
+        "iters": args.iters, "b_iters": args.b_iters, "warmup": args.warmup,
+    }
+
+    out_path = Path(args.out)
+    if not out_path.is_absolute():
+        out_path = _REPO_ROOT / out_path
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(
+        {"summary": summary, "sweep_a": sweep_a, "sweep_b": sweep_b}, indent=2),
+        encoding="utf-8")
+
+    print("=" * 72)
+    print(f"VERDICT: {verdict['verdict']}")
+    print(f"  a_spread_ms={verdict['a_spread_ms']}  "
+          f"a_monotonic_rising={verdict['a_monotonic_rising']}")
+    print(f"  b_max_abs_residual_ms={verdict['b_max_abs_residual_ms']}  "
+          f"b_ratio={verdict['b_ratio']}")
+    print(f"  any_blind={verdict['any_blind']}")
+    print(f"wrote {out_path}")
+    print("=" * 72)
+    return 0
+
+
+def _print_point_a(r: dict) -> None:
+    if r["median_ms"] is None:
+        print(f"  n_files={r['n_files']:>5}  !! nothing measured "
+              f"(n_unmeasurable={r['n_unmeasurable']})")
+        return
+    print(f"  n_files={r['n_files']:>5}  median={r['median_ms']:>7.1f}ms  "
+          f"min={r['min_ms']:>7.1f}  p95={r['p95_ms']:>7.1f}  "
+          f"pushes_with_errors={r['pushes_with_errors']}/{r['pushes_total']}  "
+          f"n_unmeasurable={r['n_unmeasurable']}"
+          + ("  BLIND" if r["blind"] else ""))
+
+
+def _print_point_b(r: dict) -> None:
+    if r["median_ms"] is None:
+        print(f"  lines={r['edit_lines']:>6}  !! nothing measured "
+              f"(n_unmeasurable={r['n_unmeasurable']})")
+        return
+    print(f"  lines={r['edit_lines']:>6}  median={r['median_ms']:>7.1f}ms  "
+          f"predicted={r['predicted_ms']:>4}ms  delta={r['residual_ms']:>+7.1f}"
+          + ("  BLIND" if r["blind"] else ""))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lsp/ts_service.py
+++ b/src/lsp/ts_service.py
@@ -37,6 +37,21 @@ settle like opengrep.py; it would defeat the reason this class exists.**
 are not available on this pin -- push-and-wait, gated by version/seq (see
 `diagnostics()`), is the only option.
 
+**Most of the measured `diagnostics` latency is a client-side timer, not
+type-checking (#278).** Two hardcoded timers in the pinned server, neither
+with a configuration gate: `cli.mjs:17868`'s
+`min(max(ceil(lineCount / 20), 300), 800)` ms delay on every `didChange`
+(our short synthetic files hit the 300 ms floor), plus `cli.mjs:20516`'s
+`pDebounce(..., 50)`. So a warm re-check on this pin costs >=350 ms of
+*client* wait before tsserver is asked anything, independent of project
+size -- a control probe sweeping project size (roughly flat ~350-380ms
+across 10..5000 files) and edit-file length (tracking the clamp's own
+formula from 350ms to 850ms) confirms this; the genuine recheck cost once
+the debounce is subtracted out is ~11-31ms, inside a 50ms bar. See
+`scripts/probe_ts_lsp_debounce.py` and #279 (a direct-`tsserver`
+`semanticDiagnosticsSync` bypass that would sidestep the client-side
+debounce entirely).
+
 Not safe for concurrent use -- one service instance == one sequential
 open/edit/query stream, matching `TsLspOracle`'s contract.
 
@@ -313,6 +328,7 @@ class TsLspService:
         self.n_calls = 0
         self.wall_s = 0.0
         self.n_timeouts = 0
+        self.n_no_publish = 0
         self.n_restarts = 0
         self.op_counts: Dict[str, int] = {}
         self.op_wall_s: Dict[str, float] = {}
@@ -475,6 +491,10 @@ class TsLspService:
             event = threading.Event()
             self._diag_events[uri] = event
         self._ensure_open(warm)
+        # Still n_timeouts, not n_no_publish (#278): a didOpen with no prior
+        # entry for this URI cannot hit cli.mjs:20524's "both sets empty"
+        # suppression -- there IS no previous set -- so no push here is a
+        # real cold-load failure, not the clean-document ambiguity.
         got = event.wait(self.timeout_s)
         with self._diag_lock:
             self._diag_events.pop(uri, None)
@@ -522,6 +542,15 @@ class TsLspService:
         version = self._versions[path]
         with self._diag_lock:
             self._update_marker[uri] = self._diag_seq_counter
+            # A push ALREADY RECORDED before this edit is not an answer to it.
+            # On the pinned 5.3.0, `publishDiagnostics` carries no `version`
+            # (cli.mjs:20535 publishes {uri, diagnostics} only), so
+            # `_push_is_current` falls through to seq-vs-marker -- and the
+            # marker is taken here, an instant before the didChange below.
+            # Without this pop, a pre-edit push satisfies `seq > marker` and is
+            # returned as the post-edit answer in ~0.3ms (#278: the min 0.292ms
+            # mode, ~28 of 200 samples in #277's run).
+            self._diag_state.pop(uri, None)
         self._notify_retrying("textDocument/didChange", _did_change_params(uri, version, text))
         return version
 
@@ -536,6 +565,14 @@ class TsLspService:
         # Server omits `version` (optional even with versionSupport: True) --
         # fall back to seq-vs-last-edit comparison. Never assume a push is
         # current just because it's the latest one seen.
+        #
+        # On the pinned typescript-language-server 5.3.0 this fallback is the
+        # ONLY live path: `version` is never populated (cli.mjs:20535 publishes
+        # `{uri, diagnostics}` only, no `version` field). The branch above is
+        # kept for a future server that does populate it, but its correctness
+        # on THIS pin rests entirely on `update()` popping `_diag_state[uri]`
+        # before bumping `_update_marker` (#278) -- otherwise a push recorded
+        # before the marker-taking instant still satisfies `seq > marker`.
         return state["seq"] > marker
 
     def diagnostics(self, path: str) -> List[Diagnostic]:
@@ -546,8 +583,18 @@ class TsLspService:
         `version`, post-dates the last `update()`/open), it is returned
         immediately from a cache -- the honest fast path for "diagnose the
         same unchanged document again", NOT a re-check. Otherwise waits up to
-        `timeout_s` for a matching push. Never raises on timeout or a dead
-        server -- returns `[]` and counts it (`n_timeouts`), `TsLspOracle`'s
+        `timeout_s` for a matching push.
+
+        `[]` is returned for TWO distinct situations that are **not
+        distinguishable** for an already-clean document on this pin: a
+        genuinely clean re-check, and "nothing has been published since the
+        edit" (`n_no_publish`, #278) -- `cli.mjs:20524` returns early and
+        never publishes when both the previous and new diagnostic sets are
+        empty, so a benign edit to an already-clean document may legitimately
+        never get a push. A stale, version-tagged push that fails
+        `_push_is_current` is a real timeout (`n_timeouts`) -- that case IS
+        distinguishable, because something was published, it just wasn't
+        current. Never raises on timeout or a dead server, `TsLspOracle`'s
         contract."""
         self._ensure_alive()
         self._ensure_open(path)
@@ -572,7 +619,7 @@ class TsLspService:
         # every call and make >=200 calls/s structurally unreachable. Do not
         # "fix" this to settle like opengrep.py -- that divergence is
         # intentional (see the module docstring).
-        got = event.wait(self.timeout_s)
+        event.wait(self.timeout_s)
         with self._diag_lock:
             self._diag_events.pop(uri, None)
             state = self._diag_state.get(uri)
@@ -580,7 +627,18 @@ class TsLspService:
 
         self._record_op("diagnostics", time.monotonic() - t0)
 
-        if not got or state is None or not self._push_is_current(state, want_version, marker):
+        if state is None:
+            # NOTHING was published for this document within timeout_s. On this
+            # pin that is AMBIGUOUS by construction: cli.mjs:20524 returns early
+            # when the previous and new diagnostic sets are BOTH empty, so a
+            # benign edit to an already-clean document legitimately never gets a
+            # push -- indistinguishable from a server that never answered.
+            # Counted separately from n_timeouts so the ambiguity is visible in
+            # the stats instead of silently folded into either a clean result or
+            # a failure.
+            self.n_no_publish += 1
+            return []
+        if not self._push_is_current(state, want_version, marker):
             self.n_timeouts += 1
             return []
         return self._filter_diagnostics_payload(list(state["payload"]), self._files[path])

--- a/tests/test_ts_service.py
+++ b/tests/test_ts_service.py
@@ -116,6 +116,40 @@ def test_update_then_diagnostics_detects_and_clears_a_break(service: TsLspServic
     assert clean == [], f"expected clean after revert, got {clean}"
 
 
+def test_benign_edit_to_clean_document_is_counted_as_no_publish():
+    """#278: `cli.mjs:20524` returns early (never publishes) when a document's
+    OLD and NEW diagnostic sets are both empty -- pinning that against the
+    real server. A fresh, short-timeout `TsLspService` (not the module-scoped
+    `service` fixture, whose counters are shared across tests and whose 10s
+    timeout would stall the suite on the wait this exercises)."""
+    svc = TsLspService(timeout_s=2.0)
+    try:
+        svc.open_project({"src/clean.ts": _OTHER_TS})
+        assert svc.diagnostics("src/clean.ts") == []
+
+        n_no_publish_before = svc.n_no_publish
+        n_timeouts_before = svc.n_timeouts
+        svc.update("src/clean.ts", _OTHER_TS + "// a benign, non-breaking comment\n")
+        result = svc.diagnostics("src/clean.ts")
+
+        # Edge case / decision rule (plan #278): if the live server DOES
+        # publish here (e.g. a diagnostic kind was never populated for this
+        # document, so cli.mjs's early-return does not fire), the counter
+        # code is still correct -- record what actually happened rather than
+        # assert a behaviour the server didn't exhibit.
+        if svc.n_no_publish == n_no_publish_before + 1:
+            assert result == []
+            assert svc.n_timeouts == n_timeouts_before
+        else:
+            assert svc.n_timeouts == n_timeouts_before, (
+                "expected either n_no_publish+1 (cli.mjs:20524 suppressed the "
+                "publish) or a real answered push (n_no_publish unchanged) -- "
+                f"got n_no_publish={svc.n_no_publish} (was {n_no_publish_before}), "
+                f"n_timeouts={svc.n_timeouts} (was {n_timeouts_before}), result={result}")
+    finally:
+        svc.close()
+
+
 def test_version_counter_is_strictly_increasing(service: TsLspService):
     v1 = service.update("src/other.ts", _OTHER_TS + "// edit 1\n")
     v2 = service.update("src/other.ts", _OTHER_TS + "// edit 2\n")

--- a/tests/test_ts_service_mechanism.py
+++ b/tests/test_ts_service_mechanism.py
@@ -146,6 +146,7 @@ class _FakeService(TsLspService):
         self.n_calls = 0
         self.wall_s = 0.0
         self.n_timeouts = 0
+        self.n_no_publish = 0
         self.n_restarts = 0
         self.op_counts: Dict[str, int] = {}
         self.op_wall_s: Dict[str, float] = {}
@@ -457,17 +458,80 @@ def test_diagnostics_version_gating(fake):
     assert svc._versions["a.ts"] == 2
 
     # A STALE v1 push arrives AFTER the edit -- must not be mistaken for current.
+    # (#278: update() now pops _diag_state[uri] under the lock, so -- unlike
+    # before the fix -- the dict genuinely has no entry for `uri` until this
+    # push is processed; `.get(uri, {})` avoids a KeyError race against the
+    # notification-reader thread rather than relying on a stale leftover
+    # entry that happened to make this assertion trivially true.)
     scripted.push_diagnostics(uri, [_raw_diag(9999, message="stale")], version=1)
-    assert _wait_until(lambda: svc._diag_state[uri]["version"] == 1)
+    assert _wait_until(lambda: svc._diag_state.get(uri, {}).get("version") == 1)
     stale_result = svc.diagnostics("a.ts")   # times out -- no v2 push yet
     assert stale_result == []
     assert svc.n_timeouts == 1
 
     # Now the real post-edit v2 push arrives.
     scripted.push_diagnostics(uri, [_raw_diag(1234, message="new error")], version=2)
-    assert _wait_until(lambda: svc._diag_state[uri]["version"] == 2)
+    assert _wait_until(lambda: svc._diag_state.get(uri, {}).get("version") == 2)
     fresh = svc.diagnostics("a.ts")
     assert [d.code for d in fresh] == ["TS1234"]
+
+
+def test_stale_push_before_didchange_is_not_returned(fake):
+    """The #278 regression test. A push already recorded BEFORE update() is
+    not an answer to the edit that follows it -- even though 5.3.0 sends no
+    `version` (so `_push_is_current` falls through to seq-vs-marker), because
+    `update()` now pops `_diag_state[uri]` under the lock before bumping the
+    marker. PRE-FIX (no pop in update()), this returns `["TS2339"]` instead
+    of `[]`: the stale pre-edit push's seq is still > the marker taken an
+    instant later, so `_push_is_current` accepts it as current."""
+    svc, scripted = fake
+    uri = _seed_open_file(svc, "a.ts", "old text", version=1)
+    svc._open.add("a.ts")
+
+    scripted.push_diagnostics(uri, [_raw_diag(2339)])   # no version -- 5.3.0's real shape
+    assert _wait_until(lambda: uri in svc._diag_state)
+
+    svc.update("a.ts", "new text")
+    assert uri not in svc._diag_state   # the pop
+
+    assert svc.diagnostics("a.ts") == []   # times out waiting for a NEW push
+    assert svc.n_no_publish == 1
+    assert svc.n_timeouts == 0
+
+
+def test_no_push_after_didchange_counts_no_publish_not_timeout(fake):
+    """Same shape as the stale-push test but with no pre-edit push at all --
+    `state is None` after the wait, classified as `n_no_publish` (the
+    ambiguous "clean or never answered" case, cli.mjs:20524), not
+    `n_timeouts`."""
+    svc, scripted = fake
+    _seed_open_file(svc, "a.ts", "old text", version=1)
+    svc._open.add("a.ts")
+
+    svc.update("a.ts", "new text")
+    assert svc.diagnostics("a.ts") == []
+    assert svc.n_no_publish == 1
+    assert svc.n_timeouts == 0
+
+
+def test_post_edit_push_still_answers(fake):
+    """The pop must not over-invalidate: a push that genuinely arrives AFTER
+    the edit is still returned."""
+    svc, scripted = fake
+    uri = _seed_open_file(svc, "a.ts", "old text", version=1)
+    svc._open.add("a.ts")
+
+    svc.update("a.ts", "new text")
+    timer = threading.Timer(
+        0.05, lambda: scripted.push_diagnostics(uri, [_raw_diag(1234)]))
+    timer.start()
+    try:
+        diags = svc.diagnostics("a.ts")
+    finally:
+        timer.join()
+    assert [d.code for d in diags] == ["TS1234"]
+    assert svc.n_no_publish == 0
+    assert svc.n_timeouts == 0
 
 
 def test_diagnostics_falls_back_to_seq_when_server_omits_version(fake):
@@ -546,3 +610,45 @@ def test_generate_project_imports_resolve_and_are_acyclic():
             assert target_path in files, f"{path} imports missing {target_path}"
             assert mod._module_index(target_path) < my_idx or target_path == "src/hub.ts", (
                 f"{path} imports {target_path}, not lower-indexed -- would create a cycle")
+
+
+# --------------------------------------------------------------------------- #
+# 10. #278 bench helpers: _pad_to_lines / _broken_variant / _diagnostics_targets
+# --------------------------------------------------------------------------- #
+
+def test_pad_to_lines_exact_and_noop():
+    mod = _bench_module()
+    text = "line1\nline2\nline3\n"   # 3 lines
+
+    padded = mod._pad_to_lines(text, 6)
+    assert padded.count("\n") == 6 or padded.rstrip("\n").count("\n") + 1 == 6
+    assert padded.startswith(text)   # original text is a prefix
+
+    # None is a no-op.
+    assert mod._pad_to_lines(text, None) == text
+    # A target at or below the current length is a no-op -- never truncates.
+    assert mod._pad_to_lines(text, 3) == text
+    assert mod._pad_to_lines(text, 1) == text
+
+
+def test_broken_variant_differs_and_is_tagged():
+    mod = _bench_module()
+    clean = "export function f(v):Vec {\n  const vx = v.x;\n  return v;\n}\n"
+    broken = mod._broken_variant(clean, 7)
+    assert broken != clean
+    assert "gorblak_7" in broken
+    assert "const vx = v.x;" not in broken
+
+    with pytest.raises(RuntimeError):
+        mod._broken_variant("no anchor here", 1)
+
+
+def test_diagnostics_targets_alternate_on_same_path():
+    mod = _bench_module()
+    mod_paths = [f"src/mod_{i:04d}.ts" for i in range(1, 4)]
+    targets = mod._diagnostics_targets(mod_paths)
+
+    assert len(targets) == 2 * len(mod_paths)
+    for k, path in enumerate(mod_paths):
+        assert targets[2 * k] == (path, True)
+        assert targets[2 * k + 1] == (path, False)


### PR DESCRIPTION
Closes #278

## The correction

PR #277 recorded `diagnostics` at 378 ms median / 3.1 calls/s on a 5000-file project and
`docs/design/12-lsp-in-the-loop.md` attributed it to *"tsserver doing real whole-program semantic
work proportional to project size."* **That attribution was wrong.** ~350 ms of it is a fixed
client-side debounce inside the pinned `typescript-language-server` 5.3.0 (`cli.mjs:17868`'s
line-count clamp + `cli.mjs:20516`'s 50 ms `pDebounce`), spent before tsserver is asked anything.

## The median got worse, and that is correct

| | pre-fix (#277) | post-fix (#278) |
|---|---:|---:|
| `diagnostics` median | 378.1 ms | **376.4 ms** |
| `diagnostics` mean | 324.1 ms | 319.1 ms |
| `diagnostics` **min** | **0.292 ms** | **2.249 ms** |
| `diagnostics` nonempty_rate | 0.0% (benign clean→clean edits) | 33.5% (`introduce` 67%, `revert` 0% — correctly clean) |
| `n_no_publish` | n/a (counter didn't exist) | 0 |

The median reads flat, but that hides the real change: pre-fix, ~14% of the 200 samples (the
`min 0.292 ms` mode) were **stale-push short-circuits** — a push recorded *before* the edit,
wrongly accepted as the edit's answer by a seq race in `_push_is_current`
(`src/lsp/ts_service.py:532-539`). `update()` now pops `_diag_state[uri]` under the lock before
bumping the marker, closing that mode: `min_ms` moves from a sub-millisecond 0.292 to 2.249 ms — no
longer sub-millisecond, but still visibly fast, because a **different, narrower, and deliberately
unfixed residual** remains: a push already *in flight* (queued by an earlier `_ensure_open()`'s
`didOpen`, since the bench's `definition`/`completions`/`quickinfo`/`document_symbols` phases
already opened every path `diagnostics` later touches) can still land after the marker is taken but
before the genuine post-edit push, on a server that never sends a `version`. That is why
`nonempty_rate` measured 33.5% rather than the ~50% a fully clean measurement would show — reported
honestly rather than adjusted to fit. #279 (below) sidesteps this whole notification-race class.

## Both control sweeps (`scripts/probe_ts_lsp_debounce.py`, `results/ts_lsp_debounce_probe.json`)

Raw JSON-RPC, no `TsLspService`, no cache, no seq-marker — timing exactly
`didChange` → `publishDiagnostics`, alternating a real type error in and out every iteration.

**A. project-size sweep** (edit-file fixed at 12 lines) — debounce predicts FLAT, whole-program work
predicts RISING:

| n_files | median | minus predicted 350 ms |
|---:|---:|---:|
| 10 | 361.7 ms | 11.7 |
| 200 | 363.3 ms | 13.3 |
| 2,000 | 371.2 ms | 21.2 |
| 5,000 | 383.2 ms | 33.2 |

**B. file-length sweep** (project fixed at 200 files), against the clamp's own formula
`min(max(ceil(lines/20),300),800)+50`:

| edit-file lines | predicted | measured | residual |
|---:|---:|---:|---:|
| 12 | 350 ms | 361.6 | +11.6 |
| 6,000 | 350 ms | 365.0 | +15.0 |
| 12,000 | 650 ms | 665.5 | +15.5 |
| 20,000 | 850 ms | 870.2 | +20.2 |

Verdict: **`DEBOUNCE_CONFIRMED`**. 6,000 lines stays at the floor while 12,000 jumps to ~650 ms — the
clamp's exact shape across a 2.4× latency range. Genuine recheck cost once the debounce is
subtracted: **~11–33 ms**, inside the 50 ms bar.

## `references` and #226 — explicitly unchanged

`references` measured **502 ms** post-fix (was 506 ms) — genuine whole-project fan-in (queries
`Vec`/`scale` in `hub.ts`, imported by all 4,998 generated modules), unaffected by this issue. Only
the `diagnostics` attribution was wrong; this is not "the whole measurement was an artifact."
`completions` at ~2,500 calls/s (was 2,629) was never in question — #226 decode-time completion-list
masking remains throughput-clear. Verdict stays **WARN**.

## `n_no_publish` ambiguity and why the bench alternates

`cli.mjs:20524` returns early (never publishes) when a document's old and new diagnostic sets are
both empty, so a benign edit to an already-clean document may legitimately never get a push —
indistinguishable on this pin from "never answered." `diagnostics()` now counts this as
`n_no_publish`, separate from `n_timeouts` (a push that arrived but didn't match). The bench's timed
loop now alternates **introduce**/**revert** on the same path every iteration instead of always
appending a benign comment, specifically to keep the *timed* measurement out of that ambiguous case —
confirmed by `n_no_publish = 0` across the whole post-fix run.

## Follow-up unblocked

**#279** — a direct-`tsserver` `semanticDiagnosticsSync` bypass that skips
`typescript-language-server`'s notification layer (and its debounce, and the in-flight-push residual
above) entirely — is filed and now unblocked by this issue's confirmation. Patching the vendored
`cli.mjs` remains off-limits under the #246 bit-identity pin discipline.

## Commits

- `experiment:` the control probe + `results/ts_lsp_debounce_probe.json`
- `fix:` close the seq race in `ts_service.py`; add `n_no_publish`; regression tests
- `feat:` bench alternates introduce/revert + `--edit-file-lines`
- `docs:` correct `docs/design/12-lsp-in-the-loop.md`; regenerate `results/ts_lsp_bench.json`

## Testing

- [x] `.venv/bin/python -m pytest -q -rs` — 1334 passed, 13 skipped
- [x] `.venv/bin/python -m pytest -q tests/test_import_guard.py`
- [x] `PATH=/usr/bin:/bin .venv/bin/python -m pytest -q tests/test_ts_service_mechanism.py` (the real CI gate, no node toolchain)
- [x] `.venv/bin/python -m pytest -q tests/test_ts_service.py` (live, 11 passed)
- [x] `test_stale_push_before_didchange_is_not_returned` verified to **fail** against the pre-fix code (stashed the pop, confirmed the `["TS2339"]` regression, restored) and pass after
- [x] `scripts/probe_ts_lsp_debounce.py` and `scripts/bench_ts_lsp.py --n-files 5000 --warmup 20 --iters 200` re-run; `results/` regenerated