### PR TITLE
feat: [M12] RLVR/GRPO with LSP/opengrep verifier reward (diagnostic-cleanliness ranking)

### DIFF
--- a/docs/design/13-code-model-moe.md
+++ b/docs/design/13-code-model-moe.md
@@ -411,6 +411,55 @@ measurement contract:
 - **Dropped arms:** two-clock "slow-clock structural state" (conflicts with the MoE spine) and the
   diffusion path.
 
+### #230 — RLVR/GRPO verifier reward (Phase 1 shipped)
+
+Promotes the LSP/opengrep oracle from a measurement-only harness to a **verifier reward**:
+GRPO's within-group standardization (`group_advantages`) is itself the diagnostic-cleanliness
+reranker, so no new sampling/training plumbing was needed — the whole net-new surface is one
+reward function (`src/train/verifiers.py`'s `diagnostics_to_reward` + `LspVerifier`) wired into
+`scripts/rlvr.py` via `--reward lsp`.
+
+- **Reward shape.** `reward = max(base_clean − Σ severity_weight(d), diag_floor)` over the
+  oracle's findings on the FULL artifact (`prompt + completion` — a completion fragment alone
+  isn't standalone TypeScript); clean → `+1.0`, each surviving Error → `−0.30` (the density term
+  that keeps an all-clean/all-dirty group from producing zero GRPO advantage), floor for an
+  honest-but-dirty attempt `−0.5`.
+- **Two anti-Goodhart guards, both dominant over the density term.** `hacked` (any #225 M5
+  escape hatch — `@ts-ignore`/`as any`/etc. — present in the completion) and `degenerate` (empty /
+  whitespace-only / comment-only / near-empty output) each force the reward to `−1.0`,
+  strictly below `diag_floor`. Without that ordering, a many-diagnostic honest attempt could
+  score *below* a suppression hack (inverting the intended ranking) or a single 20-diagnostic
+  outlier could squash an entire group's advantages toward zero after standardization — both
+  silent training failures the floor exists to prevent. Guards are evaluated on the
+  **completion alone** (the prompt may legitimately contain `as any` or an unfinished body);
+  only the model's own text is penalized.
+- **`SUPPRESSION_RE`-vs-superset — deliberately the superset.** Like #226/#227, this arm imports
+  `src.lsp.diagnostics.find_escape_hatches` (the #225 M5 ten-hatch superset), not the narrow
+  `SUPPRESSION_RE` that stays reserved for `harness.py`'s in-loop rollback control (see that
+  module's decision-record comment). `--lsp-hatches directives` restricts to the five explicit
+  directives for an ablation that isolates the two known-noisy superset members (`empty_body`,
+  `non_null_assertion`); `--lsp-hatches none` disables the hack floor entirely (control arm only).
+- **Cost model.** #278 established a ~350ms client-side debounce floor per `didChange` on the
+  pinned `typescript-language-server` 5.3.0 that no project-size reduction removes, so
+  `oracle.wall_s ≈ K × prompts_per_step × steps × per-call latency` dominates step time at
+  scale — e.g. K=8 × 200 steps ≈ 1600 calls ≈ 9–10 minutes of pure oracle wall. `--oracle ts`
+  (not `both`) is the default for this reason; `scripts/rlvr.py` logs `oracle_wall_frac`
+  (oracle wall ÷ elapsed wall) every `--log-every` step and writes `telemetry.json` so a run's
+  real cost is measured, not assumed.
+- **No prompt-baseline subtraction.** The prompt's own diagnostics are constant across all K
+  samples of a GRPO group and cancel exactly under `group_advantages`' standardization, so
+  `LspVerifier` scores `prompt + completion` without a second oracle call to subtract a
+  per-prompt baseline — it shifts `mean_reward` in the logs but not the gradient.
+- **Scope.** This is Phase 1 only (diagnostic-cleanliness + anti-hack + anti-degenerate +
+  telemetry + the `scripts/build_rlvr_prompts.py` train/val split over the checked-in
+  `eval_sets/ts_error_injection` + `humaneval_ts` sets). Phase 2 (a reference-based over-repair
+  penalty on `clean_control` rows) is deferred to a follow-up issue — it needs a
+  `{prompt, reference, kind:"clean_control"}` data-format change the issue itself sequences
+  second. The RLVR *accept* criteria (monotone `error_avoidance_rate` gain vs. a math/random
+  control, with no hatch-rate rise) need a real GPU run under the #225 M4 null-arm control and
+  are not claimed here — this PR ships the mechanism and the telemetry that makes that run
+  measurable.
+
 ### Why SSI is secondary — the recorded assessment
 
 The LSP-in-the-loop experiment (design record + measurement in

--- a/scripts/build_rlvr_prompts.py
+++ b/scripts/build_rlvr_prompts.py
@@ -1,0 +1,214 @@
+"""#230 -- build disjoint train/val RLVR prompt JSONLs from the checked-in TS
+eval sets (`eval_sets/ts_error_injection/eval.jsonl` + `clean_prefixes.jsonl`,
+optionally `eval_sets/humaneval_ts/humaneval_ts.jsonl`), stratified by
+`error_class` so every error family lands on both sides, with a reproducible
+split manifest recording the contamination boundary. Every input is already
+checked into the repo (third-party / hand-authored eval data, none of it
+Claude-generated) -- this script writes nothing new, it only re-slices.
+
+Deliberately keeps the `{"answer": ...}` field name from the source eval sets
+rather than the issue's `{prompt, reference}` rename -- `scripts/rlvr.py`
+reads `prob.get("answer", "")` and Phase 1's LSP reward ignores it entirely,
+so renaming would break `--reward math` compatibility for no gain (recorded
+as a deliberate deviation in #230's plan).
+
+  python scripts/build_rlvr_prompts.py --out-dir data/rlvr_ts --seed 0
+
+CONTAMINATION NOTE: RLVR-training on rows drawn from the #194 eval set means
+any LATER `scripts/eval_lsp_harness.py` run over the FULL `eval.jsonl` is
+contaminated and not comparable to the published #199 numbers (clean-rate
+0.887->0.962, pass@1 0.503). Report only on the held-out val split emitted
+here, or on a source the training split never touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, List, Sequence, Tuple
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EVAL_PATH = _REPO_ROOT / "eval_sets" / "ts_error_injection" / "eval.jsonl"
+DEFAULT_CLEAN_PREFIXES_PATH = _REPO_ROOT / "eval_sets" / "ts_error_injection" / "clean_prefixes.jsonl"
+DEFAULT_HUMANEVAL_PATH = _REPO_ROOT / "eval_sets" / "humaneval_ts" / "humaneval_ts.jsonl"
+
+CONTAMINATION_NOTE = (
+    "RLVR-training on rows drawn from the #194 eval set means any later "
+    "scripts/eval_lsp_harness.py run over the FULL eval.jsonl is contaminated and "
+    "not comparable to the published #199 numbers (clean-rate 0.887->0.962, "
+    "pass@1 0.503). Report only on the held-out val split, or on a source the "
+    "training split never touched."
+)
+
+
+def _load_jsonl(path: Path) -> List[dict]:
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                records.append(json.loads(line))
+    return records
+
+
+def load_prompt_records(*, eval_path: Path = DEFAULT_EVAL_PATH,
+                        clean_prefixes_path: Path = DEFAULT_CLEAN_PREFIXES_PATH,
+                        humaneval_path: Path = DEFAULT_HUMANEVAL_PATH,
+                        include_humaneval: bool = False) -> List[dict]:
+    """Load and normalize every source into `{"id", "prompt", "answer",
+    "error_class"}` (`answer` = the source's `gold_completion`). Raises on any
+    duplicate `id` across sources -- the three sources use disjoint id
+    prefixes by construction (`member-access-*`/`clean-prefix-*`/
+    `HumanEval_*`), so a collision means an input changed underneath this
+    script and must not be silently merged."""
+    sources = [eval_path, clean_prefixes_path]
+    if include_humaneval:
+        sources.append(humaneval_path)
+
+    out: List[dict] = []
+    seen_ids: set = set()
+    for path in sources:
+        for r in _load_jsonl(path):
+            rid = r["id"]
+            if rid in seen_ids:
+                raise ValueError(f"duplicate id {rid!r} across input sources "
+                                 f"(last seen while reading {path})")
+            seen_ids.add(rid)
+            out.append({
+                "id": rid,
+                "prompt": r["prompt"],
+                "answer": r.get("gold_completion", ""),
+                "error_class": r["error_class"],
+            })
+    return out
+
+
+def _stable_frac(seed: int, key: str) -> float:
+    """`sha256(f"{seed}:{key}")` mapped to `[0, 1)` -- deliberately NOT
+    Python's salted `hash()`, which is per-interpreter and not reproducible
+    across runs (the same gotcha `src/eval/ssi_contract.py:split_by_repo`
+    already documents for the #225 M3 repo split)."""
+    digest = hashlib.sha256(f"{seed}:{key}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") / float(1 << 64)
+
+
+def split_records(records: Sequence[dict], *, seed: int,
+                  val_fraction: float = 0.2) -> Tuple[List[dict], List[dict]]:
+    """Stratified stable-hash split: every `error_class` present in `records`
+    contributes to BOTH sides. A pure per-record `frac < val_fraction`
+    threshold, applied globally, could by chance strand an entire small class
+    (`clean_control` is 12 rows in the base eval set) on one side; stratifying
+    per-class and taking `round(n * val_fraction)` (at least 1 once a class has
+    more than one member) rules that out while the ranking itself still comes
+    from the stable per-id hash, so the split stays reproducible."""
+    by_class: Dict[str, List[dict]] = {}
+    for r in records:
+        by_class.setdefault(r["error_class"], []).append(r)
+
+    train: List[dict] = []
+    val: List[dict] = []
+    for recs in by_class.values():
+        ranked = sorted(recs, key=lambda r: (_stable_frac(seed, r["id"]), r["id"]))
+        n = len(ranked)
+        n_val = min(n, max(1, round(n * val_fraction))) if n > 1 else 0
+        val.extend(ranked[:n_val])
+        train.extend(ranked[n_val:])
+    return train, val
+
+
+def _ids_sha256(records: Sequence[dict]) -> str:
+    ids = sorted(r["id"] for r in records)
+    return hashlib.sha256(("\n".join(ids) + "\n").encode("utf-8")).hexdigest()
+
+
+def build_manifest(train: Sequence[dict], val: Sequence[dict], *, seed: int,
+                   val_fraction: float, sources: Sequence[str]) -> dict:
+    """Byte-reproducible manifest, following
+    `src/eval/ssi_contract.py:split_manifest`'s provenance-manifest pattern:
+    counts, per-class counts, and a sha256 over each side's sorted id list, so
+    a run's claimed split can be CHECKED, not merely trusted."""
+    classes = sorted({r["error_class"] for r in list(train) + list(val)})
+    per_class = {
+        cls: {
+            "train": sum(1 for r in train if r["error_class"] == cls),
+            "val": sum(1 for r in val if r["error_class"] == cls),
+        }
+        for cls in classes
+    }
+    manifest = {
+        "seed": seed,
+        "val_fraction": val_fraction,
+        "sources": list(sources),
+        "n_train": len(train),
+        "n_val": len(val),
+        "per_class_counts": per_class,
+        "train_ids_sha256": _ids_sha256(train),
+        "val_ids_sha256": _ids_sha256(val),
+        "contamination_note": CONTAMINATION_NOTE,
+    }
+    manifest["manifest_sha256"] = hashlib.sha256(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return manifest
+
+
+def _write_jsonl(path: Path, records: Sequence[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out-dir", type=Path, default=Path("data/rlvr_ts"),
+                    help="directory for train.jsonl/val.jsonl/rlvr_split_manifest.json; "
+                         "override individual paths with --out-train/--out-val/--out-manifest")
+    ap.add_argument("--out-train", type=Path, default=None)
+    ap.add_argument("--out-val", type=Path, default=None)
+    ap.add_argument("--out-manifest", type=Path, default=None)
+    ap.add_argument("--eval-path", type=Path, default=DEFAULT_EVAL_PATH)
+    ap.add_argument("--clean-prefixes-path", type=Path, default=DEFAULT_CLEAN_PREFIXES_PATH)
+    ap.add_argument("--humaneval-path", type=Path, default=DEFAULT_HUMANEVAL_PATH)
+    ap.add_argument("--include-humaneval", action="store_true",
+                    help="also draw clean_control prompts from eval_sets/humaneval_ts "
+                         "(159 rows; off by default to keep the base split small)")
+    ap.add_argument("--val-fraction", type=float, default=0.2)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    out_train = args.out_train or (args.out_dir / "train.jsonl")
+    out_val = args.out_val or (args.out_dir / "val.jsonl")
+    out_manifest = args.out_manifest or (args.out_dir / "rlvr_split_manifest.json")
+
+    records = load_prompt_records(eval_path=args.eval_path,
+                                  clean_prefixes_path=args.clean_prefixes_path,
+                                  humaneval_path=args.humaneval_path,
+                                  include_humaneval=args.include_humaneval)
+    train, val = split_records(records, seed=args.seed, val_fraction=args.val_fraction)
+
+    sources = [str(args.eval_path), str(args.clean_prefixes_path)]
+    if args.include_humaneval:
+        sources.append(str(args.humaneval_path))
+    manifest = build_manifest(train, val, seed=args.seed, val_fraction=args.val_fraction,
+                              sources=sources)
+
+    _write_jsonl(out_train, train)
+    _write_jsonl(out_val, val)
+    out_manifest.parent.mkdir(parents=True, exist_ok=True)
+    out_manifest.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    print(f"wrote {len(train)} train / {len(val)} val rows "
+         f"({len(train) + len(val)} total, seed={args.seed})")
+    print(f"  train    -> {out_train}")
+    print(f"  val      -> {out_val}")
+    print(f"  manifest -> {out_manifest}")
+    print()
+    print("CONTAMINATION NOTE:")
+    print(f"  {CONTAMINATION_NOTE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rlvr.py
+++ b/scripts/rlvr.py
@@ -11,14 +11,20 @@ are needed, no reference solutions (docs/design/08-corpus-pipeline.md lines 120-
 
 `--problems` is JSONL with `{"prompt": "...", "answer": "..."}` per line. `--reward math`
 (default) uses the final-number exact-match; `--reward exact` uses normalized string match.
-Code rewards need a sandbox (CodeVerifier is opt-in, off in CI) — out of scope for this
-driver. MLX-only (backend + serving recurrence), like scripts/sft.py / scripts/dpo.py.
+`--reward lsp` (#230) is the diagnostic-cleanliness verifier reward for #198's SSI RLVR
+arm — `src.train.verifiers.LspVerifier` over `src.lsp.oracle.CompositeOracle`. It is
+**static analysis only** (never executes candidate code) and is therefore safe to enable
+by default, unlike `CodeVerifier` below: real TS/Rust/SQL *execution* grading needs a
+sandbox (CodeVerifier is opt-in, off in CI) — out of scope for this driver. MLX-only
+(backend + serving recurrence), like scripts/sft.py / scripts/dpo.py.
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import time
 from functools import partial
 from pathlib import Path
 import sys
@@ -28,7 +34,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import numpy as np
 
 from src.train.grpo import group_advantages, reward_stats
-from src.train.verifiers import exact_match_reward, math_reward
+from src.train.verifiers import LspVerifier, exact_match_reward, math_reward
 
 
 def collate_rollouts(rollouts, advantages, *, pad_id: int = 0):
@@ -55,7 +61,23 @@ def main() -> None:
     ap.add_argument("--config", type=Path, default=Path("config/poc.yaml"))
     ap.add_argument("--init", type=Path, required=True, help="checkpoint weights (SFT base)")
     ap.add_argument("--problems", type=Path, required=True, help="JSONL {prompt, answer}")
-    ap.add_argument("--reward", choices=("math", "exact"), default="math")
+    ap.add_argument("--reward", choices=("math", "exact", "lsp"), default="math")
+    ap.add_argument("--oracle", choices=("ts", "opengrep", "both"), default="ts",
+                    help="--reward lsp only: diagnostic oracle (persistent TS-LSP by "
+                         "default; #278's ~350ms didChange debounce makes 'both' costly "
+                         "at K-completions-per-step scale, so 'ts' is the default)")
+    ap.add_argument("--lsp-timeout-s", type=float, default=10.0,
+                    help="--reward lsp only: per-call oracle timeout")
+    ap.add_argument("--lsp-hatches", choices=("superset", "directives", "none"), default="superset",
+                    help="--reward lsp only: escape-hatch set the hack floor enforces — "
+                         "'superset' (default, the #225 M5 gate), 'directives' (the "
+                         "narrower ts_ignore/ts_expect_error/ts_nocheck/as_any/"
+                         "as_unknown_as ablation), or 'none' (control arm, hack floor off)")
+    ap.add_argument("--lsp-ignore-module-resolution", action=argparse.BooleanOptionalAction,
+                    default=True,
+                    help="--reward lsp only: drop module-resolution diagnostics (TS2307 "
+                         "etc.) before scoring — an unresolved import only weakens "
+                         "checking, it doesn't invent errors (default on)")
     ap.add_argument("--out", type=Path, default=Path("runs/rlvr"),
                     help="output dir for weights.safetensors (default runs/rlvr); kept "
                          "separate from --init so the base checkpoint is never clobbered")
@@ -73,6 +95,17 @@ def main() -> None:
     ap.add_argument("--model-id", default=None)
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args()
+
+    # Fail fast BEFORE any model load — an --reward lsp run with no toolchain
+    # should not pay the checkpoint-load cost only to die on step 0's first reward.
+    if args.reward == "lsp":
+        from src.lsp.oracle import resolve_oracle
+        if not resolve_oracle(args.oracle):
+            raise SystemExit(
+                f"no toolchain for --oracle {args.oracle} — for 'ts'/'both', run `npm install` "
+                "in eval_sets/ts_error_injection and `npm i -D typescript-language-server`; "
+                "for 'opengrep', install opengrep and put it on PATH "
+                "(see eval_sets/opengrep_rules/README.md).")
 
     from src.model.backend import get_backend
     from src.model.blocks import load_config
@@ -106,7 +139,6 @@ def main() -> None:
     balancer = balancer_for_config(cfg)
     grpo_step = backend.make_grpo_train_step(model, opt, balancer=balancer)
     attach_balancer(balancer, model)
-    reward_fn = math_reward if args.reward == "math" else exact_match_reward
 
     problems = [json.loads(ln) for ln in args.problems.read_text(encoding="utf-8").splitlines()
                 if ln.strip()]
@@ -117,36 +149,77 @@ def main() -> None:
     out = args.out
     out.mkdir(parents=True, exist_ok=True)
     weights_path = str(out / "weights.safetensors")
+    telemetry_path = out / "telemetry.json"
 
-    for step in range(args.steps):
-        prob = problems[step % len(problems)]
-        prompt_ids = list(tok.encode(prob["prompt"])) or [eos or 0]
-        rollouts, rewards = [], []
-        for k in range(args.group_size):
-            sid = f"s{step}-{k}"
-            store.create(sid)
-            sampler = partial(sample, temperature=args.temperature, top_k=args.top_k,
-                              rng=np.random.default_rng(int(rng.integers(1 << 30))))
-            try:
-                gen = generate(store, sid, prompt_ids, sampler=sampler, to_numpy=np_to,
-                               max_new_tokens=args.max_new_tokens, eos_id=eos)
-            finally:
-                store.remove(sid)   # never leak the session if generate/sampling raises
-            rollouts.append((prompt_ids, gen or [eos or 0]))
-            rewards.append(reward_fn(tok.decode(gen), str(prob.get("answer", ""))))
+    with contextlib.ExitStack() as stack:
+        if args.reward == "math":
+            reward_fn, verifier = math_reward, None
+        elif args.reward == "exact":
+            reward_fn, verifier = exact_match_reward, None
+        else:
+            # Constructed ONCE, outside the step loop — it owns a persistent
+            # language-server subprocess, so per-step construction would dominate
+            # the wall clock. `stack` guarantees `.close()` on any exit path
+            # (normal completion, SystemExit, or an unhandled exception).
+            verifier = LspVerifier(kind=args.oracle, timeout_s=args.lsp_timeout_s,
+                                   ignore_module_resolution=args.lsp_ignore_module_resolution,
+                                   hatches=args.lsp_hatches)
+            stack.enter_context(verifier)
+            reward_fn = None  # bound per-step below with the current prompt
 
-        adv = group_advantages([rewards])[0]            # (K,)
-        metrics = grpo_step(model, [collate_rollouts(rollouts, adv)], args.lr)
-        if step % args.log_every == 0:
-            stats = reward_stats(rewards)
-            print(f"step {step:4d}  loss {metrics['loss']:.4f}  "
-                  f"mean_reward {stats['mean_reward']:.3f}  solved {stats['frac_solved']:.3f}")
-        if args.ckpt_every and step > 0 and step % args.ckpt_every == 0:
-            model.save(weights_path)
-            print(f"  [ckpt] step {step} -> {weights_path}")
+        run_start = time.monotonic()
 
-    model.save(weights_path)
-    print(f"done — wrote {weights_path}")
+        def write_telemetry() -> None:
+            elapsed = time.monotonic() - run_start
+            t = verifier.telemetry()
+            t["elapsed_wall_s"] = elapsed
+            t["oracle_wall_frac"] = (t["wall_s"] / elapsed) if elapsed > 0 else 0.0
+            telemetry_path.write_text(json.dumps(t, indent=2), encoding="utf-8")
+
+        for step in range(args.steps):
+            prob = problems[step % len(problems)]
+            prompt_ids = list(tok.encode(prob["prompt"])) or [eos or 0]
+            step_reward_fn = (partial(verifier.reward, prompt=prob["prompt"])
+                              if verifier is not None else reward_fn)
+            rollouts, rewards = [], []
+            for k in range(args.group_size):
+                sid = f"s{step}-{k}"
+                store.create(sid)
+                sampler = partial(sample, temperature=args.temperature, top_k=args.top_k,
+                                  rng=np.random.default_rng(int(rng.integers(1 << 30))))
+                try:
+                    gen = generate(store, sid, prompt_ids, sampler=sampler, to_numpy=np_to,
+                                   max_new_tokens=args.max_new_tokens, eos_id=eos)
+                finally:
+                    store.remove(sid)   # never leak the session if generate/sampling raises
+                rollouts.append((prompt_ids, gen or [eos or 0]))
+                rewards.append(step_reward_fn(tok.decode(gen), str(prob.get("answer", ""))))
+
+            adv = group_advantages([rewards])[0]            # (K,)
+            metrics = grpo_step(model, [collate_rollouts(rollouts, adv)], args.lr)
+            if step % args.log_every == 0:
+                stats = reward_stats(rewards)
+                line = (f"step {step:4d}  loss {metrics['loss']:.4f}  "
+                       f"mean_reward {stats['mean_reward']:.3f}  solved {stats['frac_solved']:.3f}")
+                if verifier is not None:
+                    t = verifier.telemetry()
+                    elapsed = time.monotonic() - run_start
+                    n = max(t["n_samples"], 1)
+                    line += (f"  oracle_calls {t['n_calls']}  oracle_wall_s {t['wall_s']:.1f}  "
+                            f"frac_hacked {t['n_hacked'] / n:.3f}  "
+                            f"frac_degenerate {t['n_degenerate'] / n:.3f}  "
+                            f"oracle_wall_frac {(t['wall_s'] / elapsed) if elapsed > 0 else 0.0:.3f}")
+                print(line)
+            if args.ckpt_every and step > 0 and step % args.ckpt_every == 0:
+                model.save(weights_path)
+                print(f"  [ckpt] step {step} -> {weights_path}")
+                if verifier is not None:
+                    write_telemetry()   # a crashed long run still leaves cost evidence
+
+        model.save(weights_path)
+        if verifier is not None:
+            write_telemetry()
+        print(f"done — wrote {weights_path}")
 
 
 if __name__ == "__main__":

--- a/src/lsp/oracle.py
+++ b/src/lsp/oracle.py
@@ -119,6 +119,23 @@ class CompositeOracle:
             "n_stall_recoveries": og.n_stall_recoveries,
         }
 
+    @property
+    def ts_stats(self) -> Optional[dict]:
+        """The TS-LSP arm's reliability/cost counters, or `None` when that arm
+        isn't active (`kind="opengrep"`). Symmetric with `opengrep_stats` above --
+        a caller (e.g. #230's `LspVerifier` telemetry) never has to reach into
+        `self._ts` directly to learn whether the persistent server restarted or
+        timed out mid-run."""
+        if self._ts is None:
+            return None
+        ts = self._ts
+        return {
+            "n_calls": ts.n_calls,
+            "wall_s": ts.wall_s,
+            "n_timeouts": ts.n_timeouts,
+            "n_restarts": ts.n_restarts,
+        }
+
     def diagnostics(self, source: str) -> List[Diagnostic]:
         """Every arm's findings, UNFILTERED (the caller applies
         `diagnostics.filter_diagnostics`, same as `TscRunner`/`TsLspOracle`),

--- a/src/train/verifiers.py
+++ b/src/train/verifiers.py
@@ -10,6 +10,15 @@ ABOVE THE SEAM — stdlib only, no backend. `exact_match_reward` / `math_reward`
 safe. `CodeVerifier` **executes untrusted model output** and is therefore disabled by
 default (`enabled=False`) and never run in CI; real TS/Rust/SQL grading uses an external
 sandbox (SandboxFusion), out of scope here.
+
+#230 adds a THIRD verifier, `LspVerifier` — the diagnostic-cleanliness reward for the
+RLVR/GRPO arm of #198's SSI axis. Unlike `CodeVerifier`, it never executes model output
+(static analysis only via `src.lsp.oracle.CompositeOracle`), so it is **enabled by
+default**. Its pure reward-shaping core (`severity_weight`, `is_degenerate_output`,
+`diagnostics_to_reward`) has no oracle/process dependency at all and is unit-testable in
+CI on synthetic `Diagnostic`s; `CompositeOracle`/`src.lsp.diagnostics` imports are kept
+function-local (repo idiom — see `src.lsp.oracle`/`src.eval.ssi_contract`) so this
+module's top-level import surface stays stdlib-only.
 """
 
 from __future__ import annotations
@@ -17,7 +26,10 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
-from typing import List, Optional, Sequence
+from typing import TYPE_CHECKING, Dict, List, Mapping, Optional, Sequence
+
+if TYPE_CHECKING:
+    from src.lsp.diagnostics import Diagnostic
 
 _WS = re.compile(r"\s+")
 _NUM = re.compile(r"-?\d+(?:\.\d+)?")
@@ -91,3 +103,266 @@ class CodeVerifier:
             except subprocess.TimeoutExpired:
                 pass
         return passed / len(tests)
+
+
+# --------------------------------------------------------------------------- #
+# #230 -- the LSP/opengrep verifier reward (diagnostic-cleanliness ranking).
+# Pure reward-shaping core first (no oracle, no process, CI-testable on
+# synthetic Diagnostics); LspVerifier wraps it around a real/fake oracle.
+# --------------------------------------------------------------------------- #
+
+#: LSP severity 1=Error .. 4=Hint. Only Errors are load-bearing today (the LSP
+#: arm already drops everything below severity 1 -- see `ts_lsp.py`'s Trap B),
+#: but the shape is severity-general so an opengrep finding (which can report
+#: any severity) or a future arm doesn't need a second reward function.
+DEFAULT_SEVERITY_WEIGHTS: Dict[int, float] = {1: 0.30, 2: 0.15, 3: 0.05, 4: 0.05}
+
+_DIRECTIVE_HATCHES = frozenset({"ts_ignore", "ts_expect_error", "ts_nocheck",
+                                "as_any", "as_unknown_as"})
+_HATCH_MODES = ("superset", "directives", "none")
+
+
+def severity_weight(d: "Diagnostic", weights: Mapping[int, float] = DEFAULT_SEVERITY_WEIGHTS,
+                    code_overrides: Optional[Mapping[str, float]] = None) -> float:
+    """The reward-shaping penalty for one diagnostic: `code_overrides[d.code]` if
+    given and present, else `weights[d.severity]`, else the Hint weight as a
+    conservative default for a severity this table doesn't recognize."""
+    if code_overrides is not None and d.code in code_overrides:
+        return code_overrides[d.code]
+    return weights.get(d.severity, weights.get(4, 0.05))
+
+
+def is_degenerate_output(text: str, *, min_code_chars: int = 2) -> Optional[str]:
+    """The empty-output-trap guard (#230): empty / whitespace-only /
+    comment-only / near-empty completions have zero diagnostics and would
+    otherwise score a perfect `+1.0`, teaching the policy to emit nothing.
+    Returns a reason string (`"empty"`, `"whitespace_only"`, `"comment_only"`,
+    `"too_short"`) so telemetry can name the trap rather than report an opaque
+    bool, or `None` if `text` looks like real code.
+
+    Masks strings/comments with `src.lsp.diagnostics.mask_strings_and_comments`
+    (function-local import, keeping this module's top-level stdlib-only), then
+    strips whitespace plus residual `/`/`*` punctuation -- that module's own
+    docstring documents that the SECOND character of a two-char comment token
+    (`//`, `/*`, `*/`) is never independently visited and survives unmasked,
+    which is exactly the stray punctuation a comment-only artifact leaves
+    behind; stripping it is what makes `"// only a comment\n"` mask down to
+    nothing rather than to one leftover character.
+    """
+    if not text:
+        return "empty"
+    if not text.strip():
+        return "whitespace_only"
+
+    from src.lsp.diagnostics import mask_strings_and_comments
+
+    masked = mask_strings_and_comments(text)
+    residual = masked.translate(str.maketrans("", "", "/*")).strip()
+    if not residual:
+        return "comment_only" if masked.strip() else "whitespace_only"
+    if len(residual) < min_code_chars:
+        return "too_short"
+    return None
+
+
+def diagnostics_to_reward(diags: Sequence["Diagnostic"], *, hacked: bool = False,
+                          degenerate: bool = False, base_clean: float = 1.0,
+                          severity_weights: Mapping[int, float] = DEFAULT_SEVERITY_WEIGHTS,
+                          code_overrides: Optional[Mapping[str, float]] = None,
+                          diag_floor: float = -0.5, hack_reward: float = -1.0,
+                          degenerate_reward: float = -1.0) -> float:
+    """`reward = max(base_clean - sum(severity_weight(d) for d in diags), diag_floor)`,
+    then `hacked or degenerate` short-circuits to `min(hack_reward, degenerate_reward)`
+    (both default to the same -1.0, but the two are configurable separately and the
+    dominance still has to hold if a caller ever splits them).
+
+    `diag_floor` (default -0.5) sits strictly ABOVE the hack floor (-1.0) on purpose:
+    without it, a many-diagnostic honest attempt could score *below* a suppression
+    hack (inverting the intended ranking) and would become a single outlier that
+    squashes an entire group's advantages toward zero after standardization. Both
+    are silent training failures the floor exists to prevent -- it is load-bearing,
+    not cosmetic.
+
+    Pure: no process, no I/O, no oracle -- takes `List[Diagnostic]` plus two bools,
+    so the whole reward shape is unit-testable in CI on synthetic diagnostics.
+    """
+    if hacked or degenerate:
+        return min(hack_reward, degenerate_reward)
+    penalty = sum(severity_weight(d, severity_weights, code_overrides) for d in diags)
+    return max(base_clean - penalty, diag_floor)
+
+
+def _select_hatches(all_hatches: Sequence[str], mode: str) -> List[str]:
+    """Filter `find_escape_hatches`' full result to the subset `mode` treats as
+    hack-floor-triggering. `"superset"` (default, the #225 M5 gate) keeps every
+    hatch; `"directives"` keeps only the five explicit-suppression hatches
+    (`ts_ignore`/`ts_expect_error`/`ts_nocheck`/`as_any`/`as_unknown_as`), for
+    the ablation that isolates the two known-noisy superset members
+    (`empty_body`, `non_null_assertion` -- see `src.lsp.diagnostics`'s module
+    docstring for their documented false positives); `"none"` disables the
+    hack floor entirely (control arm only). Always computed FROM the same
+    `find_escape_hatches` call -- never a separate regex set -- so "applied
+    identically across arms" stays a property of the import."""
+    if mode == "superset":
+        return list(all_hatches)
+    if mode == "directives":
+        return [h for h in all_hatches if h in _DIRECTIVE_HATCHES]
+    if mode == "none":
+        return []
+    raise ValueError(f"unknown hatches mode {mode!r} (want one of {_HATCH_MODES})")
+
+
+class LspVerifier:
+    """The #230 diagnostic-cleanliness verifier reward: wraps
+    `src.lsp.oracle.CompositeOracle` around `diagnostics_to_reward`. Unlike
+    `CodeVerifier`, this verifier never EXECUTES model output -- static
+    analysis only -- so it is **enabled by default**, as the issue specifies.
+
+    Scoring: the oracle sees `prompt + completion` (a full, scoreable
+    artifact -- a bare completion fragment like `name);\\n` is not standalone
+    TypeScript, so scoring it alone would be pure syntax noise). The two
+    anti-Goodhart guards (`find_escape_hatches`, `is_degenerate_output`) see
+    `completion` ALONE -- the prompt may legitimately contain `as any` or an
+    unfinished body, and only the model's own text should be penalized.
+
+    No prompt-baseline subtraction, deliberately: the prompt's own diagnostics
+    are constant across all K samples of a GRPO group, and `group_advantages`
+    standardizes within the group, so a constant offset cancels exactly.
+    Subtracting it would cost one extra oracle call per prompt for no gradient
+    change (it would shift `mean_reward` in the logs, though -- noted in the
+    design doc so that number isn't misread).
+
+    `.reward(completion, reference=None, *, prompt="")` matches
+    `scripts/rlvr.py`'s two-positional-arg `reward_fn(decoded, ref)` call site;
+    `prompt` is keyword-only and bound per training step by the driver
+    (`functools.partial`) rather than held as hidden per-prompt verifier state.
+
+    Lazy oracle + injectable seam: `oracle=None` (default) constructs a
+    `CompositeOracle` on first `.reward()` call (function-local import, so this
+    module's top-level surface stays stdlib-only); tests inject a fake exposing
+    `.diagnostics()/.close()/.n_calls/.wall_s/.ts_stats/.opengrep_stats`, so the
+    whole class is CI-testable with no toolchain.
+    """
+
+    def __init__(self, *, kind: str = "ts", timeout_s: float = 10.0,
+                ignore_module_resolution: bool = True, hatches: str = "superset",
+                oracle=None, on_error: str = "raise", **reward_kwargs):
+        if hatches not in _HATCH_MODES:
+            raise ValueError(f"unknown hatches mode {hatches!r} (want one of {_HATCH_MODES})")
+        if on_error not in ("raise", "skip"):
+            raise ValueError(f"on_error must be 'raise' or 'skip', got {on_error!r}")
+        self.kind = kind
+        self.timeout_s = timeout_s
+        self.ignore_module_resolution = ignore_module_resolution
+        self.hatches = hatches
+        self.on_error = on_error
+        self.reward_kwargs = reward_kwargs
+
+        self._oracle = oracle
+        self._closed = False
+
+        self._n_samples = 0
+        self._n_clean = 0
+        self._n_hacked = 0
+        self._n_degenerate = 0
+        self._n_oracle_errors = 0
+        self._hatch_counts: Dict[str, int] = {}
+        self._degenerate_reasons: Dict[str, int] = {}
+        self._diag_total = 0
+        self._reward_total = 0.0
+
+    def _ensure_oracle(self):
+        if self._oracle is None:
+            from src.lsp.oracle import CompositeOracle
+            self._oracle = CompositeOracle(self.kind, timeout_s=self.timeout_s)
+        return self._oracle
+
+    def reward(self, completion: str, reference: Optional[str] = None, *,
+              prompt: str = "") -> Optional[float]:
+        """Score one completion. Returns `None` only when `on_error="skip"` and
+        the oracle call raised -- the caller must then drop the WHOLE GRPO
+        group for that step (a partially-scored group has a meaningless
+        baseline). `reference` is accepted (and ignored) only to match the
+        two-positional-arg `reward_fn(decoded, ref)` call site every
+        `scripts/rlvr.py` reward function shares; Phase 1 has no reference-
+        based term (see the design doc's Phase 2 note)."""
+        from src.lsp.diagnostics import MODULE_RESOLUTION_CODES, drop_codes, find_escape_hatches
+
+        completion = "" if completion is None else str(completion)
+        self._n_samples += 1
+
+        reason = is_degenerate_output(completion)
+        degenerate = reason is not None
+        if degenerate:
+            self._n_degenerate += 1
+            self._degenerate_reasons[reason] = self._degenerate_reasons.get(reason, 0) + 1
+
+        all_hatches = find_escape_hatches(completion)
+        for h in all_hatches:
+            self._hatch_counts[h] = self._hatch_counts.get(h, 0) + 1
+        hacked = bool(_select_hatches(all_hatches, self.hatches))
+        if hacked:
+            self._n_hacked += 1
+
+        oracle = self._ensure_oracle()
+        diagnose = oracle.diagnostics
+        if self.ignore_module_resolution:
+            diagnose = drop_codes(diagnose, MODULE_RESOLUTION_CODES)
+
+        artifact = f"{prompt}{completion}"
+        try:
+            diags = diagnose(artifact)
+        except Exception:
+            self._n_oracle_errors += 1
+            if self.on_error == "skip":
+                return None
+            raise
+
+        self._diag_total += len(diags)
+        if not diags and not hacked and not degenerate:
+            self._n_clean += 1
+
+        r = diagnostics_to_reward(diags, hacked=hacked, degenerate=degenerate,
+                                  **self.reward_kwargs)
+        self._reward_total += r
+        return r
+
+    def telemetry(self) -> dict:
+        """A JSON-serializable dict: `n_samples`, `n_clean`, `n_hacked`,
+        `n_degenerate`, `n_oracle_errors`, `hatch_counts` (name -> count),
+        `degenerate_reasons` (reason -> count), `mean_diagnostics`,
+        `mean_reward`, plus the oracle's own `n_calls`/`wall_s`/`ts_stats`/
+        `opengrep_stats` (each `None` if no oracle has been constructed yet)."""
+        n = self._n_samples
+        oracle = self._oracle
+        return {
+            "n_samples": n,
+            "n_clean": self._n_clean,
+            "n_hacked": self._n_hacked,
+            "n_degenerate": self._n_degenerate,
+            "n_oracle_errors": self._n_oracle_errors,
+            "hatch_counts": dict(self._hatch_counts),
+            "degenerate_reasons": dict(self._degenerate_reasons),
+            "mean_diagnostics": (self._diag_total / n) if n else 0.0,
+            "mean_reward": (self._reward_total / n) if n else 0.0,
+            "n_calls": oracle.n_calls if oracle is not None else 0,
+            "wall_s": oracle.wall_s if oracle is not None else 0.0,
+            "ts_stats": oracle.ts_stats if oracle is not None else None,
+            "opengrep_stats": oracle.opengrep_stats if oracle is not None else None,
+        }
+
+    def close(self) -> None:
+        """Closes the held oracle (self-constructed or injected) exactly once
+        -- a second `close()`/`__exit__` is a no-op, and `telemetry()` stays
+        readable afterward (the oracle reference itself isn't dropped)."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._oracle is not None:
+            self._oracle.close()
+
+    def __enter__(self) -> "LspVerifier":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()

--- a/tests/test_build_rlvr_prompts.py
+++ b/tests/test_build_rlvr_prompts.py
@@ -1,0 +1,130 @@
+"""#230 -- split determinism / disjointness / manifest tests for
+`scripts/build_rlvr_prompts.py`. Pure Python (stdlib only), no toolchain, no
+backend -- exercises the real checked-in eval sets, not fixtures, since the
+whole point is a reproducible split OVER those files."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_rlvr_prompts.py"
+_spec = importlib.util.spec_from_file_location("build_rlvr_prompts", _SCRIPT_PATH)
+build_rlvr_prompts = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = build_rlvr_prompts
+_spec.loader.exec_module(build_rlvr_prompts)
+
+build_manifest = build_rlvr_prompts.build_manifest
+load_prompt_records = build_rlvr_prompts.load_prompt_records
+split_records = build_rlvr_prompts.split_records
+
+
+@pytest.fixture(scope="module")
+def records():
+    return load_prompt_records()
+
+
+def test_load_prompt_records_no_duplicate_ids(records):
+    ids = [r["id"] for r in records]
+    assert len(ids) == len(set(ids))
+    assert len(records) > 0
+    for r in records:
+        assert set(r) == {"id", "prompt", "answer", "error_class"}
+
+
+def test_split_same_seed_is_identical(records):
+    train_a, val_a = split_records(records, seed=0)
+    train_b, val_b = split_records(records, seed=0)
+    assert [r["id"] for r in train_a] == [r["id"] for r in train_b]
+    assert [r["id"] for r in val_a] == [r["id"] for r in val_b]
+
+
+def test_split_different_seed_differs(records):
+    train_0, val_0 = split_records(records, seed=0)
+    train_1, val_1 = split_records(records, seed=1)
+    assert {r["id"] for r in val_0} != {r["id"] for r in val_1}
+
+
+def test_split_train_val_ids_disjoint(records):
+    train, val = split_records(records, seed=0)
+    train_ids = {r["id"] for r in train}
+    val_ids = {r["id"] for r in val}
+    assert train_ids.isdisjoint(val_ids)
+    assert train_ids | val_ids == {r["id"] for r in records}
+
+
+def test_split_every_error_class_present_on_both_sides(records):
+    train, val = split_records(records, seed=0)
+    all_classes = {r["error_class"] for r in records}
+    train_classes = {r["error_class"] for r in train}
+    val_classes = {r["error_class"] for r in val}
+    assert train_classes == all_classes
+    assert val_classes == all_classes
+
+
+def test_split_respects_val_fraction_roughly(records):
+    train, val = split_records(records, seed=0, val_fraction=0.2)
+    frac = len(val) / (len(train) + len(val))
+    assert 0.1 <= frac <= 0.35   # stratified per-class rounding, not exact
+
+
+def test_manifest_sha256_stable_and_recomputable(records):
+    train, val = split_records(records, seed=0)
+    sources = ["eval.jsonl", "clean_prefixes.jsonl"]
+    m1 = build_manifest(train, val, seed=0, val_fraction=0.2, sources=sources)
+    m2 = build_manifest(train, val, seed=0, val_fraction=0.2, sources=sources)
+    assert m1["manifest_sha256"] == m2["manifest_sha256"]
+    assert m1["train_ids_sha256"] == m2["train_ids_sha256"]
+    assert m1["val_ids_sha256"] == m2["val_ids_sha256"]
+    assert m1["n_train"] == len(train)
+    assert m1["n_val"] == len(val)
+    # per_class_counts sums back to the real split.
+    total_train = sum(c["train"] for c in m1["per_class_counts"].values())
+    total_val = sum(c["val"] for c in m1["per_class_counts"].values())
+    assert total_train == len(train)
+    assert total_val == len(val)
+
+
+def test_manifest_id_hash_changes_if_split_changes(records):
+    train_0, val_0 = split_records(records, seed=0)
+    train_1, val_1 = split_records(records, seed=1)
+    m0 = build_manifest(train_0, val_0, seed=0, val_fraction=0.2, sources=[])
+    m1 = build_manifest(train_1, val_1, seed=1, val_fraction=0.2, sources=[])
+    assert m0["val_ids_sha256"] != m1["val_ids_sha256"]
+
+
+def test_include_humaneval_adds_clean_control_rows():
+    without = load_prompt_records(include_humaneval=False)
+    with_he = load_prompt_records(include_humaneval=True)
+    assert len(with_he) > len(without)
+    new_ids = {r["id"] for r in with_he} - {r["id"] for r in without}
+    assert all(rid.startswith("HumanEval_") for rid in new_ids)
+
+
+def test_main_writes_train_val_and_manifest(tmp_path):
+    out_dir = tmp_path / "rlvr_ts"
+    argv = ["build_rlvr_prompts.py", "--out-dir", str(out_dir), "--seed", "0"]
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        build_rlvr_prompts.main()
+    finally:
+        sys.argv = old_argv
+
+    train_path = out_dir / "train.jsonl"
+    val_path = out_dir / "val.jsonl"
+    manifest_path = out_dir / "rlvr_split_manifest.json"
+    assert train_path.exists()
+    assert val_path.exists()
+    assert manifest_path.exists()
+
+    import json
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    n_train_lines = sum(1 for ln in train_path.read_text(encoding="utf-8").splitlines() if ln.strip())
+    n_val_lines = sum(1 for ln in val_path.read_text(encoding="utf-8").splitlines() if ln.strip())
+    assert manifest["n_train"] == n_train_lines
+    assert manifest["n_val"] == n_val_lines
+    assert "contamination_note" in manifest

--- a/tests/test_lsp_verifier.py
+++ b/tests/test_lsp_verifier.py
@@ -1,0 +1,248 @@
+"""#230 -- CI-safe unit tests for the LSP/opengrep verifier reward: the pure
+reward-shaping core (`severity_weight`, `is_degenerate_output`,
+`diagnostics_to_reward`) on synthetic `Diagnostic`s, and `LspVerifier` against a
+fake oracle -- no toolchain, no subprocess, no real `typescript-language-server`.
+
+One toolchain-gated integration test lives at the bottom, behind the same
+`resolve_ts_lsp() is None` skip idiom `tests/test_ts_lsp.py` uses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.lsp.diagnostics import Diagnostic
+from src.train.verifiers import (LspVerifier, diagnostics_to_reward, is_degenerate_output,
+                                 severity_weight)
+
+
+def _diag(code: str = "TS2339", severity: int = 1) -> Diagnostic:
+    return Diagnostic(code=code, line=1, col=1, message="synthetic", offset=0, severity=severity)
+
+
+# --------------------------------------------------------------------------- #
+# severity_weight / diagnostics_to_reward -- pure, no oracle
+# --------------------------------------------------------------------------- #
+
+def test_severity_weight_default_table():
+    assert severity_weight(_diag(severity=1)) == pytest.approx(0.30)
+    assert severity_weight(_diag(severity=2)) == pytest.approx(0.15)
+    assert severity_weight(_diag(severity=3)) == pytest.approx(0.05)
+    assert severity_weight(_diag(severity=4)) == pytest.approx(0.05)
+
+
+def test_severity_weight_code_override():
+    d = _diag(code="TS9999", severity=1)
+    assert severity_weight(d, code_overrides={"TS9999": 0.9}) == pytest.approx(0.9)
+    # a code not in the override table falls back to the severity table.
+    assert severity_weight(_diag(code="TS1", severity=1),
+                           code_overrides={"TS9999": 0.9}) == pytest.approx(0.30)
+
+
+def test_diagnostics_to_reward_clean_is_perfect():
+    assert diagnostics_to_reward([]) == 1.0
+
+
+def test_diagnostics_to_reward_one_error():
+    assert diagnostics_to_reward([_diag(severity=1)]) == pytest.approx(0.7)
+
+
+def test_diagnostics_to_reward_three_errors():
+    assert diagnostics_to_reward([_diag(severity=1) for _ in range(3)]) == pytest.approx(0.1)
+
+
+def test_diagnostics_to_reward_clamps_at_diag_floor():
+    assert diagnostics_to_reward([_diag(severity=1) for _ in range(10)]) == pytest.approx(-0.5)
+
+
+def test_diagnostics_to_reward_severity_2_and_3_weights():
+    assert diagnostics_to_reward([_diag(severity=2)]) == pytest.approx(0.85)
+    assert diagnostics_to_reward([_diag(severity=3)]) == pytest.approx(0.95)
+
+
+def test_diagnostics_to_reward_hacked_dominates_even_when_otherwise_clean():
+    assert diagnostics_to_reward([], hacked=True) == -1.0
+
+
+def test_diagnostics_to_reward_hacked_dominates_over_diagnostics():
+    # a hacked artifact scores -1.0 no matter how many (or few) diagnostics
+    # survive -- the hack floor must sit BELOW diag_floor, never above it.
+    assert diagnostics_to_reward([_diag(severity=1)], hacked=True) == -1.0
+
+
+def test_diagnostics_to_reward_degenerate_is_minus_one():
+    assert diagnostics_to_reward([], degenerate=True) == -1.0
+
+
+def test_diagnostics_to_reward_both_flags_still_minus_one():
+    assert diagnostics_to_reward([_diag(severity=1) for _ in range(10)],
+                                 hacked=True, degenerate=True) == -1.0
+
+
+# --------------------------------------------------------------------------- #
+# is_degenerate_output -- pure, no oracle
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize("text", ["", "   \n", "// only a comment\n", "/* block */", ";"])
+def test_is_degenerate_output_flags_the_known_traps(text):
+    reason = is_degenerate_output(text)
+    assert reason is not None, f"{text!r} should be flagged degenerate"
+    assert isinstance(reason, str)
+
+
+def test_is_degenerate_output_empty_and_whitespace_reasons():
+    assert is_degenerate_output("") == "empty"
+    assert is_degenerate_output("   \n\t") == "whitespace_only"
+
+
+def test_is_degenerate_output_real_code_is_none():
+    assert is_degenerate_output("const x: number = 1 + 2;\nconsole.log(x);\n") is None
+    assert is_degenerate_output("function add(a: number, b: number) { return a + b; }") is None
+
+
+# --------------------------------------------------------------------------- #
+# LspVerifier against a fake oracle -- no real typescript-language-server
+# --------------------------------------------------------------------------- #
+
+class FakeOracle:
+    """Stands in for `CompositeOracle`'s public surface
+    (`.diagnostics()/.close()/.n_calls/.wall_s/.ts_stats/.opengrep_stats`).
+    `diags` is either a fixed list returned on every call, or a callable
+    `source -> List[Diagnostic]` for tests that need call-dependent output."""
+
+    def __init__(self, diags=None, raises: bool = False):
+        self._diags = [] if diags is None else diags
+        self._raises = raises
+        self.calls = []
+        self.n_calls = 0
+        self.wall_s = 0.0
+        self.ts_stats = {"n_calls": 0, "wall_s": 0.0, "n_timeouts": 0, "n_restarts": 0}
+        self.opengrep_stats = None
+        self.close_count = 0
+
+    def diagnostics(self, source):
+        self.calls.append(source)
+        self.n_calls += 1
+        self.wall_s += 0.01
+        if self._raises:
+            raise RuntimeError("simulated oracle failure")
+        return list(self._diags(source)) if callable(self._diags) else list(self._diags)
+
+    def close(self):
+        self.close_count += 1
+
+
+def test_lsp_verifier_clean_sample_scores_one():
+    v = LspVerifier(oracle=FakeOracle(diags=[]))
+    assert v.reward("const x = 1;\n", prompt="") == 1.0
+
+
+def test_lsp_verifier_suppression_trap_dominates_clean_diagnostics():
+    # the fake oracle reports NO diagnostics -- but `as any` in the completion
+    # must still zero the reward via the hack floor, not the (empty) diagnostic set.
+    v = LspVerifier(oracle=FakeOracle(diags=[]))
+    assert v.reward("const x = y as any;\n") == -1.0
+
+
+def test_lsp_verifier_empty_completion_trap():
+    v = LspVerifier(oracle=FakeOracle(diags=[]))
+    assert v.reward("") == -1.0
+
+
+def test_lsp_verifier_module_resolution_dropped_by_default():
+    v = LspVerifier(oracle=FakeOracle(diags=[_diag(code="TS2307")]))
+    assert v.reward("import { x } from 'y';\n") == 1.0
+
+
+def test_lsp_verifier_module_resolution_counted_when_disabled():
+    v = LspVerifier(oracle=FakeOracle(diags=[_diag(code="TS2307")]),
+                    ignore_module_resolution=False)
+    assert v.reward("import { x } from 'y';\n") == pytest.approx(0.7)
+
+
+def test_lsp_verifier_hatches_directives_ignores_superset_only_members():
+    # empty_body is a superset-only hatch (a known-noisy false positive); under
+    # "directives" it must not trip the hack floor, only the diagnostic penalty applies.
+    v = LspVerifier(oracle=FakeOracle(diags=[]), hatches="directives")
+    assert v.reward("function f() {}\n") == 1.0
+
+
+def test_lsp_verifier_hatches_none_disables_hack_floor():
+    v = LspVerifier(oracle=FakeOracle(diags=[]), hatches="none")
+    assert v.reward("const x = y as any;\n") == 1.0
+
+
+def test_lsp_verifier_telemetry_keys_and_values():
+    v = LspVerifier(oracle=FakeOracle(diags=[]))
+    v.reward("const x = y as any;\n")
+    v.reward("const y = 1;\n")
+    t = v.telemetry()
+    for key in ("n_samples", "n_clean", "n_hacked", "n_degenerate", "hatch_counts",
+               "degenerate_reasons", "mean_diagnostics", "mean_reward", "n_calls",
+               "wall_s", "ts_stats", "opengrep_stats"):
+        assert key in t
+    assert t["n_samples"] == 2
+    assert t["n_hacked"] == 1
+    assert t["n_clean"] == 1
+    assert t["hatch_counts"].get("as_any") == 1
+    assert t["n_calls"] == 2
+
+
+def test_lsp_verifier_close_is_idempotent():
+    oracle = FakeOracle(diags=[])
+    v = LspVerifier(oracle=oracle)
+    v.reward("const x = 1;\n")
+    v.close()
+    v.close()
+    assert oracle.close_count == 1
+
+
+def test_lsp_verifier_context_manager_closes_once():
+    oracle = FakeOracle(diags=[])
+    with LspVerifier(oracle=oracle) as v:
+        v.reward("const x = 1;\n")
+    v.close()  # a second close after __exit__ must still be a no-op
+    assert oracle.close_count == 1
+
+
+def test_lsp_verifier_on_error_raise_propagates():
+    v = LspVerifier(oracle=FakeOracle(raises=True))
+    with pytest.raises(RuntimeError):
+        v.reward("const x = 1;\n")
+    assert v.telemetry()["n_oracle_errors"] == 1
+
+
+def test_lsp_verifier_on_error_skip_returns_none():
+    v = LspVerifier(oracle=FakeOracle(raises=True), on_error="skip")
+    assert v.reward("const x = 1;\n") is None
+    assert v.telemetry()["n_oracle_errors"] == 1
+
+
+def test_lsp_verifier_rejects_unknown_hatches_mode():
+    with pytest.raises(ValueError):
+        LspVerifier(hatches="bogus")
+
+
+def test_lsp_verifier_rejects_unknown_on_error():
+    with pytest.raises(ValueError):
+        LspVerifier(on_error="bogus")
+
+
+# --------------------------------------------------------------------------- #
+# Toolchain-gated integration test (skipped without a real TS-LSP toolchain)
+# --------------------------------------------------------------------------- #
+
+from src.lsp.ts_lsp import resolve_ts_lsp  # noqa: E402 -- grouped with its own section
+
+_ts_lsp_available = resolve_ts_lsp() is not None
+
+
+@pytest.mark.skipif(not _ts_lsp_available,
+                    reason="no typescript-language-server toolchain on this host")
+def test_lsp_verifier_real_oracle_ranks_clean_above_broken():
+    with LspVerifier(kind="ts") as v:
+        clean = v.reward("function add(a: number, b: number): number {\n  return a + b;\n}\n")
+        broken = v.reward(
+            "function add(a: number, b: number): number {\n  return a + gorblak;\n}\n")
+        assert clean > broken
+        assert v.telemetry()["n_calls"] == 2


### PR DESCRIPTION
Closes #230

## Summary
- `src/train/verifiers.py`: pure reward-shaping core (`severity_weight`, `is_degenerate_output`, `diagnostics_to_reward`) plus `LspVerifier` wrapping `CompositeOracle` — the diagnostic-cleanliness verifier reward for #198's SSI RLVR/GRPO arm. Static-analysis only (never executes model output), so enabled by default unlike `CodeVerifier`. Two anti-Goodhart guards (escape-hatch superset, empty/whitespace/comment-only degenerate-output detection) both dominate the diagnostic-density term via a `-1.0` floor strictly below the honest-attempt `diag_floor` (`-0.5`).
- `src/lsp/oracle.py`: adds `CompositeOracle.ts_stats`, symmetric with `opengrep_stats`, so verifier telemetry never reaches into the TS-LSP arm directly.
- `scripts/rlvr.py`: wires `--reward lsp` with `--oracle`/`--lsp-timeout-s`/`--lsp-hatches`/`--lsp-ignore-module-resolution`; fails fast on a missing toolchain before any model load; builds the verifier once outside the step loop (`contextlib.ExitStack`-guarded close); logs oracle cost/hack/degenerate-rate telemetry each `--log-every` step and writes `telemetry.json` (refreshed at each `--ckpt-every`).
- `scripts/build_rlvr_prompts.py` (new): builds a disjoint, stratified train/val RLVR prompt split from the checked-in `eval_sets/ts_error_injection` (+ optional `humaneval_ts`) sets via a stable `sha256(seed:id)` hash, with a reproducible `rlvr_split_manifest.json` and the #194 contamination note.
- `docs/design/13-code-model-moe.md`: new subsection under the SSI axis recording the reward shape, guard-dominance ordering, the deliberate `SUPPRESSION_RE`-vs-escape-hatch-superset choice, and the #278-debounce-driven cost model.
- Tests: `tests/test_lsp_verifier.py` (pure reward-shaping unit tests + `LspVerifier` against a fake oracle + one toolchain-gated integration test), `tests/test_build_rlvr_prompts.py` (split determinism/disjointness/manifest tests).

Phase 1 only (diagnostic-cleanliness + anti-hack + anti-degenerate + telemetry + prompt split), per the issue's own phasing — Phase 2's reference-based over-repair penalty on `clean_control` rows is deferred to a follow-up issue (needs a `{prompt, reference, kind:"clean_control"}` data-format change).

## Testing
- [x] Tests added/updated
- [x] All tests passing — `pytest -q -rs`: 1473 passed, 13 skipped (pre-existing env gaps: no CUDA `torch.compile` toolchain, no `prettier`), 0 failed. The toolchain-gated `LspVerifier` integration test ran for real against a live `typescript-language-server` on this box (not skipped) and passed.
- [x] Manual testing completed — `scripts/build_rlvr_prompts.py --out-dir ... --seed 0` produced a 236/60 train/val split with every `error_class` on both sides; a 3-step/group-size-4 GRPO smoke run with `--reward lsp` completed cleanly, wrote non-zero-`n_calls` telemetry (`oracle_wall_frac` ≈0.86, consistent with the design doc's toy-scale cost-model note), and left no orphaned `typescript-language-server` process on exit; `scripts/smoke_test.py` passed (exact resume + eval).

Not covered here (explicitly out of scope per the plan): the RLVR *accept* criteria (`error_avoidance_rate` gain vs. a math/random control under the #225 M4 null-arm) need a real GPU run — this PR ships the mechanism and telemetry that makes that run measurable.