### PR TITLE
feat: [M12] SSI measurement contract (M1–M5) + escape-hatch gate

### DIFF
--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -584,7 +584,12 @@ for a metric that, on this evidence, would not even move.
   has a *higher* baseline clean-rate and a perfect `error_avoidance_rate` (see Ablations). The
   saturation is a property of the task, not of model capacity.
 - **Reward hacking**: `SUPPRESSION_RE` (`@ts-ignore`/`as any`) forces not-clean regardless of
-  `tsc`'s verdict; zero suppression hacks were observed in any table's transcript.
+  `tsc`'s verdict; zero suppression hacks were observed in any table's transcript. Note: the
+  clean-rate (0.887→0.962) and pass@1 (0.503) numbers above were measured under this **narrow**
+  three-hatch `SUPPRESSION_RE`, before the #225 ten-hatch escape-hatch gate
+  (`ESCAPE_HATCH_PATTERNS`, [`15-ssi-measurement-contract.md`](15-ssi-measurement-contract.md))
+  existed — a re-run under the extended gate has not been done and could in principle surface
+  suppression moves these numbers didn't catch.
 
 # Stage A — the real-analysis oracle: persistent TS-LSP + opengrep (#199 follow-up)
 

--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -394,11 +394,13 @@ as "the router is fine" — each case raises or is recorded as an explicit `None
 **secondary measurement-and-training-signal** axis riding on the MoE model, under a formal
 measurement contract:
 
-- **SSI-M — measurement contract** (#225): one variable per arm, ≥3 seeds + paired
+- **SSI-M — measurement contract** (#225, **done**): one variable per arm, ≥3 seeds + paired
   Wilcoxon/McNemar, repo-level contamination split, availability-vs-use null arms, and a shared
-  **escape-hatch lint gate** (extends `SUPPRESSION_RE` in `src/lsp/diagnostics.py` with
-  `as unknown as`, `@ts-nocheck`, non-null `!`, empty bodies, `throw …not implemented`, `declare`
-  stubs, deletion-of-target).
+  **escape-hatch lint gate** (extends `SUPPRESSION_RE`'s hatch set — the constant itself stays
+  byte-identical — with `as unknown as`, `@ts-nocheck`, non-null `!`, empty bodies, `throw …not
+  implemented`, `declare` stubs, deletion-of-target). See
+  [`15-ssi-measurement-contract.md`](15-ssi-measurement-contract.md) and
+  `src/eval/ssi_contract.py`.
 - **Surviving arms:** completion-list logit masking / constrained decode (#226), diagnostic
   supervision — rejection-sampled FT + contrastive hard negatives (#227), and **RLVR/GRPO with an
   LSP/opengrep verifier reward** (#230).

--- a/docs/design/15-ssi-measurement-contract.md
+++ b/docs/design/15-ssi-measurement-contract.md
@@ -1,0 +1,256 @@
+# The SSI measurement contract (#225)
+
+[← Index](README.md)
+
+The SSI axis ([topic 12](12-lsp-in-the-loop.md)'s arc-level assessment; [topic 13](13-code-model-moe.md)'s
+"SSI fold") is a *validated clean-rate tool with a found functional ceiling* — models get
+type-clean (0.887 → 0.962) without getting more correct (pass@1 flat at 0.503). That is
+precisely the situation where an under-specified measurement lets a reward-hacked or confounded
+result read as a win: a small, secondary axis with three still-unbuilt arms (#226 completion-list
+logit masking, #227 diagnostic supervision, #230 RLVR/opengrep verifier reward) is exactly where
+a shortcut is cheapest to take and hardest to notice. This doc encodes the contract those three
+arms must satisfy — **once**, in code, so compliance is checkable rather than asserted in a PR
+description. The module is `src/eval/ssi_contract.py`; every claim below carries a `src/...`
+path.
+
+Two concrete failure shapes motivated this (from the #225 issue body):
+
+1. **Confounded arms** — an arm that changes the signal *and* the prompt shape *and* the token
+   budget, so a delta can't be attributed to the signal; single-seed results reported as
+   effects; file-level (not repo-level) contamination splits leaking a near-duplicate sibling
+   file into eval.
+2. **Reward hacking that reads as clean** — the model makes `tsc` silent without fixing
+   anything. `SUPPRESSION_RE` (`src/lsp/diagnostics.py:49`) already catches three moves
+   (`@ts-ignore`, `@ts-expect-error`, `as any`); seven more (`as unknown as`, `@ts-nocheck`,
+   non-null `!`, empty bodies, `throw …not implemented`, `declare` stubs, deletion-of-target)
+   were invisible before this issue, so a #230 verifier reward would have paid for them.
+
+## M1 — one variable per arm
+
+**Rule.** Each declared arm changes exactly one thing relative to its baseline arm.
+
+**Why.** An arm that simultaneously changes the structural signal *and* the prompt shape *and*
+the token budget produces a delta that can't be attributed to any one of those — the classic
+confound this whole contract exists to prevent.
+
+**Mechanism.** `ArmSpec` (`src/eval/ssi_contract.py`) makes the variable a field, not a
+convention: `name`, `variable` (the one thing that changed), `baseline` (the arm it's compared
+against — a root/control arm self-references), `signal_available`, `signal_used` (see M4),
+`seeds` (see M2), `notes`. `validate_arms(arms)` raises `ContractViolation` when an arm declares
+an empty `variable`, when its `baseline` doesn't resolve to a declared arm, or when two arms
+compared against the *same* baseline declare the *same* `variable` **and** the same
+`signal_used` value — that last qualifier matters: an M4 null/treatment pair is *required* to
+share `(baseline, variable)` and differ only in `signal_used`, so the collision check is scoped
+to exclude exactly that deliberate pairing while still catching a genuine relabeling confound
+(two arms that are supposed to test different things sharing a variable name by mistake).
+`validate_arms` never returns a silent "looks fine" for an **empty** arm set — it raises, per the
+repo's standing rule that a check that cannot observe its target reports BLIND, never healthy.
+
+**How a run proves it.** `validate_arms(arms)` is called once, at the top of the arm's driver
+script, before any generation happens. A passing run's `contract_report(...)` output includes
+every arm's full `ArmSpec` (see the reporting block below), so the "one variable" claim is an
+artifact, not a sentence in a PR description.
+
+## M2 — ≥3 seeds + paired stats
+
+**Rule.** Every arm reports ≥3 seeds, and the arm-vs-baseline comparison uses paired statistics:
+per-seed McNemar (binary metrics), a cross-seed sign test, and — for continuous per-record
+metrics — exact Wilcoxon signed-rank.
+
+**Why.** A single-seed delta reported as "the effect" is exactly the kind of result this contract
+exists to prevent from reading as a win; the existing `src.eval.lsp_eval.compare`/
+`mcnemar_p_value` machinery (`src/eval/lsp_eval.py:139,154`) is strictly single-seed,
+single-pair, and `scripts/eval_lsp_harness.py` takes one `--seed` — neither aggregates.
+
+**Mechanism.** `ssi_contract.py` wraps, never reimplements, `lsp_eval.compare`:
+
+- `validate_arms` rejects any arm with `len(set(seeds)) < 3`.
+- `per_seed_compare(baseline_by_seed, other_by_seed, *, key)` runs one `compare(...)` per seed.
+  Paired means paired: it raises `ContractViolation` if the two arms' seed sets differ, or if any
+  seed's baseline/other record `id` sequence differs — `compare`'s own docstring puts the
+  sort/align burden on the caller, so this wrapper is what actually enforces it.
+- `pooled_compare(...)` concatenates every seed's aligned records into one `compare(...)` call,
+  reported *alongside*, never instead of, the per-seed table.
+- `sign_test_p(n_positive, n_negative)` is an exact two-sided binomial on the seed-level effect
+  *directions* (same sign in every seed?) — the same exact-enumeration style as
+  `mcnemar_p_value`, deliberately mirrored: `sign_test_p(3, 0) == 0.25`, `sign_test_p(0, 0) ==
+  1.0`, symmetric in its two arguments.
+- `wilcoxon_signed_rank_p(deltas)` is **exact** (enumerates all `2**n` sign assignments over the
+  ranks of the nonzero `|delta|`s) for continuous per-record metrics (BPB, pass@k rates) where
+  McNemar's binary table doesn't apply. `n > 20` raises `ValueError` rather than silently falling
+  back to a normal approximation — the same failure mode `mcnemar_p_value`'s docstring already
+  rejects (an approximation that's wrong at small `n`).
+- `summarize_arm(per_seed, sign_p, pooled)` is the reportable block: per-seed rates, mean ±
+  spread, the sign test, the pooled McNemar, and an explicit `"consistent_direction"` bool — a
+  reader sees directly whether every seed agreed on direction rather than inferring it from a
+  p-value.
+
+**How a run proves it.** The `stats` block of `contract_report(...)` carries `summarize_arm`'s
+output for every arm-vs-baseline pair — `n_seeds >= 3` and `consistent_direction` are visible
+without recomputing anything.
+
+## M3 — repo-level contamination split with a logged manifest
+
+**Rule.** Train/eval contamination splitting for any SSI corpus is done at repo granularity, not
+file granularity, and the split is logged in a manifest that can be checked, not just trusted.
+
+**Why.** `src/data/dedup.py`'s `Decontaminator` and `scripts/build_decontam_blocklist.py` do
+*benchmark-text* decontamination (n-gram matching against a fixed blocklist) — a different
+problem from partitioning a *training* corpus by repo so a near-duplicate sibling file from the
+same repo can't leak from train into eval. Repo identity already exists in the corpus:
+`src/data/stack_v2.py:93` sets `meta["repo"] = row["repo_name"]`, carried through
+`Record.meta` (`src/data/corpus.py:44-57`).
+
+**Mechanism.**
+
+- `repo_of(record)` reads `meta["repo"]` off either a `Record`-like object or a plain dict.
+  Returns `None` when absent — it never invents an identity.
+- `split_by_repo(records, *, eval_fraction, seed, on_unknown="raise")` assigns **whole repos** to
+  train/eval by a stable hash: `sha256(f"{seed}:{repo}")`'s leading 8 bytes, as a fraction of
+  `2**64`, compared against `eval_fraction`. Deliberately **not** Python's `hash()` — salted per
+  interpreter (the same gotcha already called out at `scripts/eval_code_suite.py:404`), so a
+  `hash()`-based split isn't reproducible across runs. A record with no repo identity is, per
+  `on_unknown`: `"raise"` (default) — because silently repo-splitting a corpus with no repo
+  identity would produce a *file-level* split wearing a repo-level label, the exact defect M3
+  exists to prevent — or `"quarantine"` — routed to a bucket in **neither** side, counted in the
+  manifest, never silently folded into train.
+- `assert_disjoint(train, eval)` raises `ContractViolation` if any repo appears on both sides —
+  the file-vs-repo bug this rule exists to catch.
+- `split_manifest(split)` returns `{n_train, n_eval, n_quarantine, n_train_repos, n_eval_repos,
+  eval_fraction, seed, eval_repos_sha256, manifest_sha256}`, following the byte-reproducible
+  manifest pattern of `scripts/build_decontam_blocklist.py`'s `blocklist.manifest.json`.
+  `eval_repos_sha256` hashes the sorted, newline-joined eval repo list, so two runs claiming the
+  same split can be *checked* against each other rather than trusted.
+
+**How a run proves it.** `contract_report(...)`'s `splits` block is `{name: split_manifest(...)}`
+for every corpus split the arm used — `n_quarantine` and `eval_repos_sha256` are visible without
+re-deriving the split.
+
+## M4 — availability-vs-use null arms
+
+**Rule.** Any arm with `signal_used=True` has a sibling null arm: same `variable`, same
+`baseline`, `signal_available=True`, `signal_used=False`.
+
+**Why.** Without the null arm, "the signal helped" is indistinguishable from "the arm got extra
+tokens / extra compute / a different prompt shape because the signal's plumbing was present" —
+an availability confound wearing an effect's clothes.
+
+**Mechanism.** `validate_arms` checks, for every `signal_used=True` arm, that some *other*
+declared arm shares its `(variable, baseline)`, has `signal_available=True`, and
+`signal_used=False`. No such sibling → `ContractViolation`.
+
+**How a run proves it.** The arm list in `contract_report(...)` is the `ArmSpec` for every arm
+that ran — a null arm with `signal_available=True, signal_used=False` sitting next to its
+treatment sibling is visible by inspection, and `validate_arms` having not raised is itself the
+proof the pairing exists.
+
+## M5 — the shared escape-hatch lint gate
+
+**Rule.** Every SSI arm gates its generated artifacts through the same escape-hatch detector
+before scoring "clean".
+
+**Why.** `SUPPRESSION_RE` (`src/lsp/diagnostics.py:49`) catches three reward-hacking moves
+(`@ts-ignore`, `@ts-expect-error`, `as any`) but not the other seven a model can use to make
+`tsc` silent without fixing anything.
+
+**Decision — two tiers, not an in-place widening of `SUPPRESSION_RE`.** `SUPPRESSION_RE` stays
+byte-identical and narrow. It is a *live in-loop control*, not just a metric:
+`src/lsp/harness.py:321` (`_is_clean`) uses it to force a mid-generation rollback, and
+`src/lsp/harness.py:501` (`generate_slow_loop`) uses it to set `reward_hack_detected`. Widening it
+in place would (a) silently redefine what the already-published #199 numbers (clean-rate
+0.887→0.962, pass@1 0.503) measured, making old and new runs non-comparable, and (b) put a
+non-null-`!` false positive — logical negation is the single most common operator in the
+language — on a hard rollback path. So the ten-hatch superset lives in a **new** constant,
+`ESCAPE_HATCH_PATTERNS`, that every SSI arm uses instead.
+
+**Mechanism** (`src/lsp/diagnostics.py`):
+
+- `mask_strings_and_comments(text)` blanks every character inside a string/template literal or a
+  comment to a space, preserving `len(text)` and every newline — built on the same
+  string/template/comment-aware `_scan` walk that `close_open_delimiters`/`statement_boundary`
+  already use, so all three agree on what counts as "inside a string/comment". `${...}`
+  interpolations stay live code (`_scan`'s own stack push takes them back to code context), which
+  is correct: a hatch written inside an interpolation is real code, not string content.
+- `ESCAPE_HATCH_PATTERNS: Dict[str, re.Pattern]` — nine named regex hatches (a tenth,
+  `deletion_of_target`, is structural, see below):
+
+  | Name | Text matched | Notes |
+  |---|---|---|
+  | `ts_ignore` / `ts_expect_error` / `ts_nocheck` | raw | directives live inside comments by definition |
+  | `as_any` / `as_unknown_as` | masked | prose ("`// use as any`") must not fire |
+  | `non_null_assertion` | masked | postfix `!` only — lookbehind + `(?!=)` excludes `!=`/`!==`/prefix `!x` |
+  | `empty_body` | masked | `)…{}`  or `=>…{}` |
+  | `declare_stub` | masked | `^\s*declare (function\|const\|…)` |
+  | `throw_not_implemented` | raw, guarded | see below |
+
+  `throw_not_implemented` is the one hatch that must see real, unmasked string content — the
+  thing it's checking (`"not implemented"`/`"unimplemented"`/`"TODO"`) **is** the string content,
+  so masking it away would make the hatch permanently dead. It matches raw text, but a candidate
+  match whose `throw` keyword itself falls inside a masked span (the statement is commented out,
+  or sits inside an unrelated string) is discarded — checking whether `masked[start:start+5]`
+  still reads `"throw"` is exactly that signal.
+- `find_escape_hatches(text) -> List[str]` returns the sorted names present;
+  `has_escape_hatch(text) -> bool` is the go/no-go form.
+- `deletion_of_target(before, after, *, anchors)` is the **tenth**, structural hatch — the
+  degenerate "delete the thing the diagnostic was about" move. Returns the `anchors` present in
+  `before` and absent from `mask_strings_and_comments(after)` (so commenting the target out
+  counts as deletion too). Anchors are **injected by the calling arm** (the symbol under test,
+  its signature, the call site) — never guessed from the text, because guessing is exactly the
+  silent-mismatch failure this whole contract exists to prevent.
+- `src/eval/ssi_contract.py` re-exports `find_escape_hatches`/`has_escape_hatch`/
+  `deletion_of_target` so an arm has one import surface
+  (`from src.eval.ssi_contract import ...`) — "applied identically across arms" becomes a
+  property of the import, not of discipline.
+
+**How a run proves it.** Every scored record an arm reports should carry
+`find_escape_hatches(artifact)`; a nonempty list forces the record to score not-clean regardless
+of `tsc`'s own verdict, mirroring `score_record`'s existing `suppression_hack` handling
+(`src/eval/lsp_eval.py:64`).
+
+## The reporting block
+
+`contract_report(arms, splits, stats)` (`src/eval/ssi_contract.py`) assembles the JSON block a
+run writes next to its results — the artifact that makes M1–M5 compliance auditable after the
+fact rather than asserted in a PR description:
+
+```json
+{
+  "arms": [
+    {"name": "...", "variable": "...", "baseline": "...",
+     "signal_available": true, "signal_used": false, "seeds": [1, 2, 3], "notes": "..."}
+  ],
+  "splits": {"main": {"n_train": 0, "n_eval": 0, "n_quarantine": 0,
+                       "n_train_repos": 0, "n_eval_repos": 0,
+                       "eval_fraction": 0.0, "seed": 0,
+                       "eval_repos_sha256": "...", "manifest_sha256": "..."}},
+  "stats": {"treatment_vs_baseline": {"n_seeds": 3, "mean_delta": 0.0,
+                                        "delta_spread": 0.0, "sign_test_p": 0.0,
+                                        "pooled": {}, "consistent_direction": true}}
+}
+```
+
+## Known limits
+
+- **`non_null_assertion` false positives.** `a! = b` (a space before `=` defeats the `(?!=)`
+  negative lookahead) is a known, accepted residual false positive. Kept out of `SUPPRESSION_RE`
+  on purpose (see M5) so it never reaches the hard-rollback path.
+- **`empty_body` false positives.** A legitimately empty `catch {}` or `constructor() {}` fires.
+  Accepted — the gate is conservative by design (a hatch present scores not-clean), and
+  `find_escape_hatches` names *which* hatch fired so a caller can see this rather than eat an
+  opaque bool.
+- **`mask_strings_and_comments` residual imprecision.** `_scan` yields only one index for a
+  two-character token (`\x` escape, `${`, `*/`, opening `//`); the *second* character of such a
+  token is never independently visited and can survive unmasked as stray punctuation. This
+  cannot itself spell a whole hatch pattern except in a contrived, invalid-TypeScript corner case
+  (an empty `${}` interpolation) — documented, not fixed.
+- **Exact Wilcoxon's `n <= 20` ceiling.** `wilcoxon_signed_rank_p` raises past 20 nonzero deltas
+  rather than falling back to a normal approximation. An arm with a larger continuous-metric
+  record count needs a different (not-yet-built) exact or resampling method; using the normal
+  approximation silently would reintroduce the small-`n` unreliability `mcnemar_p_value`'s
+  docstring already rejects.
+- **`deletion_of_target` anchors are arm-supplied**, never inferred. A caller that skips this or
+  supplies a vacuous anchor set gets a silent `[]` — the function has no way to detect "the arm
+  forgot to pass real anchors" versus "the target genuinely survived".
+- **`meta["repo"]` availability.** Only `src/data/stack_v2.py` populates it today. `on_unknown=
+  "raise"` is the default specifically so a corpus without repo identity fails loud instead of
+  producing a file-level split wearing a repo-level label.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -59,6 +59,10 @@ Every claim here is sourced from a docstring or config comment in the code, with
 14. [The native inference + training engine (Swift + MLX)](14-inference-engine.md) — the M13
     engine (#163): prefill-via-scan, quantization, speculative decoding, the Swift train step +
     checkpoint I/O, and the B1–B4 investigation behind **Swift/MLX, Mac-first**.
+15. [The SSI measurement contract](15-ssi-measurement-contract.md) — **done** (#225): the M1–M5
+    rules every SSI arm (#226/#227/#230) must satisfy — one variable per arm, ≥3 seeds + paired
+    McNemar/sign-test/Wilcoxon, repo-level contamination split with a logged manifest,
+    availability-vs-use null arms, and the ten-hatch shared escape-hatch lint gate.
 
 > **The live program is topic 13** (M12, [#198](https://github.com/travisgalloway/monica/issues/198)):
 > a from-scratch Mamba-2 hybrid **MoE code model** with the structural-signal (SSI) fold as a
@@ -92,6 +96,7 @@ Every claim here is sourced from a docstring or config comment in the code, with
 | Tokenizer (M12) | **own byte-level BPE — native Swift** (`swift/MonicaTokenizer`, #191/#245) | cross-platform (macOS + Linux/CUDA), bit-identical; own tiktoken-style format; o200k-style pretokenizer (digit-split ≤3, indentation merge); uint16; **MLX deliberately not used** (BPE is CPU/integer work). Python code-path retired | `docs/design/13-code-model-moe.md` (MHM-P1b) |
 | Model sizes (M12) | small ~120M-act/700M-tot; large "Large A" ~700M-act/3.5B-tot — **both at `d_model 768`** | large is **sparse-upcycled** from the small dense ckpt (#200); ablation sweep picks the layout (#219). **Resolved 2026-08-09 (#272):** Large A was re-shaped from `d_model 1536` to 768 (56 layers, `moe_every 3`, 64 experts top-8, `moe_d_ff = d_inner` → 3.88B/710M) so a single dense run seeds both rungs. **#271** (FSDP/expert-parallel) is still unbuilt and blocks the large run | `docs/design/13-code-model-moe.md` |
 | Structural signal (M12, secondary) | LSP/opengrep as measurement + training signal (SSI) | validated clean-rate tool, functional ceiling found; #225/#226/#227/#230 | `docs/design/13-code-model-moe.md` |
+| SSI measurement contract | M1–M5: one variable/arm, ≥3 seeds + paired stats, repo-level split, null arms, ten-hatch lint gate | prevents confounded arms and reward hacking from reading as a win (#225) | `src/eval/ssi_contract.py`, `docs/design/15-ssi-measurement-contract.md` |
 | Data framework | `datatrove` + R2 + RunPod | builds the M12 corpus (Essential-Web + Stack-v2, #193) + reserve data. For the M12 code corpus, Python **cleans** (→ `cleaned.jsonl`); the native Swift `monica-tokenize pack` **tokenizes+packs** | `docs/design/08-corpus-pipeline.md` |
 | Native engine (M13) | **Swift + MLX, Mac-first** (B1); ggml/llama.cpp port deferred | reuses our MLX numerics/weights/quant and the native `swift/MonicaTokenizer`; parity-checkable against the Python seam at fp32 ~1e-4. Not Mac-locked (mlx-swift#320 CUDA build) but Apple Silicon first; ggml is gated on arch freeze + MoE-Mamba support and has no training path | `docs/design/14-inference-engine.md` |
 | Build method (reserve) | **distillation** from a frozen teacher — Qwen3 vocab, `Qwen/Qwen3-4B-Thinking-2507`, ~1B student | M10 program, **dropped 2026-07-19**; machinery built then pruned from the tree (#189/#248), design record kept as history | `docs/reserve/10-distillation.md` |

--- a/src/eval/ssi_contract.py
+++ b/src/eval/ssi_contract.py
@@ -1,0 +1,387 @@
+"""#225 -- the SSI measurement contract (M1-M5): the shared module every SSI arm
+(#226 completion-list logit masking, #227 diagnostic supervision, #230 RLVR/
+opengrep verifier reward) imports, so "applied identically across arms" is a
+property of the import surface, not of discipline. Full rule / why / mechanism
+/ how-a-run-proves-compliance writeup: `docs/design/15-ssi-measurement-contract.md`.
+
+Wraps, never duplicates: `src.eval.lsp_eval.compare`/`mcnemar_p_value` for the
+per-seed paired statistic (M2), and re-exports `src.lsp.diagnostics`'s
+escape-hatch gate (M5) so an arm has one import surface for the whole contract.
+
+Portable, stdlib-only (`dataclasses`, `hashlib`, `json`, `math.comb`) -- mirrors
+`lsp_eval.py`'s own constraint (no numpy), so nothing new for the import guard
+to worry about beyond the `PORTABLE_MODULES` listing.
+
+ABOVE THE SEAM -- stdlib only. No `mlx`/`torch` import anywhere in this module
+(guarded by `tests/test_import_guard.py`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from math import comb
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from ..lsp.diagnostics import deletion_of_target, find_escape_hatches, has_escape_hatch
+from .lsp_eval import compare
+
+__all__ = [
+    "ContractViolation",
+    "ArmSpec", "validate_arms",
+    "per_seed_compare", "pooled_compare", "sign_test_p", "wilcoxon_signed_rank_p",
+    "summarize_arm",
+    "repo_of", "RepoSplit", "split_by_repo", "split_manifest", "assert_disjoint",
+    "find_escape_hatches", "has_escape_hatch", "deletion_of_target",
+    "contract_report",
+]
+
+
+class ContractViolation(Exception):
+    """Raised whenever an arm set, a paired comparison, or a repo split fails
+    one of the #225 M1-M5 rules."""
+
+
+# --------------------------------------------------------------------------- #
+# M1 + M4 -- arm declaration and validation
+# --------------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class ArmSpec:
+    """One measured SSI arm. `variable` is the ONE thing this arm changes vs.
+    `baseline` -- M1's "one variable per arm" rule made a field instead of a
+    convention. A root/control arm self-references (`baseline == name`), which
+    trivially satisfies "baseline resolves to a declared arm"."""
+    name: str
+    variable: str
+    baseline: str
+    signal_available: bool
+    signal_used: bool
+    seeds: Tuple[int, ...]
+    notes: str = ""
+
+
+def validate_arms(arms: Sequence[ArmSpec]) -> None:
+    """Raise `ContractViolation` if `arms` fails M1 (one variable per arm), M2
+    (>=3 seeds), or M4 (availability-vs-use null arms).
+
+    Never returns a "looks fine" for an EMPTY arm set -- per the repo's
+    standing rule that a check that cannot observe its target reports BLIND,
+    never healthy (an empty set is not evidence of a compliant set).
+    """
+    if not arms:
+        raise ContractViolation("empty arm set -- nothing was validated")
+
+    by_name = {a.name: a for a in arms}
+
+    for a in arms:
+        if not a.variable:
+            raise ContractViolation(f"arm {a.name!r} declares an empty variable")
+        if a.baseline not in by_name:
+            raise ContractViolation(
+                f"arm {a.name!r} declares baseline {a.baseline!r}, which is not a "
+                f"declared arm")
+        if len(set(a.seeds)) < 3:
+            raise ContractViolation(
+                f"arm {a.name!r} declares {len(set(a.seeds))} distinct seed(s), "
+                f"M2 requires >= 3")
+
+    # M1: two arms compared against the SAME baseline must not share `variable`
+    # -- that would be two confounded changes measured as if they were one.
+    # Scoped by `signal_used` too: an M4 null/treatment PAIR is REQUIRED to
+    # share (baseline, variable) and differ only in signal_used -- that is not
+    # the confound M1 exists to catch, it is the deliberate pairing M4 demands.
+    seen: Dict[Tuple[str, str, bool], str] = {}
+    for a in arms:
+        key = (a.baseline, a.variable, a.signal_used)
+        if key in seen and seen[key] != a.name:
+            raise ContractViolation(
+                f"arms {seen[key]!r} and {a.name!r} both declare variable "
+                f"{a.variable!r} against baseline {a.baseline!r} with the same "
+                f"signal_used={a.signal_used}")
+        seen[key] = a.name
+
+    # M4: every signal_used arm needs a null sibling -- same variable/baseline,
+    # signal_available=True, signal_used=False. Without it, "the signal helped"
+    # is indistinguishable from "the arm got extra tokens / compute / a
+    # different prompt shape".
+    for a in arms:
+        if not a.signal_used:
+            continue
+        has_null = any(
+            o.name != a.name and o.variable == a.variable and o.baseline == a.baseline
+            and o.signal_available and not o.signal_used
+            for o in arms
+        )
+        if not has_null:
+            raise ContractViolation(
+                f"arm {a.name!r} has signal_used=True but no availability-vs-use "
+                f"null sibling (same variable/baseline, signal_available=True, "
+                f"signal_used=False)")
+
+
+# --------------------------------------------------------------------------- #
+# M2 -- multi-seed paired stats, built on lsp_eval.compare
+# --------------------------------------------------------------------------- #
+
+def per_seed_compare(baseline_by_seed: Mapping[int, Sequence[dict]],
+                      other_by_seed: Mapping[int, Sequence[dict]],
+                      *, key: str) -> Dict[int, dict]:
+    """One `lsp_eval.compare(...)` per seed. Paired means paired: raises if the
+    two arms' seed sets differ, or if any seed's baseline/other record `id`
+    sequence differs between arms -- `compare` matches by position and its
+    docstring already puts the sort/align burden on the caller; this wrapper
+    enforces that the caller actually did it.
+    """
+    if set(baseline_by_seed) != set(other_by_seed):
+        raise ContractViolation(
+            f"seed sets differ: baseline has {sorted(baseline_by_seed)}, "
+            f"other has {sorted(other_by_seed)}")
+
+    out: Dict[int, dict] = {}
+    for seed, baseline_recs in baseline_by_seed.items():
+        other_recs = other_by_seed[seed]
+        base_ids = [r["id"] for r in baseline_recs]
+        other_ids = [r["id"] for r in other_recs]
+        if base_ids != other_ids:
+            raise ContractViolation(
+                f"seed {seed}: record id order differs between baseline and "
+                f"other ({base_ids} vs {other_ids})")
+        out[seed] = compare(baseline_recs, other_recs, key=key)
+    return out
+
+
+def pooled_compare(baseline_by_seed: Mapping[int, Sequence[dict]],
+                    other_by_seed: Mapping[int, Sequence[dict]],
+                    *, key: str) -> dict:
+    """Concatenate every seed's aligned records and run ONE `compare`. Reported
+    alongside, never instead of, `per_seed_compare`'s per-seed table."""
+    if set(baseline_by_seed) != set(other_by_seed):
+        raise ContractViolation(
+            f"seed sets differ: baseline has {sorted(baseline_by_seed)}, "
+            f"other has {sorted(other_by_seed)}")
+
+    baseline_all: List[dict] = []
+    other_all: List[dict] = []
+    for seed in sorted(baseline_by_seed):
+        baseline_all.extend(baseline_by_seed[seed])
+        other_all.extend(other_by_seed[seed])
+    return compare(baseline_all, other_all, key=key)
+
+
+def sign_test_p(n_positive: int, n_negative: int) -> float:
+    """Exact two-sided sign test on the seed-level effect directions: does the
+    delta have the same sign in every seed more than chance would predict?
+    Same exact-enumeration style as `lsp_eval.mcnemar_p_value`, which it
+    deliberately mirrors (`(3, 0) -> 0.25`, `(0, 0) -> 1.0`, symmetric in its
+    two arguments).
+    """
+    n = n_positive + n_negative
+    if n == 0:
+        return 1.0
+    k = min(n_positive, n_negative)
+    tail = sum(comb(n, i) for i in range(0, k + 1)) / (2 ** n)
+    return min(1.0, 2 * tail)
+
+
+def wilcoxon_signed_rank_p(deltas: Sequence[float]) -> float:
+    """Exact two-sided Wilcoxon signed-rank test p-value, for continuous
+    per-record metrics (BPB, pass@k rates) where McNemar's binary
+    discordant-pair table doesn't apply. Zero-valued deltas carry no
+    directional information and are dropped before ranking (standard
+    procedure) -- an all-zero delta vector is therefore `n == 0` and returns
+    `1.0`.
+
+    Exact by enumerating all `2**n` sign assignments over the ranks of the
+    surviving `|delta|`s. `n > 20` raises `ValueError` rather than silently
+    falling back to a normal approximation -- an approximation that is wrong
+    at small `n` is the same failure mode `mcnemar_p_value`'s docstring
+    already rejects.
+    """
+    nonzero = [d for d in deltas if d != 0]
+    n = len(nonzero)
+    if n == 0:
+        return 1.0
+    if n > 20:
+        raise ValueError(
+            f"wilcoxon_signed_rank_p is exact only up to n=20 nonzero deltas, got {n}")
+
+    abs_deltas = [abs(d) for d in nonzero]
+    order = sorted(range(n), key=lambda i: abs_deltas[i])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and abs_deltas[order[j + 1]] == abs_deltas[order[i]]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg_rank
+        i = j + 1
+
+    signs = [1 if d > 0 else -1 for d in nonzero]
+    w_observed = sum(r for r, s in zip(ranks, signs) if s > 0)
+    center = sum(ranks) / 2.0
+    dist = abs(w_observed - center)
+
+    extreme = 0
+    for mask in range(2 ** n):
+        w = sum(ranks[i] for i in range(n) if (mask >> i) & 1)
+        if abs(w - center) >= dist - 1e-9:
+            extreme += 1
+    return min(1.0, extreme / (2 ** n))
+
+
+def summarize_arm(per_seed: Mapping[int, dict], sign_p: float, pooled: dict) -> dict:
+    """The reportable block for one arm's M2 comparison: per-seed rates, mean +-
+    spread, the sign test across seeds, the pooled McNemar, and an explicit
+    `"consistent_direction"` bool -- a caller sees directly whether every seed
+    agreed on direction rather than having to infer it from a p-value.
+    """
+    deltas = [s["other_rate"] - s["baseline_rate"] for s in per_seed.values()]
+    n = len(deltas)
+    mean_delta = (sum(deltas) / n) if n else float("nan")
+    delta_spread = (max(deltas) - min(deltas)) if n else float("nan")
+    signs = {(1 if d > 0 else (-1 if d < 0 else 0)) for d in deltas}
+    consistent_direction = bool(signs) and (signs - {0} in ({1}, {-1}, set()))
+
+    return {
+        "n_seeds": n,
+        "per_seed": {
+            seed: {"baseline_rate": s["baseline_rate"], "other_rate": s["other_rate"],
+                   "mcnemar_p": s["mcnemar_p"]}
+            for seed, s in per_seed.items()
+        },
+        "mean_delta": mean_delta,
+        "delta_spread": delta_spread,
+        "sign_test_p": sign_p,
+        "pooled": pooled,
+        "consistent_direction": consistent_direction,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# M3 -- repo-level contamination split + manifest
+# --------------------------------------------------------------------------- #
+
+def repo_of(record: Any) -> Optional[str]:
+    """`record.meta["repo"]` (populated only by `src.data.stack_v2:93` today).
+    Returns `None` when absent -- never invents an identity. Accepts either a
+    `src.data.corpus.Record`-like object (`.meta` attribute) or a plain dict
+    with a `"meta"` key, so callers aren't forced through one shape."""
+    meta = getattr(record, "meta", None)
+    if meta is None and isinstance(record, Mapping):
+        meta = record.get("meta")
+    return (meta or {}).get("repo")
+
+
+@dataclass(frozen=True)
+class RepoSplit:
+    train: Tuple[Any, ...]
+    eval: Tuple[Any, ...]
+    quarantine: Tuple[Any, ...]
+    eval_fraction: float
+    seed: int
+
+
+def split_by_repo(records: Sequence[Any], *, eval_fraction: float, seed: int,
+                   on_unknown: str = "raise") -> RepoSplit:
+    """Assign WHOLE repos to train/eval by a stable hash --
+    `sha256(f"{seed}:{repo}")` compared against `eval_fraction` -- deliberately
+    NOT Python's `hash()`, which is salted per interpreter (the same gotcha
+    already called out at `scripts/eval_code_suite.py:404`) and so is not
+    reproducible across runs.
+
+    Records whose repo is `None` (`repo_of` returned nothing) are, per
+    `on_unknown`: `"raise"` (default) -- an SSI arm silently repo-splitting a
+    corpus with no repo identity would produce a *file-level* split wearing a
+    repo-level label, exactly the defect M3 exists to prevent; or
+    `"quarantine"` -- routed to a bucket that is in NEITHER side and IS
+    counted in the manifest, never silently dropped into train.
+    """
+    if on_unknown not in ("raise", "quarantine"):
+        raise ValueError(f"on_unknown must be 'raise' or 'quarantine', got {on_unknown!r}")
+
+    train: List[Any] = []
+    ev: List[Any] = []
+    quarantine: List[Any] = []
+    repo_side: Dict[str, str] = {}
+
+    for rec in records:
+        repo = repo_of(rec)
+        if repo is None:
+            if on_unknown == "raise":
+                raise ContractViolation(
+                    "record has no meta['repo'] -- cannot repo-split it (pass "
+                    "on_unknown='quarantine' to bucket instead of raising)")
+            quarantine.append(rec)
+            continue
+        side = repo_side.get(repo)
+        if side is None:
+            digest = hashlib.sha256(f"{seed}:{repo}".encode("utf-8")).digest()
+            frac = int.from_bytes(digest[:8], "big") / float(1 << 64)
+            side = "eval" if frac < eval_fraction else "train"
+            repo_side[repo] = side
+        (ev if side == "eval" else train).append(rec)
+
+    return RepoSplit(train=tuple(train), eval=tuple(ev), quarantine=tuple(quarantine),
+                      eval_fraction=eval_fraction, seed=seed)
+
+
+def assert_disjoint(train: Sequence[Any], eval_: Sequence[Any]) -> None:
+    """Raise `ContractViolation` if any repo appears on both sides -- the
+    file-vs-repo bug M3 exists to catch (a near-duplicate sibling file from the
+    same repo landing in eval)."""
+    train_repos = {r for r in (repo_of(rec) for rec in train) if r is not None}
+    eval_repos = {r for r in (repo_of(rec) for rec in eval_) if r is not None}
+    overlap = train_repos & eval_repos
+    if overlap:
+        raise ContractViolation(f"repos present on both sides of the split: {sorted(overlap)}")
+
+
+def split_manifest(split: RepoSplit) -> dict:
+    """Byte-reproducible manifest for a `RepoSplit`, following
+    `scripts/build_decontam_blocklist.py`'s provenance-manifest pattern.
+    `eval_repos_sha256` is over the sorted, newline-joined eval repo list, so
+    two runs claiming the same split can be CHECKED, not merely trusted.
+    """
+    train_repos = sorted({r for r in (repo_of(rec) for rec in split.train) if r is not None})
+    eval_repos = sorted({r for r in (repo_of(rec) for rec in split.eval) if r is not None})
+    eval_repos_sha256 = hashlib.sha256(
+        ("\n".join(eval_repos) + "\n").encode("utf-8")).hexdigest()
+
+    manifest = {
+        "n_train": len(split.train),
+        "n_eval": len(split.eval),
+        "n_quarantine": len(split.quarantine),
+        "n_train_repos": len(train_repos),
+        "n_eval_repos": len(eval_repos),
+        "eval_fraction": split.eval_fraction,
+        "seed": split.seed,
+        "eval_repos_sha256": eval_repos_sha256,
+    }
+    manifest["manifest_sha256"] = hashlib.sha256(
+        json.dumps(manifest, sort_keys=True).encode("utf-8")).hexdigest()
+    return manifest
+
+
+# --------------------------------------------------------------------------- #
+# Glue -- the single reportable artifact
+# --------------------------------------------------------------------------- #
+
+def contract_report(arms: Sequence[ArmSpec], splits: Mapping[str, RepoSplit],
+                     stats: Mapping[str, dict]) -> dict:
+    """Assemble the JSON block a run writes next to its results -- the artifact
+    that makes M1-M5 compliance auditable after the fact rather than merely
+    asserted in a PR description."""
+    return {
+        "arms": [
+            {"name": a.name, "variable": a.variable, "baseline": a.baseline,
+             "signal_available": a.signal_available, "signal_used": a.signal_used,
+             "seeds": list(a.seeds), "notes": a.notes}
+            for a in arms
+        ],
+        "splits": {name: split_manifest(s) for name, s in splits.items()},
+        "stats": dict(stats),
+    }

--- a/src/eval/ssi_contract.py
+++ b/src/eval/ssi_contract.py
@@ -73,6 +73,14 @@ def validate_arms(arms: Sequence[ArmSpec]) -> None:
     if not arms:
         raise ContractViolation("empty arm set -- nothing was validated")
 
+    seen_names: set = set()
+    for a in arms:
+        if not a.name:
+            raise ContractViolation("arm declares an empty name")
+        if a.name in seen_names:
+            raise ContractViolation(f"duplicate arm name {a.name!r}")
+        seen_names.add(a.name)
+
     by_name = {a.name: a for a in arms}
 
     for a in arms:
@@ -165,8 +173,16 @@ def pooled_compare(baseline_by_seed: Mapping[int, Sequence[dict]],
     baseline_all: List[dict] = []
     other_all: List[dict] = []
     for seed in sorted(baseline_by_seed):
-        baseline_all.extend(baseline_by_seed[seed])
-        other_all.extend(other_by_seed[seed])
+        baseline_recs = baseline_by_seed[seed]
+        other_recs = other_by_seed[seed]
+        base_ids = [r["id"] for r in baseline_recs]
+        other_ids = [r["id"] for r in other_recs]
+        if base_ids != other_ids:
+            raise ContractViolation(
+                f"seed {seed}: record id order differs between baseline and "
+                f"other ({base_ids} vs {other_ids})")
+        baseline_all.extend(baseline_recs)
+        other_all.extend(other_recs)
     return compare(baseline_all, other_all, key=key)
 
 
@@ -244,7 +260,10 @@ def summarize_arm(per_seed: Mapping[int, dict], sign_p: float, pooled: dict) -> 
     mean_delta = (sum(deltas) / n) if n else float("nan")
     delta_spread = (max(deltas) - min(deltas)) if n else float("nan")
     signs = {(1 if d > 0 else (-1 if d < 0 else 0)) for d in deltas}
-    consistent_direction = bool(signs) and (signs - {0} in ({1}, {-1}, set()))
+    # All-zero deltas carry no direction to be consistent about -- exclude {0}
+    # from the "consistent" outcomes (an empty non-zero-sign set, e.g. n == 0
+    # or every delta exactly 0, is correctly `False` here).
+    consistent_direction = (signs - {0}) in ({1}, {-1})
 
     return {
         "n_seeds": n,
@@ -362,7 +381,8 @@ def split_manifest(split: RepoSplit) -> dict:
         "eval_repos_sha256": eval_repos_sha256,
     }
     manifest["manifest_sha256"] = hashlib.sha256(
-        json.dumps(manifest, sort_keys=True).encode("utf-8")).hexdigest()
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
     return manifest
 
 

--- a/src/lsp/diagnostics.py
+++ b/src/lsp/diagnostics.py
@@ -453,7 +453,9 @@ def mask_strings_and_comments(text: str) -> str:
 
 # Directive hatches live inside comments by definition -> matched against RAW
 # text. `throw_not_implemented` is also matched raw (see `find_escape_hatches`'s
-# docstring for why) but is handled separately, not listed here.
+# docstring for why) but is handled separately in that function's own logic,
+# not added to THIS frozenset -- it is still one of the nine regex entries in
+# `ESCAPE_HATCH_PATTERNS` below.
 _RAW_HATCH_NAMES = frozenset({"ts_ignore", "ts_expect_error", "ts_nocheck"})
 
 #: The #225 M5 superset -- ten hatches total counting `deletion_of_target`
@@ -495,9 +497,11 @@ def find_escape_hatches(text: str) -> List[str]:
     contract.md` (M5).
 
     Directive hatches (`ts_ignore`/`ts_expect_error`/`ts_nocheck`) match RAW
-    text. The other five regex hatches match `mask_strings_and_comments(text)`
-    so prose ("// don't use as any here", a string literal containing "as any")
-    never counts.
+    text. Of the six remaining (non-directive) regex hatches, five --
+    `as_any`/`as_unknown_as`/`non_null_assertion`/`empty_body`/`declare_stub`
+    -- match `mask_strings_and_comments(text)` so prose ("// don't use as any
+    here", a string literal containing "as any") never counts. The sixth,
+    `throw_not_implemented`, is the raw-text exception described next.
 
     `throw_not_implemented` is the one hatch that must see real, unmasked string
     content (the error message it is checking is itself string content) -- it is
@@ -529,17 +533,20 @@ def has_escape_hatch(text: str) -> bool:
 def deletion_of_target(before: str, after: str, *, anchors: Sequence[str]) -> List[str]:
     """The tenth #225 escape hatch, structural rather than lexical: the model
     "fixes" a diagnostic by deleting the thing it was about. Returns the sorted
-    subset of `anchors` present in `before` and absent from
-    `mask_strings_and_comments(after)` -- masking `after` (not `before`) means
-    commenting the target out counts as deletion too, matching the "delete the
-    evidence" move this hatch exists to catch.
+    subset of `anchors` present in `mask_strings_and_comments(before)` and
+    absent from `mask_strings_and_comments(after)` -- masking `before` avoids a
+    false "was present" from an anchor that only ever appeared inside a
+    string/comment (never real code) in `before`; masking `after` means
+    commenting the target out there counts as deletion too, matching the
+    "delete the evidence" move this hatch exists to catch.
 
     `anchors` are injected by the CALLER (the symbol under test, its signature,
     the call site) -- never guessed from the text, because guessing is exactly
     the kind of silent mismatch this measurement contract exists to prevent.
     """
+    before_masked = mask_strings_and_comments(before)
     after_masked = mask_strings_and_comments(after)
-    return sorted(a for a in anchors if a in before and a not in after_masked)
+    return sorted(a for a in anchors if a in before_masked and a not in after_masked)
 
 
 def statement_boundary(text: str) -> Optional[int]:

--- a/src/lsp/diagnostics.py
+++ b/src/lsp/diagnostics.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import bisect
 import re
 from dataclasses import dataclass, replace
-from typing import Callable, Iterator, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, Iterator, List, Optional, Sequence, Tuple
 
 # --------------------------------------------------------------------------- #
 # Parsing
@@ -46,6 +46,16 @@ _DIAG_RE_PRETTY = re.compile(
 )
 
 # Reward-hacking suppressions: these make `tsc` "clean" without fixing anything.
+#
+# LEFT NARROW ON PURPOSE (#225 decision record). This is a live in-loop control, not
+# just a metric: `harness.py`'s `_is_clean` uses it to force a mid-generation rollback,
+# and `generate_slow_loop` uses it to set `reward_hack_detected`. Widening it in place
+# would (a) silently redefine what the already-published #199 numbers (clean-rate
+# 0.887->0.962, pass@1 0.503) measured, making old and new runs non-comparable, and
+# (b) put a non-null-`!` false positive -- logical negation is the single most common
+# operator in the language -- on a hard rollback path. #225's superset of 10 hatches
+# lives in `ESCAPE_HATCH_PATTERNS` below instead; every SSI arm (#226/#227/#230) uses
+# that, not this constant. See `docs/design/15-ssi-measurement-contract.md` (M5).
 SUPPRESSION_RE = re.compile(r"@ts-ignore|@ts-expect-error|\bas\s+any\b")
 
 # The TS1xxx family: syntax-incompleteness codes (e.g. TS1003 "Identifier
@@ -399,6 +409,137 @@ def close_open_delimiters(source: str) -> str:
         else:
             parts.append(item)
     return source + "".join(parts)
+
+
+def mask_strings_and_comments(text: str) -> str:
+    """Blank out every character that lives inside a string/template literal or a
+    comment, replacing it with a space -- preserves `len(text)` and every newline
+    position, so offsets computed against the masked text stay meaningful against
+    `text` itself. Built on `_scan`, the same string/template/comment-aware
+    delimiter walk `close_open_delimiters`/`statement_boundary` already use, so
+    all three agree on what counts as "inside a string/comment" vs "real code".
+
+    A character is masked if the open-delimiter stack was in a danger state
+    either *before* or *after* it was consumed -- covering both the opening and
+    the closing delimiter of a string/comment, not just its interior (`_scan`
+    pops the stack before yielding a closer, so checking only the post-consumption
+    top would leave the closing quote/`*/` unmasked). `${...}` interpolations
+    inside a template literal are NOT masked -- `_scan`'s own stack push takes
+    them back to "real code" context, which is correct: a hatch written inside an
+    interpolation is live code, not string content.
+
+    Known residual imprecision: `_scan` yields only one index for a two-character
+    token (`\\x` escape, `${`, `*/`, the opening `//`), so the *second* character
+    of such a token is never independently visited and can survive unmasked as
+    stray punctuation. This never spells a real word, so it cannot itself satisfy
+    any `ESCAPE_HATCH_PATTERNS` entry except in a contrived, invalid-TypeScript
+    corner case (e.g. an empty `${}` interpolation) -- documented, not fixed.
+    """
+    danger = _QUOTES + ("/*", "//")
+    out = list(text)
+    prev_top: Optional[str] = None
+    for i, c, stack in _scan(text):
+        top = stack[-1] if stack else None
+        if c != "\n" and (prev_top in danger or top in danger):
+            out[i] = " "
+        prev_top = top
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# #225 M5 — the escape-hatch gate (the superset SUPPRESSION_RE deliberately
+# does not become; see the comment on SUPPRESSION_RE above).
+# --------------------------------------------------------------------------- #
+
+# Directive hatches live inside comments by definition -> matched against RAW
+# text. `throw_not_implemented` is also matched raw (see `find_escape_hatches`'s
+# docstring for why) but is handled separately, not listed here.
+_RAW_HATCH_NAMES = frozenset({"ts_ignore", "ts_expect_error", "ts_nocheck"})
+
+#: The #225 M5 superset -- ten hatches total counting `deletion_of_target`
+#: (structural, defined below, not a regex). Each hatch has a NAME so a caller
+#: sees *which* move fired rather than an opaque bool. `SUPPRESSION_RE` above
+#: covers `ts_ignore`/`ts_expect_error`/`as_any`; the rest are new for #225.
+ESCAPE_HATCH_PATTERNS: Dict[str, re.Pattern] = {
+    "ts_ignore": re.compile(r"@ts-ignore"),
+    "ts_expect_error": re.compile(r"@ts-expect-error"),
+    "ts_nocheck": re.compile(r"@ts-nocheck"),
+    "as_any": re.compile(r"\bas\s+any\b"),
+    "as_unknown_as": re.compile(r"\bas\s+unknown\s+as\b"),
+    # Postfix non-null assertion (`foo!.bar`, `arr[i]!`) -- NOT prefix `!x`, NOT
+    # `!=`/`!==`. The lookbehind requires an identifier/closer/quote character
+    # immediately before `!`; `(?!=)` excludes `!=`/`!==`. Known residual false
+    # positive: `a! = b` (a space before `=` defeats the negative lookahead).
+    "non_null_assertion": re.compile(r"(?<=[\w\)\]\"'`])!(?!=)"),
+    # `)[: ReturnType] {}` or `=> {}` -- an empty function/arrow body. Known
+    # residual false positive: a legitimately empty `catch {}`/`constructor() {}`
+    # also fires; accepted (the gate is conservative by design -- see the design
+    # doc's known-limits section).
+    "empty_body": re.compile(r"(?:\)\s*(?::[^;{}\n]+)?|=>\s*)\{\s*\}"),
+    "throw_not_implemented": re.compile(
+        r"throw\s+new\s+\w*Error\s*\(\s*['\"`][^'\"`]*(?:not\s*implemented|unimplemented|TODO)",
+        re.I,
+    ),
+    "declare_stub": re.compile(
+        r"^\s*declare\s+(?:function|const|let|var|class|module|namespace|global|type)\b",
+        re.M,
+    ),
+}
+
+
+def find_escape_hatches(text: str) -> List[str]:
+    """Return the sorted names of every #225 escape hatch present in `text` (a
+    generated TS artifact/completion) -- the shared gate every SSI arm
+    (#226/#227/#230) imports so "applied identically across arms" is a property
+    of the import, not of discipline. See `docs/design/15-ssi-measurement-
+    contract.md` (M5).
+
+    Directive hatches (`ts_ignore`/`ts_expect_error`/`ts_nocheck`) match RAW
+    text. The other five regex hatches match `mask_strings_and_comments(text)`
+    so prose ("// don't use as any here", a string literal containing "as any")
+    never counts.
+
+    `throw_not_implemented` is the one hatch that must see real, unmasked string
+    content (the error message it is checking is itself string content) -- it is
+    matched against raw text, but a candidate match whose `throw` keyword falls
+    inside a masked span (the statement is itself commented out, or living
+    inside an unrelated string) is discarded: `masked[start:start+5]` differing
+    from `"throw"` is exactly that signal.
+    """
+    masked = mask_strings_and_comments(text)
+    found = set()
+    for name, pattern in ESCAPE_HATCH_PATTERNS.items():
+        raw = name in _RAW_HATCH_NAMES or name == "throw_not_implemented"
+        haystack = text if raw else masked
+        for m in pattern.finditer(haystack):
+            if name == "throw_not_implemented":
+                start = m.start()
+                if masked[start:start + 5] != text[start:start + 5]:
+                    continue
+            found.add(name)
+    return sorted(found)
+
+
+def has_escape_hatch(text: str) -> bool:
+    """`bool(find_escape_hatches(text))` -- the go/no-go form for a caller that
+    doesn't need to know which hatch fired."""
+    return bool(find_escape_hatches(text))
+
+
+def deletion_of_target(before: str, after: str, *, anchors: Sequence[str]) -> List[str]:
+    """The tenth #225 escape hatch, structural rather than lexical: the model
+    "fixes" a diagnostic by deleting the thing it was about. Returns the sorted
+    subset of `anchors` present in `before` and absent from
+    `mask_strings_and_comments(after)` -- masking `after` (not `before`) means
+    commenting the target out counts as deletion too, matching the "delete the
+    evidence" move this hatch exists to catch.
+
+    `anchors` are injected by the CALLER (the symbol under test, its signature,
+    the call site) -- never guessed from the text, because guessing is exactly
+    the kind of silent mismatch this measurement contract exists to prevent.
+    """
+    after_masked = mask_strings_and_comments(after)
+    return sorted(a for a in anchors if a in before and a not in after_masked)
 
 
 def statement_boundary(text: str) -> Optional[int]:

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -91,6 +91,7 @@ PORTABLE_MODULES = [
     "src.eval.probes",
     "src.eval.ts_error_eval",
     "src.eval.lsp_eval",
+    "src.eval.ssi_contract",
     "src.lsp.tsc",
     "src.lsp.prettier",
     "src.lsp.diagnostics",

--- a/tests/test_lsp_diagnostics.py
+++ b/tests/test_lsp_diagnostics.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 
 import pytest
 
-from src.lsp.diagnostics import (Diagnostic, FORWARD_RESOLVABLE_CODES,
+from src.lsp.diagnostics import (Diagnostic, ESCAPE_HATCH_PATTERNS, FORWARD_RESOLVABLE_CODES,
                                   MODULE_RESOLUTION_CODES, SUPPRESSION_RE,
-                                  close_open_delimiters, drop_codes, filter_diagnostics,
+                                  close_open_delimiters, deletion_of_target, drop_codes,
+                                  filter_diagnostics, find_escape_hatches, has_escape_hatch,
                                   is_incomplete, is_source_balanced, line_col_to_offset,
-                                  offset_to_lsp_position, parse_tsc_output,
-                                  statement_boundary, strip_suggestion)
+                                  mask_strings_and_comments, offset_to_lsp_position,
+                                  parse_tsc_output, statement_boundary, strip_suggestion)
 
 
 # --------------------------------------------------------------------------- #
@@ -398,3 +399,132 @@ def test_offset_to_lsp_position_rejects_offset_past_end():
     source = "abc"
     with pytest.raises(ValueError):
         offset_to_lsp_position(source, len(source) + 1)
+
+
+# --------------------------------------------------------------------------- #
+# #225 M5 -- mask_strings_and_comments
+# --------------------------------------------------------------------------- #
+
+def test_mask_preserves_length_and_newlines():
+    source = 'const s = "a\nb";\n// comment\nconst t = 1;\n'
+    masked = mask_strings_and_comments(source)
+    assert len(masked) == len(source)
+    newline_positions = [i for i, c in enumerate(source) if c == "\n"]
+    for i in newline_positions:
+        assert masked[i] == "\n"
+
+
+def test_mask_blanks_string_content():
+    masked = mask_strings_and_comments('const s = "cast it as any";')
+    assert "as any" not in masked
+    assert masked.startswith("const s = ")
+
+
+def test_mask_blanks_line_comment_content():
+    masked = mask_strings_and_comments("// don't use as any here\nfoo();")
+    assert "as any" not in masked
+    assert "foo();" in masked
+
+
+def test_mask_blanks_block_comment_content():
+    masked = mask_strings_and_comments("/* as any */ foo();")
+    assert "as any" not in masked
+    assert "foo();" in masked
+
+
+def test_mask_leaves_template_interpolation_as_code():
+    masked = mask_strings_and_comments("const s = `hi ${1 as any}`;")
+    assert "as any" in masked
+
+
+# --------------------------------------------------------------------------- #
+# #225 M5 -- find_escape_hatches / has_escape_hatch
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("name,snippet", [
+    ("ts_ignore", "// @ts-ignore\nfoo();"),
+    ("ts_expect_error", "// @ts-expect-error\nfoo();"),
+    ("ts_nocheck", "// @ts-nocheck\nfoo();"),
+    ("as_any", "const v = u as any;"),
+    ("as_unknown_as", "const v = u as unknown as Foo;"),
+    ("non_null_assertion", "foo!.bar();"),
+    ("empty_body", "function f(): void {}"),
+    ("throw_not_implemented", 'throw new Error("not implemented");'),
+    ("declare_stub", "declare function foo(): void;"),
+])
+def test_find_escape_hatches_positive(name, snippet):
+    assert name in find_escape_hatches(snippet)
+    assert has_escape_hatch(snippet)
+
+
+def test_escape_hatch_patterns_has_the_nine_regex_hatches():
+    # Ten total per #225 M5, but deletion_of_target is structural, not a regex.
+    assert set(ESCAPE_HATCH_PATTERNS) == {
+        "ts_ignore", "ts_expect_error", "ts_nocheck", "as_any", "as_unknown_as",
+        "non_null_assertion", "empty_body", "throw_not_implemented", "declare_stub",
+    }
+
+
+def test_ts_ignore_fires_inside_block_comment():
+    # Directives are raw-matched -- this IS a positive, not a trap.
+    assert "ts_ignore" in find_escape_hatches("/* @ts-ignore in a block comment */")
+
+
+@pytest.mark.parametrize("snippet", [
+    "a !== b;",
+    "a != b;",
+    "if (!x) { foo(); }",
+])
+def test_non_null_assertion_negative_traps(snippet):
+    assert "non_null_assertion" not in find_escape_hatches(snippet)
+
+
+@pytest.mark.parametrize("snippet", [
+    'const s = "cast it as any";',
+    "// don't use as any here",
+])
+def test_as_any_negative_traps(snippet):
+    assert "as_any" not in find_escape_hatches(snippet)
+
+
+def test_declare_stub_negative_inside_string():
+    assert "declare_stub" not in find_escape_hatches(
+        'const s = "declare function foo(): void;";'
+    )
+
+
+def test_empty_body_negative_on_nonempty_body():
+    assert "empty_body" not in find_escape_hatches("function f() { return 1; }")
+
+
+def test_throw_not_implemented_negative_on_unrelated_message():
+    assert "throw_not_implemented" not in find_escape_hatches('throw new Error("boom");')
+
+
+def test_find_escape_hatches_empty_on_clean_code():
+    assert find_escape_hatches("function add(a: number, b: number): number {\n"
+                                "  return a + b;\n"
+                                "}\n") == []
+    assert not has_escape_hatch("const x = 1;\n")
+
+
+# --------------------------------------------------------------------------- #
+# #225 M5 -- deletion_of_target
+# --------------------------------------------------------------------------- #
+
+def test_deletion_of_target_flags_removed_anchor():
+    before = "function target(): void { throw new Error('x'); }\ntarget();"
+    after = "\ntarget();"
+    assert deletion_of_target(before, after, anchors=["function target"]) == ["function target"]
+
+
+def test_deletion_of_target_flags_commented_out_anchor():
+    before = "function target(): void {}\n"
+    after = "// function target(): void {}\n"
+    assert deletion_of_target(before, after, anchors=["function target"]) == ["function target"]
+
+
+def test_deletion_of_target_empty_when_anchor_survives():
+    before = "function target(): void { return; }\n"
+    after = "function target(): void { return 1; }\n"
+    assert deletion_of_target(before, after, anchors=["function target"]) == []

--- a/tests/test_ssi_contract.py
+++ b/tests/test_ssi_contract.py
@@ -1,0 +1,265 @@
+"""Tests for `src/eval/ssi_contract.py` -- the #225 M1-M5 measurement contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.eval.ssi_contract import (ArmSpec, ContractViolation, RepoSplit, assert_disjoint,
+                                    contract_report, deletion_of_target, find_escape_hatches,
+                                    has_escape_hatch, per_seed_compare, pooled_compare,
+                                    repo_of, sign_test_p, split_by_repo, split_manifest,
+                                    summarize_arm, validate_arms, wilcoxon_signed_rank_p)
+
+
+def _arm(name, variable, baseline, *, signal_available=False, signal_used=False,
+         seeds=(1, 2, 3)):
+    return ArmSpec(name=name, variable=variable, baseline=baseline,
+                    signal_available=signal_available, signal_used=signal_used, seeds=seeds)
+
+
+# --------------------------------------------------------------------------- #
+# validate_arms -- M1, M2, M4
+# --------------------------------------------------------------------------- #
+
+def test_validate_arms_rejects_empty_set():
+    with pytest.raises(ContractViolation):
+        validate_arms([])
+
+
+def test_validate_arms_rejects_fewer_than_three_seeds():
+    arms = [_arm("baseline", "control", "baseline"),
+            _arm("treatment", "masking", "baseline", seeds=(1, 2))]
+    with pytest.raises(ContractViolation):
+        validate_arms(arms)
+
+
+def test_validate_arms_rejects_unknown_baseline():
+    arms = [_arm("treatment", "masking", "nonexistent")]
+    with pytest.raises(ContractViolation):
+        validate_arms(arms)
+
+
+def test_validate_arms_rejects_empty_variable():
+    arms = [_arm("baseline", "control", "baseline"),
+            ArmSpec(name="treatment", variable="", baseline="baseline",
+                    signal_available=False, signal_used=False, seeds=(1, 2, 3))]
+    with pytest.raises(ContractViolation):
+        validate_arms(arms)
+
+
+def test_validate_arms_rejects_two_same_baseline_arms_sharing_a_variable():
+    arms = [
+        _arm("baseline", "control", "baseline"),
+        _arm("treatment_a", "masking", "baseline"),
+        _arm("treatment_b", "masking", "baseline"),
+    ]
+    with pytest.raises(ContractViolation):
+        validate_arms(arms)
+
+
+def test_validate_arms_rejects_signal_used_arm_with_no_null_sibling():
+    arms = [
+        _arm("baseline", "control", "baseline"),
+        _arm("treatment", "masking", "baseline", signal_available=True, signal_used=True),
+    ]
+    with pytest.raises(ContractViolation):
+        validate_arms(arms)
+
+
+def test_validate_arms_accepts_wellformed_baseline_null_treatment_set():
+    arms = [
+        _arm("baseline", "control", "baseline"),
+        _arm("null", "masking", "baseline", signal_available=True, signal_used=False),
+        _arm("treatment", "masking", "baseline", signal_available=True, signal_used=True),
+    ]
+    validate_arms(arms)  # must not raise
+
+
+# --------------------------------------------------------------------------- #
+# per_seed_compare / pooled_compare
+# --------------------------------------------------------------------------- #
+
+def _rec(rid, clean):
+    return {"id": rid, "clean": clean}
+
+
+def test_per_seed_compare_raises_on_mismatched_seed_sets():
+    baseline_by_seed = {1: [_rec("a", True)], 2: [_rec("a", True)]}
+    other_by_seed = {1: [_rec("a", True)]}
+    with pytest.raises(ContractViolation):
+        per_seed_compare(baseline_by_seed, other_by_seed, key="clean")
+
+
+def test_per_seed_compare_raises_on_mismatched_record_id_order():
+    baseline_by_seed = {1: [_rec("a", True), _rec("b", False)]}
+    other_by_seed = {1: [_rec("b", True), _rec("a", False)]}
+    with pytest.raises(ContractViolation):
+        per_seed_compare(baseline_by_seed, other_by_seed, key="clean")
+
+
+def test_per_seed_compare_returns_expected_2x2_table():
+    # Seed 1: a both-true, b baseline-false/other-true (a "flip to true").
+    baseline_by_seed = {1: [_rec("a", True), _rec("b", False)]}
+    other_by_seed = {1: [_rec("a", True), _rec("b", True)]}
+    result = per_seed_compare(baseline_by_seed, other_by_seed, key="clean")
+    assert set(result) == {1}
+    table = result[1]["table"]
+    assert table == {"both_true": 1, "baseline_true_other_false": 0,
+                      "baseline_false_other_true": 1, "both_false": 0}
+
+
+def test_pooled_compare_concatenates_all_seeds():
+    baseline_by_seed = {1: [_rec("a", True)], 2: [_rec("b", False)]}
+    other_by_seed = {1: [_rec("a", True)], 2: [_rec("b", True)]}
+    pooled = pooled_compare(baseline_by_seed, other_by_seed, key="clean")
+    assert pooled["n"] == 2
+    assert pooled["table"]["both_true"] == 1
+    assert pooled["table"]["baseline_false_other_true"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# sign_test_p
+# --------------------------------------------------------------------------- #
+
+def test_sign_test_p_known_values():
+    assert sign_test_p(3, 0) == pytest.approx(0.25)
+    assert sign_test_p(0, 0) == 1.0
+
+
+def test_sign_test_p_symmetric():
+    assert sign_test_p(4, 1) == pytest.approx(sign_test_p(1, 4))
+
+
+# --------------------------------------------------------------------------- #
+# wilcoxon_signed_rank_p
+# --------------------------------------------------------------------------- #
+
+def test_wilcoxon_rejects_more_than_20_nonzero_deltas():
+    with pytest.raises(ValueError):
+        wilcoxon_signed_rank_p(list(range(1, 22)))
+
+
+def test_wilcoxon_all_positive_gives_minimum_attainable_p():
+    deltas = [1.0, 2.0, 3.0, 4.0, 5.0]
+    p = wilcoxon_signed_rank_p(deltas)
+    n = len(deltas)
+    assert p == pytest.approx(2 / (2 ** n))
+
+
+def test_wilcoxon_all_zero_deltas_give_one():
+    assert wilcoxon_signed_rank_p([0.0, 0.0, 0.0]) == 1.0
+
+
+# --------------------------------------------------------------------------- #
+# summarize_arm
+# --------------------------------------------------------------------------- #
+
+def test_summarize_arm_reports_consistent_direction():
+    per_seed = {
+        1: {"baseline_rate": 0.5, "other_rate": 0.6, "mcnemar_p": 0.5},
+        2: {"baseline_rate": 0.4, "other_rate": 0.5, "mcnemar_p": 0.5},
+    }
+    out = summarize_arm(per_seed, sign_test_p(2, 0), {"n": 2})
+    assert out["consistent_direction"] is True
+    assert out["n_seeds"] == 2
+
+
+def test_summarize_arm_reports_inconsistent_direction():
+    per_seed = {
+        1: {"baseline_rate": 0.5, "other_rate": 0.6, "mcnemar_p": 0.5},
+        2: {"baseline_rate": 0.5, "other_rate": 0.4, "mcnemar_p": 0.5},
+    }
+    out = summarize_arm(per_seed, sign_test_p(1, 1), {"n": 2})
+    assert out["consistent_direction"] is False
+
+
+# --------------------------------------------------------------------------- #
+# repo_of / split_by_repo / assert_disjoint / split_manifest
+# --------------------------------------------------------------------------- #
+
+def _repo_rec(repo, i):
+    return {"id": f"{repo}:{i}", "meta": {"repo": repo} if repo is not None else {}}
+
+
+def test_repo_of_reads_meta_repo_and_returns_none_when_absent():
+    assert repo_of({"meta": {"repo": "org/name"}}) == "org/name"
+    assert repo_of({"meta": {}}) is None
+    assert repo_of({}) is None
+
+
+def test_split_by_repo_whole_repos_land_on_one_side():
+    records = [_repo_rec(f"org/repo{i}", j) for i in range(20) for j in range(3)]
+    split = split_by_repo(records, eval_fraction=0.3, seed=42)
+    assert_disjoint(split.train, split.eval)  # must not raise
+
+
+def test_split_by_repo_stable_across_processes():
+    # Hard-coded expected assignment for seed=42 -- a salted `hash()` based
+    # implementation would fail this (it isn't stable across interpreters).
+    records = [_repo_rec("org/alpha", 0), _repo_rec("org/beta", 0),
+               _repo_rec("org/gamma", 0)]
+    split = split_by_repo(records, eval_fraction=0.5, seed=42)
+    eval_repos = sorted({repo_of(r) for r in split.eval})
+    train_repos = sorted({repo_of(r) for r in split.train})
+    assert eval_repos == ["org/alpha", "org/beta"]
+    assert train_repos == ["org/gamma"]
+
+
+def test_split_by_repo_on_unknown_raises_by_default():
+    records = [_repo_rec(None, 0)]
+    with pytest.raises(ContractViolation):
+        split_by_repo(records, eval_fraction=0.5, seed=1)
+
+
+def test_split_by_repo_on_unknown_quarantine_buckets_and_counts():
+    records = [_repo_rec(None, 0), _repo_rec("org/alpha", 0)]
+    split = split_by_repo(records, eval_fraction=0.5, seed=1, on_unknown="quarantine")
+    assert len(split.quarantine) == 1
+    manifest = split_manifest(split)
+    assert manifest["n_quarantine"] == 1
+
+
+def test_split_manifest_byte_reproducible():
+    records = [_repo_rec(f"org/repo{i}", 0) for i in range(10)]
+    split_a = split_by_repo(records, eval_fraction=0.4, seed=7)
+    split_b = split_by_repo(records, eval_fraction=0.4, seed=7)
+    assert split_manifest(split_a)["manifest_sha256"] == split_manifest(split_b)["manifest_sha256"]
+
+
+def test_split_manifest_changes_when_eval_repos_change():
+    records = [_repo_rec(f"org/repo{i}", 0) for i in range(10)]
+    split_a = split_by_repo(records, eval_fraction=0.4, seed=7)
+    manifest_a = split_manifest(split_a)
+
+    more_records = records + [_repo_rec("org/extra", 0)]
+    split_b = split_by_repo(more_records, eval_fraction=0.9, seed=7)
+    manifest_b = split_manifest(split_b)
+
+    assert manifest_a["eval_repos_sha256"] != manifest_b["eval_repos_sha256"]
+
+
+def test_assert_disjoint_raises_on_overlap():
+    a = [_repo_rec("org/shared", 0)]
+    b = [_repo_rec("org/shared", 1)]
+    with pytest.raises(ContractViolation):
+        assert_disjoint(a, b)
+
+
+# --------------------------------------------------------------------------- #
+# Glue -- re-exports + contract_report
+# --------------------------------------------------------------------------- #
+
+def test_ssi_contract_reexports_the_m5_gate():
+    assert has_escape_hatch("const v = u as any;")
+    assert "as_any" in find_escape_hatches("const v = u as any;")
+    assert deletion_of_target("function f() {}\n", "\n", anchors=["function f"]) == ["function f"]
+
+
+def test_contract_report_assembles_arms_splits_stats():
+    arms = [_arm("baseline", "control", "baseline")]
+    records = [_repo_rec("org/repo0", 0)]
+    split = split_by_repo(records, eval_fraction=0.0, seed=1)
+    report = contract_report(arms, {"main": split}, {"baseline_vs_null": {"n": 1}})
+    assert report["arms"][0]["name"] == "baseline"
+    assert "main" in report["splits"]
+    assert report["stats"]["baseline_vs_null"]["n"] == 1


### PR DESCRIPTION
Closes #225

## Summary
- `src/eval/ssi_contract.py` (new, portable, stdlib-only): `ArmSpec`/`validate_arms` (M1 one-variable-per-arm + M4 availability-vs-use null arms), `per_seed_compare`/`pooled_compare`/`sign_test_p`/`wilcoxon_signed_rank_p`/`summarize_arm` (M2 multi-seed paired stats, wrapping `lsp_eval.compare` rather than reimplementing it), `repo_of`/`split_by_repo`/`split_manifest`/`assert_disjoint` (M3 repo-level contamination split with a byte-reproducible manifest), and `contract_report` (the auditable JSON block a run writes next to its results). Re-exports the M5 gate so every arm has one import surface.
- `src/lsp/diagnostics.py`: `ESCAPE_HATCH_PATTERNS` (the ten-hatch superset), `find_escape_hatches`/`has_escape_hatch`, `mask_strings_and_comments`, `deletion_of_target` (structural, the "delete the evidence" move). `SUPPRESSION_RE` itself is left byte-identical (a live in-loop rollback control in `harness.py`) — confirmed via `git diff` showing zero deletions on that line — so the published #199 numbers (clean-rate 0.887→0.962, pass@1 0.503) stay comparable.
- `docs/design/15-ssi-measurement-contract.md`: the M1–M5 rule / why / mechanism / how-a-run-proves-compliance record, plus a known-limits section. Wired into `docs/design/README.md` (topic 15 + locked-decisions row) and cross-referenced from `13-code-model-moe.md` (SSI-M bullet → done) and `12-lsp-in-the-loop.md` (notes the published numbers predate the extended gate).
- Tests: `tests/test_ssi_contract.py` (new, 28 tests) + extended `tests/test_lsp_diagnostics.py` (positive/negative cases per hatch, masking, deletion-of-target) + `tests/test_import_guard.py` (new portable module registered).

One resolved ambiguity in the issue's own text: M4 requires a null/treatment arm pair to share `(baseline, variable)`, which is exactly what M1's naive "no two same-baseline arms share a variable" reading would forbid. `validate_arms`'s M1 collision check is scoped to `(baseline, variable, signal_used)` so the deliberate null/treatment pairing M4 requires is not flagged as the confound M1 exists to catch — documented in the module and design doc.

## Testing
- [x] Tests added/updated
- [x] All tests passing (`.venv/bin/python -m pytest -q -rs`: 1390 passed, 13 skipped — all pre-existing environment skips, unrelated to this change)
- [x] Manual verification: `git diff` shows zero deletions on the `SUPPRESSION_RE` line; `find_escape_hatches` run over all 96 `eval_sets/ts_error_injection/eval.jsonl` gold completions fires on exactly one record (`undefined-name-006`, a legitimately empty `if (...) {}` body) — the pre-documented, accepted `empty_body` false-positive shape, not a miscalibration.