### PR TITLE
ci: [M13] gate the poc-scale Swift parity fixture (#267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,8 +785,12 @@ jobs:
           N=$(wc -l < oracle/poc-manifest.txt)
           [ "$N" -eq 7 ] || { echo "BLIND: short oracle manifest ($N lines)"; exit 2; }
           diff oracle/poc-manifest.txt "$RUNNER_TEMP/poc-manifest-local.txt"
-          test -s oracle/meta.json || { echo "BLIND: oracle meta.json missing/empty"; exit 2; }
-          diff <(python3 -c 'import json,sys;print(json.dumps(json.load(open(sys.argv[1])),sort_keys=True))' oracle/meta.json) \
+          # upload-artifact's multi-path least-common-ancestor is $RUNNER_TEMP (shared by
+          # poc-manifest.txt and poc-fixture/meta.json in job 9), so the poc-fixture/
+          # subdir survives into the download — the file lands at oracle/poc-fixture/meta.json,
+          # not oracle/meta.json.
+          test -s oracle/poc-fixture/meta.json || { echo "BLIND: oracle meta.json missing/empty"; exit 2; }
+          diff <(python3 -c 'import json,sys;print(json.dumps(json.load(open(sys.argv[1])),sort_keys=True))' oracle/poc-fixture/meta.json) \
                <(python3 -c 'import json,sys;print(json.dumps(json.load(open(sys.argv[1])),sort_keys=True))' "$RUNNER_TEMP/poc-fixture/meta.json")
       - name: Record the poc-scale tolerance headroom (informational, but printed)
         # NOT a threshold check — src/conformance/tolerances.py's fp32 band (rtol=1e-4/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+  # #267: the poc-scale Swift parity gate (jobs 9/10 below) runs ONLY on
+  # workflow_dispatch or this weekly schedule — never on pull_request/push. Monday
+  # 09:17 UTC, an off-the-hour time to avoid the top-of-hour GitHub Actions scheduler
+  # crunch.
+  schedule:
+    - cron: "17 9 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -643,6 +649,169 @@ jobs:
       - name: Guard — swift/ (MonicaTokenizer) stays dependency-free (#167)
         # Cheap, and it fails loudly the day someone "simplifies" the two packages into one.
         # The engine -> tokenizer edge (Package.swift) must never become tokenizer -> engine.
+        run: |
+          cd swift
+          OUT=$(swift package show-dependencies --format flatlist)
+          echo "output: '$OUT'"
+          [ -z "$OUT" ]
+
+  # ── Job 9: the poc-scale parity oracle, generation side (#267) ────────────
+  # Dispatch/schedule-only — see the `on:` block above. Generation side of the
+  # two-process #298 guard job 10 completes: #298 (MLX 0.32.0 buffer-reuse
+  # corruption) is deterministic PER PROCESS, so two independent fresh-process
+  # generations, on two separate runners, have to corrupt identically to survive
+  # the manifest `diff` in job 10. Python+MLX only — NO Swift toolchain, so this
+  # job cannot be contaminated by the thing it is generating an oracle FOR.
+  # Uploads a ~2 KB manifest, never the 571 MB fixture itself: job 10 regenerates
+  # its own copy in ~6 s, which is both cheaper than moving the bytes and
+  # strictly stronger evidence (two processes, two runners, not one process
+  # trusted twice).
+  poc-fixture-oracle:
+    name: poc parity oracle — generate (macOS, Python MLX)
+    runs-on: macos-latest
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install (mlx only — no data/torch needed to export a fixture)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,mlx]"
+      - name: Export the poc-scale fixture
+        # config/poc.yaml is fp16 by default; --precision fp32 overrides it (the harness
+        # gates fp32 — see export_parity_fixture.py's --precision help). Measured on an
+        # M1 Pro during planning: 5.77s wall, 571 MB output.
+        run: |
+          /usr/bin/time -l python scripts/export_parity_fixture.py \
+            --config config/poc.yaml --precision fp32 --batch 1 --seq 128 \
+            --out "$RUNNER_TEMP/poc-fixture"
+          du -sh "$RUNNER_TEMP/poc-fixture"
+          cat "$RUNNER_TEMP/poc-fixture/meta.json"
+      - name: Manifest (relative paths, so job 10's own copy is comparable)
+        run: |
+          cd "$RUNNER_TEMP/poc-fixture"
+          find . -type f | sort | xargs shasum -a 256 > "$RUNNER_TEMP/poc-manifest.txt"
+          cat "$RUNNER_TEMP/poc-manifest.txt"
+          # A manifest that cannot observe its target must never read green: an empty
+          # or short manifest would `cmp` clean against another equally-empty one. Exactly
+          # 7 files: generation/inputs/meta.json/prefill/reference/weights.safetensors +
+          # weights.safetensors.config.json.
+          N=$(wc -l < "$RUNNER_TEMP/poc-manifest.txt")
+          [ "$N" -eq 7 ] || { echo "BLIND: expected 7 fixture files, got $N"; exit 2; }
+          grep -q 'weights.safetensors$' "$RUNNER_TEMP/poc-manifest.txt"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: poc-fixture-manifest
+          path: |
+            ${{ runner.temp }}/poc-manifest.txt
+            ${{ runner.temp }}/poc-fixture/meta.json
+          retention-days: 30
+          if-no-files-found: error      # never let an empty artifact upload look like success
+
+  # ── Job 10: the poc-scale parity gate, Swift consumer side (#267) ─────────
+  # Dispatch/schedule-only. `needs: [swift-engine, poc-fixture-oracle]` — depending on
+  # swift-engine is deliberate and free: it makes this job start AFTER swift-engine has
+  # written the `swift-engine-${{ runner.os }}-…` xcodebuild cache, so this job's
+  # mlx-swift build is a warm restore + incremental build rather than a second cold
+  # 20-40 min vendored-C++ compile. It does NOT modify swift-engine itself — that job
+  # gains no `needs:`, so it can never be skip-propagated by this new dependency.
+  poc-parity:
+    name: poc parity gate (macOS, mlx-swift, dispatch/schedule only)
+    runs-on: macos-latest
+    needs: [swift-engine, poc-fixture-oracle]
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - name: Toolchain
+        run: swift --version | tee .swift-toolchain-version
+      # Same rationale as swift-engine's identical step above: mlx-swift's Metal kernels
+      # need Xcode's `metal` compiler, which plain `swift build` never invokes.
+      - name: Ensure Metal toolchain
+        run: |
+          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+          xcodebuild -downloadComponent MetalToolchain || true
+          xcodebuild -showComponent MetalToolchain
+          xcrun -sdk macosx metal --version
+      - uses: actions/cache@v4
+        with:
+          path: swift/engine/.build-xcode
+          # IDENTICAL key to swift-engine's cache, plus a restore-keys prefix: this job
+          # wants a warm restore of the cache swift-engine (an earlier job in this same
+          # run, via `needs:`) just wrote, not a fresh cold build.
+          key: swift-engine-${{ runner.os }}-${{ hashFiles('swift/engine/Package.resolved') }}-${{ hashFiles('.swift-toolchain-version') }}
+          restore-keys: |
+            swift-engine-${{ runner.os }}-
+      - name: Build (xcodebuild, so mlx-swift's Metal kernels actually get compiled)
+        working-directory: swift/engine
+        run: |
+          xcodebuild build -scheme MonicaEngine-Package -destination 'platform=macOS' \
+            -derivedDataPath .build-xcode -skipPackagePluginValidation
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install (mlx only — no data/torch needed to export a fixture)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,mlx]"
+      - name: Regenerate the fixture in THIS job's own fresh process
+        # The other half of the #298 cross-process guard: a second, independent
+        # generation on a SECOND runner, in a fresh Python process that has never touched
+        # job 9's. #298's corruption is deterministic per-process, so two independent
+        # processes have to corrupt identically to fool the diff below.
+        run: |
+          python scripts/export_parity_fixture.py \
+            --config config/poc.yaml --precision fp32 --batch 1 --seq 128 \
+            --out "$RUNNER_TEMP/poc-fixture"
+          cd "$RUNNER_TEMP/poc-fixture"
+          find . -type f | sort | xargs shasum -a 256 > "$RUNNER_TEMP/poc-manifest-local.txt"
+      - uses: actions/download-artifact@v4      # errors (fails the job) if the artifact is absent
+        with:
+          name: poc-fixture-manifest
+          path: oracle
+      - name: "#298 guard — two fresh processes on two runners must agree byte-for-byte"
+        # This MUST run, and pass, BEFORE monica-parity below ever reads poc-fixture — an
+        # oracle that disagrees with its own independent regeneration is not a valid
+        # oracle regardless of what the Swift side says about it.
+        run: |
+          test -s oracle/poc-manifest.txt || { echo "BLIND: oracle manifest missing/empty"; exit 2; }
+          N=$(wc -l < oracle/poc-manifest.txt)
+          [ "$N" -eq 7 ] || { echo "BLIND: short oracle manifest ($N lines)"; exit 2; }
+          diff oracle/poc-manifest.txt "$RUNNER_TEMP/poc-manifest-local.txt"
+          test -s oracle/meta.json || { echo "BLIND: oracle meta.json missing/empty"; exit 2; }
+          diff <(python3 -c 'import json,sys;print(json.dumps(json.load(open(sys.argv[1])),sort_keys=True))' oracle/meta.json) \
+               <(python3 -c 'import json,sys;print(json.dumps(json.load(open(sys.argv[1])),sort_keys=True))' "$RUNNER_TEMP/poc-fixture/meta.json")
+      - name: Record the poc-scale tolerance headroom (informational, but printed)
+        # NOT a threshold check — src/conformance/tolerances.py's fp32 band (rtol=1e-4/
+        # atol=1e-5, reused unmodified — see #267's scope) is enforced by the exporter
+        # itself (it refuses to write a fixture that fails its own forward/step parity
+        # check) and by monica-parity's gate step below. This just makes the measured
+        # numbers a standing CI observation instead of a one-off in a plan file.
+        run: |
+          python3 -c "import json;m=json.load(open('$RUNNER_TEMP/poc-fixture/meta.json'));print('forward_step_max_abs_diff=%s greedy_margin_min=%s prefill_decode_max_abs_diff=%s' % (m['forward_step_max_abs_diff'], m['greedy_margin_min'], m['prefill_decode_max_abs_diff']))"
+      - name: Swift logit + greedy-id parity at poc scale (GATE)
+        working-directory: swift/engine
+        run: |
+          BIN=$(find .build-xcode/Build/Products -type f -name monica-parity -perm -u+x -print -quit)
+          if [ -z "$BIN" ]; then
+            echo "monica-parity binary not found under .build-xcode/Build/Products" >&2
+            find .build-xcode/Build/Products -maxdepth 3 >&2 || true
+            exit 1
+          fi
+          "$BIN" --fixtures "$RUNNER_TEMP/poc-fixture" | tee "$RUNNER_TEMP/poc-parity.log"
+          # Exit 0 is not sufficient evidence a real comparison happened: main.swift
+          # already fails on an empty fixture set ("no fixtures to check"), but this makes
+          # the observation explicit at this call site too — a check that cannot observe
+          # its target must never read green.
+          grep -qE '^OK — all 1 fixtures pass forward \+ step parity' "$RUNNER_TEMP/poc-parity.log"
+      - name: Guard — swift/ (MonicaTokenizer) stays dependency-free (#167)
         run: |
           cd swift
           OUT=$(swift package show-dependencies --format flatlist)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,15 @@ suite entirely: `swift-macos` and `swift-linux` (the official `swift:latest` con
 build the package and run `monica-selfcheck` — `swift test` is still a no-op, there is no
 `.testTarget` — then train a fixed fixture corpus (`swift/Fixtures/parity-corpus.jsonl`) into
 a `tokenizer.json` artifact; `swift-parity` downloads both artifacts and `cmp`s them, turning
-#191/#245's bit-identical-output claim into an enforced gate rather than a comment.
+#191/#245's bit-identical-output claim into an enforced gate rather than a comment. Two more
+jobs (#267), `poc-fixture-oracle` and `poc-parity`, gate the Swift/MLX model port at
+**poc scale** (`config/poc.yaml`, d_model 768/24 layers/vocab 50280) rather than only the
+checked-in toy fixtures `swift-engine` uses — the first job generates the 571 MB fixture on a
+macOS runner and uploads a ~2 KB sha256 manifest, the second regenerates it independently on a
+second runner and `cmp`s the two manifests (the #298 cross-process corruption guard) before
+running `monica-parity` against it. Both are **dispatch/schedule-only**
+(`workflow_dispatch` or a weekly `schedule:`) — **never `pull_request`/`push`** — so a green
+PR run never implies poc scale was exercised; see `swift/engine/Fixtures/README.md` §poc.
 
 ## The seam — the most important architectural rule
 

--- a/docs/design/14-inference-engine.md
+++ b/docs/design/14-inference-engine.md
@@ -409,6 +409,29 @@ The #163 dependency order:
 4. **#197** (LSP harness — **done**), **#168** (quantization — **done**), **#169** (Swift
    prefill — **done**), **#170** (Apple-Silicon benchmark harness — **done**).
 5. Stretch: **#171** (fused Metal kernel), **#172** (speculative decoding).
+6. **#267 — done: the poc-scale Swift parity gate, generate-on-runner (CI, dispatch/schedule
+   only).** #166 gated `swift-engine` against four checked-in *toy*-scale fixtures and
+   verified `config/poc.yaml` (d_model 768, 24 layers, vocab 50280) manually, once, locally.
+   #267 turns that into a standing gate without checking the 571 MB poc fixture into git:
+   two new jobs, `poc-fixture-oracle` (macOS, Python+MLX, no Swift toolchain — generates the
+   fixture, hashes it, uploads a ~2 KB sha256 manifest + `meta.json`) and `poc-parity`
+   (macOS, `needs: [swift-engine, poc-fixture-oracle]` so it restores swift-engine's warm
+   xcodebuild cache — regenerates its own independent copy, `cmp`s the two manifests, THEN
+   runs `monica-parity --fixtures` against the verified fixture). Measured on an M1 Pro
+   during planning: **5.2-5.8 s wall, ~2 GB peak RSS, 571 MB output**, and the two
+   independent generations were **bit-identical, 7/7 files** — which is what makes the
+   manifest `diff` a real guard against **#298** (MLX 0.32.0's deterministic-per-process
+   buffer-reuse corruption) rather than a coin flip: two fresh processes on two runners would
+   have to corrupt identically to pass it. Both jobs are gated
+   `if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'` (a new
+   weekly Monday `schedule:` trigger) — **never `pull_request`/`push`** — because poc adds
+   zero new *code-path* coverage over `toy` (pure Mamba, no attention/MoE/quant); what it adds
+   is *scale* coverage of the tolerance contract (R2 below), which does not change PR to PR,
+   so per-PR cost (a second macOS mlx-swift build) isn't worth paying. `swift-engine` gains
+   no `needs:` and no existing job's cache key/`if:` changed. No change to
+   `src/conformance/tolerances.py`, `scripts/export_parity_fixture.py`, or any checked-in
+   fixture. See `swift/engine/Fixtures/README.md` §poc for the operator-facing version and
+   the local reproduction command.
 
 **Deferred set:** Linux/CUDA for the Swift engine, the ggml port, continuous batching, and Swift
 DPO/GRPO step factories.
@@ -539,6 +562,24 @@ DPO/GRPO step factories.
   `default.metallib`), so every genuinely local-hardware Swift-engine number in
   `docs/benchmarks.md` is recorded as "not yet measured" with the exact command to fill
   it in. Python-MLX numbers (no such constraint) are measured locally where noted.
+- **R2 (#267) — the fp32 parity band is relative-dominated at poc scale, not
+  absolute-dominated like it was derived to be.** `src/conformance/tolerances.py`'s Step 2
+  designs the fp32 band (`rtol=1e-4/atol=1e-5`) to be absolute-dominated for `|logit| ~ 8`
+  ("`rtol = atol / 8` so the relative term contributes at most one `atol` at the largest
+  logit"), calibrated on the `toy*.yaml` configs only. At `config/poc.yaml` scale
+  (d_model 768, 24 layers, vocab 50280), measured `forward_step_max_abs_diff = 3.62e-05` is
+  already 3.6x `atol` on its own, and `greedy_margin_min = 23.94` — logits ~3x larger than
+  toy's — mean the check only passes because the relative term (`rtol * |logit| ~= 2.4e-3`)
+  carries it: the band has flipped to relative-dominated. Net headroom is still ~66x (vs
+  toy's ~70x), so the contract holds *today*, and #267's `poc-parity` CI job (dispatch/
+  schedule-only, above) is what keeps that a monitored fact instead of a one-off measurement
+  that silently goes stale. **If a future mlx-swift version introduces a benign op-order
+  difference, this gate could trip at poc scale while every toy fixture stays green — that
+  is a finding to triage (is the drift real, or just the relative term catching up), not a
+  number to widen.** The only sanctioned escape hatch, if one is ever needed, is a *measured*
+  poc-scale row added to `src/conformance/tolerances.py` with its derivation recorded the
+  same way the existing toy-derived bands are — never an ad-hoc `rtol`/`atol` literal in the
+  CI workflow YAML.
 
 ## See also
 

--- a/swift/engine/Fixtures/README.md
+++ b/swift/engine/Fixtures/README.md
@@ -412,9 +412,10 @@ It IS still gated in CI (#267), just not on every PR: jobs `poc-fixture-oracle` 
 `poc-parity` in `.github/workflows/ci.yml`, triggered only on `workflow_dispatch` or a
 weekly `schedule` (Monday 09:17 UTC) — **never on `pull_request` or `push`**. Generation is
 cheap (measured on an M1 Pro): **5.2-5.8 s wall**, ~2 GB peak RSS — not the ~10 minutes an
-earlier draft of this note assumed — so the fixture is never checked in and never crosses
-the network either: `poc-fixture-oracle` generates it, hashes it, and uploads only a **~2 KB
-sha256 manifest + `meta.json`**; `poc-parity` regenerates its own independent copy on a
+earlier draft of this note assumed — so the fixture is never checked in, and the **571 MB
+fixture output itself never crosses the network**: `poc-fixture-oracle` generates it, hashes
+it, and uploads only a **~2 KB sha256 manifest + `meta.json`** (those two small files *do*
+cross the network as a CI artifact); `poc-parity` regenerates its own independent copy on a
 second runner and `cmp`s the two manifests before trusting either as an oracle (the
 cross-process #298 guard below) — measured **bit-identical, 7/7 files**, during planning.
 

--- a/swift/engine/Fixtures/README.md
+++ b/swift/engine/Fixtures/README.md
@@ -403,9 +403,22 @@ Swift gate testing a stale oracle.
 
 ## `poc` is deliberately NOT checked in
 
-At fp32 the `config/poc.yaml` weights alone are ~508 MB. The exporter supports it and
-`monica-parity --fixtures <dir>` takes any fixture directory, so the poc run is a **manual,
-local acceptance step**, not a CI gate:
+At fp32 the `config/poc.yaml` fixture is **571 MB** total (`weights.safetensors` 507 MB,
+`reference.safetensors` 62.9 MB, `prefill.safetensors` 28.8 MB, the remaining 4 files under
+2 KB combined) — too large to check into git or Git LFS for a fixture that shares 100% of its
+code paths with `toy` (pure Mamba, no attention, no MoE) at larger dimensions.
+
+It IS still gated in CI (#267), just not on every PR: jobs `poc-fixture-oracle` +
+`poc-parity` in `.github/workflows/ci.yml`, triggered only on `workflow_dispatch` or a
+weekly `schedule` (Monday 09:17 UTC) — **never on `pull_request` or `push`**. Generation is
+cheap (measured on an M1 Pro): **5.2-5.8 s wall**, ~2 GB peak RSS — not the ~10 minutes an
+earlier draft of this note assumed — so the fixture is never checked in and never crosses
+the network either: `poc-fixture-oracle` generates it, hashes it, and uploads only a **~2 KB
+sha256 manifest + `meta.json`**; `poc-parity` regenerates its own independent copy on a
+second runner and `cmp`s the two manifests before trusting either as an oracle (the
+cross-process #298 guard below) — measured **bit-identical, 7/7 files**, during planning.
+
+Run it locally the same way CI does:
 
 ```bash
 .venv/bin/python scripts/export_parity_fixture.py \
@@ -414,8 +427,24 @@ local acceptance step**, not a CI gate:
 cd swift/engine && swift run monica-parity --fixtures /tmp/monica-poc-fixture
 ```
 
-poc shares 100% of its code paths with `toy` (pure Mamba, no attention, no MoE) at larger
-dimensions, so gating it in CI would need Git LFS or a ~10-minute in-runner generation step
-for no new coverage. The known upgrade path, if it is ever wanted: have the existing
-`full-macos` job (which already installs MLX) generate the fixture and hand it to a
-dependent job as an artifact.
+**Why generate-on-runner isn't vacuous.** The oracle (Python/MLX,
+`scripts/export_parity_fixture.py`) and the consumer (`swift/engine`'s hand-written
+mlx-swift port) share nothing but the `.safetensors` bytes — running them in the same CI
+run changes nothing about that independence; it only avoids paying to move 571 MB over the
+network. What this gate buys over `toy` is **scale coverage of the tolerance contract**,
+not new code-path coverage: at poc, `forward_step_max_abs_diff = 3.62e-05` (25x toy's
+1.43e-06) and `greedy_margin_min = 23.94`, so `src/conformance/tolerances.py`'s fp32 band
+(`rtol=1e-4/atol=1e-5`, derived on toy configs and assuming an absolute-dominated band at
+`|logit| ~ 8`) becomes **relative-dominated** at poc's larger logits. Headroom is still
+~66x, so the contract holds — but nothing kept that true before this gate existed.
+
+**The #298 cross-process guard.** #298 is silent, deterministic-per-process numerical
+corruption during MLX 0.32.0 export. Two independently-generated fixtures, on two separate
+runners, in two fresh processes, would have to corrupt identically to pass the manifest
+`diff` — so a `poc-fixture-oracle`/`poc-parity` manifest mismatch is treated as a #298
+sighting, not a flake to rerun past.
+
+**Why dispatch/schedule only, not per-PR.** `poc-parity` is a second macOS runner carrying
+an mlx-swift xcodebuild (warm-cache: minutes; cold: up to 40) plus a `pip install mlx` —
+against zero new code-path coverage over `toy`, that is not a per-PR trade worth making. See
+`docs/design/14-inference-engine.md` §Staged roadmap for the full record.


### PR DESCRIPTION
Closes #267

## Summary

- Adds two dispatch/schedule-only CI jobs: `poc-fixture-oracle` (macOS, Python+MLX — generates the poc-scale fixture and uploads a ~2 KB sha256 manifest + `meta.json`) and `poc-parity` (macOS, `needs: [swift-engine, poc-fixture-oracle]` — regenerates an independent copy on a second runner, `cmp`s the two manifests as the #298 cross-process buffer-reuse-corruption guard, then runs `monica-parity --fixtures` against the verified fixture).
- Both jobs are gated `if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'` and a new weekly `schedule:` (Monday 09:17 UTC) is added to `on:` — **never `pull_request`/`push`**. No existing job's `needs:`/`if:`/cache key changes.
- The 571 MB poc fixture is never checked into git and never crosses the network — both jobs regenerate it locally (~5.2-5.8s measured) and only the manifest/`meta.json` is handed off as an artifact.
- No change to `src/conformance/tolerances.py`, `scripts/export_parity_fixture.py`, or any checked-in fixture (the #266 tolerance contract is reused as-is).
- Docs updated in the same commit: `swift/engine/Fixtures/README.md` §poc (replaces the false ~10-minute estimate with measured numbers), `docs/design/14-inference-engine.md` (Staged roadmap entry + Risks R2 on the relative-dominated tolerance band at poc scale), `CLAUDE.md`'s CI job inventory.

## Why this PR's own CI does not exercise the new gate

`poc-fixture-oracle`/`poc-parity` are deliberately `workflow_dispatch`/`schedule`-only, so this PR's own `pull_request` CI run will show them as **skipped**, not exercised. A green PR check here is *not* evidence the new gate works. Validation is via a separate `gh workflow run ci.yml --ref feature/267-ci-poc-parity-fixture` dispatch run on this branch — link and outcome to follow in a comment once it completes.

## Testing

- [x] `.venv/bin/python -m pytest -q -rs` — 1595 passed, 11 skipped (pre-existing, hardware-gated), 0 failed, 299.91s
- [x] `.venv/bin/python scripts/smoke_test.py --data <freshly-built toy split>` — SMOKE TEST PASSED
- [x] Local poc-scale fixture generation (matches CI job 9/10's exact command): 5.17-5.77s wall, 571 MB output, 7 files; two independent generations bit-identical (7/7 sha256 match) — the premise the #298 cross-process guard depends on
- [x] `cd swift && swift build` / `swift run monica-selfcheck` / `swift package show-dependencies --format flatlist` (empty) — all pass
- [x] `cd swift/engine && swift build` — passes (Metal/mlx-swift execution is CI-only on this host: "Failed to load the default metallib", pre-existing)
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses; `actionlint` clean
- [ ] `workflow_dispatch` run on this branch — **in progress**, will comment with the run URL and outcome
- [ ] Deliberate-failure dispatch run (V8) demonstrating a broken artifact name fails loudly — pending