### PR TITLE
fix: [M12] Dedupe allowed_ids before the rng.choice fallback in constrained decode

### DIFF
--- a/docs/parked-findings.md
+++ b/docs/parked-findings.md
@@ -99,3 +99,9 @@ Format: date, `file:line`, what was seen, what task surfaced it, rough severity.
   ~70 s of which is the LSP client's own #278 debounce paid 192 times. There is no `slow`/`live`
   pytest marker in this repo to gate it behind. Found while adding the gate. Severity: test
   runtime, non-blocking.
+
+- [2026-08-19] `swift/engine/Sources/MonicaEngine/Sampler.swift:146-148`, the Swift port's
+  all-non-finite fallback carries the same duplicate bias #285 fixed on the Python side, and
+  rebuilds the in-range `ids` array a second time rather than reusing the one built for the mask.
+  Found while fixing #285. Severity: cosmetic, non-blocking (sampled draws are not a
+  cross-language parity contract; only greedy is).

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -87,7 +87,7 @@ Last audited 2026-08-18 (`/closure-audit`, whole repo: 81 capabilities × 131 te
 | SERVE-1 | `test_generate.py` | `test_generate.py` | `scripts/smoke_test.py`, CI `swift-engine` `monica-generate` steps | EOS handling, max tokens | none |
 | SERVE-2 | `test_repetition_penalty.py`, `test_generate.py`, `test_constrained_sampling.py` | same | `scripts/smoke_test.py` | temp 0, top-p renormalization, all-non-finite fallback | none |
 | SERVE-3 | `test_serve.py` | `test_serve.py` | none | snapshot/restore of the recurrent state | no CLI or serving entry point reaches `RewindTree` — unit-tested only |
-| SERVE-4 | `test_constrained_sampling.py`, `test_masked_decode.py`, `test_completion_mask.py` | CI `swift-macos` mask-set parity (Python vs Swift `VocabTrie`) | CI `swift-engine` `monica-generate --lsp-mask` | empty/all-out-of-range `allowed_ids` | none |
+| SERVE-4 | `test_constrained_sampling.py`, `test_masked_decode.py`, `test_completion_mask.py` | CI `swift-macos` mask-set parity (Python vs Swift `VocabTrie`) | CI `swift-engine` `monica-generate --lsp-mask` | empty/all-out-of-range/duplicate-bearing `allowed_ids` | none |
 | SERVE-5 | `test_spec_decode.py` (mlx-gated) | none | none | greedy-equivalence assertion | Swift side has only the `verifyBlock` prerequisite; full spec decode not built (#172) |
 
 ## Evaluation

--- a/src/serve/sampling.py
+++ b/src/serve/sampling.py
@@ -61,6 +61,9 @@ def sample(
 
     `allowed_ids` (constrained decode, #226): restrict the draw to exactly this id set.
     `None` is a no-op. An empty sequence raises `ValueError` — see the module docstring.
+    Duplicate ids are dropped, first occurrence winning, so the id set keeps the
+    caller's order and the fallback draw below is uniform over *distinct* allowed ids
+    rather than weighted by how often a caller happened to list one (#285).
     Ids outside `[0, vocab)` are dropped, mirroring the repetition block's own
     out-of-range guard — but if that drops every id (all of `allowed_ids` was
     out-of-range), the result is the same as an empty `allowed_ids` and raises
@@ -79,6 +82,12 @@ def sample(
                 "constraint set (that is a masker bug, not 'nothing is valid'; the "
                 "caller should bypass the mask for this step instead)")
         ids = np.asarray(list(allowed_ids), dtype=np.int64)
+        # Dedupe preserving first-seen order (#285): duplicates are harmless for the
+        # mask (writing 0.0 twice to a slot is the same mask) but bias the uniform
+        # `rng.choice` fallback below toward whatever the caller happened to list
+        # twice. `np.unique` with `return_index` gives the index of each value's
+        # FIRST occurrence; taking those indices in sorted order restores input order.
+        ids = ids[np.sort(np.unique(ids, return_index=True)[1])]
         ids = ids[(ids >= 0) & (ids < logits.size)]
         if ids.size == 0:
             raise ValueError(

--- a/tests/test_constrained_sampling.py
+++ b/tests/test_constrained_sampling.py
@@ -65,6 +65,42 @@ def test_all_finite_fallback_stays_within_allowed_ids_when_repetition_bans_the_r
     assert seen <= {0, 1}
 
 
+def test_duplicate_allowed_ids_do_not_bias_the_fallback_draw():
+    # #285: the fallback draws uniformly over the DISTINCT allowed ids. Listing 7
+    # three times must not make it 3x as likely as 9. Same fallback recipe as the
+    # test above: no_repeat_ngram_size=1 with previous_tokens covering the whole
+    # allowed set bans every remaining logit, so the all-non-finite fallback fires.
+    logits = np.zeros(12, dtype=np.float32)
+    rng = np.random.default_rng(11)
+    draws = [sample(logits, temperature=1.0, rng=rng, allowed_ids=[7, 7, 7, 9],
+                    previous_tokens=[7, 9], no_repeat_ngram_size=1)
+             for _ in range(2000)]
+    assert set(draws) == {7, 9}
+    for tok in (7, 9):
+        share = draws.count(tok) / len(draws)
+        # Pre-fix 7 takes ~75%; post-fix ~50%. At n=2000, p=0.5 this band is ~4.5 sigma.
+        assert 0.4 <= share <= 0.6, f"id {tok} drawn {share:.3f} of the time"
+
+
+def test_all_duplicates_allowed_ids_draws_the_single_candidate():
+    # Every entry is the same id -> exactly one candidate after the dedupe, so the
+    # fallback returns it deterministically.
+    logits = np.zeros(8, dtype=np.float32)
+    rng = np.random.default_rng(5)
+    for _ in range(50):
+        tok = sample(logits, temperature=1.0, rng=rng, allowed_ids=[5, 5, 5],
+                     previous_tokens=[5], no_repeat_ngram_size=1)
+        assert tok == 5
+
+
+def test_duplicate_out_of_range_allowed_ids_still_raise():
+    # Dedupe must not weaken the all-out-of-range guard: {99, -1} is still empty
+    # after the range filter, so this raises rather than narrowing silently.
+    logits = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    with pytest.raises(ValueError, match="no ids within"):
+        sample(logits, temperature=0.0, allowed_ids=[99, 99, -1])
+
+
 # --------------------------------------------------------------------------- #
 # ordering: mask first, then repetition penalty, then temperature/top-k/top-p
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #285

## Summary
- `sample(allowed_ids=...)` (`src/serve/sampling.py`) now dedupes the allowed-id array **once at the build site**, preserving first-seen order, so the in-range filter, the empty-set guard, the mask and the all-non-finite fallback `rng.choice(ids)` all read the same set.
- Duplicates were harmless for the mask (writing `0.0` twice to a slot is the same mask) but skewed the fallback draw toward whatever the caller happened to list twice: with `allowed_ids=[7, 7, 7, 9]`, id 7 was drawn **76%** of the time pre-fix, ~50% after.
- The constrained-decode contract was never broken — every draw still came from `allowed_ids`; only the fallback's *distribution* was off. No in-repo caller passes duplicates (`CompletionMasker.mask_for` and `masked_decode` both hand over sorted/deduped sets), so this is defensive for external callers and nothing in this tree changes behaviour.
- Guards untouched: dedupe never adds ids, so an all-out-of-range set is still empty after filtering and still raises the existing message.
- `sample()`'s `allowed_ids` docstring block updated in place to state the dedupe; `docs/test-plan.md` row `SERVE-4` edge cases now read `empty/all-out-of-range/duplicate-bearing`. `docs/feature-matrix.md` row `SERVE-4` reviewed and deliberately unchanged — a distribution fix inside an already-`Shipped` capability is not a status transition.

Three new cases in `tests/test_constrained_sampling.py`: uniform-ish draw over `[7, 7, 7, 9]` (2000 draws, each id within `[0.4, 0.6]`), all-duplicates `[5, 5, 5]` returning its single candidate, and duplicated out-of-range ids still raising.

## Testing
- [x] Tests added/updated
- [x] All tests passing — `.venv/bin/python -m pytest -q -rs`: **1645 passed, 12 skipped** (skips are CUDA/fp8/torch.compile environment gates)
- [x] Manual testing completed — the new bias test **fails on `main`** (id 7 drawn 0.760) and passes on this branch; smoke gate `scripts/smoke_test.py` green on a freshly built toy split (resume max|loss diff| 2.4e-07, prefill/decode parity 1.4e-06); `tests/test_import_guard.py` green (`sampling.py` stays portable numpy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ur4BdaFTqnwqSUAx5TrX8