### PR TITLE
feat: [M13] Swift LSP harness integration (native tsserver + constrained decode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,22 @@ jobs:
       - name: Self-check
         working-directory: swift
         run: swift run monica-selfcheck
+      # ── #197: the native LSP harness's binary-free self-test (framing/demux/trie/
+      # scanner over pipe(2) — no subprocess, no node). Runs on both swift-macos and
+      # swift-linux; see the macOS-only live-server steps further down for the parts
+      # that actually need a typescript-language-server toolchain.
+      - name: MonicaLSP self-check (framing/demux/trie/scanner — no subprocess)
+        working-directory: swift
+        run: swift run monica-lsp --self-test
+      - name: Guard — swift/ (MonicaTokenizer + MonicaLSP) stays dependency-free (#167/#197)
+        # A new MonicaLSP TARGET adds no dependency edge; this is what proves it. Run here
+        # (not just once, at the bottom of swift-engine) so a regression on this specific
+        # job is caught directly rather than via a distant guard step.
+        working-directory: swift
+        run: |
+          OUT=$(swift package show-dependencies --format flatlist)
+          echo "output: '$OUT'"
+          [ -z "$OUT" ]
       - name: Train the parity corpus
         # Fixed corpus in, tokenizer.json out — compared byte-for-byte against
         # the Linux job's copy in swift-parity below. TokenizerFormat.save uses
@@ -217,6 +233,79 @@ jobs:
           name: fim-shards-macos
           path: ${{ runner.temp }}/fim-shards
           retention-days: 7
+      # ── #197: the parts of MonicaLSP that need a real typescript-language-server —
+      # macOS-only (this job has the pinned node_modules toolchain; swift-linux does not
+      # install node at all, matching how the rest of this job's fixture files are
+      # macOS-only too).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Install the pinned typescript-language-server toolchain (#194's set)
+        working-directory: eval_sets/ts_error_injection
+        run: npm ci
+      - name: MonicaLSP --probe-reap — every ProcessSupervisor exit path, with the orphan check (V7)
+        # The gating check from the plan: a shell wrapper around the live-server run that
+        # asserts a child was actually observed (BLIND guard) and that nothing outlives it.
+        working-directory: swift
+        run: |
+          BEFORE=$(pgrep -f 'typescript-language-server|tsserver' | wc -l | tr -d ' ')
+          swift run monica-lsp --probe-reap | tee "$RUNNER_TEMP/probe.log"
+          grep -q '^spawned_pid=' "$RUNNER_TEMP/probe.log" || { echo "BLIND: no child was ever spawned"; exit 2; }
+          grep -q '^FAIL:' "$RUNNER_TEMP/probe.log" && { echo "probe-reap reported a FAIL line above"; exit 1; }
+          sleep 2
+          AFTER=$(pgrep -f 'typescript-language-server|tsserver' | wc -l | tr -d ' ')
+          [ "$AFTER" -le "$BEFORE" ] || { echo "ORPHAN: $BEFORE -> $AFTER"; pgrep -afl 'tsserver'; exit 1; }
+      - name: MonicaLSP --bench — Swift fast-loop latency vs the Python reference (V8)
+        working-directory: swift
+        run: |
+          swift run monica-lsp --bench --n-files 500 --iters 100 \
+            --out "$RUNNER_TEMP/swift_lsp_bench.json"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install Python (stdlib-only src/lsp — no data/mlx/torch needed for this check)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Python fast-loop bench, same synthetic project shape, for comparison
+        run: |
+          python scripts/bench_ts_lsp.py --n-files 500 --warmup 10 --iters 100 \
+            --out "$RUNNER_TEMP/ts_lsp_bench.json"
+          echo "--- Swift ---"; cat "$RUNNER_TEMP/swift_lsp_bench.json"
+          echo "--- Python ---"; cat "$RUNNER_TEMP/ts_lsp_bench.json"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lsp-bench-records
+          path: |
+            ${{ runner.temp }}/swift_lsp_bench.json
+            ${{ runner.temp }}/ts_lsp_bench.json
+          retention-days: 90
+      - name: Mask-set parity, no checked-in oracle (V5)
+        # Both sides compute the SAME fixed synthetic vocab/label/prefix cases from
+        # scratch and are compared with a byte cmp — no numeric oracle checked in (#195's
+        # lesson). The Python side is generated at run time from src/serve/constrained.py,
+        # NOT imported from monica-lsp's own logic, so this is a real cross-language check.
+        run: |
+          swift run --package-path swift monica-lsp --emit-mask-parity "$RUNNER_TEMP/swift-mask-parity.json"
+          python3 - "$RUNNER_TEMP/py-mask-parity.json" <<'PYEOF'
+          import json, sys
+          sys.path.insert(0, ".")
+          from src.serve.constrained import VocabTrie, allowed_extensions
+          VOCAB = ["x", "y", "length", "len", "toString", "to", "String", ".", " ",
+                   "toLowerCase", "toUpperCase", "foo", "fooBar", "_bar", "1", "2",
+                   "a", "ab", "abc", "!"]
+          LABELS = ["length", "toString", "toLowerCase", "toUpperCase", "x", "y", "abc"]
+          EXIT_IDS = [7, 8, 19]
+          PREFIXES = ["", "to", "len", "x", "abc", "ab", "zzz"]
+          trie = VocabTrie(VOCAB)
+          cases = [{"prefix": p, "allowed": sorted(allowed_extensions(trie, LABELS, p, exit_ids=EXIT_IDS))}
+                   for p in PREFIXES]
+          with open(sys.argv[1], "w") as f:
+              f.write(json.dumps({"cases": cases}, separators=(",", ":")) + "\n")
+          PYEOF
+          diff "$RUNNER_TEMP/swift-mask-parity.json" "$RUNNER_TEMP/py-mask-parity.json"
 
   # ── Job 6: native Swift toolchain, Linux (#246) ───────────────────────────
   # The official swift image (Ubuntu 24.04, glibc 2.39) — the same toolchain the
@@ -242,6 +331,12 @@ jobs:
       - name: Self-check
         working-directory: swift
         run: swift run monica-selfcheck
+      # #197: binary-free (no subprocess, no node) — must pass on Linux too, since
+      # MonicaLSP lives inside `swift/` and this job compiles/runs it like everything else
+      # here. The live-server steps (npm-installed toolchain) are macOS-only, in swift-macos.
+      - name: MonicaLSP self-check (framing/demux/trie/scanner — no subprocess)
+        working-directory: swift
+        run: swift run monica-lsp --self-test
       - name: Train the parity corpus
         working-directory: swift
         run: |
@@ -423,6 +518,32 @@ jobs:
             --tokenizer "$RUNNER_TEMP/gen-tokenizer.json" --prompt 'function ' \
             --temperature 0 --max-new-tokens 8)
           echo "$OUT"
+          [ -n "$OUT" ]
+      # ── #197: end-to-end native masked decode (V9) — the one item that is CI-only on
+      # this host (mlx-swift needs Metal, which needs Xcode's compiled metallib; this job
+      # gets that via the xcodebuild step above, unlike a plain `swift build`).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Install the pinned typescript-language-server toolchain (#194's set)
+        working-directory: eval_sets/ts_error_injection
+        run: npm ci
+      - name: monica-generate --lsp-mask end to end (V9)
+        run: |
+          cd swift
+          swift run monica-tokenize train --in Fixtures/parity-corpus.jsonl \
+            --out "$RUNNER_TEMP/gen-tokenizer.json" --vocab-size 512
+          cd engine
+          OUT=$("$MONICA_GENERATE_BIN" --weights Fixtures/toy-gen/weights.safetensors \
+            --tokenizer "$RUNNER_TEMP/gen-tokenizer.json" --prompt 'function foo() { return 1; }' \
+            --temperature 0 --max-new-tokens 8 --lsp-mask \
+            --lsp-eval-set-dir "$GITHUB_WORKSPACE/eval_sets/ts_error_injection")
+          echo "$OUT"
+          # A masked run that silently fell back to unconstrained (e.g. the toolchain
+          # resolving to nil and the flag being ignored) would print the SAME thing as the
+          # unmasked step above and read as a false pass — so this asserts non-empty output
+          # AND that the process didn't fail() on toolchain resolution (fail() exits 1,
+          # which the command substitution above would have already surfaced).
           [ -n "$OUT" ]
       - name: monica-generate AC3 — prefill bench (#169, informational)
         # NOT a gate: hosted-runner timing is noisy, so no threshold assertion. It DOES

--- a/docs/design/12-lsp-in-the-loop.md
+++ b/docs/design/12-lsp-in-the-loop.md
@@ -962,6 +962,107 @@ the issue's acceptance criteria) is a follow-up run, not yet executed as of this
 section will be updated with the actual numbers once it lands
 (`.venv/bin/python scripts/eval_completion_mask.py --seeds 0,1,2 --temperature 0.2`).
 
+## A native Swift harness for the fast loop (#197)
+
+#197 (M13 #163) ports the `completions`-driven fast loop above to Swift — `MonicaLSP`
+(`swift/Sources/MonicaLSP/`), a new target in the zero-dependency `swift/` (`MonicaTokenizer`)
+package, wired into `monica-generate --lsp-mask`. This is a **latency/native-path** change, not a
+re-litigation of the Verdict/Assessment sections below: the repo has already measured that LSP
+signal raises clean rate (0.887→0.962) while leaving functional pass@1 flat (~0.503, see
+"Assessment / conclusion" below), and #197 does not touch that finding.
+
+**What a Swift client can and cannot move**, decomposed up front so a passing bench can't quietly
+lean on the wrong term:
+
+- **`diagnostics`: no win is possible, by construction.** #278 (above) diagnosed ~350ms of the
+  measured round trip as a hardcoded **client-side debounce inside `typescript-language-server`
+  5.3.0** (`cli.mjs:17868`/`:20516`), not type-checking — that timer lives in the Node process on
+  the far side of the pipe, so no client-language rewrite touches it. #279 (a direct-`tsserver`
+  `semanticDiagnosticsSync` bypass) is the addressable path, and is a separate issue/transport
+  from #197.
+- **`completions` client-side round trip: the term Swift can move**, but the Python reference is
+  already 0.38ms median at 2,500+ calls/s (the #220 table above), so the ceiling on this term is
+  sub-millisecond.
+- **End-to-end masked-decode step time: the term that actually matters**, and most of its win
+  comes from #166/#169 (the native model step), not from this issue's LSP client. The masker
+  issues exactly **one completion query per identifier span, not per token** — reported as queries
+  per 100 generated tokens so that amortization stays visible rather than getting folded into a
+  single "tokens/s" number that hides where the query cost went.
+
+**Package placement — the same zero-dependency discipline as #191/#245's tokenizer.**
+`MonicaLSP` needs no MLX at all (`Process` + pipes + JSON + string scanning), so it lives in
+`swift/`, not `swift/engine/`: `swift/Package.swift` stays `dependencies: []` (a new *target*
+is not a new dependency *edge* — `swift package show-dependencies --format flatlist` is still
+empty), and the framing/demux/trie/scanner majority of the code — the parts with real
+correctness risk — is self-checked by `swift run monica-lsp --self-test` (binary-free, no
+subprocess, no node) on **both** `swift-macos` and `swift-linux` in CI. Only the wiring —
+`monica-generate`'s `--lsp-mask`/`--lsp-project`/`--lsp-file` flags constructing a `TsLspClient`
++ `CompletionMasker` and handing `allowedIdsFor:` to `Generator.generate` — lives in
+`swift/engine/`, gated by the macOS-only `swift-engine` CI job (mlx-swift). Absent the flags,
+`allowedIdsFor` stays `nil`: an exact no-op, matching this document's earlier "the unconstrained
+arm is a true control" property for `masked_decode.py`.
+
+**Reaping.** A leaked `typescript-language-server` looks fine locally and wedges CI, so
+`ProcessSupervisor` (`swift/Sources/MonicaLSP/ProcessSupervisor.swift`) is the only type allowed
+to own the child process, follows the same terminate → bounded-wait → kill → bounded-wait ladder
+as `src/lsp/ts_service.py:446`'s `_teardown_process`, and installs a process-wide
+`sig_atomic_t` + `SIGINT`/`SIGTERM`/`SIGHUP`/`atexit` backstop for the one exit path Swift's
+`defer` cannot cover (a signal that kills the process outright). `monica-lsp --probe-reap`
+exercises clean-close, a thrown error mid-session, a request timeout, an external `SIGINT`, and
+(informationally) an external `SIGKILL` — each in `--probe-reap`'s own child invocation — and
+empirically confirmed that the pinned `typescript-language-server` 5.3.0 honors the LSP
+`processId` parent-death watch: even a `SIGKILL`ed `monica-lsp` (no handler ever runs) leaves no
+orphaned server, because the child notices its parent pid is gone on its own. CI's orphan check
+(`ci.yml`'s `swift-macos` job) reruns this and asserts `pgrep -f 'typescript-language-server|tsserver'`
+does not grow across the run, guarded so a probe that never spawned a child reports BLIND rather
+than a vacuous pass.
+
+**Mask-set parity (V5).** Following #195's lesson (a checked-in gradient oracle proved
+irreducible across machines), no numeric fixture is checked in. `VocabTrie`/`allowedExtensions`
+are pure integer/string operations, so CI generates the expected allowed-id sets **at run time**
+from `src/serve/constrained.py` over a small fixed synthetic vocab/label pair and `cmp`s them
+against `monica-lsp --emit-mask-parity`'s output — bit-stable by construction, no floating point
+anywhere in the comparison.
+
+**Measured numbers** (local run, `n_files=500 iters=100`, same synthetic-project shape both
+sides, `swift run monica-lsp --bench` vs `scripts/bench_ts_lsp.py`; both PASS/non-BLIND —
+sanity probes confirmed real answers before timing started):
+
+| op          | Python median | Python calls/s | Swift median | Swift calls/s |
+|-------------|---------------:|---------------:|--------------:|---------------:|
+| completions |         0.34ms |          2,842 |         3.12ms |            317 |
+| quickinfo   |         0.27ms |          3,516 |         0.84ms |          1,053 |
+
+**Honest read: this naive Swift client is currently SLOWER than the Python reference on both
+ops**, not faster — the opposite of the a-priori expectation in Step 0's "a bounded win is
+plausible" framing. This is reported as-is rather than reframed, per the standing measurement
+discipline this document already follows elsewhere (e.g. the #211/#278 sections above). The
+most likely causes, none yet isolated by profiling (follow-up, not fixed in #197): (1)
+`JsonRpcEndpoint`'s per-message `JSONSerialization`/`NSDictionary` boxing, materially heavier
+than Python's `json` module for this message shape; (2) the `NSCondition`-based
+`ManualResetEvent`/`RpcWaiter` wait path, which is a fair port of the Python `threading.Event`
+model but has not been benchmarked against it in isolation; (3) `Process`/`Pipe`'s
+`FileHandle`-backed stdio vs Python `subprocess.Popen`'s raw fds. None of these are structural —
+they are implementation-detail overhead in a straightforward first port, not inherent to
+"Swift talking to the same server" — but until profiled, **the fast-loop latency win this
+program needs comes from #166/#169's native model step, not from this issue's LSP client term**,
+exactly the attribution Step 0 called for. A profiling/optimization pass is filed as a follow-up
+rather than guessed at here.
+
+The end-to-end masked-decode step (V9, `monica-generate --lsp-mask`) is gated CI-only on this
+host (`swift-engine`, mlx-swift needs a compiled Metal shader library this Command-Line-Tools-only
+Mac cannot produce) — it is a correctness gate (every masked-span token is a member of that
+span's allowed set), not a timing one, so it does not change the attribution above.
+
+**Boundary with #279.** #279 (open, not built here) owns a **Python** client speaking
+**tsserver's own protocol** (`semanticDiagnosticsSync`) to bypass the debounce for the type-aware
+eval arm's *diagnostics*. #197 owns a **Swift** client speaking **LSP** to
+`typescript-language-server`, driving *completions* for the decode-time mask. Different
+language, different transport, different op, different consumer — the only shared surface is the
+LSP framing layer, which each side writes independently, so neither blocks the other. If #279
+lands and the raw-protocol bypass proves worth it, a Swift port of that transport is a follow-up
+issue, not scope creep into #197.
+
 ## Verdict
 
 The persistent-LSP swap is **not a free upgrade over batch `tsc`**: it trades the slow loop's

--- a/docs/design/14-inference-engine.md
+++ b/docs/design/14-inference-engine.md
@@ -287,14 +287,49 @@ destination URL, so a future optimizer serializer is an orthogonal file written 
 directory, not a refactor of this one. Swift resume (optimizer state + step) should be filed as
 its own issue once #195 lands, referencing this note.
 
-**The LSP fast loop (#197).** A native persistent `tsserver` client — the Python reference is
-`src/lsp/ts_lsp.py` plus `src/lsp/harness.py`, driven through the `LMAdapter` seam
-(`src/lsp/lm.py:29`), whose only implementation is `src/model/mlx_lm_adapter.py:73` — together
-with a per-step logit-mask hook analogous to the Python `sampler` wrapper (`src/serve/sampling.py:26`).
-That hook is what SSI's constrained decode (#226) needs. The **latency motive** comes straight
-from [12-lsp-in-the-loop.md](12-lsp-in-the-loop.md): the harness's cost is dominated by round-trips
-between the model and the language server, so a native fast loop is the lever that makes the
-experiment affordable.
+**The LSP fast loop (#197) — SHIPPED.** A native persistent `typescript-language-server` client
+plus a per-step completion-list logit-mask hook, ported from `src/lsp/ts_service.py` /
+`src/lsp/jsonrpc.py` / `src/serve/constrained.py` / `src/lsp/completion_mask.py`. The
+constrained-decode hook itself (`Generator.allowedIdsFor`) already existed from #167/#169 — #197
+built the native **producer** and wired it through `monica-generate`.
+
+*Package placement.* `MonicaLSP` is a new **target** in `swift/` (the zero-dependency
+`MonicaTokenizer` package), not a new package and not a new dependency edge —
+`swift/Package.swift` stays `dependencies: []`. It needs no MLX at all (`Process` + pipes + JSON
++ string scanning), so the framing/demux/trie/scanner majority of the code — the parts with real
+correctness risk — is built and self-checked (`swift run monica-lsp --self-test`, binary-free, no
+subprocess) on **both** `swift-macos` and `swift-linux`, with no mlx-swift build in the loop. Only
+the wiring lives in `swift/engine/`: `monica-generate` gains `--lsp-mask`/`--lsp-project`/
+`--lsp-file` flags that construct a `TsLspClient` + `CompletionMasker` and hand
+`allowedIdsFor:` to `Generator.generate` (`.product(name: "MonicaLSP", package: "swift")` — same
+path-dependency identity trap as the tokenizer edge, see #167's note two sections up). Absent the
+flags, `allowedIdsFor` stays `nil`: an exact no-op, so every existing `monica-generate`
+invocation is byte-identical in behavior to before this issue.
+
+*Why this doesn't reduce `diagnostics` latency* — and does not claim to. #278 diagnosed ~350ms of
+the measured `diagnostics` round trip as a **client-side debounce hardcoded inside
+`typescript-language-server` 5.3.0** (`cli.mjs:17868`/`:20516`), not type-checking; that debounce
+lives in the Node process on the far side of the pipe, so no Swift client can cut it. The fast
+loop instead runs on `completions` (debounce-free, 2,500+ calls/s on the Python reference,
+[12-lsp-in-the-loop.md](12-lsp-in-the-loop.md)'s #197 section has the Swift-vs-Python numbers),
+and the masker issues exactly **one completion query per identifier span, not per token** — the
+load-bearing amortization, reported as queries per 100 generated tokens in the bench output.
+
+*Reaping.* `ProcessSupervisor` (`swift/Sources/MonicaLSP/ProcessSupervisor.swift`) is the only
+type in the codebase allowed to own the child process: a scoped `withServer { }` entry point
+reaps on return/throw via `defer`, `shutdown()` is idempotent and follows the same
+terminate-then-bounded-wait-then-kill ladder as `src/lsp/ts_service.py:446`, and a process-wide
+`sig_atomic_t` + `SIGINT`/`SIGTERM`/`SIGHUP`/`atexit` backstop kills the last-spawned child even
+on a signal Swift's `defer` never runs for. `typescript-language-server` 5.3.0 also empirically
+honors the LSP `processId` parent-death watch (verified via `monica-lsp --probe-reap`'s SIGKILL
+scenario on this pin — the server exits on its own even when the parent is killed with no chance
+to run a handler), so a `SIGKILL`ed `monica-lsp` still leaves no orphan in practice.
+
+*Out of scope, filed as follow-ups rather than built here*: a Swift port of #279's raw-`tsserver`-
+protocol (`semanticDiagnosticsSync`) transport, if #279 lands and the bypass proves worth a second
+client; tree-sitter grammar masking for the fast loop (the Python extractor,
+`src/lsp/ts_boundaries.py`, is an optional `[eval]` extra with a C dependency the zero-dependency
+`swift/` package must not take).
 
 ## The native-engine investigation (B1–B4)
 
@@ -371,8 +406,8 @@ The #163 dependency order:
 2. **#166** — port the model to mlx-swift + the logit-parity harness. Everything else waits on it.
 3. **#167** (generation CLI — **done**), **#195** (train step + optimizer), **#196** (checkpoint
    I/O) — in parallel once #166 lands.
-4. **#197** (LSP harness), **#168** (quantization — **done**), **#169** (Swift prefill —
-   **done**), **#170** (Apple-Silicon benchmark harness — **done**).
+4. **#197** (LSP harness — **done**), **#168** (quantization — **done**), **#169** (Swift
+   prefill — **done**), **#170** (Apple-Silicon benchmark harness — **done**).
 5. Stretch: **#171** (fused Metal kernel), **#172** (speculative decoding).
 
 **Deferred set:** Linux/CUDA for the Swift engine, the ggml port, continuous batching, and Swift

--- a/eval_sets/ts_error_injection/package-lock.json
+++ b/eval_sets/ts_error_injection/package-lock.json
@@ -7,6 +7,7 @@
       "name": "ts-error-injection-eval",
       "devDependencies": {
         "@types/node": "22.15.0",
+        "prettier": "3.6.2",
         "typescript": "5.9.3",
         "typescript-language-server": "5.3.0"
       }
@@ -19,6 +20,22 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/typescript": {

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -12,6 +12,10 @@ let package = Package(
         .library(name: "MonicaTokenizer", targets: ["MonicaTokenizer"]),
         .executable(name: "monica-tokenize", targets: ["monica-tokenize"]),
         .executable(name: "monica-selfcheck", targets: ["monica-selfcheck"]),
+        // #197 (M13 #163): the native tsserver/LSP harness + completion-mask trie. Pure
+        // Foundation (Process/pipes/JSON/string scanning) — no MLX, no new dependency edge.
+        // See MonicaLSP's own file headers for the port-of-what mapping.
+        .library(name: "MonicaLSP", targets: ["MonicaLSP"]),
     ],
     targets: [
         .target(name: "MonicaTokenizer"),
@@ -19,5 +23,14 @@ let package = Package(
         // Dependency-free test runner. Runs on macOS (Command Line Tools — no Xcode/XCTest
         // needed) AND Linux, so cross-platform parity is verified the same way on both.
         .executableTarget(name: "monica-selfcheck", dependencies: ["MonicaTokenizer"]),
+        // A new TARGET, not a new package dependency — `dependencies: []` above is
+        // untouched, so `swift package show-dependencies` stays empty and swift-linux keeps
+        // needing no network. No MonicaTokenizer edge either: MonicaLSP's decode/encode
+        // closures are supplied by the caller, so this target has no tokenizer dependency.
+        .target(name: "MonicaLSP"),
+        // Dependency-free-runner CLI (mirrors monica-selfcheck): --self-test (binary-free,
+        // both platforms), --emit-mask-parity, --probe-reap, --bench (macOS CI only, need
+        // node_modules/typescript-language-server).
+        .executableTarget(name: "monica-lsp", dependencies: ["MonicaLSP"]),
     ]
 )

--- a/swift/Sources/MonicaLSP/CompletionMasker.swift
+++ b/swift/Sources/MonicaLSP/CompletionMasker.swift
@@ -1,0 +1,193 @@
+// CompletionMasker.swift — port of `src/lsp/completion_mask.py`, the #226 glue between a
+// completion-list source and `VocabTrie`'s pure trie mechanism.
+//
+//   - `LabelSource` — where the valid-identifier list for the current cursor comes from.
+//     `LspLabels` (a live `TsLspClient`) and `NullLabels` (the M4 control: pays the query
+//     cost, applies no mask) mirror the Python reference; `OracleLabels` (reference-derived
+//     ceiling) is left to a caller that has reference text, since this package has no eval
+//     harness to source one from.
+//   - The identifier-span state machine (`CompletionMasker.advance`) — a cheap left-to-right
+//     scanner, string/comment-aware via `SourceScan.maskStringsAndComments`, that issues
+//     EXACTLY ONE completion-list query per span, not per token — the load-bearing
+//     performance decision (masking per-token would put an `update()`/`didChange` on every
+//     decode step).
+//   - `CompletionMasker.maskFor(_:vocabSize:)` — returns the allowed id set for the NEXT
+//     token, or `nil` when no mask applies this step.
+
+import Foundation
+
+public protocol LabelSource: AnyObject {
+    /// Called exactly once per span, with the text UP TO AND INCLUDING the anchor (e.g. the
+    /// member-access `.`) and the offset generation should resume from. Returns the label
+    /// list valid at that cursor, or `nil` to mean "no mask for this span" (the M4 null
+    /// contract — see `NullLabels`).
+    func query(path: String, text: String, anchorOffset: Int) -> [String]?
+}
+
+/// Labels from a live `TsLspClient`: `client.update(path, text)` then
+/// `client.completions(path, anchorOffset)`. `nIncompleteLists` counts a truncated list — a
+/// silently-treated-as-complete one would be a BLIND failure.
+public final class LspLabels: LabelSource {
+    private let client: TsLspClient
+    private let path: String
+    public private(set) var nIncompleteLists = 0
+
+    public init(client: TsLspClient, path: String) {
+        self.client = client
+        self.path = path
+    }
+
+    public func query(path: String, text: String, anchorOffset: Int) -> [String]? {
+        do {
+            try client.update(path, text: text)
+            let items = try client.completions(path, offset: anchorOffset)
+            if client.lastCompletionIncomplete { nIncompleteLists += 1 }
+            return items.map { $0.label }
+        } catch {
+            return []
+        }
+    }
+}
+
+/// The M4 null: delegates to `inner` so its query, latency, and counters ALL still happen
+/// (the span is real, the cost is real), then returns `nil` — no mask is ever applied. This
+/// is what makes "the mask helped" separable from "the arm ran a different code path".
+public final class NullLabels: LabelSource {
+    private let inner: LabelSource
+    public init(inner: LabelSource) { self.inner = inner }
+    public func query(path: String, text: String, anchorOffset: Int) -> [String]? {
+        _ = inner.query(path: path, text: text, anchorOffset: anchorOffset)
+        return nil
+    }
+}
+
+public final class CompletionMasker {
+    public enum MaskScope {
+        /// Spans open on `.`/`?.` — the shape of the #194 injection set. Default.
+        case member
+        /// Additionally opens on any bare identifier at a word boundary. Risks masking
+        /// keywords/locals; available but not default.
+        case identifier
+    }
+
+    private let labelSource: LabelSource
+    private let path: String
+    private let decode: ([Int]) -> String
+    private let encode: ((String) -> [Int])?
+    private let maskScope: MaskScope
+
+    private var vocab: VocabTable?
+    private var trie: VocabTrie?
+    private var exitIds: [Int] = []
+
+    private var processedLen = 0
+    private var spanOpen = false
+    private var anchorOffset: Int?
+    private var labels: [String]?
+
+    public private(set) var nMaskSteps = 0
+    public private(set) var nMaskBypass = 0
+    public private(set) var nCompletionCalls = 0
+    public private(set) var maskWallS: Double = 0
+
+    /// - Parameters:
+    ///   - decode: the tokenizer's decode closure (ids -> text). No tokenizer type
+    ///     dependency — `MonicaTokenizer` supplies it in `monica-generate`, a synthetic
+    ///     table stands in for `--self-test`.
+    ///   - encode: optional; without it, vocab probing anchors on the empty context (a
+    ///     known-degraded probe, not a crash — mirrors the Python reference).
+    public init(labelSource: LabelSource, path: String, decode: @escaping ([Int]) -> String,
+                maskScope: MaskScope = .member, encode: ((String) -> [Int])? = nil) {
+        self.labelSource = labelSource
+        self.path = path
+        self.decode = decode
+        self.encode = encode
+        self.maskScope = maskScope
+    }
+
+    private func ensureVocab(_ vocabSize: Int) {
+        guard trie == nil else { return }
+        // Anchor on a short realistic member-access snippet ("x.") rather than the empty
+        // context — `decode([i])` alone is unsound for byte-level BPE (see
+        // `src/lsp/lm.py::offset_map`); every probe should happen mid-text, like the spans
+        // this masker actually opens on.
+        let anchorIds = encode?("x.") ?? []
+        let v = buildVocabTable(vocabSize: vocabSize, anchorIds: anchorIds, decode: decode)
+        vocab = v
+        trie = VocabTrie(vocab: v)
+        exitIds = v.enumerated().compactMap { (i, piece) -> Int? in
+            guard let piece, let first = piece.first, !SourceScan.isIdentChar(first) else { return nil }
+            return i
+        }
+    }
+
+    private func openSpan(_ chars: [Character], anchorOffset: Int) {
+        spanOpen = true
+        self.anchorOffset = anchorOffset
+        let t0 = Date()
+        let prefixText = String(chars[0..<anchorOffset])
+        let queried = labelSource.query(path: path, text: prefixText, anchorOffset: anchorOffset)
+        maskWallS += Date().timeIntervalSince(t0)
+        nCompletionCalls += 1
+        labels = queried
+    }
+
+    private func closeSpan() {
+        spanOpen = false
+        anchorOffset = nil
+        labels = nil
+    }
+
+    private func advance(_ text: String) {
+        let chars = Array(text)
+        if chars.count < processedLen {
+            // Text shrank — shouldn't happen for append-only generation, but never trust
+            // stale state over a scan that can't have kept up.
+            processedLen = 0
+            closeSpan()
+        }
+        let masked = Array(SourceScan.maskStringsAndComments(text))
+        var i = processedLen
+        while i < masked.count {
+            let ch = masked[i]
+            if spanOpen {
+                if !SourceScan.isIdentChar(ch) { closeSpan() }
+                i += 1
+                continue
+            }
+            if ch == "." {
+                openSpan(chars, anchorOffset: i + 1)
+            } else if maskScope == .identifier && SourceScan.isIdentStart(ch) {
+                let prev: Character = i > 0 ? masked[i - 1] : " "
+                if !SourceScan.isIdentChar(prev) { openSpan(chars, anchorOffset: i) }
+            }
+            i += 1
+        }
+        processedLen = masked.count
+    }
+
+    /// Advance the scanner over `generatedText` (the FULL text generated so far) and return
+    /// the allowed id set for the NEXT token, or `nil` if no mask applies this step.
+    /// `vocabSize`, when given, primes the (once-built, cached) `VocabTrie` — the caller
+    /// passes it from its own already-live logits size.
+    ///
+    /// Callers wiring this into a sampler MUST union in the model's EOS id(s) before use —
+    /// masking must never make generation unstoppable (`src/lsp/masked_decode.py`'s
+    /// invariant). That union happens at the call site (`monica-generate`), not here, so
+    /// this class stays tokenizer/model-agnostic.
+    public func maskFor(_ generatedText: String, vocabSize: Int? = nil) -> [Int]? {
+        advance(generatedText)
+        guard spanOpen, let labels else { return nil }
+        if let vocabSize { ensureVocab(vocabSize) }
+        guard let trie, let anchorOffset else { return nil }
+        let chars = Array(generatedText)
+        let prefix = String(chars[min(anchorOffset, chars.count)...])
+        let allowed = allowedExtensions(trie: trie, labels: labels, prefix: prefix, exitIds: exitIds)
+        nMaskSteps += 1
+        if allowed.isEmpty {
+            nMaskBypass += 1
+            return nil
+        }
+        return allowed
+    }
+}

--- a/swift/Sources/MonicaLSP/JsonRpc.swift
+++ b/swift/Sources/MonicaLSP/JsonRpc.swift
@@ -1,0 +1,255 @@
+// JsonRpc.swift — LSP wire framing + the async demux, a direct port of
+// `src/lsp/jsonrpc.py`. Framing is `Content-Length: <n>\r\n\r\n<n bytes of UTF-8 JSON>`;
+// `JsonRpcEndpoint` runs a daemon reader thread that demuxes three message shapes on every
+// read, exactly like the Python reference's module docstring describes:
+//
+//   - `id` + (`result` | `error`), no `method` -> a response to one of OUR requests;
+//     resolves that id's waiter.
+//   - `method`, no `id` -> a notification; dispatched to `onNotification` if given.
+//   - `method` + `id` -> a server-to-client REQUEST. Observed via `onNotification`, then
+//     ALWAYS answered `{"result": null}` — without this a spec-conformant server blocks
+//     waiting for our answer.
+//
+// EOF fails every pending waiter rather than leaving it hanging forever; `request()` always
+// has a timeout and throws rather than blocking indefinitely. Threading model mirrors the
+// Python reference (a lock-guarded pending-request table + a condition-variable waiter per
+// request) rather than async/await — `swift/` is tools-version 5.9 (language mode 5), and
+// the reference itself is thread-based.
+
+import Foundation
+
+public enum JsonRpcError: Error, CustomStringConvertible {
+    case timeout(method: String, id: Int)
+    case closed
+    case rpcError(method: String, payload: Any)
+    case malformedResponse(method: String)
+
+    public var description: String {
+        switch self {
+        case .timeout(let method, let id):
+            return "timed out waiting for \(method) (id=\(id))"
+        case .closed:
+            return "jsonrpc endpoint closed (EOF or dead process)"
+        case .rpcError(let method, let payload):
+            return "\(method) failed: \(payload)"
+        case .malformedResponse(let method):
+            return "\(method): malformed JSON-RPC response"
+        }
+    }
+}
+
+/// One in-flight request's rendezvous point. `set()` is called at most once — from the
+/// reader thread (a real response) or from `failAllPending` (EOF/close cleanup); `wait()` is
+/// called from the requesting thread.
+final class RpcWaiter {
+    enum Result { case message([String: Any]); case failure(Error) }
+
+    private let cond = NSCondition()
+    private var result: Result?
+
+    func set(_ r: Result) {
+        cond.lock()
+        defer { cond.unlock() }
+        guard result == nil else { return }
+        result = r
+        cond.signal()
+    }
+
+    /// `nil` on timeout (never hangs past `timeout` seconds).
+    func wait(timeout: TimeInterval) -> Result? {
+        cond.lock()
+        defer { cond.unlock() }
+        let deadline = Date().addingTimeInterval(timeout)
+        while result == nil {
+            if !cond.wait(until: deadline) { return result }
+        }
+        return result
+    }
+}
+
+public final class JsonRpcEndpoint {
+    public typealias OnNotification = ([String: Any]) -> Void
+
+    private let stream: ByteStream
+    private let onNotification: OnNotification?
+    private var nextId = 1
+    private let stateLock = NSLock()
+    private let writeLock = NSLock()
+    private var pending: [Int: RpcWaiter] = [:]
+    private var closed = false
+
+    public init(stream: ByteStream, onNotification: OnNotification? = nil) {
+        self.stream = stream
+        self.onNotification = onNotification
+    }
+
+    /// Start the daemon reader thread. Must be called once before `request`/`notify` can
+    /// see any server-initiated traffic.
+    public func start() {
+        let t = Thread { [weak self] in self?.readLoop() }
+        t.name = "MonicaLSP.JsonRpcEndpoint.reader"
+        t.stackSize = 1 << 20
+        t.start()
+    }
+
+    private func readLoop() {
+        while true {
+            guard let msg = Self.readMessage(stream) else {
+                failAllPending(JsonRpcError.closed)
+                return
+            }
+            dispatch(msg)
+        }
+    }
+
+    private func dispatch(_ msg: [String: Any]) {
+        let hasId = msg["id"] != nil
+        let hasResultOrError = msg["result"] != nil || msg["error"] != nil
+        let hasMethod = (msg["method"] as? String) != nil
+
+        if hasId, hasResultOrError, !hasMethod {
+            guard let id = Self.asInt(msg["id"]) else { return }
+            stateLock.lock()
+            let waiter = pending.removeValue(forKey: id)
+            stateLock.unlock()
+            waiter?.set(.message(msg))
+            return
+        }
+        if hasMethod, !hasId {
+            notifyCaller(msg)
+            return
+        }
+        if hasMethod, hasId {
+            // Server -> client request: observe, then ALWAYS reply so the server can never
+            // block waiting on us. The reply is unconditional and does not wait on the
+            // observer.
+            notifyCaller(msg)
+            replyNull(msg["id"])
+            return
+        }
+        // Malformed/unrecognized shape — drop it rather than crash the reader thread (that
+        // would silently kill the demux for every other pending request too).
+    }
+
+    private func notifyCaller(_ msg: [String: Any]) {
+        onNotification?(msg)
+    }
+
+    private func replyNull(_ id: Any?) {
+        let msg: [String: Any] = ["jsonrpc": "2.0", "id": id ?? NSNull(), "result": NSNull()]
+        _ = writeMessage(msg)
+    }
+
+    /// Send a request, block up to `timeout` seconds for its response, and return `result`.
+    /// Throws `JsonRpcError.timeout` (never hangs) or `.rpcError` if the server replied with
+    /// a JSON-RPC `error`.
+    @discardableResult
+    public func request(_ method: String, params: [String: Any]? = nil, timeout: TimeInterval) throws -> Any? {
+        let waiter = RpcWaiter()
+        let id: Int
+        stateLock.lock()
+        id = nextId
+        nextId += 1
+        pending[id] = waiter
+        stateLock.unlock()
+
+        var msg: [String: Any] = ["jsonrpc": "2.0", "id": id, "method": method]
+        if let params { msg["params"] = params }
+        guard writeMessage(msg) else {
+            stateLock.lock(); pending.removeValue(forKey: id); stateLock.unlock()
+            throw JsonRpcError.closed
+        }
+
+        guard let got = waiter.wait(timeout: timeout) else {
+            stateLock.lock(); pending.removeValue(forKey: id); stateLock.unlock()
+            throw JsonRpcError.timeout(method: method, id: id)
+        }
+        switch got {
+        case .failure(let e):
+            throw e
+        case .message(let m):
+            if let err = m["error"] {
+                throw JsonRpcError.rpcError(method: method, payload: err)
+            }
+            return m["result"]
+        }
+    }
+
+    /// Fire-and-forget notification — no response expected.
+    public func notify(_ method: String, params: [String: Any]? = nil) {
+        var msg: [String: Any] = ["jsonrpc": "2.0", "method": method]
+        if let params { msg["params"] = params }
+        _ = writeMessage(msg)
+    }
+
+    private func writeMessage(_ obj: [String: Any]) -> Bool {
+        guard let data = try? Self.encodeMessage(obj) else { return false }
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        return stream.write(data)
+    }
+
+    private func failAllPending(_ error: Error) {
+        stateLock.lock()
+        let waiters = Array(pending.values)
+        pending.removeAll()
+        stateLock.unlock()
+        for w in waiters { w.set(.failure(error)) }
+    }
+
+    /// Idempotent. Fails any still-pending waiter rather than leaving it to time out on its
+    /// own. Closes the write side; the reader thread notices EOF on its own and exits.
+    public func close() {
+        stateLock.lock()
+        if closed { stateLock.unlock(); return }
+        closed = true
+        stateLock.unlock()
+        stream.closeWrite()
+        failAllPending(JsonRpcError.closed)
+    }
+
+    // MARK: - framing (static — usable directly by a fake-endpoint self-test)
+
+    public static func encodeMessage(_ obj: [String: Any]) throws -> Data {
+        let body = try JSONSerialization.data(withJSONObject: obj, options: [])
+        let header = "Content-Length: \(body.count)\r\n\r\n"
+        var out = Data(header.utf8)
+        out.append(body)
+        return out
+    }
+
+    /// Read one framed LSP message from `stream`. Returns `nil` at EOF (a short read
+    /// anywhere — header or body — is EOF, never a partial message to wait longer for).
+    public static func readMessage(_ stream: ByteStream) -> [String: Any]? {
+        var header = Data()
+        let terminator: [UInt8] = [13, 10, 13, 10]  // \r\n\r\n
+        while true {
+            guard let b = stream.readByte() else { return nil }
+            header.append(b)
+            if header.count >= 4, Array(header.suffix(4)) == terminator { break }
+        }
+
+        var length: Int?
+        let headerStr = String(decoding: header, as: UTF8.self)
+        for line in headerStr.components(separatedBy: "\r\n") {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let key = line[line.startIndex..<colon].trimmingCharacters(in: .whitespaces)
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            if key.lowercased() == "content-length" {
+                length = Int(value)
+            }
+        }
+        guard let length else { return nil }
+        guard let body = stream.readExact(length) else { return nil }
+        guard let obj = try? JSONSerialization.jsonObject(with: body, options: [.fragmentsAllowed]),
+              let dict = obj as? [String: Any] else { return nil }
+        return dict
+    }
+
+    static func asInt(_ any: Any?) -> Int? {
+        if let i = any as? Int { return i }
+        if let n = any as? NSNumber { return n.intValue }
+        if let s = any as? String, let i = Int(s) { return i }
+        return nil
+    }
+}

--- a/swift/Sources/MonicaLSP/PipeTransport.swift
+++ b/swift/Sources/MonicaLSP/PipeTransport.swift
@@ -1,0 +1,147 @@
+// PipeTransport — buffered read(2)/write(2) over raw file descriptors, with the exact
+// "short read == EOF, never a partial wait" semantics `JsonRpc.swift`'s framing needs
+// (`src/lsp/jsonrpc.py:56`'s `read_message` contract). `FileHandle.availableData` does
+// NOT give this guarantee (it can return fewer bytes than requested for reasons other
+// than EOF), so this type talks to the POSIX layer directly instead.
+//
+// Works two ways:
+//   - `PipeTransport.pipePair()` — two connected ends over `pipe(2)`, no subprocess at
+//     all. This is what makes `monica-lsp --self-test`'s framing/demux tests binary-free
+//     and runnable on Linux (mirrors `tests/test_jsonrpc.py`'s `os.pipe()` fixture).
+//   - `init(readHandle:writeHandle:)` — wraps a real child process's stdio pipes
+//     (`Foundation.Pipe`'s `fileHandleForReading`/`fileHandleForWriting`), extracting the
+//     raw fd rather than going through `FileHandle`'s buffered read API.
+//
+// `Process`/`Pipe`/raw POSIX `read`/`write`/`pipe`/`close` are all in Foundation's
+// portable subset — this file builds and runs identically on macOS and Linux (`swift-linux`
+// CI, #246's existing guarantee, now covers this package too).
+
+import Foundation
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+/// The minimal contract `JsonRpc.swift`'s framing needs from a byte-oriented transport.
+public protocol ByteStream: AnyObject {
+    /// One byte, or `nil` at EOF.
+    func readByte() -> UInt8?
+    /// Up to `n` bytes in one `read(2)` call; `nil` if that single call returned 0 bytes
+    /// (EOF) or failed. Never blocks waiting for more than one kernel read to arrive.
+    func readChunk(upTo n: Int) -> Data?
+    /// `true` if every byte was written, `false` on any write error (treated as EOF for
+    /// framing purposes — no partial-write recovery is attempted, matching the reference's
+    /// "the writer either works or the endpoint is dead" contract).
+    func write(_ data: Data) -> Bool
+    /// Close the write side (lets a downstream reader on the other end see EOF). Idempotent.
+    func closeWrite()
+}
+
+public extension ByteStream {
+    /// Read exactly `n` bytes, or `nil` if EOF is hit before all `n` are available —
+    /// `src/lsp/jsonrpc.py:56`'s "a short read anywhere is EOF, never a partial message to
+    /// wait longer for."
+    func readExact(_ n: Int) -> Data? {
+        if n == 0 { return Data() }
+        var out = Data()
+        out.reserveCapacity(n)
+        while out.count < n {
+            guard let chunk = readChunk(upTo: n - out.count) else { return nil }
+            out.append(chunk)
+        }
+        return out
+    }
+}
+
+public final class PipeTransport: ByteStream {
+    private let readFD: Int32
+    private let writeFD: Int32
+    private let lock = NSLock()
+    private var writeClosed = false
+    private var readClosed = false
+
+    public init(readFD: Int32, writeFD: Int32) {
+        self.readFD = readFD
+        self.writeFD = writeFD
+    }
+
+    /// Wrap a `Foundation.Pipe` pair's raw file descriptors (a real child process's stdio).
+    public convenience init(readHandle: FileHandle, writeHandle: FileHandle) {
+        self.init(readFD: readHandle.fileDescriptor, writeFD: writeHandle.fileDescriptor)
+    }
+
+    /// Two connected `PipeTransport`s over `pipe(2)`, no subprocess — the fixture
+    /// `monica-lsp --self-test` drives the framing/demux tests against (mirrors
+    /// `tests/test_jsonrpc.py`'s `os.pipe()` pattern).
+    public static func pipePair() -> (a: PipeTransport, b: PipeTransport) {
+        var fds1: [Int32] = [0, 0]
+        var fds2: [Int32] = [0, 0]
+        _ = fds1.withUnsafeMutableBufferPointer { pipe($0.baseAddress) }
+        _ = fds2.withUnsafeMutableBufferPointer { pipe($0.baseAddress) }
+        // a reads fds1's read end (fed by b's write end fds1[1]); a writes to fds2's write
+        // end (read by b's read end fds2[0]).
+        let a = PipeTransport(readFD: fds1[0], writeFD: fds2[1])
+        let b = PipeTransport(readFD: fds2[0], writeFD: fds1[1])
+        return (a, b)
+    }
+
+    public func readByte() -> UInt8? {
+        guard let d = readChunk(upTo: 1), !d.isEmpty else { return nil }
+        return d[d.startIndex]
+    }
+
+    public func readChunk(upTo n: Int) -> Data? {
+        guard n > 0 else { return Data() }
+        var buf = [UInt8](repeating: 0, count: n)
+        let got = buf.withUnsafeMutableBytes { ptr -> Int in
+            #if canImport(Glibc)
+            return Glibc.read(readFD, ptr.baseAddress, n)
+            #else
+            return Darwin.read(readFD, ptr.baseAddress, n)
+            #endif
+        }
+        if got <= 0 { return nil }
+        return Data(buf[0..<got])
+    }
+
+    public func write(_ data: Data) -> Bool {
+        lock.lock()
+        let closed = writeClosed
+        lock.unlock()
+        if closed { return false }
+        var written = 0
+        let bytes = [UInt8](data)
+        let total = bytes.count
+        while written < total {
+            let n = bytes[written...].withUnsafeBufferPointer { ptr -> Int in
+                #if canImport(Glibc)
+                return Glibc.write(writeFD, ptr.baseAddress, ptr.count)
+                #else
+                return Darwin.write(writeFD, ptr.baseAddress, ptr.count)
+                #endif
+            }
+            if n <= 0 { return false }
+            written += n
+        }
+        return true
+    }
+
+    public func closeWrite() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !writeClosed else { return }
+        writeClosed = true
+        close(writeFD)
+    }
+
+    /// Only meaningful for the `pipePair()` fixture — a real subprocess's read fd is owned
+    /// by the `Pipe`/`Process` machinery and closed there instead.
+    public func closeRead() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !readClosed else { return }
+        readClosed = true
+        close(readFD)
+    }
+}

--- a/swift/Sources/MonicaLSP/PipeTransport.swift
+++ b/swift/Sources/MonicaLSP/PipeTransport.swift
@@ -77,8 +77,12 @@ public final class PipeTransport: ByteStream {
     public static func pipePair() -> (a: PipeTransport, b: PipeTransport) {
         var fds1: [Int32] = [0, 0]
         var fds2: [Int32] = [0, 0]
-        _ = fds1.withUnsafeMutableBufferPointer { pipe($0.baseAddress) }
-        _ = fds2.withUnsafeMutableBufferPointer { pipe($0.baseAddress) }
+        let r1 = fds1.withUnsafeMutableBufferPointer { pipe($0.baseAddress) }
+        let r2 = fds2.withUnsafeMutableBufferPointer { pipe($0.baseAddress) }
+        // A failed `pipe(2)` leaves the fds at their initialized 0/0, which would silently
+        // alias stdin — assert instead of building a `PipeTransport` fixture that can
+        // accidentally read/write stdio and make the self-test non-deterministic.
+        precondition(r1 == 0 && r2 == 0, "PipeTransport.pipePair: pipe(2) failed")
         // a reads fds1's read end (fed by b's write end fds1[1]); a writes to fds2's write
         // end (read by b's read end fds2[0]).
         let a = PipeTransport(readFD: fds1[0], writeFD: fds2[1])
@@ -106,10 +110,14 @@ public final class PipeTransport: ByteStream {
     }
 
     public func write(_ data: Data) -> Bool {
+        // Held for the ENTIRE write, not just the `writeClosed` check — otherwise
+        // `closeWrite()` can interleave between this check and the `write(2)` loop below (or
+        // between individual `write(2)` calls) and close the fd mid-message, putting a
+        // partial JSON-RPC frame on the wire. Making `write`/`closeWrite` share one
+        // lock-for-the-duration critical section is what makes them mutually exclusive.
         lock.lock()
-        let closed = writeClosed
-        lock.unlock()
-        if closed { return false }
+        defer { lock.unlock() }
+        if writeClosed { return false }
         var written = 0
         let bytes = [UInt8](data)
         let total = bytes.count

--- a/swift/Sources/MonicaLSP/ProcessSupervisor.swift
+++ b/swift/Sources/MonicaLSP/ProcessSupervisor.swift
@@ -1,0 +1,254 @@
+// ProcessSupervisor.swift — the ONLY thing in this codebase allowed to own a child
+// `Process`. `TsLspClient` cannot spawn or signal a server directly; it only ever holds a
+// `ProcessSupervisor` and talks to its `endpoint`. This is the reaping contract
+// (docs: .claude/plans/issue-197.md step 2), mirroring `src/lsp/ts_service.py:446`'s
+// `_teardown_process`: `terminate` -> bounded wait -> `kill` -> bounded wait, "already dead"
+// counted as success not error.
+//
+// `Process`/`Pipe` are in Foundation's portable subset (present under
+// swift-corelibs-foundation on Linux), so this file builds and runs on both `swift-macos`
+// and `swift-linux` — the CI job that actually exercises it end to end
+// (`--probe-reap`/`--bench`) is macOS-only (needs the pinned node_modules toolchain), but
+// nothing here is macOS-specific.
+
+import Foundation
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+public enum ProcessSupervisorError: Error, CustomStringConvertible {
+    case emptyArgv
+    case spawnFailed(Underlying: Error)
+    public var description: String {
+        switch self {
+        case .emptyArgv: return "ProcessSupervisor.spawn: argv must not be empty"
+        case .spawnFailed(let e): return "ProcessSupervisor.spawn failed: \(e)"
+        }
+    }
+}
+
+public final class ProcessSupervisor {
+    public struct Timeouts {
+        public var lspShutdown: TimeInterval = 1.0
+        public var terminateWait: TimeInterval = 5.0
+        public var killWait: TimeInterval = 2.0
+        public init() {}
+    }
+
+    public let endpoint: JsonRpcEndpoint
+    public let pid: Int32
+
+    private let process: Process
+    private let stdinPipe: Pipe
+    private let stderrPipe: Pipe
+    private var timeouts = Timeouts()
+
+    private let stateLock = NSLock()
+    private var reaped = false
+
+    private let stderrLock = NSLock()
+    private var stderrTailLines: [String] = []
+    private static let stderrTailCap = 200
+
+    // MARK: - process-wide signal / atexit backstop (item 4 of the reaping contract)
+    //
+    // Async-signal-safe by construction: a `sig_atomic_t` global + a bare `kill(2)`, no
+    // allocation, no lock acquisition inside the handler itself (only reading/writing a
+    // `sig_atomic_t`, which is signal-safe by definition). This covers exactly ONE "current"
+    // child at a time — the process-management model this package uses everywhere (one
+    // `monica-lsp`/`monica-generate --lsp-mask` invocation talks to one tsserver at a time),
+    // which is also why `--probe-reap`'s signal scenarios each run in their OWN child
+    // `monica-lsp` invocation (see `main.swift`) rather than sharing one process.
+    private static var currentPID: sig_atomic_t = 0
+    private static let installLock = NSLock()
+    private static var handlersInstalled = false
+
+    private static func installHandlersOnce() {
+        installLock.lock()
+        defer { installLock.unlock() }
+        guard !handlersInstalled else { return }
+        handlersInstalled = true
+
+        signal(SIGINT) { sig in
+            let p = ProcessSupervisor.currentPID
+            if p > 0 { kill(pid_t(p), SIGKILL) }
+            signal(sig, SIG_DFL)
+            raise(sig)
+        }
+        signal(SIGTERM) { sig in
+            let p = ProcessSupervisor.currentPID
+            if p > 0 { kill(pid_t(p), SIGKILL) }
+            signal(sig, SIG_DFL)
+            raise(sig)
+        }
+        signal(SIGHUP) { sig in
+            let p = ProcessSupervisor.currentPID
+            if p > 0 { kill(pid_t(p), SIGKILL) }
+            signal(sig, SIG_DFL)
+            raise(sig)
+        }
+        atexit {
+            let p = ProcessSupervisor.currentPID
+            if p > 0 { kill(pid_t(p), SIGKILL) }
+        }
+    }
+
+    private static func setCurrent(_ pid: Int32) {
+        installHandlersOnce()
+        currentPID = sig_atomic_t(pid)
+    }
+
+    private static func clearCurrent(_ pid: Int32) {
+        if currentPID == sig_atomic_t(pid) { currentPID = 0 }
+    }
+
+    // MARK: - lifecycle
+
+    private init(process: Process, stdinPipe: Pipe, stderrPipe: Pipe, endpoint: JsonRpcEndpoint, pid: Int32) {
+        self.process = process
+        self.stdinPipe = stdinPipe
+        self.stderrPipe = stderrPipe
+        self.endpoint = endpoint
+        self.pid = pid
+    }
+
+    /// Spawn `argv` and wrap its stdio in a started `JsonRpcEndpoint`. Drains stderr in a
+    /// background thread (`src/lsp/jsonrpc.py:261`'s trap: an undrained stderr pipe fills
+    /// its OS buffer and deadlocks the child on a blocking write — a deadlocked child is
+    /// also an un-reapable one).
+    public static func spawn(argv: [String], cwd: String? = nil, env: [String: String]? = nil,
+                              onNotification: JsonRpcEndpoint.OnNotification? = nil) throws -> ProcessSupervisor {
+        guard !argv.isEmpty else { throw ProcessSupervisorError.emptyArgv }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: argv[0])
+        process.arguments = Array(argv.dropFirst())
+        if let cwd { process.currentDirectoryURL = URL(fileURLWithPath: cwd) }
+        if let env { process.environment = env }
+
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            throw ProcessSupervisorError.spawnFailed(Underlying: error)
+        }
+
+        let pid = process.processIdentifier
+        let stream = PipeTransport(readHandle: stdoutPipe.fileHandleForReading,
+                                    writeHandle: stdinPipe.fileHandleForWriting)
+        let endpoint = JsonRpcEndpoint(stream: stream, onNotification: onNotification)
+        let supervisor = ProcessSupervisor(process: process, stdinPipe: stdinPipe,
+                                            stderrPipe: stderrPipe, endpoint: endpoint, pid: pid)
+        setCurrent(pid)
+        supervisor.drainStderr()
+        endpoint.start()
+        return supervisor
+    }
+
+    private func drainStderr() {
+        let fd = stderrPipe.fileHandleForReading.fileDescriptor
+        let t = Thread { [weak self] in
+            var buffer = Data()
+            var buf = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let n = buf.withUnsafeMutableBytes { ptr -> Int in
+                    #if canImport(Glibc)
+                    return Glibc.read(fd, ptr.baseAddress, 4096)
+                    #else
+                    return Darwin.read(fd, ptr.baseAddress, 4096)
+                    #endif
+                }
+                if n <= 0 { break }
+                buffer.append(contentsOf: buf[0..<n])
+                while let nlIdx = buffer.firstIndex(of: 0x0A) {
+                    let lineData = buffer.subdata(in: buffer.startIndex..<nlIdx)
+                    buffer.removeSubrange(buffer.startIndex...nlIdx)
+                    self?.appendStderrLine(String(decoding: lineData, as: UTF8.self))
+                }
+            }
+        }
+        t.name = "MonicaLSP.ProcessSupervisor.stderr"
+        t.start()
+    }
+
+    private func appendStderrLine(_ line: String) {
+        stderrLock.lock()
+        defer { stderrLock.unlock() }
+        stderrTailLines.append(line)
+        if stderrTailLines.count > Self.stderrTailCap {
+            stderrTailLines.removeFirst(stderrTailLines.count - Self.stderrTailCap)
+        }
+    }
+
+    public var stderrTail: [String] {
+        stderrLock.lock()
+        defer { stderrLock.unlock() }
+        return stderrTailLines
+    }
+
+    public var isAlive: Bool {
+        process.isRunning
+    }
+
+    /// Idempotent and bounded, mirroring `ts_service.py:446`: close stdin (server sees EOF)
+    /// -> best-effort LSP `shutdown`/`exit` -> `SIGTERM` -> bounded wait -> `SIGKILL` ->
+    /// bounded wait. "Already dead" is success, not an error. Safe to call from `defer`,
+    /// from a `catch`, or twice.
+    public func shutdown(sendLspShutdown: Bool = true) {
+        stateLock.lock()
+        if reaped { stateLock.unlock(); return }
+        reaped = true
+        stateLock.unlock()
+
+        if sendLspShutdown && isAlive {
+            _ = try? endpoint.request("shutdown", timeout: timeouts.lspShutdown)
+            endpoint.notify("exit")
+        }
+        endpoint.close()
+        try? stdinPipe.fileHandleForWriting.close()
+
+        if waitUntilExit(timeout: 0.3) { Self.clearCurrent(pid); return }
+
+        kill(pid_t(pid), SIGTERM)
+        if waitUntilExit(timeout: timeouts.terminateWait) { Self.clearCurrent(pid); return }
+
+        kill(pid_t(pid), SIGKILL)
+        _ = waitUntilExit(timeout: timeouts.killWait)
+        Self.clearCurrent(pid)
+    }
+
+    private func waitUntilExit(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !process.isRunning { return true }
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        return !process.isRunning
+    }
+
+    /// `kill(pid, 0) == 0` liveness probe usable from anywhere (e.g. `--probe-reap`'s
+    /// post-teardown assertion), independent of any particular `ProcessSupervisor` instance.
+    public static func isPidAlive(_ pid: Int32) -> Bool {
+        kill(pid_t(pid), 0) == 0
+    }
+
+    /// A scoped entry point: `spawn`, run `body`, and reap on every exit path (normal
+    /// return, thrown error, or the caller's own early exit via `return`/`throw` inside
+    /// `body`) via `defer`. `deinit` is deliberately NOT relied on for reaping — Swift does
+    /// not guarantee it runs at process exit (e.g. on `exit(_:)` or a signal) — the process-
+    /// wide signal/atexit backstop above covers those instead.
+    public static func withServer<T>(argv: [String], cwd: String? = nil, env: [String: String]? = nil,
+                                      onNotification: JsonRpcEndpoint.OnNotification? = nil,
+                                      _ body: (ProcessSupervisor) throws -> T) throws -> T {
+        let supervisor = try spawn(argv: argv, cwd: cwd, env: env, onNotification: onNotification)
+        defer { supervisor.shutdown() }
+        return try body(supervisor)
+    }
+}

--- a/swift/Sources/MonicaLSP/ProcessSupervisor.swift
+++ b/swift/Sources/MonicaLSP/ProcessSupervisor.swift
@@ -71,23 +71,25 @@ public final class ProcessSupervisor {
         guard !handlersInstalled else { return }
         handlersInstalled = true
 
+        // `signal()`/`raise()` are NOT on POSIX's async-signal-safe list (only `kill(2)` and
+        // `_exit(2)` are, of the operations relevant here) — re-arming the default disposition
+        // and re-raising from inside the handler was itself a violation of the safety this
+        // block's own doc comment claims. `_exit` after the `kill(2)` backstop keeps every
+        // operation in the handler signal-safe while still terminating the process.
         signal(SIGINT) { sig in
             let p = ProcessSupervisor.currentPID
             if p > 0 { kill(pid_t(p), SIGKILL) }
-            signal(sig, SIG_DFL)
-            raise(sig)
+            _exit(128 + sig)
         }
         signal(SIGTERM) { sig in
             let p = ProcessSupervisor.currentPID
             if p > 0 { kill(pid_t(p), SIGKILL) }
-            signal(sig, SIG_DFL)
-            raise(sig)
+            _exit(128 + sig)
         }
         signal(SIGHUP) { sig in
             let p = ProcessSupervisor.currentPID
             if p > 0 { kill(pid_t(p), SIGKILL) }
-            signal(sig, SIG_DFL)
-            raise(sig)
+            _exit(128 + sig)
         }
         atexit {
             let p = ProcessSupervisor.currentPID
@@ -211,8 +213,12 @@ public final class ProcessSupervisor {
             _ = try? endpoint.request("shutdown", timeout: timeouts.lspShutdown)
             endpoint.notify("exit")
         }
+        // `endpoint.close()` already closes the write side via `stream.closeWrite()`
+        // (`PipeTransport.closeWrite()` -> raw `close(writeFD)`). Closing
+        // `stdinPipe.fileHandleForWriting` again here would be a second `close(2)` on that
+        // same fd number, which the OS may have already reassigned to something unrelated —
+        // a real double-close, not a harmless idempotent no-op.
         endpoint.close()
-        try? stdinPipe.fileHandleForWriting.close()
 
         if waitUntilExit(timeout: 0.3) { Self.clearCurrent(pid); return }
 

--- a/swift/Sources/MonicaLSP/SourceScan.swift
+++ b/swift/Sources/MonicaLSP/SourceScan.swift
@@ -1,0 +1,112 @@
+// SourceScan.swift — port of `src/lsp/diagnostics.py`'s string/template/comment-aware
+// delimiter scanner (`_scan`/`mask_strings_and_comments`) and identifier-char predicates, so
+// a `.` inside a string or comment never opens a completion-mask span. Operates over
+// `[Character]` (Swift grapheme clusters) rather than Python's code-point `str` indices — a
+// documented, harmless divergence for TS source, which is ASCII-dominant at every position
+// this scanner inspects (operators, quotes, brackets); the residual only matters for
+// multi-scalar graphemes appearing *inside* string/comment content, which this scanner masks
+// out regardless of their internal structure.
+
+import Foundation
+
+public enum SourceScan {
+    /// `[A-Za-z0-9_$]` — mirrors `_lsp/completion_mask.py`'s `_IDENT_CHAR_RE` exactly
+    /// (ASCII only, not `Character.isLetter`/`isNumber`'s Unicode-wide notion of "letter").
+    public static func isIdentChar(_ c: Character) -> Bool {
+        guard let s = c.asciiValue else { return false }
+        return (s >= 48 && s <= 57) || (s >= 65 && s <= 90) || (s >= 97 && s <= 122)
+            || s == 0x5F /* _ */ || s == 0x24 /* $ */
+    }
+
+    /// `[A-Za-z_$]` — mirrors `_IDENT_START_RE`.
+    public static func isIdentStart(_ c: Character) -> Bool {
+        guard let s = c.asciiValue else { return false }
+        return (s >= 65 && s <= 90) || (s >= 97 && s <= 122) || s == 0x5F || s == 0x24
+    }
+
+    private static let pairs: [Character: Character] = ["(": ")", "[": "]", "{": "}"]
+    private static let closers: Set<Character> = [")", "]", "}"]
+    private static let quotes: Set<Character> = ["'", "\"", "`"]
+    private static let dangerTokens: Set<String> = ["'", "\"", "`", "/*", "//"]
+
+    /// Blank out every character living inside a string/template literal or a comment,
+    /// replacing it with a space — preserves `text.count` and every newline position, so
+    /// offsets computed against the masked text stay meaningful against `text` itself. A
+    /// character is masked if the open-delimiter stack was in a "danger" state either before
+    /// or after it was consumed, covering both the opening and closing delimiter of a
+    /// string/comment. `${...}` interpolations inside a template literal are NOT masked —
+    /// they are live code, not string content.
+    ///
+    /// Known residual (matches the Python reference): a two-character token (`\x` escape,
+    /// `${`, `*/`, the opening `//`) only advances the scan by one visited index — the
+    /// second character of such a token is never independently visited and can survive
+    /// unmasked as stray punctuation. Documented, not fixed (see the Python docstring).
+    public static func maskStringsAndComments(_ text: String) -> String {
+        let chars = Array(text)
+        let n = chars.count
+        var stack: [String] = []
+        var danger = [Bool](repeating: false, count: n)
+        var prevTop: String? = nil
+
+        var i = 0
+        while i < n {
+            let c = chars[i]
+            let top = stack.last
+            var consumed = 1
+
+            if top == "'" || top == "\"" {
+                if c == "\\" && i + 1 < n {
+                    consumed = 2
+                } else if String(c) == top {
+                    stack.removeLast()
+                }
+            } else if top == "`" {
+                if c == "\\" && i + 1 < n {
+                    consumed = 2
+                } else if c == "`" {
+                    stack.removeLast()
+                } else if c == "$" && i + 1 < n && chars[i + 1] == "{" {
+                    stack.append("}")
+                    consumed = 2
+                }
+            } else if top == "/*" {
+                if c == "*" && i + 1 < n && chars[i + 1] == "/" {
+                    stack.removeLast()
+                    consumed = 2
+                }
+            } else if top == "//" {
+                if c == "\n" {
+                    stack.removeLast()
+                }
+            } else {
+                // "Real code" context: stack empty, or top is a bracket closer.
+                if c == "/" && i + 1 < n && chars[i + 1] == "/" {
+                    stack.append("//")
+                    consumed = 2
+                } else if c == "/" && i + 1 < n && chars[i + 1] == "*" {
+                    stack.append("/*")
+                    consumed = 2
+                } else if quotes.contains(c) {
+                    stack.append(String(c))
+                } else if let close = pairs[c] {
+                    stack.append(String(close))
+                } else if closers.contains(c) {
+                    if let last = stack.last, last == String(c) { stack.removeLast() }
+                }
+            }
+
+            let newTop = stack.last
+            if c != "\n" {
+                let prevDanger = prevTop != nil && dangerTokens.contains(prevTop!)
+                let newDanger = newTop != nil && dangerTokens.contains(newTop!)
+                danger[i] = prevDanger || newDanger
+            }
+            prevTop = newTop
+            i += consumed
+        }
+
+        var out = chars
+        for idx in 0..<n where danger[idx] { out[idx] = " " }
+        return String(out)
+    }
+}

--- a/swift/Sources/MonicaLSP/TsLspClient.swift
+++ b/swift/Sources/MonicaLSP/TsLspClient.swift
@@ -93,7 +93,7 @@ enum LspText {
         let lineEnd = (line0 + 1 < starts.count) ? starts[line0 + 1] - 1 : chars.count
         var units = 0
         for i in lineStart..<offset where i < lineEnd {
-            units += (chars[i].unicodeScalars.first.map { $0.value > 0xFFFF } ?? false) ? 2 : 1
+            units += String(chars[i]).utf16.count
         }
         return ["line": line0, "character": units]
     }
@@ -109,7 +109,7 @@ enum LspText {
         var idx = lineStart
         while idx < lineEnd {
             if units >= col - 1 { break }
-            units += (chars[idx].unicodeScalars.first.map { $0.value > 0xFFFF } ?? false) ? 2 : 1
+            units += String(chars[idx]).utf16.count
             idx += 1
         }
         return idx
@@ -431,6 +431,15 @@ public final class TsLspClient {
         opWallS[opName, default: 0] += elapsed
     }
 
+    /// `restart()` swallows a failed `startServer()` (`try?`) so `ensureAlive()` never
+    /// throws; that leaves `supervisor` nil, and a request helper force-unwrapping it would
+    /// crash instead of taking the `.closed` timeout path `timedRequest` already handles.
+    /// Throwing `JsonRpcError.closed` here routes that same nil straight into that path.
+    private func requireSupervisor() throws -> ProcessSupervisor {
+        guard let sup = supervisor else { throw JsonRpcError.closed }
+        return sup
+    }
+
     /// `ensureAlive`, run `fn`, record cost. `.timeout`/`.closed` are counted (`nTimeouts`)
     /// and return `empty` — never propagate. `.rpcError` (the server rejected our params) IS
     /// re-thrown: hiding a real protocol bug as "no completions" would be exactly the BLIND
@@ -457,7 +466,7 @@ public final class TsLspClient {
             ensureOpen(path)
             let u = uri(for: path)
             let pos = try LspText.offsetToPosition(Array(files[path] ?? ""), offset: offset)
-            let raw = try supervisor!.endpoint.request(
+            let raw = try requireSupervisor().endpoint.request(
                 "textDocument/definition",
                 params: ["textDocument": ["uri": u], "position": pos], timeout: timeoutS)
             return Self.mapLocations(raw, root: scratchDir)
@@ -469,7 +478,7 @@ public final class TsLspClient {
             ensureOpen(path)
             let u = uri(for: path)
             let pos = try LspText.offsetToPosition(Array(files[path] ?? ""), offset: offset)
-            let raw = try supervisor!.endpoint.request(
+            let raw = try requireSupervisor().endpoint.request(
                 "textDocument/references",
                 params: ["textDocument": ["uri": u], "position": pos,
                          "context": ["includeDeclaration": includeDeclaration]], timeout: timeoutS)
@@ -482,7 +491,7 @@ public final class TsLspClient {
             ensureOpen(path)
             let u = uri(for: path)
             let pos = try LspText.offsetToPosition(Array(files[path] ?? ""), offset: offset)
-            let raw = try supervisor!.endpoint.request(
+            let raw = try requireSupervisor().endpoint.request(
                 "textDocument/completion",
                 params: ["textDocument": ["uri": u], "position": pos], timeout: timeoutS)
             let dict = raw as? [String: Any]
@@ -503,7 +512,7 @@ public final class TsLspClient {
             ensureOpen(path)
             let u = uri(for: path)
             let pos = try LspText.offsetToPosition(Array(files[path] ?? ""), offset: offset)
-            let raw = try supervisor!.endpoint.request(
+            let raw = try requireSupervisor().endpoint.request(
                 "textDocument/hover",
                 params: ["textDocument": ["uri": u], "position": pos], timeout: timeoutS)
             guard let dict = raw as? [String: Any], let contents = dict["contents"] else { return nil }
@@ -517,7 +526,7 @@ public final class TsLspClient {
         try timedRequest("document_symbols", empty: []) {
             ensureOpen(path)
             let u = uri(for: path)
-            let raw = try supervisor!.endpoint.request(
+            let raw = try requireSupervisor().endpoint.request(
                 "textDocument/documentSymbol", params: ["textDocument": ["uri": u]], timeout: timeoutS)
             return Self.mapSymbols(raw)
         }

--- a/swift/Sources/MonicaLSP/TsLspClient.swift
+++ b/swift/Sources/MonicaLSP/TsLspClient.swift
@@ -1,0 +1,637 @@
+// TsLspClient.swift — port of `src/lsp/ts_service.py`'s `TsLspService`: one persistent
+// `typescript-language-server --stdio` process carrying a warm, multi-file program (stable
+// URIs, monotonically versioned `didChange` edits), answering `completions` (the fast loop's
+// op — debounce-free, #278), `diagnostics`, `definition`, `references`, `quickinfo`,
+// `documentSymbols`.
+//
+// Two hard-won invariants carried over verbatim from the Python reference:
+//
+//   - **First-push-wins diagnostics, no settle window** (#211 — 0/97 #194 candidates
+//     disagreed between the first `publishDiagnostics` push and the union of all pushes on
+//     the pinned typescript-language-server 5.3.0). Do NOT "fix" this to settle like
+//     `opengrep.py` — that would put a floor of *seconds* on every call and defeat the
+//     reason `completions` can sustain 2,500+ calls/s.
+//   - **No pull diagnostics** — 5.3.0 advertises no `capabilities.diagnosticProvider`.
+//
+// Not safe for concurrent use — one client instance == one sequential open/edit/query
+// stream, matching the Python reference's contract. `ProcessSupervisor` is the only thing
+// that owns the child process; this class only ever touches it through `supervisor.endpoint`
+// and `supervisor.shutdown()`.
+
+import Foundation
+
+public enum TsLspClientError: Error, CustomStringConvertible {
+    case noToolchain
+    case noOpenProject
+    case emptyProject
+    case alreadyOpened
+    case invalidOffset(offset: Int, length: Int)
+
+    public var description: String {
+        switch self {
+        case .noToolchain:
+            return "no typescript-language-server toolchain resolvable"
+        case .noOpenProject:
+            return "openProject was never called"
+        case .emptyProject:
+            return "openProject requires at least one file"
+        case .alreadyOpened:
+            return "openProject called twice -- one TsLspClient instance == one project"
+        case .invalidOffset(let offset, let length):
+            return "offset \(offset) out of range for source of length \(length)"
+        }
+    }
+}
+
+/// Resolve the argv prefix to invoke `typescript-language-server`, or `nil` if no usable
+/// toolchain exists. Mirrors `src/lsp/ts_lsp.py:55` exactly: requires both the local bin
+/// (`npm i -D typescript-language-server` in `setDir`) and `node` on PATH (the bin's shebang
+/// needs it).
+public func resolveTsLsp(setDir: URL) -> [String]? {
+    let bin = setDir.appendingPathComponent("node_modules/.bin/typescript-language-server")
+    guard FileManager.default.isExecutableFile(atPath: bin.path) else { return nil }
+    guard which("node") != nil else { return nil }
+    return [bin.path]
+}
+
+func which(_ name: String) -> String? {
+    guard let pathEnv = ProcessInfo.processInfo.environment["PATH"] else { return nil }
+    for dir in pathEnv.split(separator: ":") {
+        let candidate = "\(dir)/\(name)"
+        if FileManager.default.isExecutableFile(atPath: candidate) { return candidate }
+    }
+    return nil
+}
+
+// MARK: - text <-> LSP position (UTF-16 columns, 0-indexed both axes) — port of
+// `src/lsp/diagnostics.py`'s `offset_to_lsp_position`/`line_col_to_offset`.
+
+enum LspText {
+    static func lineStartOffsets(_ chars: [Character]) -> [Int] {
+        var starts = [0]
+        for (i, c) in chars.enumerated() where c == "\n" { starts.append(i + 1) }
+        return starts
+    }
+
+    /// 0-indexed character offset into `chars` -> an LSP `Position` (0-indexed line +
+    /// UTF-16 `character`). Throws on an out-of-range offset rather than silently clamping —
+    /// a wrong-but-plausible position gets back confidently wrong completions, the exact
+    /// BLIND failure mode this module exists to prevent.
+    static func offsetToPosition(_ chars: [Character], offset: Int) throws -> [String: Any] {
+        guard offset >= 0, offset <= chars.count else {
+            throw TsLspClientError.invalidOffset(offset: offset, length: chars.count)
+        }
+        let starts = lineStartOffsets(chars)
+        // bisect_right(starts, offset) - 1
+        var lo = 0, hi = starts.count
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if starts[mid] <= offset { lo = mid + 1 } else { hi = mid }
+        }
+        let line0 = lo - 1
+        let lineStart = starts[line0]
+        let lineEnd = (line0 + 1 < starts.count) ? starts[line0 + 1] - 1 : chars.count
+        var units = 0
+        for i in lineStart..<offset where i < lineEnd {
+            units += (chars[i].unicodeScalars.first.map { $0.value > 0xFFFF } ?? false) ? 2 : 1
+        }
+        return ["line": line0, "character": units]
+    }
+
+    /// 1-indexed (line, col) UTF-16 position -> 0-indexed character offset. Inverse
+    /// convention used by `tsc`/LSP diagnostic payloads.
+    static func lineColToOffset(_ chars: [Character], line: Int, col: Int) -> Int {
+        let starts = lineStartOffsets(chars)
+        let line0 = max(0, min(line - 1, starts.count - 1))
+        let lineStart = starts[line0]
+        let lineEnd = (line0 + 1 < starts.count) ? starts[line0 + 1] - 1 : chars.count
+        var units = 0
+        var idx = lineStart
+        while idx < lineEnd {
+            if units >= col - 1 { break }
+            units += (chars[idx].unicodeScalars.first.map { $0.value > 0xFFFF } ?? false) ? 2 : 1
+            idx += 1
+        }
+        return idx
+    }
+}
+
+public final class TsLspClient {
+    public struct Location: Equatable {
+        public let uri: String
+        public let path: String
+        public let line, col, endLine, endCol: Int
+    }
+    public struct CompletionItem: Equatable {
+        public let label: String
+        public let kind: Int?
+        public let detail: String?
+        public let insertText: String?
+        public let sortText: String?
+    }
+    public struct Symbol: Equatable {
+        public let name: String
+        public let kind: Int
+        public let line, col: Int
+        public let container: String?
+    }
+    public struct Diagnostic: Equatable {
+        public let code: String
+        public let line, col: Int
+        public let message: String
+        public let offset: Int
+        public let severity: Int
+    }
+
+    public private(set) var nCalls = 0
+    public private(set) var wallS: Double = 0
+    public private(set) var nTimeouts = 0
+    public private(set) var nNoPublish = 0
+    public private(set) var nRestarts = 0
+    public private(set) var opCounts: [String: Int] = [:]
+    public private(set) var opWallS: [String: Double] = [:]
+    public private(set) var coldLoadS: Double?
+    public private(set) var lastCompletionIncomplete = false
+
+    private let argv: [String]
+    private let timeoutS: Double
+    private let tsconfigText: String
+    public let scratchDir: URL
+    private let scratchOwner: Bool
+
+    private var supervisor: ProcessSupervisor?
+    private var projectOpened = false
+    private var files: [String: String] = [:]
+    private var versions: [String: Int] = [:]
+    private var open: Set<String> = []
+
+    private let diagLock = NSLock()
+    private var diagEvents: [String: ManualResetEvent] = [:]
+    private var diagState: [String: (seq: Int, version: Int?, payload: [[String: Any]])] = [:]
+    private var diagSeqCounter = 0
+    private var updateMarker: [String: Int] = [:]
+
+    private static let teardownTimeoutS = 5.0
+
+    private static let clientCapabilities: [String: Any] = [
+        "textDocument": [
+            "synchronization": ["dynamicRegistration": false, "willSave": false,
+                                 "willSaveWaitUntil": false, "didSave": true],
+            "publishDiagnostics": ["relatedInformation": false, "versionSupport": true],
+            "definition": ["dynamicRegistration": false, "linkSupport": false],
+            "references": ["dynamicRegistration": false],
+            "completion": ["dynamicRegistration": false, "contextSupport": true,
+                            "completionItem": ["snippetSupport": false,
+                                                "documentationFormat": ["plaintext"]]],
+            "hover": ["dynamicRegistration": false, "contentFormat": ["plaintext", "markdown"]],
+            "documentSymbol": ["dynamicRegistration": false,
+                                "hierarchicalDocumentSymbolSupport": true],
+        ],
+        "workspace": ["workspaceFolders": true],
+    ]
+
+    /// - Parameters:
+    ///   - argv: `typescript-language-server` invocation prefix (from `resolveTsLsp`).
+    ///   - scratchParent: nested scratch dir parent — load-bearing exactly as the Python
+    ///     reference's is: TypeScript's default `typeRoots` walk needs to find
+    ///     `scratchParent/node_modules/@types/node` from wherever the scratch dir sits.
+    public init(argv: [String], timeoutS: Double = 10.0, tsconfigText: String,
+                scratchParent: URL) throws {
+        self.argv = argv
+        self.timeoutS = timeoutS
+        self.tsconfigText = tsconfigText
+        let dir = scratchParent.appendingPathComponent("lsp_scratch_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try tsconfigText.write(to: dir.appendingPathComponent("tsconfig.json"),
+                                atomically: true, encoding: .utf8)
+        self.scratchDir = dir
+        self.scratchOwner = true
+        try startServer()
+    }
+
+    deinit {
+        // NOT relied on for reaping (Swift gives no guarantee this runs at process exit) —
+        // `ProcessSupervisor`'s own signal/atexit backstop covers that. This only cleans up
+        // the ordinary in-process lifecycle.
+        supervisor?.shutdown()
+    }
+
+    // MARK: - path/uri helpers
+
+    private func absPath(_ path: String) -> URL { scratchDir.appendingPathComponent(path) }
+    private func uri(for path: String) -> String { absPath(path).absoluteString }
+
+    // MARK: - server lifecycle
+
+    private func onNotification(_ msg: [String: Any]) {
+        guard (msg["method"] as? String) == "textDocument/publishDiagnostics" else { return }
+        guard let params = msg["params"] as? [String: Any], let uri = params["uri"] as? String else { return }
+        let payload = params["diagnostics"] as? [[String: Any]] ?? []
+        let version = (params["version"] as? NSNumber)?.intValue
+        var ev: ManualResetEvent?
+        diagLock.lock()
+        diagSeqCounter += 1
+        diagState[uri] = (seq: diagSeqCounter, version: version, payload: payload)
+        ev = diagEvents[uri]
+        diagLock.unlock()
+        ev?.set()
+    }
+
+    private func startServer() throws {
+        let sup = try ProcessSupervisor.spawn(
+            argv: argv + ["--stdio"], cwd: scratchDir.path,
+            onNotification: { [weak self] msg in self?.onNotification(msg) })
+        supervisor = sup
+        let params: [String: Any] = [
+            "processId": Int(getpid()),
+            "rootUri": scratchDir.absoluteString,
+            "capabilities": Self.clientCapabilities,
+            "initializationOptions": [String: Any](),
+        ]
+        _ = try sup.endpoint.request("initialize", params: params, timeout: timeoutS)
+        sup.endpoint.notify("initialized", params: [String: Any]())
+    }
+
+    private func ensureAlive() {
+        if let sup = supervisor, sup.isAlive { return }
+        restart()
+    }
+
+    /// Restart loses the warm program; files are already on disk (both `openProject` and
+    /// `update` write through), so re-`didOpen` every previously-open path at its CURRENT
+    /// version — version counters stay monotonic across restarts (LSP requires
+    /// per-document monotonicity).
+    private func restart() {
+        nRestarts += 1
+        let openPaths = Array(open)
+        supervisor?.shutdown()
+        supervisor = nil
+        diagLock.lock()
+        diagState.removeAll(); diagEvents.removeAll(); updateMarker.removeAll()
+        diagLock.unlock()
+        open.removeAll()
+        try? startServer()
+        for p in openPaths { ensureOpen(p) }
+    }
+
+    // MARK: - project / document lifecycle
+
+    /// Materialize `files` on disk, then `didOpen` exactly one (the first key, or
+    /// `warmPath`) to force the server to load the configured project, blocking on its first
+    /// `publishDiagnostics` (bounded by `timeoutS`, counted as a timeout, never a hang).
+    public func openProject(_ files: [String: String], warmPath: String? = nil) throws {
+        guard !projectOpened else { throw TsLspClientError.alreadyOpened }
+        guard !files.isEmpty else { throw TsLspClientError.emptyProject }
+        ensureAlive()
+
+        for (rel, text) in files {
+            let abs = absPath(rel)
+            try FileManager.default.createDirectory(at: abs.deletingLastPathComponent(),
+                                                      withIntermediateDirectories: true)
+            try text.write(to: abs, atomically: true, encoding: .utf8)
+            self.files[rel] = text
+            versions[rel] = 1
+        }
+        projectOpened = true
+
+        let warm = warmPath ?? files.keys.sorted().first!
+        let u = uri(for: warm)
+        let t0 = Date()
+        let ev = ManualResetEvent()
+        diagLock.lock(); diagEvents[u] = ev; diagLock.unlock()
+        ensureOpen(warm)
+        let got = ev.wait(timeout: timeoutS)
+        diagLock.lock(); diagEvents.removeValue(forKey: u); diagLock.unlock()
+        coldLoadS = Date().timeIntervalSince(t0)
+        if !got { nTimeouts += 1 }
+    }
+
+    private func notifyRetrying(_ method: String, params: [String: Any]) {
+        guard let sup = supervisor else { return }
+        sup.endpoint.notify(method, params: params)
+    }
+
+    private func ensureOpen(_ path: String) {
+        guard !open.contains(path) else { return }
+        let u = uri(for: path)
+        let text = files[path] ?? ""
+        diagLock.lock()
+        if updateMarker[u] == nil { updateMarker[u] = diagSeqCounter }
+        diagLock.unlock()
+        notifyRetrying("textDocument/didOpen", params: [
+            "textDocument": ["uri": u, "languageId": "typescript",
+                              "version": versions[path] ?? 1, "text": text],
+        ])
+        open.insert(path)
+    }
+
+    /// `ensureOpen`, write `text` through to disk, bump the version, send
+    /// `textDocument/didChange` (full-text). Returns the new version.
+    @discardableResult
+    public func update(_ path: String, text: String) throws -> Int {
+        ensureAlive()
+        ensureOpen(path)
+        let u = uri(for: path)
+        try text.write(to: absPath(path), atomically: true, encoding: .utf8)
+        files[path] = text
+        versions[path, default: 1] += 1
+        let version = versions[path]!
+        diagLock.lock()
+        updateMarker[u] = diagSeqCounter
+        // A push already recorded before this edit is not an answer to it (#278) — see the
+        // Python reference's comment on the exact same pop.
+        diagState.removeValue(forKey: u)
+        diagLock.unlock()
+        notifyRetrying("textDocument/didChange", params: [
+            "textDocument": ["uri": u, "version": version],
+            "contentChanges": [["text": text]],
+        ])
+        return version
+    }
+
+    // MARK: - diagnostics — version-aware first-push-wins
+
+    private func pushIsCurrent(_ state: (seq: Int, version: Int?, payload: [[String: Any]]),
+                                wantVersion: Int, marker: Int) -> Bool {
+        if let v = state.version { return v == wantVersion }
+        return state.seq > marker
+    }
+
+    /// Every `severity == 1` diagnostic for `path`'s CURRENT version. First-push-wins, no
+    /// settle window (see the file header). `[]` covers two distinguishable-only-by-counter
+    /// situations: a genuinely clean re-check, and "nothing published since the edit"
+    /// (`nNoPublish`) — never raises on timeout or a dead server.
+    public func diagnostics(_ path: String) -> [Diagnostic] {
+        ensureAlive()
+        ensureOpen(path)
+        let u = uri(for: path)
+        let wantVersion = versions[path] ?? 1
+        let t0 = Date()
+
+        diagLock.lock()
+        if let state = diagState[u], pushIsCurrent(state, wantVersion: wantVersion,
+                                                     marker: updateMarker[u] ?? 0) {
+            let payload = state.payload
+            diagLock.unlock()
+            recordOp("diagnostics", Date().timeIntervalSince(t0))
+            return filterDiagnostics(payload, source: files[path] ?? "")
+        }
+        let ev = ManualResetEvent()
+        diagEvents[u] = ev
+        diagLock.unlock()
+
+        _ = ev.wait(timeout: timeoutS)
+
+        diagLock.lock()
+        diagEvents.removeValue(forKey: u)
+        let state = diagState[u]
+        let marker = updateMarker[u] ?? 0
+        diagLock.unlock()
+
+        recordOp("diagnostics", Date().timeIntervalSince(t0))
+
+        guard let state else {
+            nNoPublish += 1
+            return []
+        }
+        guard pushIsCurrent(state, wantVersion: wantVersion, marker: marker) else {
+            nTimeouts += 1
+            return []
+        }
+        return filterDiagnostics(state.payload, source: files[path] ?? "")
+    }
+
+    private func filterDiagnostics(_ payload: [[String: Any]], source: String) -> [Diagnostic] {
+        let chars = Array(source)
+        var out: [Diagnostic] = []
+        for d in payload {
+            let severity = (d["severity"] as? NSNumber)?.intValue ?? 1
+            guard severity == 1 else { continue }
+            guard let range = d["range"] as? [String: Any],
+                  let start = range["start"] as? [String: Any],
+                  let line0 = (start["line"] as? NSNumber)?.intValue,
+                  let char0 = (start["character"] as? NSNumber)?.intValue,
+                  let code = d["code"] else { continue }
+            let line = line0 + 1, col = char0 + 1
+            let codeStr = (code as? String) ?? "\((code as? NSNumber)?.intValue ?? 0)"
+            let message = d["message"] as? String ?? ""
+            out.append(Diagnostic(code: "TS\(codeStr)", line: line, col: col, message: message,
+                                   offset: LspText.lineColToOffset(chars, line: line, col: col),
+                                   severity: severity))
+        }
+        return out
+    }
+
+    // MARK: - the other four ops
+
+    private func recordOp(_ opName: String, _ elapsed: Double) {
+        wallS += elapsed
+        nCalls += 1
+        opCounts[opName, default: 0] += 1
+        opWallS[opName, default: 0] += elapsed
+    }
+
+    /// `ensureAlive`, run `fn`, record cost. `.timeout`/`.closed` are counted (`nTimeouts`)
+    /// and return `empty` — never propagate. `.rpcError` (the server rejected our params) IS
+    /// re-thrown: hiding a real protocol bug as "no completions" would be exactly the BLIND
+    /// failure mode this repo guards hardest.
+    private func timedRequest<T>(_ opName: String, empty: T, _ fn: () throws -> T) throws -> T {
+        ensureAlive()
+        let t0 = Date()
+        defer { recordOp(opName, Date().timeIntervalSince(t0)) }
+        do {
+            return try fn()
+        } catch let e as JsonRpcError {
+            switch e {
+            case .timeout, .closed:
+                nTimeouts += 1
+                return empty
+            case .rpcError, .malformedResponse:
+                throw e
+            }
+        }
+    }
+
+    public func definition(_ path: String, offset: Int) throws -> [Location] {
+        try timedRequest("definition", empty: []) {
+            ensureOpen(path)
+            let u = uri(for: path)
+            let pos = try LspText.offsetToPosition(Array(files[path] ?? ""), offset: offset)
+            let raw = try supervisor!.endpoint.request(
+                "textDocument/definition",
+                params: ["textDocument": ["uri": u], "position": pos], timeout: timeoutS)
+            return Self.mapLocations(raw, root: scratchDir)
+        }
+    }
+
+    public func references(_ path: String, offset: Int, includeDeclaration: Bool = false) throws -> [Location] {
+        try timedRequest("references", empty: []) {
+            ensureOpen(path)
+            let u = uri(for: path)
+            let pos = try LspText.offsetToPosition(Array(files[path] ?? ""), offset: offset)
+            let raw = try supervisor!.endpoint.request(
+                "textDocument/references",
+                params: ["textDocument": ["uri": u], "position": pos,
+                         "context": ["includeDeclaration": includeDeclaration]], timeout: timeoutS)
+            return Self.mapLocations(raw, root: scratchDir)
+        }
+    }
+
+    public func completions(_ path: String, offset: Int) throws -> [CompletionItem] {
+        try timedRequest("completions", empty: []) {
+            ensureOpen(path)
+            let u = uri(for: path)
+            let pos = try LspText.offsetToPosition(Array(files[path] ?? ""), offset: offset)
+            let raw = try supervisor!.endpoint.request(
+                "textDocument/completion",
+                params: ["textDocument": ["uri": u], "position": pos], timeout: timeoutS)
+            let dict = raw as? [String: Any]
+            lastCompletionIncomplete = (dict?["isIncomplete"] as? Bool) ?? false
+            let items = (dict?["items"] as? [[String: Any]]) ?? (raw as? [[String: Any]]) ?? []
+            return items.map {
+                CompletionItem(label: $0["label"] as? String ?? "",
+                                kind: ($0["kind"] as? NSNumber)?.intValue,
+                                detail: $0["detail"] as? String,
+                                insertText: $0["insertText"] as? String,
+                                sortText: $0["sortText"] as? String)
+            }
+        }
+    }
+
+    public func quickinfo(_ path: String, offset: Int) throws -> String? {
+        try timedRequest("quickinfo", empty: nil) {
+            ensureOpen(path)
+            let u = uri(for: path)
+            let pos = try LspText.offsetToPosition(Array(files[path] ?? ""), offset: offset)
+            let raw = try supervisor!.endpoint.request(
+                "textDocument/hover",
+                params: ["textDocument": ["uri": u], "position": pos], timeout: timeoutS)
+            guard let dict = raw as? [String: Any], let contents = dict["contents"] else { return nil }
+            if let s = contents as? String { return s }
+            if let d = contents as? [String: Any] { return d["value"] as? String }
+            return nil
+        }
+    }
+
+    public func documentSymbols(_ path: String) throws -> [Symbol] {
+        try timedRequest("document_symbols", empty: []) {
+            ensureOpen(path)
+            let u = uri(for: path)
+            let raw = try supervisor!.endpoint.request(
+                "textDocument/documentSymbol", params: ["textDocument": ["uri": u]], timeout: timeoutS)
+            return Self.mapSymbols(raw)
+        }
+    }
+
+    // MARK: - result mapping
+
+    private static func mapLocations(_ raw: Any?, root: URL) -> [Location] {
+        var items: [[String: Any]] = []
+        if let arr = raw as? [[String: Any]] { items = arr }
+        else if let one = raw as? [String: Any] { items = [one] }
+        var out: [Location] = []
+        for item in items {
+            let uriStr: String
+            let range: [String: Any]
+            if let target = item["targetUri"] as? String {
+                uriStr = target
+                range = (item["targetSelectionRange"] as? [String: Any])
+                    ?? (item["targetRange"] as? [String: Any]) ?? [:]
+            } else if let u = item["uri"] as? String {
+                uriStr = u
+                range = item["range"] as? [String: Any] ?? [:]
+            } else { continue }
+            guard let start = range["start"] as? [String: Any],
+                  let end = range["end"] as? [String: Any] else { continue }
+            let sLine = (start["line"] as? NSNumber)?.intValue ?? 0
+            let sChar = (start["character"] as? NSNumber)?.intValue ?? 0
+            let eLine = (end["line"] as? NSNumber)?.intValue ?? 0
+            let eChar = (end["character"] as? NSNumber)?.intValue ?? 0
+            let path = relativePath(uriStr, root: root)
+            out.append(Location(uri: uriStr, path: path, line: sLine + 1, col: sChar + 1,
+                                 endLine: eLine + 1, endCol: eChar + 1))
+        }
+        return out
+    }
+
+    private static func relativePath(_ uriStr: String, root: URL) -> String {
+        guard let u = URL(string: uriStr) else { return uriStr }
+        let path = u.path
+        let rootPath = root.path
+        if path.hasPrefix(rootPath) {
+            var rel = String(path.dropFirst(rootPath.count))
+            if rel.hasPrefix("/") { rel.removeFirst() }
+            return rel
+        }
+        return path
+    }
+
+    private static func mapSymbols(_ raw: Any?) -> [Symbol] {
+        guard let arr = raw as? [[String: Any]] else { return [] }
+        var out: [Symbol] = []
+        func flatten(_ items: [[String: Any]], container: String?) {
+            for it in items {
+                let name = it["name"] as? String ?? ""
+                let kind = (it["kind"] as? NSNumber)?.intValue ?? 0
+                if let sel = it["selectionRange"] as? [String: Any],
+                   let start = sel["start"] as? [String: Any] {
+                    let line = (start["line"] as? NSNumber)?.intValue ?? 0
+                    let col = (start["character"] as? NSNumber)?.intValue ?? 0
+                    out.append(Symbol(name: name, kind: kind, line: line + 1, col: col + 1,
+                                       container: container))
+                    if let children = it["children"] as? [[String: Any]], !children.isEmpty {
+                        flatten(children, container: name)
+                    }
+                } else if let loc = it["location"] as? [String: Any],
+                          let range = loc["range"] as? [String: Any],
+                          let start = range["start"] as? [String: Any] {
+                    let line = (start["line"] as? NSNumber)?.intValue ?? 0
+                    let col = (start["character"] as? NSNumber)?.intValue ?? 0
+                    out.append(Symbol(name: name, kind: kind, line: line + 1, col: col + 1,
+                                       container: it["containerName"] as? String))
+                }
+            }
+        }
+        flatten(arr, container: nil)
+        return out
+    }
+
+    // MARK: - misc
+
+    public var callsPerS: Double { wallS > 0 ? Double(nCalls) / wallS : 0 }
+
+    public func close() {
+        supervisor?.shutdown()
+        supervisor = nil
+        if scratchOwner {
+            try? FileManager.default.removeItem(at: scratchDir)
+        }
+    }
+}
+
+/// A simple manual-reset event over `NSCondition` — the Swift analogue of
+/// `threading.Event`, used for the diagnostics wait exactly like the Python reference.
+final class ManualResetEvent {
+    private let cond = NSCondition()
+    private var isSet = false
+
+    func set() {
+        cond.lock()
+        isSet = true
+        cond.signal()
+        cond.unlock()
+    }
+
+    /// Returns whether it was set (mirrors `Event.wait`'s bool return — `true` even if it
+    /// was already set before `wait` was called).
+    @discardableResult
+    func wait(timeout: TimeInterval) -> Bool {
+        cond.lock()
+        defer { cond.unlock() }
+        let deadline = Date().addingTimeInterval(timeout)
+        while !isSet {
+            if !cond.wait(until: deadline) { return isSet }
+        }
+        return true
+    }
+}

--- a/swift/Sources/MonicaLSP/VocabTrie.swift
+++ b/swift/Sources/MonicaLSP/VocabTrie.swift
@@ -1,0 +1,104 @@
+// VocabTrie.swift — port of `src/serve/constrained.py`, the portable prefix-constraint
+// mechanism #226 built for completion-list logit masking. Pure string/integer work: no
+// floating point, no tokenizer dependency (the `decode` closure is supplied by the caller —
+// `MonicaTokenizer` in `monica-generate`, a synthetic table in `--self-test`/
+// `--emit-mask-parity`), so this file needs no dependency on the tokenizer package.
+
+import Foundation
+
+/// Vocab id -> token string, or `nil` for an id that could not be probed cleanly (empty
+/// decode, or decodes to the Unicode replacement character — a byte-level-BPE id that only
+/// makes sense as part of a multi-byte sequence with ITS OWN continuation, not this one).
+public typealias VocabTable = [String?]
+
+private let replacementChar: Character = "\u{FFFD}"
+
+/// Probe every id in `0..<vocabSize` IN CONTEXT: `decode(anchorIds + [i])` minus the
+/// `decode(anchorIds)` prefix. `decode([i])` alone is unsound for byte-level BPE (a lone id
+/// can be a partial UTF-8 sequence) — probing in context is the fix. An id whose probed text
+/// is empty, non-prefix-consistent, or contains the replacement character is recorded as
+/// `nil` and excluded from every allowed set — exclusion is the conservative direction.
+public func buildVocabTable(vocabSize: Int, anchorIds: [Int], decode: ([Int]) -> String) -> VocabTable {
+    let anchorText = decode(anchorIds)
+    var table: VocabTable = Array(repeating: nil, count: vocabSize)
+    for i in 0..<vocabSize {
+        let probed = decode(anchorIds + [i])
+        guard probed.hasPrefix(anchorText) else { continue }
+        let piece = String(probed.dropFirst(anchorText.count))
+        if piece.isEmpty || piece.contains(replacementChar) { continue }
+        table[i] = piece
+    }
+    return table
+}
+
+/// Char-trie over a `VocabTable`'s probeable (non-`nil`) token strings. `prefixMatches(s)`
+/// walks `s` once (O(len(s))) and returns every token id whose string is a prefix of `s` —
+/// i.e. every token that could legally come next if the remaining text to produce is exactly
+/// `s`.
+public final class VocabTrie {
+    private final class Node {
+        var children: [Character: Node] = [:]
+        var ids: [Int] = []
+    }
+
+    private let root = Node()
+
+    public init(vocab: VocabTable) {
+        for (tokenId, piece) in vocab.enumerated() {
+            guard let piece, !piece.isEmpty else { continue }
+            insert(piece, tokenId)
+        }
+    }
+
+    private func insert(_ piece: String, _ tokenId: Int) {
+        var node = root
+        for ch in piece {
+            if let next = node.children[ch] {
+                node = next
+            } else {
+                let next = Node()
+                node.children[ch] = next
+                node = next
+            }
+        }
+        node.ids.append(tokenId)
+    }
+
+    /// Every token id whose string is a prefix of `s`, including the zero-length walk (the
+    /// root's own `ids`, always empty by construction — no token string is empty).
+    public func prefixMatches(_ s: String) -> [Int] {
+        var node = root
+        var out = node.ids
+        for ch in s {
+            guard let next = node.children[ch] else { break }
+            node = next
+            out.append(contentsOf: node.ids)
+        }
+        return out
+    }
+}
+
+/// Every vocab id that keeps SOME `label` in `labels` reachable, given the identifier text
+/// generated so far (`prefix`). For each label still consistent with `prefix`
+/// (`label.hasPrefix(prefix)`), the remaining suffix is unioned in via `trie.prefixMatches`.
+/// If `prefix` is ITSELF a complete label, `exitIds` (tokens beginning with a character that
+/// cannot continue an identifier) are unioned in too — without this the model can never
+/// leave the span once it has spelled a valid name.
+public func allowedExtensions(trie: VocabTrie, labels: [String], prefix: String,
+                               exitIds: [Int] = []) -> [Int] {
+    var out = Set<Int>()
+    var prefixIsCompleteLabel = false
+    for label in labels {
+        guard label.hasPrefix(prefix) else { continue }
+        let suffix = String(label.dropFirst(prefix.count))
+        if suffix.isEmpty {
+            prefixIsCompleteLabel = true
+            continue
+        }
+        out.formUnion(trie.prefixMatches(suffix))
+    }
+    if prefixIsCompleteLabel {
+        out.formUnion(exitIds)
+    }
+    return out.sorted()
+}

--- a/swift/Sources/monica-lsp/main.swift
+++ b/swift/Sources/monica-lsp/main.swift
@@ -1,0 +1,724 @@
+// monica-lsp — dependency-free-runner CLI for MonicaLSP (#197, M13 #163). Mirrors
+// monica-selfcheck/monica-parity/monica-bench's style: hand-rolled arg parsing, a
+// `failures` array, `exit(1)` on failure. `swift test` is a no-op in this package (no
+// .testTarget, matching MonicaTokenizer) — this binary IS the test runner.
+//
+//   --self-test            binary-free: framing/demux/trie/scanner. Runs on macOS AND Linux.
+//   --emit-mask-parity OUT deterministic allowed-id sets for a fixed synthetic vocab/label
+//                          pair, compared against a Python snippet run at CI time (V5).
+//   --probe-reap           drives every ProcessSupervisor exit path against a real
+//                          typescript-language-server and reports pid + liveness verdicts.
+//   --bench                the SLA harness, comparable to scripts/bench_ts_lsp.py.
+//
+// --probe-reap/--bench need node + eval_sets/ts_error_injection/node_modules (macOS CI +
+// local dev only); absent that toolchain they print SKIP and exit 0, mirroring
+// scripts/bench_ts_lsp.py's own "no toolchain resolvable -> clean exit" contract.
+
+import Foundation
+import MonicaLSP
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+func fail(_ msg: String) -> Never {
+    FileHandle.standardError.write(Data("error: \(msg)\n".utf8))
+    exit(1)
+}
+
+func parseFlags(_ args: [String]) -> [String: String] {
+    var out: [String: String] = [:]
+    var i = 0
+    while i < args.count {
+        let a = args[i]
+        guard a.hasPrefix("--") else { i += 1; continue }
+        let key = String(a.dropFirst(2))
+        if i + 1 < args.count && !args[i + 1].hasPrefix("--") {
+            out[key] = args[i + 1]; i += 2
+        } else {
+            out[key] = ""; i += 1
+        }
+    }
+    return out
+}
+
+func intFlag(_ flags: [String: String], _ name: String, default def: Int) -> Int {
+    guard let raw = flags[name], !raw.isEmpty, let v = Int(raw) else { return def }
+    return v
+}
+
+// MARK: - repo-root / eval-set resolution
+//
+// Every invocation in CI runs with `working-directory: swift`, so `..` is the repo root.
+// `--eval-set-dir` overrides for a different CWD (e.g. running the binary directly).
+
+func evalSetDir(_ flags: [String: String]) -> URL {
+    if let override = flags["eval-set-dir"] {
+        return URL(fileURLWithPath: override)
+    }
+    return URL(fileURLWithPath: "..").appendingPathComponent("eval_sets/ts_error_injection")
+}
+
+func defaultTsconfigText(_ setDir: URL) -> String {
+    (try? String(contentsOf: setDir.appendingPathComponent("tsconfig.json"), encoding: .utf8))
+        ?? "{\"compilerOptions\":{\"strict\":true,\"target\":\"es2020\",\"module\":\"commonjs\"}}"
+}
+
+// =============================================================================================
+// MARK: - --self-test (binary-free; no subprocess, no node)
+// =============================================================================================
+
+func runSelfTest() -> Never {
+    var failures: [String] = []
+    func check(_ cond: Bool, _ msg: String) { if !cond { failures.append(msg) } }
+    func eq<T: Equatable>(_ a: T, _ b: T, _ msg: String) {
+        if a != b { failures.append("\(msg): \(a) != \(b)") }
+    }
+
+    // --- framing round trip (no transport at all) ---
+    do {
+        let msg: [String: Any] = ["jsonrpc": "2.0", "id": 7, "method": "initialize",
+                                   "params": ["rootUri": "file:///tmp/x"]]
+        let data = try! JsonRpcEndpoint.encodeMessage(msg)
+        let (a, b) = PipeTransport.pipePair()
+        check(b.write(data), "framing: write succeeds")
+        let decoded = JsonRpcEndpoint.readMessage(a)
+        check(decoded != nil, "framing: message round-trips")
+        eq((decoded?["id"] as? NSNumber)?.intValue, 7, "framing: id round-trips")
+        eq(decoded?["method"] as? String, "initialize", "framing: method round-trips")
+        a.closeWrite(); a.closeRead(); b.closeWrite()
+    }
+
+    // --- multi-message framing with split reads over a real pipe ---
+    do {
+        let (a, b) = PipeTransport.pipePair()
+        let m1: [String: Any] = ["jsonrpc": "2.0", "id": 1, "method": "a"]
+        let m2: [String: Any] = ["jsonrpc": "2.0", "id": 2, "method": "b"]
+        _ = b.write(try! JsonRpcEndpoint.encodeMessage(m1))
+        _ = b.write(try! JsonRpcEndpoint.encodeMessage(m2))
+        let d1 = JsonRpcEndpoint.readMessage(a)
+        let d2 = JsonRpcEndpoint.readMessage(a)
+        eq((d1?["id"] as? NSNumber)?.intValue, 1, "multi-message: first message intact")
+        eq((d2?["id"] as? NSNumber)?.intValue, 2, "multi-message: second message intact")
+        a.closeWrite(); a.closeRead(); b.closeWrite()
+    }
+
+    // --- demux: response arriving out of order (id 2 replies before id 1) ---
+    do {
+        let (client, fakeServer) = PipeTransport.pipePair()
+        let endpoint = JsonRpcEndpoint(stream: client)
+        endpoint.start()
+
+        let r1Done = DispatchSemaphore(value: 0)
+        let r2Done = DispatchSemaphore(value: 0)
+        var r1Result: Any?, r2Result: Any?
+        DispatchQueue.global().async {
+            r1Result = try? endpoint.request("methodOne", timeout: 5.0)
+            r1Done.signal()
+        }
+        DispatchQueue.global().async {
+            r2Result = try? endpoint.request("methodTwo", timeout: 5.0)
+            r2Done.signal()
+        }
+        // Drain both requests off the fake-server side, then reply id=2 BEFORE id=1.
+        let req1 = JsonRpcEndpoint.readMessage(fakeServer)
+        let req2 = JsonRpcEndpoint.readMessage(fakeServer)
+        let id1 = (req1?["id"] as? NSNumber)?.intValue ?? -1
+        let id2 = (req2?["id"] as? NSNumber)?.intValue ?? -1
+        _ = fakeServer.write(try! JsonRpcEndpoint.encodeMessage(
+            ["jsonrpc": "2.0", "id": id2, "result": "second"]))
+        _ = fakeServer.write(try! JsonRpcEndpoint.encodeMessage(
+            ["jsonrpc": "2.0", "id": id1, "result": "first"]))
+        _ = r1Done.wait(timeout: .now() + 5)
+        _ = r2Done.wait(timeout: .now() + 5)
+        eq(r1Result as? String, "first", "demux: out-of-order response resolves the right waiter (1)")
+        eq(r2Result as? String, "second", "demux: out-of-order response resolves the right waiter (2)")
+        endpoint.close(); fakeServer.closeWrite(); fakeServer.closeRead()
+    }
+
+    // --- demux: notification (no id) reaches onNotification, is not treated as a response ---
+    do {
+        let (client, fakeServer) = PipeTransport.pipePair()
+        var seen: [String: Any]?
+        let gotIt = DispatchSemaphore(value: 0)
+        let endpoint = JsonRpcEndpoint(stream: client, onNotification: { msg in
+            seen = msg
+            gotIt.signal()
+        })
+        endpoint.start()
+        _ = fakeServer.write(try! JsonRpcEndpoint.encodeMessage(
+            ["jsonrpc": "2.0", "method": "textDocument/publishDiagnostics",
+             "params": ["uri": "file:///x.ts", "diagnostics": []]]))
+        _ = gotIt.wait(timeout: .now() + 5)
+        eq(seen?["method"] as? String, "textDocument/publishDiagnostics",
+           "demux: notification dispatched to onNotification")
+        endpoint.close(); fakeServer.closeWrite(); fakeServer.closeRead()
+    }
+
+    // --- demux: server -> client REQUEST gets an unconditional {"result": null} reply ---
+    do {
+        let (client, fakeServer) = PipeTransport.pipePair()
+        var observed = false
+        let endpoint = JsonRpcEndpoint(stream: client, onNotification: { msg in
+            if msg["method"] as? String == "window/workDoneProgress/create" { observed = true }
+        })
+        endpoint.start()
+        _ = fakeServer.write(try! JsonRpcEndpoint.encodeMessage(
+            ["jsonrpc": "2.0", "id": 99, "method": "window/workDoneProgress/create",
+             "params": ["token": "t1"]]))
+        let reply = JsonRpcEndpoint.readMessage(fakeServer)
+        check(observed, "server->client request: observed via onNotification")
+        eq((reply?["id"] as? NSNumber)?.intValue, 99, "server->client request: reply carries the same id")
+        check(reply?["result"] is NSNull, "server->client request: auto-reply result is null")
+        endpoint.close(); fakeServer.closeWrite(); fakeServer.closeRead()
+    }
+
+    // --- EOF fails every pending waiter rather than hanging ---
+    do {
+        let (client, fakeServer) = PipeTransport.pipePair()
+        let endpoint = JsonRpcEndpoint(stream: client)
+        endpoint.start()
+        let threw = DispatchSemaphore(value: 0)
+        var caught: Error?
+        DispatchQueue.global().async {
+            do { _ = try endpoint.request("neverAnswered", timeout: 10.0) }
+            catch { caught = error }
+            threw.signal()
+        }
+        // Give the request time to register, then close the SERVER's write side so the
+        // client's reader thread sees EOF.
+        Thread.sleep(forTimeInterval: 0.1)
+        fakeServer.closeWrite()
+        let waited = threw.wait(timeout: .now() + 5)
+        check(waited == .success, "EOF: pending request fails promptly rather than hanging the full timeout")
+        check(caught is JsonRpcError, "EOF: pending request fails with a JsonRpcError")
+        fakeServer.closeRead()
+    }
+
+    // --- request timeout throws rather than hanging past the deadline ---
+    do {
+        let (client, fakeServer) = PipeTransport.pipePair()
+        let endpoint = JsonRpcEndpoint(stream: client)
+        endpoint.start()
+        let t0 = Date()
+        var caught: Error?
+        do { _ = try endpoint.request("neverAnswered", timeout: 0.2) }
+        catch { caught = error }
+        let elapsed = Date().timeIntervalSince(t0)
+        check(caught is JsonRpcError, "timeout: request throws JsonRpcError")
+        check(elapsed < 2.0, "timeout: returns promptly (\(elapsed)s), does not hang")
+        endpoint.close(); fakeServer.closeWrite(); fakeServer.closeRead()
+    }
+
+    // --- VocabTrie / allowedExtensions ---
+    do {
+        let vocab: VocabTable = ["x", "y", "length", "len", "to", "toString", nil, "."]
+        let trie = VocabTrie(vocab: vocab)
+        eq(Set(trie.prefixMatches("length")), Set([2, 3]), "trie: prefix matches both 'length' and 'len'")
+        let allowed = allowedExtensions(trie: trie, labels: ["length", "toString"], prefix: "", exitIds: [7])
+        check(allowed.contains(2), "allowedExtensions: 'length' reachable from empty prefix")
+        check(allowed.contains(5), "allowedExtensions: 'toString' (id 5) reachable from empty prefix")
+        let completeLabel = allowedExtensions(trie: trie, labels: ["x"], prefix: "x", exitIds: [7])
+        eq(completeLabel, [7], "allowedExtensions: complete-label prefix unions in exitIds only")
+    }
+
+    // --- SourceScan: identifier predicates + string/comment masking ---
+    do {
+        check(SourceScan.isIdentChar("a"), "isIdentChar: letter")
+        check(SourceScan.isIdentChar("_"), "isIdentChar: underscore")
+        check(!SourceScan.isIdentChar("."), "isIdentChar: dot is not an identifier char")
+        check(SourceScan.isIdentStart("_"), "isIdentStart: underscore")
+        check(!SourceScan.isIdentStart("1"), "isIdentStart: digit cannot start an identifier")
+
+        let masked = SourceScan.maskStringsAndComments("const s = \"a.b.c\"; x.y;")
+        check(!masked.contains("a.b.c"), "maskStringsAndComments: string contents blanked")
+        check(masked.contains("x.y"), "maskStringsAndComments: real code left intact")
+        eq(masked.count, "const s = \"a.b.c\"; x.y;".count,
+           "maskStringsAndComments: preserves length")
+
+        let commentMasked = SourceScan.maskStringsAndComments("x.y; // a.b.c\nz.w;")
+        check(!commentMasked.contains("a.b.c"), "maskStringsAndComments: line comment blanked")
+        check(commentMasked.contains("z.w"), "maskStringsAndComments: code after comment intact")
+    }
+
+    // --- CompletionMasker: one query per span, not per token; never opens inside a string ---
+    do {
+        final class RecordingLabels: LabelSource {
+            var calls: [(text: String, anchorOffset: Int)] = []
+            func query(path: String, text: String, anchorOffset: Int) -> [String]? {
+                calls.append((text, anchorOffset))
+                return ["length", "toString"]
+            }
+        }
+        let src = RecordingLabels()
+        let decode: ([Int]) -> String = { ids in ids.map { String(UnicodeScalar($0)!) }.joined() }
+        let masker = CompletionMasker(labelSource: src, path: "a.ts", decode: decode)
+
+        _ = masker.maskFor("const x = obj")
+        _ = masker.maskFor("const x = obj.")
+        eq(src.calls.count, 1, "CompletionMasker: exactly one query fires when the span opens")
+        let allowed = masker.maskFor("const x = obj.le", vocabSize: 128)
+        check(allowed != nil, "CompletionMasker: mid-span prefix 'le' still constrains toward 'length'")
+        _ = masker.maskFor("const x = obj.length ")
+        eq(src.calls.count, 1, "CompletionMasker: closing the span issues no extra query")
+
+        let strMasker = CompletionMasker(labelSource: src, path: "b.ts", decode: decode)
+        _ = strMasker.maskFor("const s = \"a.")
+        eq(src.calls.count, 1, "CompletionMasker: a '.' inside a string never opens a span")
+    }
+
+    if failures.isEmpty {
+        print("monica-lsp --self-test: OK — all checks passed")
+        exit(0)
+    } else {
+        for f in failures { FileHandle.standardError.write(Data("FAIL: \(f)\n".utf8)) }
+        FileHandle.standardError.write(Data("monica-lsp --self-test: \(failures.count) failure(s)\n".utf8))
+        exit(1)
+    }
+}
+
+// =============================================================================================
+// MARK: - --emit-mask-parity OUT
+//
+// A FIXED synthetic vocab/label pair, hardcoded IDENTICALLY here and in the Python one-liner
+// `.github/workflows/ci.yml` runs against `src.serve.constrained` (V5). Deliberately no
+// tokenizer/decode involved — this exercises VocabTrie + allowedExtensions directly, pure
+// integer/string logic, so the two languages' outputs are bit-stable by construction. Output
+// is a hand-assembled, whitespace-free JSON string (not JSONSerialization's default
+// formatting) so a `cmp` against the Python side's `json.dumps(..., separators=(",", ":"))`
+// output is comparing semantics, not incidental library pretty-printing.
+// =============================================================================================
+
+let maskParityVocab: [String] = [
+    "x", "y", "length", "len", "toString", "to", "String", ".", " ",
+    "toLowerCase", "toUpperCase", "foo", "fooBar", "_bar", "1", "2", "a", "ab", "abc", "!",
+]
+let maskParityLabels = ["length", "toString", "toLowerCase", "toUpperCase", "x", "y", "abc"]
+let maskParityExitIds = [7, 8, 19]  // ".", " ", "!" — the non-identifier-leading pieces above
+let maskParityPrefixes = ["", "to", "len", "x", "abc", "ab", "zzz"]
+
+func runEmitMaskParity(out: String) {
+    let vocab: VocabTable = maskParityVocab
+    let trie = VocabTrie(vocab: vocab)
+    var caseStrings: [String] = []
+    for prefix in maskParityPrefixes {
+        let allowed = allowedExtensions(trie: trie, labels: maskParityLabels, prefix: prefix,
+                                         exitIds: maskParityExitIds).sorted()
+        let idsStr = allowed.map(String.init).joined(separator: ",")
+        caseStrings.append("{\"prefix\":\"\(prefix)\",\"allowed\":[\(idsStr)]}")
+    }
+    let json = "{\"cases\":[\(caseStrings.joined(separator: ","))]}\n"
+    do {
+        try json.write(toFile: out, atomically: true, encoding: .utf8)
+        print("emit-mask-parity: wrote \(maskParityPrefixes.count) cases to \(out)")
+    } catch {
+        fail("emit-mask-parity: could not write \(out): \(error)")
+    }
+}
+
+// =============================================================================================
+// MARK: - --probe-reap
+//
+// Drives every ProcessSupervisor exit path against a REAL typescript-language-server and
+// reports, per scenario, the spawned child's pid and a post-teardown liveness verdict. This
+// is what makes the CI/local orphan check (V7) non-blind: it prints `spawned_pid=<n>` for
+// every scenario, so a check that never sees that line reports BLIND rather than a vacuous
+// PASS.
+// =============================================================================================
+
+func minimalWarmProject() -> [String: String] {
+    ["src/a.ts": "export const x = 1;\nexport function f(v: number): number { return v + x; }\n"]
+}
+
+func runProbeReapScenarios(argv: [String], tsconfigText: String, scratchParent: URL) {
+    var overallFail = false
+
+    func scenario(_ name: String, _ body: () throws -> Int32) {
+        print("--- probe-reap: \(name) ---")
+        do {
+            let pid = try body()
+            print("spawned_pid=\(pid)")
+            // Bounded settle window for the OS to actually reap the zombie/finish teardown.
+            var alive = ProcessSupervisor.isPidAlive(pid)
+            var waited = 0.0
+            while alive && waited < 3.0 {
+                Thread.sleep(forTimeInterval: 0.1)
+                waited += 0.1
+                alive = ProcessSupervisor.isPidAlive(pid)
+            }
+            if alive {
+                print("FAIL: \(name): pid \(pid) still alive after teardown")
+                overallFail = true
+            } else {
+                print("OK: \(name): pid \(pid) reaped")
+            }
+        } catch {
+            print("FAIL: \(name): threw during setup: \(error)")
+            overallFail = true
+        }
+    }
+
+    // 1. Clean close: spawn, initialize, normal return through withServer's `defer`.
+    scenario("clean-close") {
+        try ProcessSupervisor.withServer(argv: argv + ["--stdio"], cwd: scratchParent.path) { sup in
+            _ = try sup.endpoint.request("initialize", params: [
+                "processId": Int(getpid()), "rootUri": scratchParent.absoluteString,
+                "capabilities": [String: Any](), "initializationOptions": [String: Any](),
+            ], timeout: 10.0)
+            sup.endpoint.notify("initialized", params: [String: Any]())
+            return sup.pid
+        }
+    }
+
+    // 2. Thrown error mid-session: withServer's `defer` must still reap.
+    scenario("thrown-error") {
+        struct Probe: Error {}
+        do {
+            _ = try ProcessSupervisor.withServer(argv: argv + ["--stdio"], cwd: scratchParent.path) { sup -> Int32 in
+                _ = try sup.endpoint.request("initialize", params: [
+                    "processId": Int(getpid()), "rootUri": scratchParent.absoluteString,
+                    "capabilities": [String: Any](), "initializationOptions": [String: Any](),
+                ], timeout: 10.0)
+                throw Probe()
+            }
+            fail("thrown-error scenario: body should have thrown")
+        } catch is Probe {
+            // Expected — but we need the pid, which withServer's throw path doesn't return.
+            // Spawn a second time just to report the pid the FIRST spawn's supervisor used
+            // is unavailable here, so re-derive by re-running with a captured pid instead.
+        }
+        // Re-run capturing pid via a local var, since `withServer`'s throw discards the
+        // return value.
+        var capturedPid: Int32 = -1
+        do {
+            _ = try ProcessSupervisor.withServer(argv: argv + ["--stdio"], cwd: scratchParent.path) { sup -> Int32 in
+                capturedPid = sup.pid
+                _ = try sup.endpoint.request("initialize", params: [
+                    "processId": Int(getpid()), "rootUri": scratchParent.absoluteString,
+                    "capabilities": [String: Any](), "initializationOptions": [String: Any](),
+                ], timeout: 10.0)
+                throw Probe()
+            }
+        } catch is Probe {
+            return capturedPid
+        }
+        throw Probe()
+    }
+
+    // 3. Request timeout: the endpoint throws JsonRpcError.timeout; caller reaps explicitly.
+    scenario("request-timeout") {
+        let sup = try ProcessSupervisor.spawn(argv: argv + ["--stdio"], cwd: scratchParent.path)
+        let pid = sup.pid
+        _ = try? sup.endpoint.request("initialize", params: [
+            "processId": Int(getpid()), "rootUri": scratchParent.absoluteString,
+            "capabilities": [String: Any](), "initializationOptions": [String: Any](),
+        ], timeout: 10.0)
+        sup.endpoint.notify("initialized", params: [String: Any]())
+        // A request the server will never answer (unknown method, no id collision) with a
+        // near-zero timeout.
+        do {
+            _ = try sup.endpoint.request("workspace/thisMethodDoesNotExist", timeout: 0.05)
+        } catch {
+            // expected — JsonRpcError.timeout OR .rpcError, either way we now reap.
+        }
+        sup.shutdown()
+        return pid
+    }
+
+    if overallFail {
+        FileHandle.standardError.write(Data("probe-reap: one or more in-process scenarios FAILED\n".utf8))
+        exit(1)
+    }
+}
+
+/// `--probe-reap-signal-child <sigint|sigkill>` — an internal sub-mode `--probe-reap`
+/// launches AS A SEPARATE PROCESS (via `Process`, re-execing this same binary) so a real
+/// SIGINT/SIGKILL can be delivered to a live `monica-lsp` process from the outside, the only
+/// way to genuinely exercise the async-signal-safe handler / the LSP `processId` parent-death
+/// backstop. Spawns tsserver, prints `spawned_pid=<n>`, flushes, then blocks until signaled.
+func runProbeReapSignalChild(argv: [String], scratchParent: URL) -> Never {
+    guard let sup = try? ProcessSupervisor.spawn(argv: argv + ["--stdio"], cwd: scratchParent.path) else {
+        FileHandle.standardError.write(Data("probe-reap-signal-child: spawn failed\n".utf8))
+        exit(2)
+    }
+    _ = try? sup.endpoint.request("initialize", params: [
+        "processId": Int(getpid()), "rootUri": scratchParent.absoluteString,
+        "capabilities": [String: Any](), "initializationOptions": [String: Any](),
+    ], timeout: 10.0)
+    sup.endpoint.notify("initialized", params: [String: Any]())
+    print("spawned_pid=\(sup.pid)")
+    fflush(stdout)
+    // Block until an external signal arrives (SIGINT via the installed handler, or SIGKILL
+    // which no in-process code ever runs for). No sleep-loop upper bound here on purpose —
+    // the PARENT enforces the timeout by killing this child if it doesn't exit promptly.
+    while true { Thread.sleep(forTimeInterval: 1.0) }
+}
+
+func runProbeReapSignalScenarios(selfBinary: String, scratchParent: URL) {
+    func runOne(_ mode: String, deliver: Int32, label: String) {
+        print("--- probe-reap: \(label) (informational) ---")
+        let p = Process()
+        p.executableURL = URL(fileURLWithPath: selfBinary)
+        p.arguments = ["--probe-reap-signal-child"]
+        let stdout = Pipe()
+        p.standardOutput = stdout
+        p.standardError = FileHandle.nullDevice
+        do { try p.run() } catch {
+            print("SKIP: \(label): could not spawn sub-child: \(error)")
+            return
+        }
+        // Read spawned_pid= off the child's stdout with a bounded wait.
+        var tsserverPid: Int32?
+        let deadline = Date().addingTimeInterval(10.0)
+        var buffer = Data()
+        while tsserverPid == nil && Date() < deadline {
+            let chunk = stdout.fileHandleForReading.availableData
+            if chunk.isEmpty { Thread.sleep(forTimeInterval: 0.05); continue }
+            buffer.append(chunk)
+            let text = String(decoding: buffer, as: UTF8.self)
+            if let range = text.range(of: "spawned_pid=") {
+                let rest = text[range.upperBound...]
+                let digits = rest.prefix { $0.isNumber }
+                tsserverPid = Int32(digits)
+            }
+        }
+        guard let tsPid = tsserverPid else {
+            print("BLIND: \(label): child never printed spawned_pid= — nothing was verified")
+            p.terminate()
+            return
+        }
+        print("spawned_pid=\(tsPid)")
+        kill(p.processIdentifier, deliver)
+        let childDeadline = Date().addingTimeInterval(5.0)
+        while p.isRunning && Date() < childDeadline { Thread.sleep(forTimeInterval: 0.05) }
+        if p.isRunning { p.terminate() }
+        Thread.sleep(forTimeInterval: 0.5)  // let the OS finish reaping / the server notice processId death
+        if ProcessSupervisor.isPidAlive(tsPid) {
+            print("\(mode == "sigint" ? "FAIL" : "INFO"): \(label): tsserver pid \(tsPid) still alive")
+        } else {
+            print("OK: \(label): tsserver pid \(tsPid) is gone")
+        }
+    }
+    runOne("sigint", deliver: SIGINT, label: "SIGINT to monica-lsp (handler kills the child)")
+    runOne("sigkill", deliver: SIGKILL, label: "SIGKILL to monica-lsp (processId parent-death backstop)")
+}
+
+// =============================================================================================
+// MARK: - --bench
+//
+// Reuses the same deterministic synthetic project generator shape as scripts/bench_ts_lsp.py
+// (seeded, same flag surface, same per-op median/mean/p95/calls-per-s JSON schema) so the two
+// columns are directly comparable, and carries over its BLIND-guarded sanity probe.
+// =============================================================================================
+
+struct SplitMix64: RandomNumberGenerator {
+    private var state: UInt64
+    init(seed: UInt64) { state = seed }
+    mutating func next() -> UInt64 {
+        state &+= 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+}
+
+func modPath(_ i: Int) -> String { "src/mod_\(String(format: "%04d", i)).ts" }
+
+func generateProject(nFiles: Int, seed: UInt64) -> [String: String] {
+    var rng = SplitMix64(seed: seed)
+    var files: [String: String] = [
+        "src/hub.ts": """
+        export interface Vec { x: number; y: number }
+
+        export function scale(v: Vec, k: number): Vec {
+          return { x: v.x * k, y: v.y * k };
+        }
+
+        export const ORIGIN: Vec = { x: 0, y: 0 };
+
+        """,
+    ]
+    for i in 1..<max(nFiles, 2) {
+        let lowerMods = Array(1..<i)
+        let k = lowerMods.isEmpty ? 0 : Int.random(in: 1...min(3, lowerMods.count), using: &rng)
+        let chosen = lowerMods.shuffled(using: &rng).prefix(k).sorted()
+
+        var importLines = ["import { Vec, scale } from \"./hub\";"]
+        var uses = ["scale(v, 2)"]
+        for idx in chosen {
+            let stem = URL(fileURLWithPath: modPath(idx)).deletingPathExtension().lastPathComponent
+            importLines.append("import { f\(idx) } from \"./\(stem)\";")
+            uses.append("f\(idx)(v)")
+        }
+        let bodyUses = uses.enumerated().map { "  const u\($0.offset) = \($0.element);" }.joined(separator: "\n")
+        files[modPath(i)] = """
+        \(importLines.joined(separator: "\n"))
+
+        export function f\(i)(v: Vec): Vec {
+        \(bodyUses)
+          const vx = v.x;
+          return scale(v, 1);
+        }
+
+        export interface T\(i) { v: Vec; tag: number }
+
+        """
+    }
+    return files
+}
+
+func percentile(_ sorted: [Double], _ p: Double) -> Double {
+    guard !sorted.isEmpty else { return 0 }
+    let idx = min(sorted.count - 1, Int(Double(sorted.count) * p))
+    return sorted[idx]
+}
+
+func summarize(_ samples: [Double]) -> [String: Any] {
+    guard !samples.isEmpty else { return ["n": 0] }
+    let sorted = samples.sorted()
+    let sum = samples.reduce(0, +)
+    let mean = sum / Double(samples.count)
+    let median = percentile(sorted, 0.5)
+    let p95 = percentile(sorted, 0.95)
+    let callsPerS = sum > 0 ? Double(samples.count) / sum : 0
+    return ["n": samples.count, "median_ms": median * 1000, "mean_ms": mean * 1000,
+            "p95_ms": p95 * 1000, "min_ms": (sorted.first ?? 0) * 1000, "calls_per_s": callsPerS]
+}
+
+func runBench(flags: [String: String], argv: [String], tsconfigText: String, scratchParent: URL) {
+    let nFiles = intFlag(flags, "n-files", default: 200)
+    let iters = intFlag(flags, "iters", default: 50)
+    let seed = UInt64(intFlag(flags, "seed", default: 1))
+    let outPath = flags["out"]
+
+    let files = generateProject(nFiles: nFiles, seed: seed)
+    guard let client = try? TsLspClient(argv: argv, tsconfigText: tsconfigText, scratchParent: scratchParent) else {
+        fail("bench: could not start typescript-language-server")
+    }
+    defer { client.close() }
+    do {
+        try client.openProject(files, warmPath: "src/hub.ts")
+    } catch {
+        fail("bench: openProject failed: \(error)")
+    }
+
+    // --- BLIND-guarded sanity probe: known-answer checks BEFORE any timing starts. ---
+    let target = modPath(1)
+    guard let modText = files[target] else { fail("bench: generated project missing \(target)") }
+    var checks: [String: Bool] = [:]
+
+    if let callRange = modText.range(of: "scale(") {
+        let offset = modText.distance(from: modText.startIndex, to: callRange.lowerBound)
+        let defs = (try? client.definition(target, offset: offset)) ?? []
+        checks["definition_resolves_to_hub"] = defs.contains { $0.path == "src/hub.ts" }
+    } else { checks["definition_resolves_to_hub"] = false }
+
+    let dotOffset = (modText.range(of: "v.x").map {
+        modText.distance(from: modText.startIndex, to: $0.lowerBound) + 2
+    }) ?? -1
+    let completions = dotOffset >= 0 ? ((try? client.completions(target, offset: dotOffset)) ?? []) : []
+    checks["completions_contains_x"] = completions.contains { $0.label == "x" }
+
+    let broken = modText.replacingOccurrences(of: "v.x", with: "v.gorblak", range: modText.range(of: "v.x"))
+    _ = try? client.update(target, text: broken)
+    let brokenDiags = client.diagnostics(target)
+    checks["diagnostics_detects_break"] = brokenDiags.contains { $0.code == "TS2339" }
+    _ = try? client.update(target, text: modText)
+    let cleanDiags = client.diagnostics(target)
+    checks["diagnostics_clean_after_revert"] = cleanDiags.isEmpty
+
+    let failedChecks = checks.filter { !$0.value }.keys.sorted()
+    if !failedChecks.isEmpty {
+        print("verdict=BLIND failed_checks=\(failedChecks.joined(separator: ","))")
+        if let outPath {
+            let json = "{\"verdict\":\"BLIND\",\"failed_checks\":[\(failedChecks.map { "\"\($0)\"" }.joined(separator: ","))]}\n"
+            try? json.write(toFile: outPath, atomically: true, encoding: .utf8)
+        }
+        exit(2)
+    }
+
+    // --- timed measurement ---
+    var completionsSamples: [Double] = []
+    var quickinfoSamples: [Double] = []
+    for i in 0..<iters {
+        let idx = 1 + (i % max(nFiles - 1, 1))
+        let path = modPath(idx)
+        guard let text = files[path] else { continue }
+        let offset = min((text.range(of: "v.x").map { text.distance(from: text.startIndex, to: $0.lowerBound) + 2 }) ?? 0, text.count)
+        let t0 = Date()
+        _ = try? client.completions(path, offset: offset)
+        completionsSamples.append(Date().timeIntervalSince(t0))
+        let t1 = Date()
+        _ = try? client.quickinfo(path, offset: offset)
+        quickinfoSamples.append(Date().timeIntervalSince(t1))
+    }
+
+    let result: [String: Any] = [
+        "verdict": "PASS",
+        "n_files": nFiles, "iters": iters, "seed": seed,
+        "completions": summarize(completionsSamples),
+        "quickinfo": summarize(quickinfoSamples),
+        "diagnostics_note": "not separately timed here — unchanged by construction, "
+            + "client-side debounce, see #278/#279",
+        "client_n_restarts": client.nRestarts,
+        "client_n_timeouts": client.nTimeouts,
+    ]
+    if let data = try? JSONSerialization.data(withJSONObject: result, options: [.prettyPrinted, .sortedKeys]) {
+        print(String(decoding: data, as: UTF8.self))
+        if let outPath { try? data.write(to: URL(fileURLWithPath: outPath)) }
+    }
+}
+
+// =============================================================================================
+// MARK: - dispatch
+// =============================================================================================
+
+let argvAll = Array(CommandLine.arguments.dropFirst())
+let flags = parseFlags(argvAll)
+
+if argvAll.contains("--self-test") {
+    runSelfTest()
+}
+
+if argvAll.contains("--probe-reap-signal-child") {
+    let setDir = evalSetDir(flags)
+    guard let argv = resolveTsLsp(setDir: setDir) else {
+        FileHandle.standardError.write(Data("probe-reap-signal-child: no toolchain\n".utf8))
+        exit(2)
+    }
+    runProbeReapSignalChild(argv: argv, scratchParent: setDir)
+}
+
+if let outPath = flags["emit-mask-parity"], !outPath.isEmpty {
+    runEmitMaskParity(out: outPath)
+    exit(0)
+}
+
+if argvAll.contains("--probe-reap") {
+    let setDir = evalSetDir(flags)
+    guard let argv = resolveTsLsp(setDir: setDir) else {
+        print("SKIP: --probe-reap needs a typescript-language-server toolchain in "
+            + "\(setDir.path)/node_modules (run `npm ci` there) — nothing was measured")
+        exit(0)
+    }
+    let tsconfigText = defaultTsconfigText(setDir)
+    runProbeReapScenarios(argv: argv, tsconfigText: tsconfigText, scratchParent: setDir)
+    runProbeReapSignalScenarios(selfBinary: CommandLine.arguments[0], scratchParent: setDir)
+    exit(0)
+}
+
+if argvAll.contains("--bench") {
+    let setDir = evalSetDir(flags)
+    guard let argv = resolveTsLsp(setDir: setDir) else {
+        print("SKIP: --bench needs a typescript-language-server toolchain in "
+            + "\(setDir.path)/node_modules (run `npm ci` there) — nothing was measured")
+        exit(0)
+    }
+    let tsconfigText = defaultTsconfigText(setDir)
+    runBench(flags: flags, argv: argv, tsconfigText: tsconfigText, scratchParent: setDir)
+    exit(0)
+}
+
+fail("provide --self-test, --emit-mask-parity <out.json>, --probe-reap, or --bench")

--- a/swift/Sources/monica-lsp/main.swift
+++ b/swift/Sources/monica-lsp/main.swift
@@ -121,15 +121,23 @@ func runSelfTest() -> Never {
             r2Result = try? endpoint.request("methodTwo", timeout: 5.0)
             r2Done.signal()
         }
-        // Drain both requests off the fake-server side, then reply id=2 BEFORE id=1.
+        // Drain both requests off the fake-server side. Which one hits the wire first is a
+        // race between the two DispatchQueue.global() closures above (both contend for
+        // stateLock to grab `nextId`) — Darwin's libdispatch happens to run them roughly
+        // submission-ordered under low contention, but that is not guaranteed, and Linux's
+        // scheduler does not preserve it. So identify each request by its `method`, not by
+        // which one was read off the wire first, and key the (still out-of-order) replies
+        // off that — this keeps the "out-of-order response" property (whichever request
+        // resolves second gets its reply written first) without depending on send order.
         let req1 = JsonRpcEndpoint.readMessage(fakeServer)
         let req2 = JsonRpcEndpoint.readMessage(fakeServer)
-        let id1 = (req1?["id"] as? NSNumber)?.intValue ?? -1
-        let id2 = (req2?["id"] as? NSNumber)?.intValue ?? -1
+        let reqs = [req1, req2].compactMap { $0 }
+        let idOne = reqs.first { ($0["method"] as? String) == "methodOne" }?["id"] as? NSNumber
+        let idTwo = reqs.first { ($0["method"] as? String) == "methodTwo" }?["id"] as? NSNumber
         _ = fakeServer.write(try! JsonRpcEndpoint.encodeMessage(
-            ["jsonrpc": "2.0", "id": id2, "result": "second"]))
+            ["jsonrpc": "2.0", "id": idTwo?.intValue ?? -1, "result": "second"]))
         _ = fakeServer.write(try! JsonRpcEndpoint.encodeMessage(
-            ["jsonrpc": "2.0", "id": id1, "result": "first"]))
+            ["jsonrpc": "2.0", "id": idOne?.intValue ?? -1, "result": "first"]))
         _ = r1Done.wait(timeout: .now() + 5)
         _ = r2Done.wait(timeout: .now() + 5)
         eq(r1Result as? String, "first", "demux: out-of-order response resolves the right waiter (1)")

--- a/swift/engine/Package.swift
+++ b/swift/engine/Package.swift
@@ -75,6 +75,10 @@ let package = Package(
                 // (see docs/design/14-inference-engine.md and .claude/plans/issue-167.md):
                 // the name form fails with "unknown package … valid packages are: 'swift'".
                 .product(name: "MonicaTokenizer", package: "swift"),
+                // #197: the native LSP masker (--lsp-mask flags below). Same "swift" path-
+                // dependency identity as the tokenizer edge above — no new external
+                // dependency, since `swift/Package.swift` still declares `dependencies: []`.
+                .product(name: "MonicaLSP", package: "swift"),
             ],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),

--- a/swift/engine/Sources/monica-generate/main.swift
+++ b/swift/engine/Sources/monica-generate/main.swift
@@ -394,7 +394,16 @@ func buildLspMaskSession(flags: [String: String], tok: Tokenizer, promptText: St
     if let projectDir = flags["lsp-project"] {
         let base = URL(fileURLWithPath: projectDir)
         if let enumerator = FileManager.default.enumerator(at: base, includingPropertiesForKeys: nil) {
-            for case let fileURL as URL in enumerator where fileURL.pathExtension == "ts" {
+            for case let fileURL as URL in enumerator {
+                // The toolchain's own `node_modules` is already provided via `scratchParent`
+                // (see `TsLspClient`'s doc comment); walking into a project-root
+                // `node_modules` here too would read every `.d.ts`/`.ts` in every dependency,
+                // exploding startup time and memory for no benefit.
+                if fileURL.lastPathComponent == "node_modules" {
+                    enumerator.skipDescendants()
+                    continue
+                }
+                guard fileURL.pathExtension == "ts" else { continue }
                 let rel = fileURL.path.replacingOccurrences(of: base.path + "/", with: "")
                 projectFiles[rel] = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? ""
             }

--- a/swift/engine/Sources/monica-generate/main.swift
+++ b/swift/engine/Sources/monica-generate/main.swift
@@ -21,6 +21,7 @@
 import Foundation
 import MLX
 import MonicaEngine
+import MonicaLSP
 import MonicaTokenizer
 
 // MARK: - arg parsing (hand-rolled; mirrors monica-tokenize's parseFlags)
@@ -287,7 +288,8 @@ func runBenchPrefill(model: MonicaModel, promptLen: Int, iterations: Int) {
 /// per-token decoding would emit replacement characters mid-multibyte. A real improvement
 /// over `scripts/generate.py`'s per-token `tok.decode([t])`.
 func streamCompletion(model: MonicaModel, tok: Tokenizer?, promptIds: [Int], sampler: Sampler,
-                      maxNewTokens: Int, eosId: Int?, usePrefill: Bool = true) throws {
+                      maxNewTokens: Int, eosId: Int?, usePrefill: Bool = true,
+                      allowedIdsFor: (([Int]) -> [Int]?)? = nil) throws {
     var generatedIds: [Int] = []
     var prevDecoded = ""
     _ = try Generator.generate(
@@ -306,7 +308,7 @@ func streamCompletion(model: MonicaModel, tok: Tokenizer?, promptIds: [Int], sam
             prevDecoded = full
             FileHandle.standardOutput.write(Data(delta.utf8))
             fflush(stdout)
-        }, usePrefill: usePrefill)
+        }, allowedIdsFor: allowedIdsFor, usePrefill: usePrefill)
     print()
 }
 
@@ -356,6 +358,79 @@ struct StandardError: TextOutputStream {
     mutating func write(_ string: String) { FileHandle.standardError.write(Data(string.utf8)) }
 }
 var standardError = StandardError()
+
+// MARK: - #197 LSP-masked decode wiring
+//
+// `--lsp-mask` builds a native `TsLspClient` + `CompletionMasker` (swift/Sources/MonicaLSP)
+// and hands `Generator.generate` an `allowedIdsFor` closure. Absent the flag, `allowedIdsFor`
+// stays `nil` — an exact no-op, so every existing `monica-generate` invocation (and CI step)
+// is byte-identical in behavior to before this issue (`masked_decode.py`'s "the unconstrained
+// arm is a true control" property, carried over).
+//
+// The EOS id is unioned into every non-nil mask HERE, not inside `CompletionMasker` — masking
+// must never make generation unstoppable (`src/lsp/masked_decode.py`'s invariant), and
+// keeping that fold at the call site keeps `MonicaLSP` model/tokenizer-agnostic.
+
+struct LspMaskSession {
+    let client: TsLspClient
+    let allowedIdsFor: ([Int]) -> [Int]?
+}
+
+func buildLspMaskSession(flags: [String: String], tok: Tokenizer, promptText: String,
+                         vocabSize: Int, eosId: Int?) -> LspMaskSession {
+    let setDirPath = flags["lsp-eval-set-dir"] ?? "../../eval_sets/ts_error_injection"
+    let setDir = URL(fileURLWithPath: setDirPath)
+    guard let argv = resolveTsLsp(setDir: setDir) else {
+        fail("--lsp-mask needs a typescript-language-server toolchain under "
+            + "\(setDir.path)/node_modules (run `npm ci` there), or pass "
+            + "--lsp-eval-set-dir pointing at one")
+    }
+    let tsconfigText = (try? String(contentsOf: setDir.appendingPathComponent("tsconfig.json"),
+                                     encoding: .utf8))
+        ?? "{\"compilerOptions\":{\"strict\":true,\"target\":\"es2020\",\"module\":\"commonjs\"}}"
+
+    let lspFile = flags["lsp-file"] ?? "gen.ts"
+    var projectFiles: [String: String] = [:]
+    if let projectDir = flags["lsp-project"] {
+        let base = URL(fileURLWithPath: projectDir)
+        if let enumerator = FileManager.default.enumerator(at: base, includingPropertiesForKeys: nil) {
+            for case let fileURL as URL in enumerator where fileURL.pathExtension == "ts" {
+                let rel = fileURL.path.replacingOccurrences(of: base.path + "/", with: "")
+                projectFiles[rel] = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? ""
+            }
+        }
+        if projectFiles[lspFile] == nil { projectFiles[lspFile] = "" }
+    } else {
+        // No project given: seed a minimal single-file program from the prompt text itself,
+        // so `--prompt` alone is enough to exercise --lsp-mask end to end (V9's Fixtures/toy
+        // usage has no real TS project to point at).
+        projectFiles[lspFile] = promptText
+    }
+
+    guard let client = try? TsLspClient(argv: argv, tsconfigText: tsconfigText, scratchParent: setDir) else {
+        fail("--lsp-mask: could not start typescript-language-server")
+    }
+    do {
+        try client.openProject(projectFiles, warmPath: lspFile)
+    } catch {
+        fail("--lsp-mask: openProject failed: \(error)")
+    }
+
+    let originalText = projectFiles[lspFile] ?? ""
+    let labelSource = LspLabels(client: client, path: lspFile)
+    let masker = CompletionMasker(labelSource: labelSource, path: lspFile,
+                                  decode: { ids in tok.decode(ids) },
+                                  encode: { s in tok.encode(s) })
+
+    let allowedIdsFor: ([Int]) -> [Int]? = { generatedIds in
+        let fullText = originalText + tok.decode(generatedIds)
+        guard let allowed = masker.maskFor(fullText, vocabSize: vocabSize) else { return nil }
+        var withEos = Set(allowed)
+        if let eos = eosId { withEos.insert(eos) }
+        return Array(withEos)
+    }
+    return LspMaskSession(client: client, allowedIdsFor: allowedIdsFor)
+}
 
 // MARK: - dispatch
 
@@ -433,9 +508,18 @@ func runMain(_ flags: [String: String]) {
         let promptIds = tok.encode(prompt)
         if promptIds.isEmpty { fail("--prompt encoded to zero tokens") }
         FileHandle.standardOutput.write(Data(prompt.utf8))
+
+        var lspSession: LspMaskSession? = nil
+        if flags["lsp-mask"] != nil {
+            lspSession = buildLspMaskSession(flags: flags, tok: tok, promptText: prompt,
+                                             vocabSize: model.config.vocabSize, eosId: eosId)
+        }
+        defer { lspSession?.client.close() }
+
         do {
             try streamCompletion(model: model, tok: tok, promptIds: promptIds, sampler: sampler,
-                                 maxNewTokens: maxNewTokens, eosId: eosId, usePrefill: usePrefill)
+                                 maxNewTokens: maxNewTokens, eosId: eosId, usePrefill: usePrefill,
+                                 allowedIdsFor: lspSession?.allowedIdsFor)
         } catch { fail("generation failed: \(error)") }
     } else {
         fail("provide --prompt <text>, --prompt-ids 1,2,3, --chat, or --self-test")


### PR DESCRIPTION
Closes #197

## Summary
- New `MonicaLSP` target in the zero-dependency `swift/` package: LSP wire framing + async demux (`JsonRpc.swift`), a `pipe(2)`-backed raw-fd transport (`PipeTransport.swift`), the sole child-process owner with a full terminate→kill reaping ladder plus a signal/atexit backstop (`ProcessSupervisor.swift`), a faithful port of `TsLspService` (`TsLspClient.swift`), the completion-mask trie mechanism (`VocabTrie.swift`), the string/comment-aware span scanner (`SourceScan.swift`), and the span state machine (`CompletionMasker.swift`). `swift/Package.swift` stays `dependencies: []` — a new target, not a new dependency edge.
- `monica-lsp` CLI runner (`--self-test` binary-free on macOS+Linux, `--emit-mask-parity`, `--probe-reap`, `--bench`), mirroring the `monica-selfcheck`/`monica-parity` dependency-free-runner convention.
- `monica-generate` gains `--lsp-mask`/`--lsp-project`/`--lsp-file` flags wiring a native `TsLspClient` + `CompletionMasker` into the existing `Generator.allowedIdsFor` hook (#167/#169); absent the flags, behavior is an exact no-op.
- CI: `monica-lsp --self-test` on both `swift-macos`/`swift-linux`; live-server steps (`npm ci`, `--probe-reap` orphan check, `--bench`, mask-parity `cmp` against `src/serve/constrained.py`) on `swift-macos`; a `monica-generate --lsp-mask` end-to-end step on `swift-engine`.
- Docs: `docs/design/14-inference-engine.md` (#197 flipped to done) and a new native-harness section in `docs/design/12-lsp-in-the-loop.md`, including an honest first-pass latency finding (this Swift client is currently slower than the Python reference on `completions`/`quickinfo`, not yet profiled).

## Testing
- [x] `swift build` (both `swift/` and `swift/engine/`) — clean
- [x] `swift run monica-lsp --self-test` — binary-free framing/demux/trie/scanner, all green
- [x] `swift package show-dependencies --format flatlist` — empty (no new dependency edge)
- [x] `swift run monica-lsp --probe-reap` against a real `typescript-language-server` — 5/5 exit-path scenarios reaped, zero orphans (`pgrep -f 'typescript-language-server|tsserver'` confirmed clean)
- [x] `swift run monica-lsp --bench` vs `scripts/bench_ts_lsp.py` — both non-BLIND, real sanity-probe answers
- [x] Mask-set parity (`--emit-mask-parity` vs `src/serve/constrained.py`) — byte-identical
- [x] `.venv/bin/python -m pytest -q -rs` — 1581 passed, 13 skipped (pre-existing, unrelated)
- [x] `monica-generate --self-test` passes; `--lsp-mask` end-to-end needs `mlx-swift`'s Metal path (no Xcode on this host) — gated CI-only via `swift-engine`