### PR TITLE
feat: [M13] Swift checkpoint I/O (safetensors + config sidecar round-trip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,46 @@ jobs:
             ${{ runner.temp }}/monica-bench-toy.json
             ${{ runner.temp }}/monica-bench-toy-moe-int8.json
           retention-days: 90
+      # ── #196: checkpoint I/O — the Swift WRITER round-trips into Python ──
+      # `monica-parity`'s own round-trip section (Checkpoint.swift's `save`, gated
+      # above as part of "Logit + greedy-id parity") only proves Swift can read back
+      # what Swift wrote. The issue's other acceptance direction — "a checkpoint
+      # written by Swift loads and runs in Python" — can only be proven by a Python
+      # process, hence the two steps below.
+      - name: Emit Swift-written checkpoints for the Python round-trip gate
+        # Cheap: the binary is already built and every fixture is tiny. Reruns the
+        # same binary rather than adding a second executable/target.
+        working-directory: swift/engine
+        run: |
+          BIN=$(find .build-xcode/Build/Products -type f -name monica-parity -perm -u+x -print -quit)
+          if [ -z "$BIN" ]; then
+            echo "monica-parity binary not found under .build-xcode/Build/Products" >&2
+            exit 1
+          fi
+          "$BIN" --roundtrip-out "$RUNNER_TEMP/swift-ckpt"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install Python (mlx only — no data/torch needed for this check)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,mlx]"
+      - name: Swift -> Python checkpoint round trip (GATE)
+        # Closes the direction `monica-parity`'s own round trip cannot: sidecar
+        # dict equality, quant-block equality, key-set equality, and forward logits
+        # vs reference.safetensors, for every checkpoint the step above emitted. An
+        # empty --roundtrip-dir is a FAILURE in this script, not a silent pass — see
+        # scripts/check_swift_checkpoint.py's module docstring. If Python setup ever
+        # makes this job noticeably slower, the documented fallback (see that
+        # script's docstring and #196's plan) is to upload
+        # "$RUNNER_TEMP/swift-ckpt" as an artifact and run this check in a small
+        # separate `needs:`-gated macOS job instead of inline here.
+        run: |
+          python scripts/check_swift_checkpoint.py \
+            --roundtrip-dir "$RUNNER_TEMP/swift-ckpt" \
+            --fixtures swift/engine/Fixtures
       - name: Guard — swift/ (MonicaTokenizer) stays dependency-free (#167)
         # Cheap, and it fails loudly the day someone "simplifies" the two packages into one.
         # The engine -> tokenizer edge (Package.swift) must never become tokenizer -> engine.

--- a/docs/design/14-inference-engine.md
+++ b/docs/design/14-inference-engine.md
@@ -216,12 +216,76 @@ implementation reproduces the policy; it does not re-invent it. See
 **The gate.** Loss and grad-norm versus the Python MLX train step on a fixed-seed toy batch,
 in the spirit of `src/conformance/backend_parity.py` — fp32, ~1e-4.
 
-**Checkpoint I/O (#196).** Both directions against `src/train/checkpoint.py:75` (`save_weights`):
-safetensors plus the `<path>.config.json` sidecar. Python-written checkpoints must load in Swift
-and Swift-written checkpoints must load in Python, bit-for-bit on the tensors. The **slot-a/slot-b
-resume bundle** (`CheckpointStore`, `src/train/checkpoint.py:121`) is explicitly **out of
-scope** — that is the within-backend concern the two-concern split exists to keep separate
-(optimizer state does not need to port).
+**Checkpoint I/O (#196) — shipped.** Both directions against `src/train/checkpoint.py:75`
+(`save_weights`): safetensors plus the `<path>.config.json` sidecar. Python-written checkpoints
+load in Swift and Swift-written checkpoints load in Python, bit-for-bit on the tensors.
+
+*The reader half already existed.* `Checkpoint.load`/`loadInto`
+(`swift/engine/Sources/MonicaEngine/Checkpoint.swift`) landed with #166/#168 — decode the
+sidecar, apply an optional `quant` block, pop the non-parameter `moe_route_bias.{i}` keys, and
+`update(parameters:verify: .all)`. #196's net-new work was the **writer**
+(`Checkpoint.save`/`portableStateDict`) and the Swift→Python direction of the round trip.
+
+*The writer* mirrors `_portable_state_dict` exactly: `model.parameters().flattened()` plus,
+for each `MoEBlock` whose route bias is ACTIVE, `moe_route_bias.{i}` — emitted conditionally,
+because an unconditional key would break Python's `num_parameters()` accounting
+(`tests/test_moe.py`, `tests/test_sizing_mlx.py`; the bias is training-side routing state, not
+a parameter, on either side of the seam). It rejects `bfloat16` at save time (Python's
+`safetensors.numpy` reader has no bf16 numpy dtype — better to fail at the write, not three
+files later on the read), and writes atomically (`.safetensors`-suffixed temp path,
+`replaceItemAt`/`moveItem`), mirroring `checkpoint.py`'s `_atomic_write_bytes` discipline.
+
+*The sidecar-fidelity decision.* `MambaConfig.to_dict()` on the Python side is
+`dataclasses.asdict(self)` — **every** field (Muon / `torch_compile` / `fp8_experts` /
+data-side knobs / `quant`). Swift's `MambaConfig` only *decodes* the ~22 fields the inference
+path reads. Re-encoding just that subset on save would silently reset every other field to a
+Python dataclass default on the next Python read — a quiet corruption of the cross-backend
+bridge. Instead, `MambaConfig.load(sidecar:)` decodes the file **twice**: once into
+`MambaConfig` (typed, known fields), once into a raw `[String: JSONValue]`
+(`swift/engine/Sources/MonicaEngine/Config.swift`'s minimal `Any`-Codable enum, order-sensitive
+— `Int` is tried before `Double` so `"d_model": 64` doesn't become `64.0`). `save(sidecar:)`
+writes the raw dict back, **overlaid** with the known fields' current values, so an unmodeled
+field (or `quant`) survives verbatim while a config actually mutated in Swift is still
+reflected. This is deliberately **not** byte-identical to Python's `json.dumps(cfg, indent=2)`
+(dataclass field order can't be reproduced without hardcoding it); the gate is *semantic* dict
+equality (`scripts/check_swift_checkpoint.py`), not `cmp`. A config built directly in Swift
+(no `rawSidecar`) writes only the known fields — lossy by construction, documented at the call
+site, and not a path any checkpoint destined for Python should go through.
+
+*The round-trip gate* has two halves, because a Swift binary alone cannot prove the direction
+that matters to Python. `monica-parity --roundtrip-out <dir>` (Swift side, no new checked-in
+fixture — see `swift/engine/Fixtures/README.md`) exercises, per fixture: (a) an identity round
+trip — save, reload, assert every parameter tensor is **bit-identical** (save/load is lossless
+by construction, so `rtol`/`atol` would be the wrong tool here), the sidecar round-trips to an
+equal `MambaConfig`, and forward logits still match the Python oracle; (b) a mutation round
+trip — perturb one parameter, save, reload, confirm the perturbation survived exactly, which is
+what catches a writer that degenerates into a file copy; (c) route-bias presence/absence
+matching `_portable_state_dict`'s conditional; (d) for the quantized fixtures, that the `quant`
+block re-decodes to the same `mode`/`group_size`/`targets` (the packed tensors themselves are
+already covered by (a)'s exact comparison). `scripts/check_swift_checkpoint.py` (Python side)
+then loads what that step wrote: sidecar dict equality, quant-block equality, key-set equality,
+and forward logits vs each fixture's `reference.safetensors`. It explicitly **SKIPs** — never
+silently passes — the two quantized fixtures' model-construction/forward checks, because
+`src/eval/quantize.py` is a fake-quant *measurement* spike (see "Quantization" above): the
+Python MLX backend never builds an `nn.QuantizedLinear`/`nn.QuantizedEmbedding`, so there is no
+loader reachable from a plain `MLXMambaModel` that can consume packed
+`.weight`/`.scales`/`.biases`. Sidecar/quant-block equality still gates those two fixtures; the
+packed-tensor and quant-block round trip is gated Swift-side by (a)/(d) above. An empty
+`--roundtrip-dir` is itself a FAIL in the Python script, not a pass — a checker that can't see
+its target must never read green.
+
+*Explicitly out of scope, and why.* The **slot-a/slot-b resume bundle**
+(`CheckpointStore`, `src/train/checkpoint.py:121` — step / loss-scale / RNG / optimizer state /
+dataloader position) is **not** implemented here. That's the within-backend concern the
+two-concern split exists to keep separate from portable weights (optimizer state does not need
+to port across backends), and #196 delivers exactly concern (1) of that split. Concretely: at
+the time #196 landed, #195 (the Swift train step) had not merged — `main` had no Swift
+optimizer type, no `monica-train`, and no `train.safetensors` fixture — so there was nothing
+real to serialize yet, and inventing an optimizer-state format against nonexistent types would
+have collided with #195 when it eventually lands. `Checkpoint.save` takes only a model and a
+destination URL, so a future optimizer serializer is an orthogonal file written into the same
+directory, not a refactor of this one. Swift resume (optimizer state + step) should be filed as
+its own issue once #195 lands, referencing this note.
 
 **The LSP fast loop (#197).** A native persistent `tsserver` client — the Python reference is
 `src/lsp/ts_lsp.py` plus `src/lsp/harness.py`, driven through the `LMAdapter` seam

--- a/scripts/check_swift_checkpoint.py
+++ b/scripts/check_swift_checkpoint.py
@@ -1,0 +1,205 @@
+"""Swift -> Python checkpoint round-trip gate (#196).
+
+`monica-parity`'s round-trip section (#196) proves the Swift WRITER produces a
+checkpoint that Swift itself can read back byte-for-byte — but that claim, made
+entirely inside a Swift binary, does not discharge the issue's other acceptance
+direction: "a checkpoint written by Swift loads and runs in Python." Only a Python
+process can prove that. This script closes it.
+
+    python scripts/check_swift_checkpoint.py \\
+        --roundtrip-dir <dir written by `monica-parity --roundtrip-out`> \\
+        --fixtures swift/engine/Fixtures
+
+For each fixture subdirectory found under `--roundtrip-dir` (one per checked-in
+fixture, written by `monica-parity`'s round-trip section (a)):
+
+1. `load_config_sidecar` the Swift-written weights and the fixture's own weights;
+   assert the two `MambaConfig`s are equal FIELD-FOR-FIELD (`dataclasses.asdict`
+   equality) — this is where sidecar fidelity actually gets gated on the Python side
+   (the Swift side only proves Swift-to-Swift; this proves Swift's writer produced
+   something Python's OWN reader reconstructs identically).
+2. `load_quant_sidecar` both; assert equal (`None == None` for the five fp fixtures).
+3. For an fp fixture: build the MLX backend model from the round-tripped config,
+   `check_weight_keys` its round-tripped weights against a freshly-built model's own
+   `_portable_state_dict()`, load them, run `forward`, and compare logits against the
+   fixture's `reference.safetensors` at the fixture's own rtol/atol (falling back to
+   the repo-wide fp32 gate's `1e-4`/`1e-5`).
+4. For a quantized fixture (`toy-moe-int8`/`toy-moe-int4`, `meta.json` carries
+   `quant_bits`): steps 1-2 above still run (pure JSON, no model construction needed),
+   but step 3 is explicitly SKIPPED, not silently passed. `src/eval/quantize.py`'s own
+   docstring says quantization here is a fake-quant MEASUREMENT spike, not a servable
+   format — the Python MLX backend (`src/model/mlx_backend.py`) never builds an
+   `nn.QuantizedLinear`/`nn.QuantizedEmbedding`, so there is no loader reachable from a
+   plain `MLXMambaModel` + `_load_portable` that can consume packed
+   `.weight`/`.scales`/`.biases` tensors. The packed-tensor bit-identity and the
+   quant-block re-decode ARE gated — on the Swift side, by `monica-parity`'s round
+   trip (a) (exact tensor comparison, which covers packed tensors like any other) and
+   (d) (`QuantSpec` re-decode). This script prints an explicit SKIP line rather than
+   silently doing nothing, per the standing rule that a checker which cannot observe
+   its target must never read green.
+
+An EMPTY `--roundtrip-dir` (no subdirectories) is itself a FAILURE, not a pass, for
+the same reason: a checker pointed at nothing must say so loudly, not report OK
+because it found zero problems in zero fixtures.
+
+MLX-only where it touches the backend (imported lazily inside `_check_one`, mirroring
+`scripts/smoke_test.py`'s "keep MLX-only imports local" convention) — the argument
+parsing and directory walk above are portable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# The repo-wide fp32 parity gate's constants (`swift/engine/Sources/monica-parity/
+# main.swift`'s `rtol`/`atol`), used as the fallback when a fixture's `meta.json`
+# carries no override — matching monica-parity's own `meta.rtol ?? rtol` behavior.
+_DEFAULT_RTOL = 1e-4
+_DEFAULT_ATOL = 1e-5
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Load Swift-written portable checkpoints in Python/MLX and verify "
+                    "they reproduce each fixture's config and reference logits (#196).")
+    p.add_argument("--roundtrip-dir", required=True, type=Path,
+                   help="directory of Swift-written checkpoints, one subdirectory per "
+                        "fixture: <dir>/<fixture>/weights.safetensors[.config.json] "
+                        "(written by `monica-parity --roundtrip-out <dir>`)")
+    p.add_argument("--fixtures", required=True, type=Path,
+                   help="the checked-in fixtures directory, e.g. swift/engine/Fixtures")
+    return p.parse_args()
+
+
+def _check_one(name: str, rt_weights: Path, fixture_dir: Path) -> tuple[str, str]:
+    """Check one fixture's Swift-written round-trip checkpoint. Returns
+    `(status, message)` with `status` in `{"OK", "FAIL", "SKIP"}`. Never raises for an
+    ordinary check failure (those become `"FAIL"`); the caller still guards against a
+    genuinely unexpected exception so one bad fixture can't silently truncate the run.
+    """
+    from src.model.mlx_backend import MLXMambaModel  # local: MLX-only (see module docstring)
+    from src.train.checkpoint import (
+        check_weight_keys,
+        load_config_sidecar,
+        load_quant_sidecar,
+        load_weights_dict,
+    )
+
+    fixture_weights = fixture_dir / "weights.safetensors"
+    if not fixture_weights.exists():
+        return "FAIL", f"no fixture weights.safetensors at {fixture_weights}"
+
+    meta_path = fixture_dir / "meta.json"
+    meta = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+    quant_bits = meta.get("quant_bits")
+
+    # --- 1. sidecar fidelity: Swift's writer must reproduce the SAME MambaConfig ------
+    rt_cfg = load_config_sidecar(str(rt_weights))
+    fx_cfg = load_config_sidecar(str(fixture_weights))
+    if rt_cfg is None or fx_cfg is None:
+        return "FAIL", (f"missing MambaConfig sidecar (roundtrip="
+                        f"{'present' if rt_cfg is not None else 'MISSING'}, fixture="
+                        f"{'present' if fx_cfg is not None else 'MISSING'})")
+    rt_dict, fx_dict = dataclasses.asdict(rt_cfg), dataclasses.asdict(fx_cfg)
+    if rt_dict != fx_dict:
+        diff = {k: (rt_dict[k], fx_dict[k]) for k in rt_dict
+                if rt_dict[k] != fx_dict.get(k)}
+        return "FAIL", f"sidecar MambaConfig fields differ (roundtrip, fixture): {diff}"
+
+    # --- 2. the quant block rides the same sidecar; must survive independently -------
+    rt_quant = load_quant_sidecar(str(rt_weights))
+    fx_quant = load_quant_sidecar(str(fixture_weights))
+    if rt_quant != fx_quant:
+        return "FAIL", f"quant sidecar differs: roundtrip={rt_quant} fixture={fx_quant}"
+
+    if quant_bits is not None:
+        # See module docstring: no Python loader for packed checkpoints exists to skip
+        # TO — this is a real, explained SKIP, not a placeholder for future work.
+        return "SKIP", (
+            f"quant_bits={quant_bits} — Python's MLX backend has no "
+            "QuantizedLinear/QuantizedEmbedding loader reachable from a plain "
+            "MLXMambaModel; sidecar fidelity (checks 1-2 above) still gates this "
+            "fixture, and the packed-tensor / quant-block round trip is gated on the "
+            "Swift side (monica-parity round trip (a)/(d))")
+
+    # --- 3. build + load the round-tripped fp checkpoint, compare against the oracle -
+    model = MLXMambaModel(rt_cfg)
+    rt_weights_dict = load_weights_dict(str(rt_weights))
+    try:
+        check_weight_keys(rt_weights_dict, model._portable_state_dict(),
+                          where=f"{name} (Swift round trip)")
+    except ValueError as e:
+        return "FAIL", f"weight-key check failed: {e}"
+    model._load_portable(rt_weights_dict)
+
+    inputs = load_weights_dict(str(fixture_dir / "inputs.safetensors"))
+    reference = load_weights_dict(str(fixture_dir / "reference.safetensors"))
+    tokens = inputs["tokens"]
+    ref_forward = reference["forward_logits"]
+
+    logits = np.array(model.forward(tokens), dtype=np.float32)
+    rtol = float(meta.get("rtol", _DEFAULT_RTOL))
+    atol = float(meta.get("atol", _DEFAULT_ATOL))
+    if not np.allclose(logits, ref_forward, rtol=rtol, atol=atol):
+        max_abs = float(np.abs(
+            logits.astype(np.float64) - ref_forward.astype(np.float64)).max())
+        return "FAIL", (f"forward logits vs reference.safetensors differ "
+                        f"(max|d|={max_abs:.3e}, rtol={rtol} atol={atol})")
+
+    return "OK", f"sidecar + key-set + forward logits match (rtol={rtol} atol={atol})"
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if not args.roundtrip_dir.is_dir():
+        print(f"FAIL: --roundtrip-dir {args.roundtrip_dir} does not exist")
+        sys.exit(1)
+
+    subdirs = sorted(p for p in args.roundtrip_dir.iterdir() if p.is_dir())
+    if not subdirs:
+        # A checker that cannot see its target must never read green: an empty
+        # round-trip dir means the Swift emit step didn't run (or wrote somewhere this
+        # script can't see), not that every fixture silently passed.
+        print(f"FAIL: {args.roundtrip_dir} contains no fixture subdirectories — the "
+              "Swift emit step (`monica-parity --roundtrip-out`) did not run, or wrote "
+              "somewhere this script isn't looking")
+        sys.exit(1)
+
+    results: list[tuple[str, str, str]] = []
+    for sub in subdirs:
+        name = sub.name
+        rt_weights = sub / "weights.safetensors"
+        fixture_dir = args.fixtures / name
+        if not rt_weights.exists():
+            results.append((name, "FAIL", f"no weights.safetensors under {sub}"))
+            continue
+        if not fixture_dir.is_dir():
+            results.append(
+                (name, "FAIL", f"no matching fixture directory at {fixture_dir}"))
+            continue
+        try:
+            status, msg = _check_one(name, rt_weights, fixture_dir)
+        except Exception as e:  # a single bad fixture must not silently end the run
+            status, msg = "FAIL", f"threw: {e!r}"
+        results.append((name, status, msg))
+
+    for name, status, msg in results:
+        print(f"{status}: {name} — {msg}")
+
+    n_ok = sum(1 for _, s, _ in results if s == "OK")
+    n_skip = sum(1 for _, s, _ in results if s == "SKIP")
+    n_fail = sum(1 for _, s, _ in results if s == "FAIL")
+    print(f"\n{len(results)} fixture(s) checked: {n_ok} OK, {n_skip} SKIP, {n_fail} FAIL")
+    if n_fail:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/swift/engine/Fixtures/README.md
+++ b/swift/engine/Fixtures/README.md
@@ -20,6 +20,23 @@ function and a mismatch between them is exactly the bug this harness exists to c
   wrong carry-out is silent (the prompt's own logits still look right) and only corrupts
   tokens generated afterwards, so it is checked element-wise, not just via logits.
 
+## The checkpoint round trip (#196) adds NO fixture
+
+`monica-parity`'s round-trip section (`Checkpoint.save`/`portableStateDict`, #196) proves the
+Swift **writer** produces a checkpoint Swift can read back byte-for-byte, and
+`scripts/check_swift_checkpoint.py` proves Python can too — but neither check needed, or got,
+a new checked-in tensor. Every comparison is computed **in-process** from the fixture already
+loaded above: save the already-loaded model, reload it, and diff against the SAME model
+object's own tensors/config/logits, all in the same run. This is deliberate, not an oversight:
+#195 (the Swift train step) shipped a checked-in **gradient** oracle that turned out to
+diverge across macOS machines (`grad.0.layers.0.conv.weight` by `max|d|=1.226e-02` on the
+hosted CI runner vs. locally) — forward/step *logit* and *weight* fixtures have never shown
+that failure mode, but the safest fix is to not add another checked-in tensor of any kind. The
+round trip's two EXACT (no-tolerance) comparisons — save→load tensor bit-identity, and the
+mutation round trip's exact-preservation check — are therefore same-process, same-machine
+comparisons by construction, which makes them immune to the cross-machine drift that broke
+#195's fixture regardless of what hardware CI runs on next.
+
 ## Files in a fixture
 
 | File | What |

--- a/swift/engine/Sources/MonicaEngine/Checkpoint.swift
+++ b/swift/engine/Sources/MonicaEngine/Checkpoint.swift
@@ -131,7 +131,7 @@ public enum Checkpoint {
     /// half-written weights file. `MambaConfig.save(sidecar:)` does its own atomic write
     /// for the sidecar.
     public static func save(_ model: MonicaModel, to weightsURL: URL) throws {
-        var sd = portableStateDict(model)
+        let sd = portableStateDict(model)
         for (k, v) in sd where v.dtype == .bfloat16 {
             // `safetensors.numpy.load_file` (what `load_weights_dict` uses on the Python
             // side) has no bf16 numpy dtype and would fail on the Python side, far from
@@ -144,18 +144,6 @@ public enum Checkpoint {
         // Realize the lazy graph before handing arrays to mlx-swift's `save`, which
         // needs concrete (not lazily-graphed) arrays.
         MLX.eval(Array(sd.values))
-
-        // Force each tensor into a genuinely independent, host-backed buffer — a real
-        // byte-for-byte copy, not merely an evaluated-but-possibly-shared handle. Without
-        // this, a parameter whose value was produced in place over a buffer this process
-        // still shares with (or aliases the identity of) an earlier load/eval graph node
-        // can, in edge cases, have its write dispatch resolve against stale/shared state
-        // instead of the model's current values — exactly the failure mode #196's
-        // round-trip (b) mutation check guards against ("the writer may be copying the
-        // source file rather than serializing the model's actual parameters"). Routing
-        // through `asData(access: .copy)` (an explicit host memcpy) and rebuilding a
-        // fresh `MLXArray` from those bytes breaks any such aliasing unconditionally.
-        sd = sd.mapValues { MLXArray(data: $0.asData(access: .copy)) }
 
         let fm = FileManager.default
         let dir = weightsURL.deletingLastPathComponent()

--- a/swift/engine/Sources/MonicaEngine/Checkpoint.swift
+++ b/swift/engine/Sources/MonicaEngine/Checkpoint.swift
@@ -22,7 +22,9 @@ import MLX
 import MLXNN
 
 public enum Checkpoint {
-    static let moeBiasPrefix = "moe_route_bias."
+    // `public` (not just `internal`) so `monica-parity`'s #196 round-trip section can
+    // check a saved file's raw key set for this prefix without duplicating the literal.
+    public static let moeBiasPrefix = "moe_route_bias."
 
     /// Load `<weightsURL>` (safetensors) plus `<weightsURL>.config.json` into a fresh model.
     /// Returns the model and the checkpoint's parameter key set (the caller asserts it
@@ -95,5 +97,65 @@ public enum Checkpoint {
         // rather than inside the first forward. (Nothing to do with code evaluation.)
         MLX.eval(model.parameters())
         return Set(params.map { $0.0 })
+    }
+
+    // --- writer (#196) ------------------------------------------------------------
+
+    /// The portable state dict for `model`: `model.parameters().flattened()` plus, for
+    /// each `MoEBlock` whose route bias is ACTIVE, `moe_route_bias.{i}` — the exact
+    /// mirror of `_portable_state_dict` (`mlx_backend.py:1043-1061`), including its
+    /// "emit only when active" rule. An unconditional key would break Python's
+    /// `num_parameters()` accounting (`tests/test_moe.py`, `tests/test_sizing_mlx.py`):
+    /// the bias genuinely is not a parameter (see `MoEBlock.routeBias`'s docstring for
+    /// why it is deliberately invisible to mlx-swift's parameter reflection), so it
+    /// can't ride the `parameters()` flatten and doesn't belong in that count either way.
+    public static func portableStateDict(_ model: MonicaModel) -> [String: MLXArray] {
+        var out = Dictionary(uniqueKeysWithValues: model.parameters().flattened())
+        for (i, layer) in model.layers.enumerated() {
+            guard let moe = layer as? MoEBlock, let bias = moe.routeBias else { continue }
+            out["\(moeBiasPrefix)\(i)"] = MLXArray(bias)
+        }
+        return out
+    }
+
+    /// Write `model` as a portable checkpoint: `<weightsURL>` (safetensors) plus
+    /// `<weightsURL>.config.json` (the sidecar) — the Swift mirror of `save`
+    /// (`mlx_backend.py:1029-1032`). The sidecar path is built the same
+    /// `path + ".config.json"` way `load` above already does, so the writer and reader
+    /// cannot drift apart on the naming convention.
+    ///
+    /// Atomic: the safetensors file is written to a sibling temp path (kept
+    /// `.safetensors`-suffixed — mlx-swift's `save(arrays:...)` dispatches on the URL's
+    /// extension and rejects anything else) and moved/replaced into place, mirroring
+    /// `checkpoint.py`'s `_atomic_write_bytes` discipline: a reader must never observe a
+    /// half-written weights file. `MambaConfig.save(sidecar:)` does its own atomic write
+    /// for the sidecar.
+    public static func save(_ model: MonicaModel, to weightsURL: URL) throws {
+        let sd = portableStateDict(model)
+        for (k, v) in sd where v.dtype == .bfloat16 {
+            // `safetensors.numpy.load_file` (what `load_weights_dict` uses on the Python
+            // side) has no bf16 numpy dtype and would fail on the Python side, far from
+            // this call. float16 is fine and preserved as-is — upcasting it to fp32 here
+            // would double the file size and change the bytes Python reads back.
+            throw EngineError.badCheckpoint(
+                "cannot save bfloat16 tensor '\(k)' to the portable format — Python's "
+                + "safetensors reader has no bf16 numpy dtype")
+        }
+        // Realize the lazy graph before handing arrays to mlx-swift's `save`, which
+        // needs concrete (not lazily-graphed) arrays.
+        MLX.eval(Array(sd.values))
+
+        let fm = FileManager.default
+        let dir = weightsURL.deletingLastPathComponent()
+        let tmp = dir.appendingPathComponent(".tmp-\(UUID().uuidString).safetensors")
+        try MLX.save(arrays: sd, url: tmp)
+        if fm.fileExists(atPath: weightsURL.path) {
+            _ = try fm.replaceItemAt(weightsURL, withItemAt: tmp)
+        } else {
+            try fm.moveItem(at: tmp, to: weightsURL)
+        }
+
+        let sidecarURL = URL(fileURLWithPath: weightsURL.path + ".config.json")
+        try model.config.save(sidecar: sidecarURL)
     }
 }

--- a/swift/engine/Sources/MonicaEngine/Checkpoint.swift
+++ b/swift/engine/Sources/MonicaEngine/Checkpoint.swift
@@ -131,7 +131,7 @@ public enum Checkpoint {
     /// half-written weights file. `MambaConfig.save(sidecar:)` does its own atomic write
     /// for the sidecar.
     public static func save(_ model: MonicaModel, to weightsURL: URL) throws {
-        let sd = portableStateDict(model)
+        var sd = portableStateDict(model)
         for (k, v) in sd where v.dtype == .bfloat16 {
             // `safetensors.numpy.load_file` (what `load_weights_dict` uses on the Python
             // side) has no bf16 numpy dtype and would fail on the Python side, far from
@@ -144,6 +144,18 @@ public enum Checkpoint {
         // Realize the lazy graph before handing arrays to mlx-swift's `save`, which
         // needs concrete (not lazily-graphed) arrays.
         MLX.eval(Array(sd.values))
+
+        // Force each tensor into a genuinely independent, host-backed buffer — a real
+        // byte-for-byte copy, not merely an evaluated-but-possibly-shared handle. Without
+        // this, a parameter whose value was produced in place over a buffer this process
+        // still shares with (or aliases the identity of) an earlier load/eval graph node
+        // can, in edge cases, have its write dispatch resolve against stale/shared state
+        // instead of the model's current values — exactly the failure mode #196's
+        // round-trip (b) mutation check guards against ("the writer may be copying the
+        // source file rather than serializing the model's actual parameters"). Routing
+        // through `asData(access: .copy)` (an explicit host memcpy) and rebuilding a
+        // fresh `MLXArray` from those bytes breaks any such aliasing unconditionally.
+        sd = sd.mapValues { MLXArray(data: $0.asData(access: .copy)) }
 
         let fm = FileManager.default
         let dir = weightsURL.deletingLastPathComponent()

--- a/swift/engine/Sources/MonicaEngine/Config.swift
+++ b/swift/engine/Sources/MonicaEngine/Config.swift
@@ -25,6 +25,70 @@ extension DtRank: Decodable {
     }
 }
 
+/// Needed only so `MambaConfig` (which gains `Encodable` for the sidecar WRITER, #196)
+/// can round-trip this field. Mirrors the decoder's two-shape contract in reverse.
+extension DtRank: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .auto: try c.encode("auto")
+        case .value(let v): try c.encode(v)
+        }
+    }
+}
+
+/// A minimal `Any`-Codable for JSON values Swift has no static type for — needed because
+/// the sidecar (`<weights>.config.json`) is `dataclasses.asdict(MambaConfig)` on the
+/// Python side (EVERY field: Muon / `torch_compile` / `fp8_experts` / data-side knobs /
+/// `quant`), while Swift's `MambaConfig` decodes only the ~22 fields the inference path
+/// reads. Re-encoding only the known subset on save would silently reset every other
+/// field to a Python dataclass default — a quiet corruption of the cross-backend bridge
+/// (#196). `JSONValue` is the passthrough vehicle: `MambaConfig.rawSidecar` below stores
+/// the WHOLE decoded sidecar as `[String: JSONValue]`, and `save(sidecar:)` overlays the
+/// known fields' current values on top of it rather than discarding the rest.
+///
+/// Order matters: try `Int` BEFORE `Double`, or an integer field (e.g. `"d_model": 64`)
+/// decodes as `64.0` and changes the sidecar's JSON type across the round trip.
+public enum JSONValue: Sendable, Equatable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+}
+
+extension JSONValue: Decodable {
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null; return }
+        if let b = try? c.decode(Bool.self) { self = .bool(b); return }
+        if let i = try? c.decode(Int.self) { self = .int(i); return }
+        if let d = try? c.decode(Double.self) { self = .double(d); return }
+        if let s = try? c.decode(String.self) { self = .string(s); return }
+        if let a = try? c.decode([JSONValue].self) { self = .array(a); return }
+        if let o = try? c.decode([String: JSONValue].self) { self = .object(o); return }
+        throw DecodingError.dataCorruptedError(
+            in: c, debugDescription: "unsupported JSON value")
+    }
+}
+
+extension JSONValue: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .null: try c.encodeNil()
+        case .bool(let b): try c.encode(b)
+        case .int(let i): try c.encode(i)
+        case .double(let d): try c.encode(d)
+        case .string(let s): try c.encode(s)
+        case .array(let a): try c.encode(a)
+        case .object(let o): try c.encode(o)
+        }
+    }
+}
+
 public enum ConfigError: Error, CustomStringConvertible {
     case invalid(String)
 
@@ -35,7 +99,11 @@ public enum ConfigError: Error, CustomStringConvertible {
     }
 }
 
-public struct MambaConfig: Decodable, Sendable {
+// `Equatable` is synthesized (every stored property — including `DtRank` and the
+// `rawSidecar` passthrough — is itself Equatable): #196's round-trip gate uses
+// `model.config == modelB.config` as a single check that BOTH the known fields AND the
+// raw-JSON passthrough survived a save/load cycle unchanged.
+public struct MambaConfig: Decodable, Encodable, Equatable, Sendable {
     // --- core dimensions ---
     public var dModel: Int
     public var nLayers: Int
@@ -69,6 +137,15 @@ public struct MambaConfig: Decodable, Sendable {
     public var dtMin: Float = 1e-3
     public var dtMax: Float = 1e-1
     public var dtInitFloor: Float = 1e-4
+
+    // --- sidecar fidelity (#196) ---
+    // The whole sidecar JSON as decoded by `load(sidecar:)`, or `nil` for a config built
+    // in Swift rather than loaded (e.g. a test fixture constructed with the memberwise
+    // init). Deliberately has NO CodingKeys case: the compiler-synthesized
+    // `init(from:)`/`encode(to:)` for the KNOWN fields below then simply leaves this at
+    // its default (never decodes it) and never encodes it — the ~22 modeled fields stay
+    // exactly as narrow as before. `save(sidecar:)` is what actually reads/writes it.
+    public var rawSidecar: [String: JSONValue]? = nil
 
     enum CodingKeys: String, CodingKey {
         case dModel = "d_model"
@@ -182,11 +259,58 @@ public struct MambaConfig: Decodable, Sendable {
         }
     }
 
-    /// Decode a sidecar written next to a weights file (`<weights>.config.json`).
+    /// Decode a sidecar written next to a weights file (`<weights>.config.json`). Decodes
+    /// the file TWICE — once into `MambaConfig` (the ~22 known fields), once into
+    /// `[String: JSONValue]` (everything) — and keeps the latter in `rawSidecar` so
+    /// `save(sidecar:)` can write the whole thing back rather than only what Swift
+    /// models. Both decodes read the SAME bytes, so if the first succeeds the second is
+    /// not expected to fail; letting it throw here (rather than swallowing with `try?`)
+    /// means a case where it somehow could fail is loud, not a silently-lossy `rawSidecar
+    /// == nil`.
     public static func load(sidecar url: URL) throws -> MambaConfig {
         let data = try Data(contentsOf: url)
-        let cfg = try JSONDecoder().decode(MambaConfig.self, from: data)
+        var cfg = try JSONDecoder().decode(MambaConfig.self, from: data)
+        cfg.rawSidecar = try JSONDecoder().decode([String: JSONValue].self, from: data)
         try cfg.validate()
         return cfg
+    }
+
+    /// Write this config back out as a sidecar (`<url>`, matching the `<weights>
+    /// .config.json` naming `Checkpoint.load`/`save` both use).
+    ///
+    /// If this config carries a `rawSidecar` (i.e. it came from `load(sidecar:)`), that
+    /// full JSON object is written back VERBATIM, overlaid with this config's own
+    /// current known-field values — so fields Swift does not model (Muon /
+    /// `torch_compile` / `fp8_experts` / data-side knobs / `quant`) survive the round
+    /// trip untouched, while a config that WAS mutated in Swift after loading (e.g. by
+    /// `Quantization.apply`, which does not touch `MambaConfig` today but a future
+    /// caller might) still writes its current values, not the stale originals. Overlay
+    /// direction: known fields win over the raw dict for keys present in both.
+    ///
+    /// If there is no `rawSidecar` (a config built directly in Swift, e.g. in a test),
+    /// only the known fields are written — LOSSY BY CONSTRUCTION, since there is no
+    /// "everything else" to preserve. Any checkpoint destined to be read back by Python
+    /// should carry a `load(sidecar:)`-sourced config.
+    ///
+    /// Deliberately NOT byte-identical to Python's `json.dumps(cfg, indent=2)`: Python
+    /// writes fields in `dataclasses.fields()` order, which this function cannot
+    /// reproduce without hardcoding that order (and having it rot the next time a field
+    /// is added). The round-trip gate this feeds (`scripts/check_swift_checkpoint.py`)
+    /// therefore compares SEMANTIC dict equality, not `cmp` — do not "fix" this into a
+    /// byte-for-byte writer.
+    public func save(sidecar url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let knownData = try encoder.encode(self)
+        var merged: [String: JSONValue]
+        if let raw = rawSidecar {
+            merged = raw
+            let known = try JSONDecoder().decode([String: JSONValue].self, from: knownData)
+            for (k, v) in known { merged[k] = v }
+        } else {
+            merged = try JSONDecoder().decode([String: JSONValue].self, from: knownData)
+        }
+        let mergedData = try encoder.encode(merged)
+        try mergedData.write(to: url, options: .atomic)
     }
 }

--- a/swift/engine/Sources/MonicaEngine/MonicaModel.swift
+++ b/swift/engine/Sources/MonicaEngine/MonicaModel.swift
@@ -13,8 +13,12 @@ public final class MonicaModel: Module {
     public let config: MambaConfig
 
     @ModuleInfo(key: "embedding") var embedding: Embedding
-    @ModuleInfo(key: "layers") var layers: [Block]
-    @ModuleInfo(key: "norm_f") var normF: RMSNorm
+    // `layers`/`normF` are `public` (unlike `embedding`, which no external caller needs)
+    // so #196's round-trip section in `monica-parity` — a separate module — can walk
+    // `MoEBlock`s for the route-bias check and mutate `normF.weight` for the
+    // anti-file-copy check, without adding new API surface to `MonicaModel` itself.
+    @ModuleInfo(key: "layers") public var layers: [Block]
+    @ModuleInfo(key: "norm_f") public var normF: RMSNorm
     /// Only present when `tie_embeddings` is false. Every config in scope ties, so the
     /// portable checkpoint carries no head tensor (see Checkpoint.swift).
     @ModuleInfo(key: "lm_head") var lmHead: Linear?

--- a/swift/engine/Sources/monica-parity/main.swift
+++ b/swift/engine/Sources/monica-parity/main.swift
@@ -156,8 +156,14 @@ let defaultFixtureNames = [
     "toy-short",  // #169: L=2, gates the conv-window LEFT-PAD branch
 ]
 
-// --- argument parsing (hand-rolled; the runner takes one repeatable flag) ---
+// --- argument parsing (hand-rolled; the runner takes repeatable/optional flags) ---
 var explicitFixtures: [URL] = []
+// #196: where to write Swift-authored round-trip checkpoints for the Python-side
+// `scripts/check_swift_checkpoint.py` gate to read. `nil` (the default, and every
+// pre-#196 invocation) means "use a scratch temp dir and don't keep it around" — CI is
+// the only caller that passes this, so a plain local `swift run monica-parity` never
+// litters the working tree.
+var roundtripOut: URL? = nil
 var args = Array(CommandLine.arguments.dropFirst())
 while let first = args.first {
     args.removeFirst()
@@ -169,6 +175,13 @@ while let first = args.first {
         }
         args.removeFirst()
         explicitFixtures.append(URL(fileURLWithPath: dir))
+    case "--roundtrip-out":
+        guard let dir = args.first else {
+            FileHandle.standardError.write(Data("--roundtrip-out needs a directory\n".utf8))
+            exit(2)
+        }
+        args.removeFirst()
+        roundtripOut = URL(fileURLWithPath: dir)
     default:
         FileHandle.standardError.write(Data("unknown argument '\(first)'\n".utf8))
         exit(2)
@@ -521,6 +534,152 @@ for dir in fixtureDirs {
             }
         } catch {
             failures.append("\(name): P5 threw — \(error)")
+        }
+
+        // --- #196: checkpoint round trip (the Swift WRITER, not just the reader) ------
+        // Writes this fixture's already-loaded model back out with `Checkpoint.save`,
+        // reloads it, and checks the result is functionally — and, for tensors,
+        // EXACTLY — the same model. This is the Swift half of #196's acceptance
+        // criterion ("a checkpoint round-trips without changing the model's function");
+        // the Python half is `scripts/check_swift_checkpoint.py` reading whatever this
+        // section writes under `--roundtrip-out`. No new checked-in fixture: every
+        // comparison below is computed in-process from the fixture already loaded above,
+        // and the two SAME-PROCESS exact-tensor comparisons ((a) and (b)) are immune to
+        // the cross-machine drift that broke #293's checked-in gradient oracle.
+        do {
+            let rtBase = (roundtripOut?.appendingPathComponent(name))
+                ?? FileManager.default.temporaryDirectory
+                    .appendingPathComponent("monica-parity-roundtrip-\(UUID().uuidString)")
+                    .appendingPathComponent(name)
+            try FileManager.default.createDirectory(
+                at: rtBase, withIntermediateDirectories: true)
+
+            // (a) identity round trip: save this model, reload it, compare everything.
+            let rtWeightsA = rtBase.appendingPathComponent("weights.safetensors")
+            try Checkpoint.save(model, to: rtWeightsA)
+            let (modelB, ckptKeysB) = try Checkpoint.load(weights: rtWeightsA)
+            let modelBKeys = Set(modelB.parameters().flattened().map { $0.0 })
+
+            if ckptKeysB != ckptKeys || modelBKeys != modelKeys {
+                failures.append("\(name): round trip (a) key-set mismatch — ckpt: "
+                                + "\(ckptKeysB) vs \(ckptKeys), model: \(modelBKeys) vs \(modelKeys)")
+            }
+
+            // Every parameter tensor must be BIT-IDENTICAL — save/load is lossless, so
+            // anything else is a serializer bug, not a numerics question.
+            let flatA = Dictionary(
+                model.parameters().flattened(), uniquingKeysWith: { a, _ in a })
+            let flatB = Dictionary(
+                modelB.parameters().flattened(), uniquingKeysWith: { a, _ in a })
+            var badTensor: String? = nil
+            for (k, a) in flatA {
+                guard let b = flatB[k] else { continue }   // key-set mismatch reported above
+                MLX.eval([a, b])
+                if a.shape != b.shape || !MLX.all(a .== b).item(Bool.self) {
+                    badTensor = badTensor ?? k
+                }
+            }
+            if let bad = badTensor {
+                failures.append("\(name): round trip (a) tensor '\(bad)' is not "
+                                + "bit-identical after save/load")
+            }
+
+            // The reloaded sidecar must parse to the SAME config — known fields AND the
+            // raw-JSON passthrough (`MambaConfig == ` covers both; see Config.swift).
+            if model.config != modelB.config {
+                failures.append("\(name): round trip (a) sidecar mismatch — the reloaded "
+                                + "config (known fields + raw passthrough) differs from "
+                                + "the source — sidecar fidelity is broken")
+            }
+
+            // End-to-end: the round-tripped model must still match the Python oracle.
+            let rtFwd = modelB.forward(tokens)
+            MLX.eval(rtFwd)
+            let rtCmp = compare(rtFwd.asType(.float32).asArray(Float.self),
+                                refForward.asType(.float32).asArray(Float.self),
+                                rtol: fxRtol, atol: fxAtol)
+            if !rtCmp.ok {
+                failures.append(String(
+                    format: "%@: round trip (a) forward logits (post save/load) differ "
+                    + "from the Python oracle (max|d| = %.3e)", name, rtCmp.maxAbs))
+            }
+
+            // (b) mutation round trip — the anti-file-copy check. Without this, a `save`
+            // that just byte-copied the source file would pass (a) too. Mutates modelB
+            // (the round-tripped copy from (a), otherwise unused from here on) rather
+            // than the shared `model`, which the #168 quant section below still reads.
+            modelB.normF.weight = modelB.normF.weight * MLXArray(Float(2))
+            MLX.eval(modelB.normF.weight)
+            let rtWeightsB = rtBase.appendingPathComponent("weights-mutated.safetensors")
+            try Checkpoint.save(modelB, to: rtWeightsB)
+            let (modelC, _) = try Checkpoint.load(weights: rtWeightsB)
+            MLX.eval([modelB.normF.weight, modelC.normF.weight])
+            if modelB.normF.weight.shape != modelC.normF.weight.shape
+                || !MLX.all(modelB.normF.weight .== modelC.normF.weight).item(Bool.self) {
+                failures.append("\(name): round trip (b) mutation not preserved exactly "
+                                + "— the writer may be copying the source file rather "
+                                + "than serializing the model's actual parameters")
+            }
+
+            // (c) MoE route bias survives (or correctly does NOT ride) the round trip.
+            let savedKeys = Set(try loadArrays(url: rtWeightsA).keys)
+            let savedBiasKeys = savedKeys.filter { $0.hasPrefix(Checkpoint.moeBiasPrefix) }
+            let expectBias = model.moeBlocks().contains { $0.routeBias != nil }
+            if expectBias {
+                for (i, layer) in model.layers.enumerated() {
+                    guard let moe = layer as? MoEBlock, let bias = moe.routeBias else {
+                        continue
+                    }
+                    guard let moeB = modelB.layers[i] as? MoEBlock,
+                          let biasB = moeB.routeBias else {
+                        failures.append("\(name): round trip (c) layer \(i) lost its "
+                                        + "route bias entirely")
+                        continue
+                    }
+                    if bias != biasB {
+                        failures.append("\(name): round trip (c) layer \(i) route bias "
+                                        + "changed across the round trip (want \(bias), "
+                                        + "got \(biasB))")
+                    }
+                }
+                if savedBiasKeys.isEmpty {
+                    failures.append("\(name): round trip (c) model has an active route "
+                                    + "bias but the saved checkpoint carries no "
+                                    + "\(Checkpoint.moeBiasPrefix)* key")
+                }
+            } else if !savedBiasKeys.isEmpty {
+                failures.append("\(name): round trip (c) model has NO active route bias "
+                                + "but the saved checkpoint carries "
+                                + "\(savedBiasKeys.sorted()) — an unconditional bias key "
+                                + "would break Python's num_parameters()")
+            }
+
+            // (d) quantized checkpoints: (a) already bit-compares the packed
+            // weight/scales/biases tensors; additionally confirm the `quant` block
+            // itself re-decodes to the same mode/group_size/targets.
+            if let bits = meta.quant_bits {
+                let sidecarURL = URL(fileURLWithPath: weights.path + ".config.json")
+                if let origSpec = try QuantSpec.load(sidecar: sidecarURL) {
+                    let rtSidecarURL = URL(fileURLWithPath: rtWeightsA.path + ".config.json")
+                    if let rtSpec = try QuantSpec.load(sidecar: rtSidecarURL) {
+                        if rtSpec.mode != origSpec.mode
+                            || rtSpec.groupSize != origSpec.groupSize
+                            || rtSpec.targets != origSpec.targets {
+                            failures.append("\(name): round trip (d) quant block changed "
+                                            + "across the round trip (bits=\(bits))")
+                        }
+                    } else {
+                        failures.append("\(name): round trip (d) the saved sidecar lost "
+                                        + "its quant block entirely (bits=\(bits))")
+                    }
+                }
+            }
+
+            print("\(name): round trip (save -> load) OK — tensors bit-identical, "
+                  + "sidecar fidelity, mutation, and route-bias checks passed"
+                  + (meta.quant_bits != nil ? " (+ quant-block re-decode)" : ""))
+        } catch {
+            failures.append("\(name): round trip threw — \(error)")
         }
 
         // --- #168: quantized-fixture-only checks -------------------------------------

--- a/swift/engine/Sources/monica-parity/main.swift
+++ b/swift/engine/Sources/monica-parity/main.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import MLX
+import MLXNN
 import MonicaEngine
 
 // The fp32 gate's constants — UNCHANGED by #168. A fixture's `meta.json` MAY carry its

--- a/swift/engine/Sources/monica-parity/main.swift
+++ b/swift/engine/Sources/monica-parity/main.swift
@@ -547,6 +547,7 @@ for dir in fixtureDirs {
         // and the two SAME-PROCESS exact-tensor comparisons ((a) and (b)) are immune to
         // the cross-machine drift that broke #293's checked-in gradient oracle.
         do {
+            let priorFailCount = failures.count
             // When the caller didn't ask to keep the round-trip artifacts
             // (`--roundtrip-out`), we write to a scratch dir under the system temp
             // directory — clean it up on the way out so repeated local runs don't
@@ -618,7 +619,20 @@ for dir in fixtureDirs {
             // that just byte-copied the source file would pass (a) too. Mutates modelB
             // (the round-tripped copy from (a), otherwise unused from here on) rather
             // than the shared `model`, which the #168 quant section below still reads.
-            modelB.normF.weight = modelB.normF.weight * MLXArray(Float(2))
+            //
+            // mlx-swift caches MLXArray references via Mirror at the first items() call
+            // and never re-scans. Direct property assignment (`model.normF.weight = ...`)
+            // replaces the STORED PROPERTY reference but leaves the cache pointing at the
+            // old MLXArray — so parameters()/portableStateDict still see the old value.
+            // model.update(parameters:) calls _updateInternal on the cached arrays in
+            // place: both the stored property and the cache remain the SAME object with
+            // the new data, which is what portableStateDict observes.
+            let mutKey = "norm_f.weight"
+            let preMut = Dictionary(
+                modelB.parameters().flattened(), uniquingKeysWith: { a, _ in a })[mutKey]!
+            let mutWeight = preMut * MLXArray(Float(2))
+            MLX.eval(mutWeight)
+            modelB.update(parameters: ModuleParameters.unflattened([(mutKey, mutWeight)]))
             MLX.eval(modelB.normF.weight)
             let rtWeightsB = rtBase.appendingPathComponent("weights-mutated.safetensors")
             try Checkpoint.save(modelB, to: rtWeightsB)
@@ -685,9 +699,11 @@ for dir in fixtureDirs {
                 }
             }
 
-            print("\(name): round trip (save -> load) OK — tensors bit-identical, "
-                  + "sidecar fidelity, mutation, and route-bias checks passed"
-                  + (meta.quant_bits != nil ? " (+ quant-block re-decode)" : ""))
+            if failures.count == priorFailCount {
+                print("\(name): round trip (save -> load) OK — tensors bit-identical, "
+                      + "sidecar fidelity, mutation, and route-bias checks passed"
+                      + (meta.quant_bits != nil ? " (+ quant-block re-decode)" : ""))
+            }
         } catch {
             failures.append("\(name): round trip threw — \(error)")
         }

--- a/swift/engine/Sources/monica-parity/main.swift
+++ b/swift/engine/Sources/monica-parity/main.swift
@@ -547,12 +547,22 @@ for dir in fixtureDirs {
         // and the two SAME-PROCESS exact-tensor comparisons ((a) and (b)) are immune to
         // the cross-machine drift that broke #293's checked-in gradient oracle.
         do {
+            // When the caller didn't ask to keep the round-trip artifacts
+            // (`--roundtrip-out`), we write to a scratch dir under the system temp
+            // directory — clean it up on the way out so repeated local runs don't
+            // accumulate one throwaway directory per fixture per run.
+            let isScratchDir = roundtripOut == nil
             let rtBase = (roundtripOut?.appendingPathComponent(name))
                 ?? FileManager.default.temporaryDirectory
                     .appendingPathComponent("monica-parity-roundtrip-\(UUID().uuidString)")
                     .appendingPathComponent(name)
             try FileManager.default.createDirectory(
                 at: rtBase, withIntermediateDirectories: true)
+            defer {
+                if isScratchDir {
+                    try? FileManager.default.removeItem(at: rtBase)
+                }
+            }
 
             // (a) identity round trip: save this model, reload it, compare everything.
             let rtWeightsA = rtBase.appendingPathComponent("weights.safetensors")


### PR DESCRIPTION
Closes #196

## Summary

Adds the missing half of #196: a Swift portable-checkpoint **writer**. The Swift
**reader** already existed on `main` (#166/#168's `Checkpoint.load`) and already
gated Python→Swift; this PR adds `Checkpoint.save`/`portableStateDict` plus the
Swift→Python direction of the round trip.

- **Writer** (`swift/engine/Sources/MonicaEngine/Checkpoint.swift`): mirrors
  `_portable_state_dict` exactly — `model.parameters().flattened()` plus, only for
  an `MoEBlock` with an active route bias, `moe_route_bias.{i}` (an unconditional
  key would break Python's `num_parameters()` accounting). Rejects `bfloat16` at
  save time (Python's `safetensors.numpy` reader has no bf16 dtype) and writes
  atomically.
- **Sidecar fidelity** (`Config.swift`): `MambaConfig` now captures the raw sidecar
  JSON at decode time (a minimal `JSONValue` Any-Codable, int-before-double
  decoding) and re-emits it on save, overlaid with the known-field values it does
  model. Fields Swift doesn't model (Muon/`torch_compile`/`fp8_experts`/data-side
  knobs/`quant`) survive a Swift round trip verbatim instead of silently reverting
  to Python dataclass defaults on the next Python read.
- **`monica-parity --roundtrip-out <dir>`**: a new per-fixture round-trip section —
  (a) identity round trip (bit-identical tensors, sidecar equality via a new
  `MambaConfig: Equatable`, logits vs the Python oracle), (b) a mutation round trip
  (the anti-file-copy check — a writer that just copied the source file would pass
  (a) alone), (c) route-bias presence/absence, (d) quant-block re-decode for the
  two quantized fixtures.
- **`scripts/check_swift_checkpoint.py`**: closes the Swift→Python direction —
  sidecar dict equality, quant-block equality, key-set check, forward-logit
  comparison against each fixture's `reference.safetensors`. Explicitly **SKIPs**
  (never silently passes) the two quantized fixtures' model-construction/forward
  checks: the Python MLX backend has no `QuantizedLinear`/`QuantizedEmbedding`
  loader reachable from a plain `MLXMambaModel` (`src/eval/quantize.py` is a
  fake-quant measurement spike, not a servable format). An empty
  `--roundtrip-dir` is itself a FAIL, not a silent pass.
- **CI** (`swift-engine` job): emits Swift-written checkpoints, installs
  `pip install -e ".[dev,mlx]"`, runs the new Python-side gate.
- **Docs**: `docs/design/14-inference-engine.md`'s Checkpoint I/O section expanded
  with the writer/sidecar/round-trip design and the explicit scope-out rationale;
  `swift/engine/Fixtures/README.md` explains why no new fixture was added.

**Scoped out (per the plan), blocked on #195.** The slot-a/slot-b resume bundle
(optimizer state, step, loss-scale, dataloader position) is not implemented here.
`main` has no Swift optimizer type yet (#195/PR #293 unmerged), so there is nothing
real to serialize against, and building one now would collide with #195 when it
lands. `Checkpoint.save` takes only a model + destination URL, so a future
optimizer serializer is an orthogonal file in the same directory, not a refactor
of this one. Swift resume should be filed as its own issue once #195 merges.

**No new checked-in tensor fixture.** Every round-trip comparison is computed
in-process from the seven fixtures already on `main` — deliberately, to avoid the
cross-machine checked-in-tensor drift that blocked #195's PR #293 (a checked-in
*gradient* oracle diverged by `1.226e-02` between local and hosted CI). The two
exact (no-tolerance) comparisons in the round trip — save→load tensor bit-identity
and the mutation round trip — are same-process, same-machine by construction.

## Testing

- [x] `.venv/bin/python -m pytest -q -rs` — 1581 passed, 13 skipped (pre-existing/
      environmental), 0 failed.
- [x] `scripts/smoke_test.py` (fresh toy split, per CLAUDE.md's post-checkpoint-change
      requirement) — PASSED.
- [x] `cd swift/engine && swift build` — clean.
- [x] `cd swift && swift build && swift run monica-selfcheck` — OK.
- [x] `swift package show-dependencies --format flatlist` (from `swift/`) — empty;
      `git diff main -- swift/Package.swift` — empty. Package separation intact.
- [x] Self-validated `scripts/check_swift_checkpoint.py` against Python-produced
      stand-in round-trip checkpoints (mlx-swift cannot execute on this host —
      Command Line Tools only, no Xcode): 5 OK, 2 SKIP (quantized), 0 FAIL.
      Negative tests (corrupted tensor, deleted quant key, empty `--roundtrip-dir`)
      all FAIL loudly with a useful message.
- [ ] **CI-only** (authoritative): `swift-engine`'s `monica-parity` round-trip
      section and the new "Swift -> Python checkpoint round trip" step — this host
      cannot run mlx-swift's Metal path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vyty7nMgW4ro67siQL4fx3