### PR TITLE
feat: [M13] MLX 0.32.0 buffer-reuse can silently corrupt an unrelated later computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,9 @@ activemq-data/
 .envrc
 .venv
 .venv-dt/
+# #298 version-comparison probe venvs (scripts/probe_mlx_buffer_reuse.py under an
+# explicitly pinned mlx==X.Y.Z); throwaway, never a dev environment.
+.venv-mlx*/
 env/
 venv/
 ENV/

--- a/docs/design/14-inference-engine.md
+++ b/docs/design/14-inference-engine.md
@@ -722,6 +722,177 @@ DPO/GRPO step factories.
   tensor's own absmax entirely, and reinterpreting axis order (not tolerance) resolved it.
   Not folded into #298, and #298 is not folded into this.
 
+## MLX 0.32.0 buffer reuse (#298)
+
+**Status: OPEN upstream, GUARDED here.** This section is the written half of #298. Nothing below
+claims the defect is fixed — it is an MLX bug this repository cannot fix. What #298 shipped is
+(a) a guard that makes a corrupted oracle impossible to check in unnoticed and (b) these measured
+answers. #298 stays open as an upstream-tracking item.
+
+**The defect.** Calling `MLXMambaModel.mixing_matrices` (or any accessor that forks a lazy `h`
+into two independent consumers) on a freshly-constructed model silently corrupts a *later,
+unrelated* computation on that same model — `prefill(..., last_only=True)` in the observed case.
+Correct shapes, no exception, no log, and the corruption is catastrophic rather than marginal:
+`max|d|` on fp32 logits is **6-9**, not `1e-5`. It is deterministic within a process but varies
+between processes, so a rerun "fixes" it and it reads as a flake.
+
+All numbers below are from `scripts/probe_mlx_buffer_reuse.py` on this host (M1 Pro, macOS,
+Python 3.14.6), 2026-08-19. The probe compares every trial to an **accessor-free reference**
+(`prefill` on a fresh model with no interpretability call), *not* to trial 0 — with the accessor in
+the loop roughly half of the trials including trial 0 are corrupt, so a trial-0 reference reports
+the clean trials as the failures and undercounts by ~2x. The reference is recomputed at the end of
+every run and a run whose reference moved is reported `BLIND`, never clean.
+
+### D1 — Is it version-specific? Is there an upstream fix?
+
+**No, and none found.** `pyproject.toml` pins only `mlx>=0.18`; three released versions were built
+into throwaway venvs and run through the identical probe (`--pattern mixing --trials 40 --seq 129`,
+barrier removed, buffer cache on):
+
+| mlx | toy.yaml | toy-hybrid.yaml | toy-moe.yaml |
+|-----|----------|-----------------|--------------|
+| 0.31.2 (2026-04-22) | 35/40 | 16/40 | 14/40 |
+| 0.32.0 (2026-07-07, the installed build) | 30/40 | 18/40 | 11/40 |
+| 0.32.1 (2026-08-18, latest) | 27/40 | 24/40 | 16/40 |
+
+The rates are the same order across all three, so **downgrading to 0.31.2 is not a remedy and
+upgrading to 0.32.1 is not either.** Reproduce with:
+
+```bash
+python -m venv .venv-mlx031 && .venv-mlx031/bin/pip install "mlx==0.31.2" numpy safetensors pyyaml
+PYTHONPATH=. .venv-mlx031/bin/python scripts/probe_mlx_buffer_reuse.py \
+    --pattern mixing --trials 40 --seq 129 --config config/toy.yaml
+```
+
+**Upstream search (2026-08-19), what was searched and what was found.** `ml-explore/mlx` issues
+and PRs via `gh api search/issues` for *buffer cache corruption*, *set_cache_limit*, *allocator
+reuse wrong results*, *silent wrong results*, *hazard tracking*, *untracked hazard*, *lazy graph
+fork wrong results*, *nondeterministic results same input*; plus the release notes for v0.32.0 and
+v0.32.1. **Result: no upstream issue matching this defect.** The near neighbours are all different
+bugs — #3866 (int32 corruption under `async_eval` + in-place slice updates, closed), #3461/#3462
+(buffer destroyed mid-flight under *untracked hazard mode with custom kernels*, closed), #3912 /
+#4253 / #4261 (quantized-matmul and `gather_mm` wrong results), #3350 (the cache pool retaining
+unusable buffers — a memory-growth bug, not a correctness one). This is a **documented negative**:
+no upstream fix exists to wait for, and no upstream issue has been filed by this project either.
+
+### D2 — Does the barrier belong on the training/inference path? **No.**
+
+**Decision: the `mx.eval(h)` barrier and `mx.set_cache_limit(0)` both stay OFF the
+training/inference path.** Two independent reasons, one structural and one measured.
+
+*Structural.* `mixing_matrices` is the only place in the backend that forks a **lazy** `h` into two
+independent consumers — `layer.mixing_matrix(h)` and `layer_fn(h)` — without materialising it
+first. No training or inference path does that: `forward`/`forward_seq`, `prefill` and `step` each
+consume `h` linearly, one consumer per value. The interpretability accessors (`mixing_matrices`,
+`hidden_states`) are the exception, and they are not on any hot path.
+
+*Measured.* `--pattern hotpath --trials 30` — `forward`, `prefill`, three stacked `step`s, and a
+real `make_train_step` over 30 freshly-constructed models, buffer cache **on**:
+
+| config | failures |
+|--------|----------|
+| toy.yaml | 0/30 |
+| toy-hybrid.yaml | 0/30 |
+| toy-moe.yaml | 0/30 |
+
+That clean result is evidence **because the same instrument, on the same host, in the same
+session, does see the defect** at 11-30/40 in the `mixing` pattern. A clean run from an instrument
+that had never demonstrated detection would be BLIND, and the probe exits non-zero rather than
+report it.
+
+*Cost, so the decision is grounded rather than asserted.* `--pattern throughput --trials 30`
+(forward + `make_train_step`, timed with the cache on and then at limit 0, toy scale):
+
+| config | cache on | limit 0 | slowdown |
+|--------|----------|---------|----------|
+| toy.yaml | 0.317 s | 0.358 s | **+13.0%** |
+| toy-moe.yaml | 0.477 s | 0.623 s | **+30.5%** |
+
+Toy scale overstates the penalty for a real run (allocator cost is largest where allocation
+dominates compute) but the sign and order are clear, and at ~99 s/step for the poc protocol a
+double-digit percentage is not a cost to take on speculatively. If a future reader wants to widen
+the scope, the cost is on record either way.
+
+### D3 — The guard, and what it does and does not claim
+
+`scripts/export_parity_fixture.py` now exports **twice, in two fresh processes**, and compares the
+trees byte-for-byte (`src/conformance/fixture_digest.py`, portable) before leaving anything at
+`--out`. On agreement `--out` is kept; on disagreement **nothing** is left at `--out`, both trees
+are preserved as `--out.mismatch-1`/`-2`, the per-file verdicts print, and the process exits 2.
+`--no-double-export` opts out (and is set automatically on the child, bounding the recursion).
+
+The defect is deterministic *per process*, so two independent interpreters would have to corrupt
+identically to agree — that is the whole content of the guard, and it is why the second export
+lives in `main()` rather than inside `build_fixture` (an in-process repeat would prove nothing).
+
+**Scope: intra-machine only.** Two processes on ONE host. Cross-machine byte identity is *not*
+claimed and is known to be false — CI's `train-fixture-oracle`/`-verify` pair measures ~1e-8 drift
+in `train.safetensors` between runner instances.
+
+**Confinement, now checkable in one command.** One helper, `disable_buffer_cache()` /
+`disable_buffer_cache_for_process()`, in `scripts/export_parity_fixture.py`, with **five** call
+sites: `build_fixture`, `tests/test_mlx_mixing_matrix.py`, `tests/test_parity_fixture_export.py`,
+`tests/test_train_parity_fixture_export.py`, `tests/test_lowp_parity_band.py`. The issue text says
+two and the plan said three; both undercounted — #264's mitigation had already been copy-pasted
+into two more test modules. `git grep -n set_cache_limit -- src scripts tests` now names
+`export_parity_fixture.py` and nothing else, which is what makes the confinement an observation
+rather than an assumption. The helper **raises** (naming `mx.__version__`) if the limit does not
+take effect, so an MLX API change fails loudly instead of silently no-op'ing; MLX 0.32.0 exposes no
+`get_cache_limit`, so it confirms via a second `set_cache_limit(0)` plus `get_cache_memory()`.
+
+**Determinism of the export graph, i.e. why byte-for-byte is the right predicate.** The export has
+no dropout and no sampling: `generation.safetensors` is a **greedy** decode, `mx.random.seed(seed)`
+is re-applied at the top of each `run()`, and `_export_train_oracle` already re-runs its trajectory
+and refuses a non-reproducing one. Measured: 20/20 in-process `build_fixture("config/toy.yaml")`
+runs reproduce the checked-in oracle exactly (D4), and the double-export agrees on all 8 files.
+
+### D4 — The `mixing.N` near-zero flake (the escalation comment)
+
+CI run 31806256071 failed `test_checked_in_toy_fixture_matches_todays_backend` once with
+`mixing.1 max|d| = 2.694e-05` against `rtol=1e-4/atol=1e-5`, then passed on rerun. `--pattern
+export --trials 20` regenerates `toy` twenty times and diffs every `mixing.{i}` key plus
+`forward_logits` as a control, against the checked-in oracle:
+
+| key | max\|d\| over 20 | nonzero trials |
+|-----|------------------|----------------|
+| `mixing.0` | 0.0 | 0/20 |
+| `mixing.1` | 0.0 | 0/20 |
+| `forward_logits` | 0.0 | 0/20 |
+
+**Branch fired: no drift reproduces, so nothing is loosened.** No tolerance changed — not for
+`mixing.*`, and certainly not for `forward_logits`/`step_logits`/`greedy_ids`.
+`src/conformance/tolerances.py` is untouched by #298. The near-zero concern is real in principle
+(the causal mixing matrix's strict upper triangle is *exactly* zero, so at `|b| ~ 0` the
+`np.allclose` band collapses to `atol=1e-5` with no `rtol` headroom, and the observed 2.694e-05 is
+~2.7x over) — but widening a band to absorb an unreproduced failure would be picking a number to
+make a run green, which is the one thing the tolerance contract forbids.
+
+What that leaves open, stated plainly: the CI failure was **not** reproduced here, so its cause is
+undetermined. The two live hypotheses are a #298 sighting on the CI runner (in which case the
+right response is the guard, not a tolerance) and fp32 accumulation-order nondeterminism specific
+to that runner's hardware. Given the drift magnitudes measured above — #298 corrupts by **6-9**,
+not by 2.7e-05 — the second is the more likely of the two, and neither is closed. If it recurs,
+re-run `--pattern export --trials 20` on the runner that saw it before touching any band.
+
+### D5 — What stays open
+
+- The upstream MLX defect itself. Unfixed in 0.31.2, 0.32.0 and 0.32.1; no upstream issue found;
+  none filed from here. **#298 remains open as an upstream-tracking item.**
+- **#264's `mx.eval(h)` barrier is not sufficient on its own.** With the barrier in place and the
+  buffer cache on, the probe still measures 18/40 (toy.yaml) and 20/40 (toy-moe.yaml) corrupt
+  trials; only 0/40 for toy-hybrid.yaml. The mitigation that actually holds on this host is
+  `set_cache_limit(0)`: barrier **plus** limit 0 gives **0/40 on all three configs**, on 0.32.0 and
+  on 0.31.2. Every path that writes a checked-in oracle already runs under that combination, so the
+  fixtures are covered — but a caller invoking `mixing_matrices` outside the exporter and the four
+  test modules is **not** protected by the barrier alone. Parked in `docs/parked-findings.md`;
+  changing it is a behaviour decision beyond #298's contract.
+- Pinning `mlx==` in `pyproject.toml`. Out of scope for #298 (a repo-wide dependency decision) and
+  pointless as a remedy anyway, since all three tested versions are affected.
+- A PR-time CI job for the double-export. The guard is in the CLI the regeneration command already
+  invokes, and the dispatch-only `poc-fixture-oracle`/`poc-parity` and `train-fixture-oracle`/
+  `-verify` pairs already do the cross-runner form; an always-on macOS job is a runtime-cost
+  decision for the user.
+
 ## See also
 
 - [01-architecture-seam.md](01-architecture-seam.md) — the seam whose Python implementation is the

--- a/docs/design/14-inference-engine.md
+++ b/docs/design/14-inference-engine.md
@@ -834,9 +834,11 @@ in `train.safetensors` between runner instances.
 sites: `build_fixture`, `tests/test_mlx_mixing_matrix.py`, `tests/test_parity_fixture_export.py`,
 `tests/test_train_parity_fixture_export.py`, `tests/test_lowp_parity_band.py`. The issue text says
 two and the plan said three; both undercounted — #264's mitigation had already been copy-pasted
-into two more test modules. `git grep -n set_cache_limit -- src scripts tests` now names
-`export_parity_fixture.py` and nothing else, which is what makes the confinement an observation
-rather than an assumption. The helper **raises** (naming `mx.__version__`) if the limit does not
+into two more test modules. `git grep -n set_cache_limit -- src scripts tests` now returns **no
+call site** outside that one file: the remaining hits are prose comments plus the monkeypatch
+stubs in `test_mlx_mixing_matrix.py` that falsify the fail-loud check. That is what makes the
+confinement an observation rather than an assumption — and in particular there is no call on the
+training/inference path. The helper **raises** (naming `mx.__version__`) if the limit does not
 take effect, so an MLX API change fails loudly instead of silently no-op'ing; MLX 0.32.0 exposes no
 `get_cache_limit`, so it confirms via a second `set_cache_limit(0)` plus `get_cache_memory()`.
 

--- a/docs/design/14-inference-engine.md
+++ b/docs/design/14-inference-engine.md
@@ -861,7 +861,7 @@ export --trials 20` regenerates `toy` twenty times and diffs every `mixing.{i}` 
 | `mixing.1` | 0.0 | 0/20 |
 | `forward_logits` | 0.0 | 0/20 |
 
-**Branch fired: no drift reproduces, so nothing is loosened.** No tolerance changed — not for
+**Branch fired for the isolated exporter: no drift reproduces there, so nothing is loosened.** No tolerance changed — not for
 `mixing.*`, and certainly not for `forward_logits`/`step_logits`/`greedy_ids`.
 `src/conformance/tolerances.py` is untouched by #298. The near-zero concern is real in principle
 (the causal mixing matrix's strict upper triangle is *exactly* zero, so at `|b| ~ 0` the
@@ -869,12 +869,47 @@ export --trials 20` regenerates `toy` twenty times and diffs every `mixing.{i}` 
 ~2.7x over) — but widening a band to absorb an unreproduced failure would be picking a number to
 make a run green, which is the one thing the tolerance contract forbids.
 
-What that leaves open, stated plainly: the CI failure was **not** reproduced here, so its cause is
-undetermined. The two live hypotheses are a #298 sighting on the CI runner (in which case the
-right response is the guard, not a tolerance) and fp32 accumulation-order nondeterminism specific
-to that runner's hardware. Given the drift magnitudes measured above — #298 corrupts by **6-9**,
-not by 2.7e-05 — the second is the more likely of the two, and neither is closed. If it recurs,
-re-run `--pattern export --trials 20` on the runner that saw it before touching any band.
+**But the CI flake IS reproducible — in a populated pytest process, and it is worse than the CI
+report suggested.** `build_fixture` in isolation is clean; run it after a module that exercises the
+interpretability accessors and it corrupts. Measured on `main` (i.e. this **pre-dates** #298's
+guard and is not caused by it), 12 runs each:
+
+| pytest invocation | failures |
+|---|---|
+| `pytest tests/test_parity_fixture_export.py` | **0/12** |
+| `pytest tests/test_mlx_mixing_matrix.py tests/test_parity_fixture_export.py` | **3/12** |
+
+```bash
+# reproduce (~3 s per run; expect roughly 1 in 4 to fail)
+.venv/bin/python -m pytest tests/test_mlx_mixing_matrix.py \
+    tests/test_parity_fixture_export.py -q -p no:cacheprovider
+```
+
+The failing assertion is **not** `mixing.N` and **not** a tolerance at all — it is `greedy_ids`,
+compared as exact integers:
+
+```
+greedy_ids drifted from the checked-in Swift-parity oracle
+Mismatched elements: 16 / 16 (100%)
+ [0]: 222 (ACTUAL), 4 (DESIRED)
+```
+
+16 of 16 ids wrong, by 222 rather than by one — the same catastrophic signature as the `mixing`
+probe's 6-9 logit drift, not the 2.694e-05 the CI comment reported. So **D4's third branch is the
+one that fires**: this is a live recurrence of #298, and the correct response is to record it, not
+to loosen anything. No band moved.
+
+Two consequences worth stating explicitly, because both are easy to assume away:
+
+1. **`set_cache_limit(0)` does not compose across pytest modules.** Both modules in the failing
+   pair apply the process-wide disable at import, and the corruption still occurs. The 0/40 clean
+   results in D1-D3 were all measured in *dedicated* processes; a long-lived pytest process that
+   has already run ~19 other MLX modules is a different regime, and the mitigation is not known to
+   hold there.
+2. **The CI comment's `mixing.1 max|d| = 2.694e-05` is therefore probably a *different* event**
+   from the one reproduced here — a near-miss at the atol floor rather than this wholesale
+   corruption. That one is still unreproduced (0/20 fresh exports), and widening a band to absorb
+   an unreproduced near-miss would be picking a number to make a run green. Left alone.
 
 ### D5 — What stays open
 
@@ -888,6 +923,11 @@ re-run `--pattern export --trials 20` on the runner that saw it before touching 
   fixtures are covered — but a caller invoking `mixing_matrices` outside the exporter and the four
   test modules is **not** protected by the barrier alone. Parked in `docs/parked-findings.md`;
   changing it is a behaviour decision beyond #298's contract.
+- **The `full-macos` suite is flaky at ~1-in-4 for the module pair above**, pre-dating this work.
+  #298's guard protects what gets *committed* as an oracle; it does nothing for a test process that
+  corrupts mid-run. Making the suite robust (process isolation for the MLX fixture modules, e.g.
+  `pytest-forked`/`-p xdist --forked`, or dropping the accessor tests into their own job) is a
+  test-infrastructure decision beyond this issue's contract. Parked.
 - Pinning `mlx==` in `pyproject.toml`. Out of scope for #298 (a repo-wide dependency decision) and
   pointless as a remedy anyway, since all three tested versions are affected.
 - A PR-time CI job for the double-export. The guard is in the CLI the regeneration command already

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -135,6 +135,7 @@ Last audited 2026-08-18 (`/closure-audit`, whole repo).
 | ENGINE-7 | A person can round-trip a checkpoint Swift to Python | done | done | n/a | done | Shipped | #196 | design/14 |
 | ENGINE-8 | A person gets a fused Metal SSD-scan/conv kernel | n/a | n/a | n/a | none | Planned | #171 | design/14 |
 | ENGINE-9 | A person can decode speculatively in the Swift engine | n/a | n/a | n/a | none | Planned | #172 | design/14 |
+| ENGINE-10 | A person can trust a checked-in parity oracle was not silently corrupted | done | done | n/a | n/a | Shipped | #298 | design/14 |
 
 ## Conformance
 

--- a/docs/parked-findings.md
+++ b/docs/parked-findings.md
@@ -131,3 +131,11 @@ Format: date, `file:line`, what was seen, what task surfaced it, rough severity.
   (`poc-fixture-oracle`/`poc-parity`, `train-fixture-oracle`/`-verify`,
   `.github/workflows/ci.yml`) are dispatch/schedule-only. Adding an always-on macOS job is a
   runtime-cost decision. Found while closing #298. Severity: coverage, non-blocking.
+
+- [2026-08-19] `CLAUDE.md` and `.claude/plans/issue-298.md`'s V8 both give the Swift gate as
+  `cd swift/engine && swift run monica-parity`, which cannot work: mlx-swift's `default.metallib`
+  is an Xcode-only build product, so `swift run` builds fine and then dies with "Failed to load
+  the default metallib". `.github/workflows/ci.yml:446-487` documents this and uses `xcodebuild`
+  + the product binary instead. On a host with only Command Line Tools installed the gate is not
+  runnable at all. Found while closing #298. Severity: docs/tooling, non-blocking (CI runs the
+  real form).

--- a/docs/parked-findings.md
+++ b/docs/parked-findings.md
@@ -139,3 +139,11 @@ Format: date, `file:line`, what was seen, what task surfaced it, rough severity.
   + the product binary instead. On a host with only Command Line Tools installed the gate is not
   runnable at all. Found while closing #298. Severity: docs/tooling, non-blocking (CI runs the
   real form).
+
+- [2026-08-19] `tests/test_parity_fixture_export.py:90`, the macOS suite is flaky at ~1-in-4 when
+  `tests/test_mlx_mixing_matrix.py` runs before it in the same process (3/12 measured on `main`,
+  0/12 for the export module alone). The failure is `greedy_ids` as EXACT ints — 16/16 wrong, by
+  222 — i.e. #298 corruption, not a tolerance. Both modules already apply `set_cache_limit(0)`, so
+  the mitigation does not compose across pytest modules. Fixing it means process isolation for the
+  MLX fixture modules (pytest-forked, or a separate CI job), which is test-infrastructure work.
+  Found while verifying #298. Severity: CI reliability, non-blocking but recurring.

--- a/docs/parked-findings.md
+++ b/docs/parked-findings.md
@@ -105,3 +105,29 @@ Format: date, `file:line`, what was seen, what task surfaced it, rough severity.
   rebuilds the in-range `ids` array a second time rather than reusing the one built for the mask.
   Found while fixing #285. Severity: cosmetic, non-blocking (sampled draws are not a
   cross-language parity contract; only greedy is).
+
+- [2026-08-19] `src/model/mlx_backend.py:948`, #264's `mx.eval(h)` barrier in
+  `mixing_matrices` reduces but does not eliminate the #298 corruption: measured 18/40 (toy.yaml)
+  and 20/40 (toy-moe.yaml) corrupt trials with the barrier in place and the MLX buffer cache on
+  (`scripts/probe_mlx_buffer_reuse.py --pattern mixing --barrier --trials 40`). Only barrier +
+  `set_cache_limit(0)` gives 0/40. Every path that writes a checked-in oracle already runs under
+  both, so the fixtures are covered — an arbitrary caller of `mixing_matrices`/`hidden_states` is
+  not. Found while closing #298. Severity: correctness, non-blocking (deciding what a bare caller
+  should get is a behaviour change beyond #298's contract).
+
+- [2026-08-19] `src/model/mlx_backend.py:938` `hidden_states` forks a lazy `h` the same way
+  `mixing_matrices` does (`layer_fn(h)` advancing while the previous `h` is retained in `hs`) and
+  carries no barrier at all. Unmeasured — the #298 probe only exercises `mixing_matrices`. Found
+  while closing #298. Severity: correctness, unquantified.
+
+- [2026-08-19] `pyproject.toml:30` pins only `mlx>=0.18` while the repo's numerical contracts
+  (fp32 `1e-4/1e-5`, the #266 low-precision bands, every checked-in oracle) are all calibrated on
+  one build. #298 measured three releases behaving differently under the same probe. Whether to
+  pin a floor/ceiling is a repo-wide dependency decision. Found while closing #298. Severity:
+  reproducibility, non-blocking.
+
+- [2026-08-19] No PR-time CI job runs `export_parity_fixture.py --double-export`; the guard only
+  fires when a human regenerates a fixture. The cross-runner equivalents
+  (`poc-fixture-oracle`/`poc-parity`, `train-fixture-oracle`/`-verify`,
+  `.github/workflows/ci.yml`) are dispatch/schedule-only. Adding an always-on macOS job is a
+  runtime-cost decision. Found while closing #298. Severity: coverage, non-blocking.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -135,6 +135,7 @@ Last audited 2026-08-18 (`/closure-audit`, whole repo: 81 capabilities × 131 te
 | ENGINE-7 | n/a | `scripts/check_swift_checkpoint.py` | CI `swift-engine` Swift→Python round-trip (GATE) | the direction `monica-parity` alone cannot prove | none |
 | ENGINE-8 | n/a | n/a | n/a | n/a | n/a — not built (#171) |
 | ENGINE-9 | n/a | n/a | n/a | n/a | n/a — only the `verifyBlock` prerequisite exists (#172) |
+| ENGINE-10 | `test_fixture_digest.py` (portable), `test_mlx_mixing_matrix.py`'s `disable_buffer_cache` cases | `test_parity_fixture_export.py`, `test_train_parity_fixture_export.py` | `export_parity_fixture.py --double-export` (default on); CI `poc-fixture-oracle` + `poc-parity`, `train-fixture-oracle` + `-verify` | flipped byte, dropped file, size mismatch, nested file, **empty tree is BLIND not clean**, MLX API change fails loudly, near-zero `mixing.*` entries | **intra-machine only** — two processes on ONE host; cross-machine determinism is not claimed and `train.safetensors` is known to drift ~1e-8 across runner instances. No PR-time CI job runs the double-export; the underlying MLX defect is unfixed upstream (design/14 §#298) |
 
 ## Conformance
 

--- a/scripts/export_parity_fixture.py
+++ b/scripts/export_parity_fixture.py
@@ -32,16 +32,99 @@ import argparse
 import ast
 import json
 import os
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
 
 import numpy as np
 
+from src.conformance.fixture_digest import compare_trees, digest_tree
 from src.conformance.forward_step_parity import check_forward_step_parity
 from src.conformance.prefill_decode_parity import check_prefill_decode_parity
 from src.conformance.quant_parity import check_quant_parity
 from src.conformance.tolerances import LOWP_MEAN_KL_MAX, band_for, route_margin_min
 from src.model.blocks import load_config
+
+
+# --- #264/#298: the MLX buffer-cache mitigation, in ONE place -------------------------
+#
+# This local MLX build (0.32.0) has been observed to silently corrupt a computation
+# (deterministic-per-process, exact-shape results, no exception, no log) when many
+# independently-constructed `MLXMambaModel`s allocate/free/reuse buffers of the same size
+# class within one process. `mx.set_cache_limit(0)` — proven in isolation to take the
+# observed failure rate from ~50-100% down to 0/10 trials — disables MLX's buffer-cache
+# pool, trading allocator throughput (irrelevant for a one-shot export or a test module)
+# for correctness.
+#
+# The defect is UPSTREAM and is not fixed here; see `docs/design/14-inference-engine.md`
+# §"MLX 0.32.0 buffer reuse (#298)" for the measurements and what stays open.
+#
+# It lives here, as one symbol, because #298's own definition of done requires the
+# mitigation's confinement to be *checkable* rather than assumed: `git grep set_cache_limit
+# -- src scripts tests` must name this file and nothing else, and in particular nothing on
+# the training/inference path. Callers: `build_fixture` below, plus the four MLX test
+# modules that construct models in a loop.
+
+
+def _apply_cache_disable() -> int:
+    """Drop MLX's buffer cache and pin its limit to 0; return the previous limit.
+
+    Raises rather than degrading to a silent no-op if the limit did not take effect —
+    an MLX version bump that changes `set_cache_limit`'s semantics must fail LOUDLY,
+    because a mitigation that has quietly stopped applying is indistinguishable from one
+    that is working right up until it bakes a corrupted oracle into the Swift gate.
+    """
+    import mlx.core as mx
+
+    # MLX 0.32.0 exposes no `get_cache_limit`, so the confirmation is built from what IS
+    # observable: `set_cache_limit` returns the limit that was in force before the call,
+    # therefore a second `set_cache_limit(0)` returning anything but 0 means the first one
+    # did not stick. `get_cache_memory()` then confirms the pool is actually empty.
+    prev = mx.set_cache_limit(0)
+    confirm = mx.set_cache_limit(0)
+    mx.clear_cache()
+    held = mx.get_cache_memory()
+    if confirm != 0 or held != 0:
+        # Restore before raising: a half-applied mitigation must not also leave the
+        # process's allocator settings changed behind it.
+        mx.set_cache_limit(prev)
+        raise RuntimeError(
+            f"mx.set_cache_limit(0) did not take effect on mlx {mx.__version__}: a second "
+            f"set_cache_limit(0) reported a prior limit of {confirm!r} and the buffer pool "
+            f"still holds {held!r} bytes. The #298 buffer-reuse mitigation is NOT active, "
+            "so any fixture written now may be silently corrupted. Refusing to continue — "
+            "see docs/design/14-inference-engine.md §'MLX 0.32.0 buffer reuse (#298)'.")
+    return prev
+
+
+@contextmanager
+def disable_buffer_cache():
+    """Scoped form: disable MLX's buffer cache, restoring the previous limit on exit.
+
+    Used by `build_fixture`, so the disable covers the entire export (including every
+    early `raise SystemExit` refusal path) without leaving the process-wide limit changed
+    for whatever runs next in the same interpreter.
+    """
+    prev = _apply_cache_disable()
+    try:
+        yield
+    finally:
+        import mlx.core as mx
+        mx.set_cache_limit(prev)
+
+
+def disable_buffer_cache_for_process() -> None:
+    """Unscoped form: disable MLX's buffer cache for the rest of this interpreter.
+
+    Deliberately never restored. This is the module-prologue form the MLX test modules
+    need: their models are constructed at various points across many tests, so the
+    mitigation has to outlive any single `with` block. Only ever called from test modules
+    and this script — never from the training/inference path.
+    """
+    _apply_cache_disable()
 
 
 def _tree_add(a, b):
@@ -353,25 +436,16 @@ def build_fixture(config_path: str, out_dir: str, *, batch: int, seq: int,
     from src.serve.sessions import SessionStore
     from src.train.checkpoint import save_weights
 
-    # #264: disable MLX's buffer-cache pool for the duration of this export. Diagnosed
-    # while adding the mixing-matrix oracle — this local MLX build (0.32.0) has been
-    # observed to silently corrupt a computation (deterministic-per-process, exact-shape
-    # results, no exceptions) when many independently-constructed `MLXMambaModel`s
-    # allocate/free/reuse buffers of the same size class in one process, which this
-    # exporter does far more of than any other caller (repeated regeneration, the #166
-    # staleness test re-invoking `build_fixture` inside an already-populated pytest
-    # process). `mx.set_cache_limit(0)` (proven in isolation to take the observed failure
-    # rate from ~50-100% down to 0/10 trials) trades allocator throughput — irrelevant for
-    # a one-shot fixture export — for correctness; it must not be ported into a hot
-    # training/inference path.
-    mx.clear_cache()
-    # #264 (review follow-up): capture the prior limit and restore it in `finally`
-    # below so the disable is scoped to this export, not process-global — while still
-    # covering the ENTIRE rest of the function (including every early `raise SystemExit`
-    # refusal path), so the cache stays off for the full duration the mitigation above
-    # depends on.
-    _prev_cache_limit = mx.set_cache_limit(0)
-    try:
+    # #264/#298: disable MLX's buffer-cache pool for the duration of this export — this
+    # exporter constructs far more independent `MLXMambaModel`s per process than any other
+    # caller (repeated regeneration, the #166 staleness test re-invoking `build_fixture`
+    # inside an already-populated pytest process), which is the shape that triggers the
+    # silent corruption. The rationale, the measurement and the loud-failure contract all
+    # live on `disable_buffer_cache` above; this is one of its four call sites.
+    #
+    # The scope covers the ENTIRE rest of the function, including every early
+    # `raise SystemExit` refusal path, and restores the previous limit on exit.
+    with disable_buffer_cache():
         mx.random.seed(seed)
         cfg = load_config(config_path)
         if precision is not None:
@@ -869,8 +943,105 @@ def build_fixture(config_path: str, out_dir: str, *, batch: int, seq: int,
                                              train_steps=train_steps, seed=seed))
         (out / "meta.json").write_text(json.dumps(meta, indent=2) + "\n")
         return meta
+
+
+# --- #298: the double-export guard ----------------------------------------------------
+
+_CHILD_SUFFIX = ".double-export-check"
+
+
+def _child_argv(args, out: str) -> list:
+    """Rebuild this invocation's argv for the second, fresh-process export.
+
+    Built from the parsed namespace rather than sliced out of `sys.argv`, so a flag spelled
+    `--seq=129` or defaulted is reproduced identically either way. `--no-double-export`
+    bounds the recursion to exactly one extra process — an explicit flag, not an env var,
+    so the mechanism is visible in the command the fixture README records.
+    """
+    argv = [sys.executable, str(Path(__file__).resolve()),
+            "--config", args.config, "--out", out,
+            "--batch", str(args.batch), "--seq", str(args.seq),
+            "--gen-steps", str(args.gen_steps), "--seed", str(args.seed),
+            "--quant-group-size", str(args.quant_group_size),
+            "--train-steps", str(args.train_steps),
+            "--no-double-export"]
+    if args.precision is not None:
+        argv += ["--precision", args.precision]
+    if args.vocab_size is not None:
+        argv += ["--vocab-size", str(args.vocab_size)]
+    if args.quant_bits is not None:
+        argv += ["--quant-bits", str(args.quant_bits)]
+    if args.quant_head_bits is not None:
+        argv += ["--quant-head-bits", str(args.quant_head_bits)]
+    if args.packed_doc_lengths is not None:
+        argv += ["--packed-doc-lengths", args.packed_doc_lengths]
+    if args.moe_bias:
+        argv.append("--moe-bias")
+    if args.allow_moe_load_omit:
+        argv.append("--allow-moe-load-omit")
+    return argv
+
+
+def _double_export(args) -> None:
+    """Re-export into a fresh process and refuse to leave `--out` in place unless the two
+    trees are byte-for-byte identical.
+
+    #298 is silent, deterministic-PER-PROCESS corruption: an export that hits it writes a
+    plausible fixture with no error. A second interpreter would have to corrupt identically
+    to agree, so a match is real evidence — while a mismatch means one of the two trees is
+    wrong and there is no way to tell which, so NEITHER may be kept at `--out`.
+
+    On disagreement both trees are preserved (`--out.mismatch-1`, `--out.mismatch-2`) for
+    diagnosis, the per-file verdicts are printed, and the process exits 2. Nothing is left
+    at `--out`, so a corrupted oracle cannot be checked in unnoticed.
+
+    Scope: intra-machine determinism — two processes on ONE host. Cross-machine byte
+    identity is not claimed (see `src/conformance/fixture_digest.py`).
+    """
+    first = Path(args.out)
+    second = Path(str(first) + _CHILD_SUFFIX)
+    if second.exists():
+        shutil.rmtree(second)
+    try:
+        argv = _child_argv(args, str(second))
+        print(f"double-export: re-exporting in a fresh process -> {second}")
+        subprocess.run(argv, check=True)
+
+        if args._corrupt_after_first:
+            # Hidden negative control (#298 verification V4): flip one byte in the first
+            # tree so a guard that cannot fail is proven to fail. Never used by the
+            # regeneration commands; argparse.SUPPRESS keeps it out of --help.
+            target = first / args._corrupt_after_first
+            blob = bytearray(target.read_bytes())
+            blob[len(blob) // 2] ^= 0x01
+            target.write_bytes(bytes(blob))
+            print(f"double-export: DEBUG corrupted {target} (negative control)")
+
+        verdicts = compare_trees(first, second)
+        if not verdicts:
+            n = len(digest_tree(first))
+            print(f"double-export: {n} files identical across two fresh processes")
+            shutil.rmtree(second)
+            return
+
+        one, two = Path(str(first) + ".mismatch-1"), Path(str(first) + ".mismatch-2")
+        for stale in (one, two):
+            if stale.exists():
+                shutil.rmtree(stale)
+        first.rename(one)
+        second.rename(two)
+        print(f"double-export: MISMATCH — two fresh exports of {first} disagree.\n"
+              f"  This is a #298 sighting (silent MLX 0.32.0 buffer-reuse corruption), "
+              f"not a flake to rerun past.\n"
+              f"  Neither tree is trustworthy, so nothing was left at {first}; both are "
+              f"kept for diagnosis:\n"
+              f"    {one}\n    {two}")
+        for v in verdicts:
+            print(f"  - {v}")
+        raise SystemExit(2)
     finally:
-        mx.set_cache_limit(_prev_cache_limit)
+        if second.exists():
+            shutil.rmtree(second)
 
 
 def main() -> None:
@@ -916,6 +1087,22 @@ def main() -> None:
                         "omit load.{i}/moe_load_layers instead of raising, and record why "
                         "in meta.json's moe_load_omitted_reason — only use after a --seed "
                         "search and --moe-bias have both failed to clear the margin guard")
+    p.add_argument("--double-export", dest="double_export", action="store_true",
+                   default=True,
+                   help="#298 (DEFAULT ON): after writing --out, export a second time in a "
+                        "FRESH process and compare the two trees byte-for-byte. On "
+                        "agreement --out is kept; on disagreement nothing is left at --out "
+                        "and the two trees are preserved as --out.mismatch-1/-2 (exit 2). "
+                        "Guards against MLX 0.32.0's silent, deterministic-per-process "
+                        "buffer-reuse corruption baking a wrong oracle into the Swift gate")
+    p.add_argument("--no-double-export", dest="double_export", action="store_false",
+                   help="skip the #298 second export. Set automatically on the child "
+                        "process; use it by hand for the poc fixture, where CI's "
+                        "poc-fixture-oracle/poc-parity pair already performs the same check "
+                        "across two runners and a local repeat would double a ~571 MB, "
+                        "multi-minute export")
+    p.add_argument("--_corrupt-after-first", dest="_corrupt_after_first", default=None,
+                   help=argparse.SUPPRESS)
     args = p.parse_args()
 
     quant_head_bits = args.quant_head_bits
@@ -929,7 +1116,9 @@ def main() -> None:
                          quant_head_bits=quant_head_bits, train_steps=args.train_steps,
                          packed_doc_lengths=args.packed_doc_lengths,
                          allow_moe_load_omit=args.allow_moe_load_omit)
-    print(f"wrote {args.out}: {json.dumps(meta)}")
+    print(f"wrote {args.out}: {json.dumps(meta)}", flush=True)
+    if args.double_export:
+        _double_export(args)
 
 
 if __name__ == "__main__":

--- a/scripts/export_parity_fixture.py
+++ b/scripts/export_parity_fixture.py
@@ -64,9 +64,10 @@ from src.model.blocks import load_config
 #
 # It lives here, as one symbol, because #298's own definition of done requires the
 # mitigation's confinement to be *checkable* rather than assumed: `git grep set_cache_limit
-# -- src scripts tests` must name this file and nothing else, and in particular nothing on
-# the training/inference path. Callers: `build_fixture` below, plus the four MLX test
-# modules that construct models in a loop.
+# -- src scripts tests` must show no CALL site outside this file (prose mentions like this
+# comment block, and the fail-loud test's monkeypatch stubs, are expected hits and are not
+# calls) — and in particular nothing on the training/inference path. Callers: `build_fixture`
+# below, plus the four MLX test modules that construct models in a loop.
 
 
 def _apply_cache_disable() -> int:

--- a/scripts/export_parity_fixture.py
+++ b/scripts/export_parity_fixture.py
@@ -41,7 +41,7 @@ from pathlib import Path
 
 import numpy as np
 
-from src.conformance.fixture_digest import compare_trees, digest_tree
+from src.conformance.fixture_digest import compare_trees
 from src.conformance.forward_step_parity import check_forward_step_parity
 from src.conformance.prefill_decode_parity import check_prefill_decode_parity
 from src.conformance.quant_parity import check_quant_parity
@@ -993,7 +993,10 @@ def _double_export(args) -> None:
 
     On disagreement both trees are preserved (`--out.mismatch-1`, `--out.mismatch-2`) for
     diagnosis, the per-file verdicts are printed, and the process exits 2. Nothing is left
-    at `--out`, so a corrupted oracle cannot be checked in unnoticed.
+    at `--out`, so a corrupted oracle cannot be checked in unnoticed. The same holds if the
+    second export's subprocess itself fails (MLX import error, OOM, non-zero exit, ...): the
+    guard never got to compare, so the first export is unverified and is likewise moved out
+    of `--out` rather than left in place.
 
     Scope: intra-machine determinism — two processes on ONE host. Cross-machine byte
     identity is not claimed (see `src/conformance/fixture_digest.py`).
@@ -1005,7 +1008,25 @@ def _double_export(args) -> None:
     try:
         argv = _child_argv(args, str(second))
         print(f"double-export: re-exporting in a fresh process -> {second}")
-        subprocess.run(argv, check=True)
+        try:
+            subprocess.run(argv, check=True)
+        except subprocess.CalledProcessError as exc:
+            one = Path(str(first) + ".mismatch-1")
+            if one.exists():
+                shutil.rmtree(one)
+            first.rename(one)
+            partial_note = ""
+            if second.exists():
+                two = Path(str(first) + ".mismatch-2")
+                if two.exists():
+                    shutil.rmtree(two)
+                second.rename(two)
+                partial_note = f" (partial child output kept at {two})"
+            print(f"double-export: the second export subprocess failed ({exc}).\n"
+                  f"  The guard never got to compare, so the first export is unverified — "
+                  f"nothing is left at {first}; it is kept for diagnosis at {one}"
+                  f"{partial_note}.")
+            raise SystemExit(2)
 
         if args._corrupt_after_first:
             # Hidden negative control (#298 verification V4): flip one byte in the first
@@ -1019,7 +1040,9 @@ def _double_export(args) -> None:
 
         verdicts = compare_trees(first, second)
         if not verdicts:
-            n = len(digest_tree(first))
+            # compare_trees() already digested (fully hashed) both trees above; count
+            # files via a plain directory walk instead of re-hashing them a second time.
+            n = sum(1 for p in first.rglob("*") if p.is_file())
             print(f"double-export: {n} files identical across two fresh processes")
             shutil.rmtree(second)
             return

--- a/scripts/export_parity_fixture.py
+++ b/scripts/export_parity_fixture.py
@@ -1038,7 +1038,29 @@ def _double_export(args) -> None:
             target.write_bytes(bytes(blob))
             print(f"double-export: DEBUG corrupted {target} (negative control)")
 
-        verdicts = compare_trees(first, second)
+        try:
+            verdicts = compare_trees(first, second)
+        except (FileNotFoundError, ValueError) as exc:
+            # compare_trees (via digest_tree) raises rather than returning [] when a tree
+            # is missing/empty (the anti-blind rule) — that is not an "identical" verdict
+            # and not a "mismatch" verdict either, but it is still a case where neither
+            # export is verified, so it gets the same quarantine as a mismatch: nothing
+            # stays at `--out`.
+            one = Path(str(first) + ".mismatch-1")
+            two = Path(str(first) + ".mismatch-2")
+            for stale in (one, two):
+                if stale.exists():
+                    shutil.rmtree(stale)
+            first.rename(one)
+            partial_note = ""
+            if second.exists():
+                second.rename(two)
+                partial_note = f" (second export kept at {two})"
+            print(f"double-export: comparison failed ({exc}).\n"
+                  f"  The guard could not verify agreement, so neither export is "
+                  f"trustworthy — nothing was left at {first}; the first export is kept "
+                  f"for diagnosis at {one}{partial_note}.")
+            raise SystemExit(2)
         if not verdicts:
             # compare_trees() already digested (fully hashed) both trees above; count
             # files via a plain directory walk instead of re-hashing them a second time.

--- a/scripts/probe_mlx_buffer_reuse.py
+++ b/scripts/probe_mlx_buffer_reuse.py
@@ -1,0 +1,393 @@
+"""Measure MLX 0.32.0's buffer-reuse corruption (#298) — the instrument, not a gate.
+
+#298: on this repo's MLX 0.32.0 Apple-Silicon build, repeated `MLXMambaModel` construction
+plus computation within ONE process has been observed to silently corrupt an unrelated
+later computation — deterministic per process, correct shapes, no exception, no log. The
+defect is upstream; this repo cannot fix it. What it can do is *measure* it, and #298's
+definition of done is a set of written, measured answers rather than a cure.
+
+This script is where those numbers come from. It is a probe (precedent:
+`scripts/probe_ts_lsp_debounce.py`), NOT part of the test suite: it is slow, it is
+deliberately allowed to fail, and its output is transcribed into
+`docs/design/14-inference-engine.md` §"MLX 0.32.0 buffer reuse (#298)".
+
+    .venv/bin/python scripts/probe_mlx_buffer_reuse.py --pattern mixing   --trials 20
+    .venv/bin/python scripts/probe_mlx_buffer_reuse.py --pattern hotpath  --trials 30
+    .venv/bin/python scripts/probe_mlx_buffer_reuse.py --pattern export   --trials 20
+    .venv/bin/python scripts/probe_mlx_buffer_reuse.py --pattern throughput --trials 30
+
+## Patterns
+
+`mixing`   — the reproducer shape #264 root-caused, with the `mx.eval(h)` barrier REMOVED.
+             Many freshly-constructed models each run the mixing-matrix accessor (which
+             forks a lazy `h` into two independent consumers without materialising it) and
+             then `prefill(..., last_only=True)`. This is the pattern with a *known*
+             positive control, so it is the probe's own self-check.
+`hotpath`  — the training/inference shape: `forward` / stacked `step` / `prefill` /
+             `make_train_step` over many freshly-constructed models, no interpretability
+             accessors, i.e. no lazy fork. This is what the hot-path decision rests on.
+`export`   — N in-process `build_fixture` runs, reporting the `mixing.{i}` drift
+             distribution against the checked-in `toy` oracle. This is what the `mixing.N`
+             near-zero escalation rests on.
+`throughput` — the cost side: repeated forward + train_step timed at both cache settings,
+             so "keep it off the hot path" is grounded rather than asserted.
+
+## The anti-blind rule
+
+MLX is deterministic given identical inputs and this graph has no dropout and no sampling,
+so every trial from the same seed must be bit-identical to trial 0. A difference is
+corruption, full stop — there is no tolerance to argue about.
+
+`--pattern mixing` is the probe's POSITIVE CONTROL. If it does not reproduce with the
+barrier removed and the cache on, the instrument cannot detect the defect on this host, so
+a clean `hotpath` result is *no evidence at all*. In that case the probe prints `BLIND` and
+exits non-zero, rather than reporting "clean" — a check that cannot observe its target must
+say so.
+
+MLX-only, like `scripts/smoke_test.py`: it does not run on a Linux/CUDA host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOY_FIXTURE = REPO_ROOT / "swift" / "engine" / "Fixtures" / "toy"
+
+
+def _tokens(cfg, seq: int, seed: int = 0):
+    return np.random.default_rng(seed).integers(
+        0, cfg.vocab_size, size=(2, seq)).astype(np.int32)
+
+
+def _mixing_matrices_no_barrier(model, tokens):
+    """`MLXMambaModel.mixing_matrices` with the #264 `mx.eval(h)` barrier REMOVED.
+
+    Kept here rather than monkeypatched into the backend so the probe cannot accidentally
+    leave the production accessor unbarriered; it is a verbatim copy of the loop minus the
+    one `mx.eval(h)` line. This is the positive control's whole content — the lazy `h`
+    forking into `layer.mixing_matrix(h)` and `layer_fn(h)` without being materialised.
+    """
+    import mlx.core as mx
+
+    from src.model.mlx_backend import _cast
+
+    h = _cast(model.embedding(mx.array(tokens)), model._cd)
+    out = []
+    for i, (layer, layer_fn) in enumerate(zip(model.layers, model._layer_fns)):
+        if not model.config.is_attention_layer(i) and not model.config.is_moe_layer(i):
+            out.append((i, layer.mixing_matrix(h).mean(axis=1)))
+        h = layer_fn(h)
+    return out
+
+
+def _fresh_model(cfg, seed: int):
+    import mlx.core as mx
+
+    from src.model.mlx_backend import MLXMambaModel
+
+    mx.random.seed(seed)
+    return MLXMambaModel(cfg)
+
+
+_USE_BARRIER = False
+
+
+def _run_mixing(cfg, tokens, seed: int):
+    """One `mixing` trial: read the mixing matrices through the UNBARRIERED accessor, then
+    do an unrelated `prefill` on the same model. #264's finding is that the corruption
+    lands on the *later, unrelated* call, not on the values read here."""
+    import mlx.core as mx
+
+    model = _fresh_model(cfg, seed)
+    # `--barrier` swaps the unbarriered copy for the SHIPPED accessor, so the same trial
+    # loop measures whether #264's `mx.eval(h)` fix actually holds rather than assuming it.
+    mats = (model.mixing_matrices(mx.array(tokens)) if _USE_BARRIER
+            else _mixing_matrices_no_barrier(model, tokens))
+    mx.eval([m for _, m in mats])
+    logits, _ = model.prefill(mx.array(tokens), last_only=True)
+    mx.eval(logits)
+    return np.array(logits)
+
+
+def _run_hotpath(cfg, tokens, seed: int):
+    """One `hotpath` trial: exactly the surfaces training and inference use — `forward`,
+    stacked `step`, `prefill`, and a real `make_train_step` — and no interpretability
+    accessor, so `h` is never forked into two consumers."""
+    import mlx.core as mx
+
+    model = _fresh_model(cfg, seed)
+    tok = mx.array(tokens)
+
+    fwd = model.forward(tok)
+    mx.eval(fwd)
+
+    # prefill over the prompt, then three stacked `step`s off the returned state — the
+    # serving path, and the one #264 saw corrupted (`prefill(..., last_only=True)`).
+    pre_logits, state = model.prefill(tok[:, :-4])
+    mx.eval(pre_logits)
+    step_logits = []
+    for j in range(3):
+        lg, state = model.step(tok[:, -4 + j], state)
+        step_logits.append(lg)
+    mx.eval(step_logits)
+
+    last_only, _ = model.prefill(tok[:, :-1], last_only=True)
+    mx.eval(last_only)
+
+    stats = _train_step_stats(model, cfg, tokens)
+
+    return np.concatenate([
+        np.array(fwd).ravel(),
+        np.array(pre_logits).ravel(),
+        np.concatenate([np.array(lg).ravel() for lg in step_logits]),
+        np.array(last_only).ravel(),
+        np.array([stats["loss"], stats["grad_norm"]], dtype=np.float32),
+    ])
+
+
+def _train_step_stats(model, cfg, tokens) -> dict:
+    """One real `make_train_step` step — the production primitive `src/train/loop.py` is
+    injected with, so the hot-path pattern exercises backward as well as forward."""
+    import mlx.optimizers as optim
+
+    from src.model.mlx_train_step import make_train_step
+
+    train_step = make_train_step(model, optim.AdamW(learning_rate=1e-3))
+    inputs = tokens[:, :-1].astype(np.int32)
+    targets = tokens[:, 1:].astype(np.int32)
+    return train_step(model, [(inputs, targets)], 1e-3)
+
+
+def _clean_reference(cfg, tokens, seed: int):
+    """The known-good value for the `mixing` pattern: `prefill(..., last_only=True)` on a
+    freshly-constructed model with NO interpretability accessor called at all.
+
+    Trial 0 is NOT a safe reference. Measured on this host (toy-moe.yaml, seq 129): with
+    `mixing_matrices` in the loop, roughly half of the trials — including trial 0 — return
+    a corrupted prefill, so comparing trials to trial 0 reports the *clean* trials as the
+    failures and undercounts by ~2x. Without the accessor the same loop is bit-identical
+    8/8, which is what makes this the reference and not just another sample.
+    """
+    import mlx.core as mx
+
+    model = _fresh_model(cfg, seed)
+    logits, _ = model.prefill(mx.array(tokens), last_only=True)
+    mx.eval(logits)
+    return np.array(logits)
+
+
+def _bit_identical_trials(runner, cfg, tokens, trials: int, seed: int,
+                          reference_runner=None) -> dict:
+    """Run `runner` `trials` times in ONE process and compare every result to a reference.
+
+    fp32 MLX is deterministic given identical inputs, and this graph has no dropout and no
+    sampling, so anything but bit-identity is corruption. `max|d|` is reported only to
+    characterise a failure, never as a tolerance to pass under.
+
+    `reference_runner` (defaulting to `runner` itself, i.e. trial 0) produces the value
+    every trial is compared against. It is re-run at the END as well, and disagreement
+    between the two reference computations makes the whole run BLIND — a reference that
+    moved cannot adjudicate anything.
+    """
+    reference_runner = reference_runner or runner
+    ref = reference_runner(cfg, tokens, seed)
+
+    failures, drifts = 0, []
+    for _ in range(trials):
+        got = runner(cfg, tokens, seed)
+        if got.shape != ref.shape:
+            failures += 1
+            drifts.append(float("inf"))
+            continue
+        d = float(np.max(np.abs(got - ref)))
+        drifts.append(d)
+        if d != 0.0:
+            failures += 1
+
+    ref_again = reference_runner(cfg, tokens, seed)
+    ref_stable = bool(ref.shape == ref_again.shape
+                      and np.max(np.abs(ref - ref_again)) == 0.0)
+    return {
+        "trials": trials,
+        "failures": failures,
+        "failure_rate": failures / trials,
+        "max_drift": max(drifts) if drifts else 0.0,
+        "median_drift": statistics.median(drifts) if drifts else 0.0,
+        "reference_stable": ref_stable,
+    }
+
+
+def _run_export(trials: int, seq: int) -> dict:
+    """`mixing.{i}` drift across `trials` fresh in-process `build_fixture` runs, measured
+    against the CHECKED-IN toy oracle — the exact comparison
+    `tests/test_parity_fixture_export.py` makes, which is the one that flaked in CI
+    (`mixing.1 max|d| = 2.694e-05` on run 31806256071).
+
+    `forward_logits` rides along as a control: it shares the export but not the near-zero
+    structure, so if only `mixing.*` drifts the cause is the comparison's atol floor rather
+    than the export.
+    """
+    from safetensors.numpy import load_file
+
+    from scripts.export_parity_fixture import build_fixture
+
+    ref = load_file(str(TOY_FIXTURE / "reference.safetensors"))
+    keys = sorted(k for k in ref if k.startswith("mixing.")) + ["forward_logits"]
+    per_key = {k: [] for k in keys}
+
+    with tempfile.TemporaryDirectory() as td:
+        for t in range(trials):
+            out = Path(td) / f"toy-{t}"
+            build_fixture("config/toy.yaml", str(out), batch=2, seq=seq,
+                          packed_doc_lengths="Q,2*Q,5")
+            fresh = load_file(str(out / "reference.safetensors"))
+            for k in keys:
+                per_key[k].append(float(np.max(np.abs(fresh[k] - ref[k]))))
+
+    return {
+        "trials": trials,
+        "vs": str(TOY_FIXTURE.relative_to(REPO_ROOT)),
+        "per_key": {k: {"max": max(v), "median": statistics.median(v),
+                        "nonzero_trials": sum(1 for x in v if x != 0.0)}
+                    for k, v in per_key.items()},
+        # The near-zero structure the escalation comment points at: the causal mixing
+        # matrix's strict upper triangle is EXACTLY zero, so at |b| ~ 0 the np.allclose
+        # band collapses to atol with no rtol headroom at all.
+        "mixing_abs_max_in_oracle": {
+            k: float(np.max(np.abs(ref[k]))) for k in keys if k.startswith("mixing.")},
+    }
+
+
+def _run_throughput(cfg, tokens, trials: int, seed: int) -> dict:
+    """Wall-clock cost of `set_cache_limit(0)`: the same forward + train_step loop timed
+    with the buffer cache on and off, in two fresh sub-measurements within this process.
+
+    Toy scale, so this is an *upper bound on the shape* of the cost rather than the poc
+    number — the allocator penalty is largest where allocation dominates compute, which is
+    exactly the toy regime.
+    """
+    import mlx.core as mx
+    import mlx.optimizers as optim
+
+    from scripts.export_parity_fixture import disable_buffer_cache
+    from src.model.mlx_train_step import make_train_step
+
+    def _timed() -> float:
+        model = _fresh_model(cfg, seed)
+        train_step = make_train_step(model, optim.AdamW(learning_rate=1e-3))
+        inputs = tokens[:, :-1].astype(np.int32)
+        targets = tokens[:, 1:].astype(np.int32)
+        train_step(model, [(inputs, targets)], 1e-3)          # warm-up, uncounted
+        t0 = time.perf_counter()
+        for _ in range(trials):
+            out = model.forward(mx.array(tokens))
+            mx.eval(out)
+            train_step(model, [(inputs, targets)], 1e-3)
+        return time.perf_counter() - t0
+
+    cache_on = _timed()
+    with disable_buffer_cache():
+        cache_off = _timed()
+
+    return {
+        "trials": trials,
+        "seconds_cache_on": cache_on,
+        "seconds_cache_limit_zero": cache_off,
+        "slowdown_pct": 100.0 * (cache_off - cache_on) / cache_on,
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--pattern", required=True,
+                   choices=["mixing", "hotpath", "export", "throughput"])
+    p.add_argument("--cache-limit", default="default", choices=["default", "zero"],
+                   help="'default' leaves MLX's buffer-cache pool alone (the state the "
+                        "defect needs); 'zero' applies the #264 mitigation")
+    p.add_argument("--trials", type=int, default=20)
+    p.add_argument("--seq", type=int, default=129)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--config", default="config/toy-moe.yaml",
+                   help="the DEFAULT is toy-moe.yaml, not toy.yaml, because that is where "
+                        "the positive control actually reproduces on this host — an "
+                        "instrument that defaults to a blind configuration is worse than "
+                        "no instrument (see the --pattern mixing sweep in design/14)")
+    p.add_argument("--barrier", action="store_true",
+                   help="--pattern mixing: use the SHIPPED `MLXMambaModel.mixing_matrices` "
+                        "(with #264's mx.eval(h) barrier) instead of the unbarriered copy, "
+                        "to measure whether the shipped fix holds")
+    p.add_argument("--json", action="store_true", help="emit the result dict as JSON only")
+    args = p.parse_args()
+
+    import mlx.core as mx
+
+    from scripts.export_parity_fixture import disable_buffer_cache_for_process
+    from src.model.blocks import load_config
+
+    if args.cache_limit == "zero":
+        disable_buffer_cache_for_process()
+
+    global _USE_BARRIER
+    _USE_BARRIER = args.barrier
+
+    cfg = load_config(args.config)
+    tokens = _tokens(cfg, args.seq, args.seed)
+
+    if args.pattern == "mixing":
+        # The reference is deliberately NOT trial 0 — see `_clean_reference`.
+        result = _bit_identical_trials(_run_mixing, cfg, tokens, args.trials, args.seed,
+                                       reference_runner=_clean_reference)
+    elif args.pattern == "hotpath":
+        # No accessor-free variant exists to compare against here: the hot path IS the
+        # clean variant, so trial 0 is the reference and `reference_stable` is the check.
+        result = _bit_identical_trials(_run_hotpath, cfg, tokens, args.trials, args.seed)
+    elif args.pattern == "export":
+        result = _run_export(args.trials, args.seq)
+    else:
+        result = _run_throughput(cfg, tokens, args.trials, args.seed)
+
+    # `export` always builds toy.yaml (it compares against the checked-in `toy` oracle),
+    # so it reports that rather than --config, which it ignores.
+    config_label = "config/toy.yaml" if args.pattern == "export" else args.config
+    result = {"pattern": args.pattern, "cache_limit": args.cache_limit,
+              "mlx_version": mx.__version__, "config": config_label, **result}
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result, indent=2))
+
+    # The anti-blind rule. `mixing` with the cache ON is the positive control: it is the
+    # ONE pattern known to reproduce. If it does not, this instrument cannot see the defect
+    # on this host, and every other pattern's clean result is unknown rather than good news.
+    if args.pattern in ("mixing", "hotpath") and not result.get("reference_stable", True):
+        print("BLIND: the reference value itself moved between its two computations, so "
+              "no trial verdict in this run means anything. Do not report it.")
+        raise SystemExit(3)
+
+    if args.pattern == "mixing" and args.cache_limit == "default" and not args.barrier:
+        if result["failures"] == 0:
+            print("BLIND: the positive control did NOT reproduce on this host "
+                  f"({result['trials']} trials, mlx {mx.__version__}, {args.config}, "
+                  f"seq={args.seq}). A clean `hotpath` result is therefore NOT evidence "
+                  "that the hot path is immune — the instrument cannot detect the defect "
+                  "at all here. Do not report this run as 'clean'. Reproduction is "
+                  "shape-dependent: toy-moe.yaml and toy-hybrid.yaml at seq=129 DO "
+                  "reproduce on this host; toy.yaml and seq=512 do not.")
+            raise SystemExit(3)
+        print(f"positive control reproduced: {result['failures']}/{result['trials']} "
+              "trials diverged from the accessor-free reference — the instrument can see "
+              "the defect.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/conformance/fixture_digest.py
+++ b/src/conformance/fixture_digest.py
@@ -1,0 +1,130 @@
+"""Byte-for-byte comparison of two fixture trees (#298).
+
+`swift/engine/Fixtures/` holds frozen Python-MLX oracles that the Swift port is gated
+against. #298 is the failure mode that makes those oracles untrustworthy: on this repo's
+MLX 0.32.0 Apple-Silicon build, repeated `MLXMambaModel` construction inside one process
+can silently corrupt an unrelated later computation — correct shapes, no exception, no
+log. An export that corrupts that way writes a *plausible* fixture, and every downstream
+gate then happily agrees with the wrong numbers.
+
+The guard is not a cure (the defect is upstream in MLX and this repo cannot fix it): it is
+a **two-fresh-processes** cross-check. `scripts/export_parity_fixture.py` exports twice,
+in two independent interpreters, and refuses to leave anything at `--out` unless the two
+trees are identical byte-for-byte. #298 is deterministic *per process*, so two processes
+would have to corrupt identically to slip past.
+
+This module is the comparison half, and it is deliberately **portable** — hashlib +
+pathlib only, no numpy, no mlx, no torch (see `tests/test_import_guard.py`'s
+`PORTABLE_MODULES`). That is what lets the guard's own logic be unit-tested on the Linux
+`portable` CI job, where no MLX exists to produce a fixture in the first place.
+
+## The anti-blind rule
+
+`digest_tree` **raises** on a missing or empty tree rather than returning `{}`. Two empty
+trees comparing "identical" is precisely the BLIND failure this guard exists to prevent:
+a check that cannot observe its target must report that it could not, never agreement.
+`compare_trees` inherits the behaviour, since it calls `digest_tree` on both sides.
+
+## Scope
+
+Intra-machine determinism only: two processes on ONE host. Cross-machine byte-identity is
+**not** claimed and is known to be false — CI's `train-fixture-oracle`/`-verify` pair
+measures ~1e-8 drift in `train.safetensors` between runner instances
+(`.github/workflows/ci.yml`). Use this to compare a tree against a second export of
+itself, not against a tree produced elsewhere.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Dict, List
+
+# Fixtures reach 571 MB at poc scale (`swift/engine/Fixtures/README.md` §poc), so every
+# read here is streamed — never `Path.read_bytes()` on a fixture file.
+_CHUNK = 1 << 20
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        while True:
+            block = fh.read(_CHUNK)
+            if not block:
+                break
+            h.update(block)
+    return h.hexdigest()
+
+
+def digest_tree(root: Path | str) -> Dict[str, str]:
+    """Map every file under `root` to its sha256, keyed by POSIX-style relative path.
+
+    Raises `FileNotFoundError` if `root` is not a directory and `ValueError` if it holds
+    no files. Both are the anti-blind rule: an unreadable or empty tree is *unknown*, and
+    returning `{}` would make it compare clean against another unknown.
+    """
+    root = Path(root)
+    if not root.is_dir():
+        raise FileNotFoundError(
+            f"cannot digest {root}: not a directory. An unreadable tree is BLIND, not "
+            "clean — refusing to report agreement.")
+    out: Dict[str, str] = {}
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        out[path.relative_to(root).as_posix()] = _sha256(path)
+    if not out:
+        raise ValueError(
+            f"cannot digest {root}: it contains no files. Two empty trees comparing "
+            "'identical' is the BLIND failure this check exists to prevent.")
+    return out
+
+
+def _first_difference(a: Path, b: Path) -> int:
+    """Byte offset of the first difference between two files, or the length of the
+    shorter one when it is a prefix of the longer. Streamed, like `_sha256`."""
+    offset = 0
+    with a.open("rb") as fa, b.open("rb") as fb:
+        while True:
+            ba, bb = fa.read(_CHUNK), fb.read(_CHUNK)
+            if not ba and not bb:
+                return offset
+            if ba != bb:
+                for i in range(min(len(ba), len(bb))):
+                    if ba[i] != bb[i]:
+                        return offset + i
+                return offset + min(len(ba), len(bb))
+            offset += len(ba)
+
+
+def compare_trees(a: Path | str, b: Path | str) -> List[str]:
+    """Compare two fixture trees byte-for-byte.
+
+    Returns `[]` when they are identical, otherwise one human-readable verdict per
+    offending file: present on only one side, a size mismatch, or the byte offset at
+    which the contents first diverge. Never raises for a *disagreement* — a disagreement
+    is the answer. It does raise (via `digest_tree`) when either side is missing or
+    empty, because that is not an answer.
+    """
+    a, b = Path(a), Path(b)
+    da, db = digest_tree(a), digest_tree(b)
+
+    verdicts: List[str] = []
+    for rel in sorted(set(da) | set(db)):
+        if rel not in db:
+            verdicts.append(f"{rel}: present in {a}, missing from {b}")
+            continue
+        if rel not in da:
+            verdicts.append(f"{rel}: missing from {a}, present in {b}")
+            continue
+        if da[rel] == db[rel]:
+            continue
+        pa, pb = a / rel, b / rel
+        sa, sb = pa.stat().st_size, pb.stat().st_size
+        if sa != sb:
+            verdicts.append(
+                f"{rel}: size mismatch ({sa} vs {sb} bytes), sha256 "
+                f"{da[rel][:12]}… vs {db[rel][:12]}…")
+        else:
+            verdicts.append(
+                f"{rel}: {sa} bytes, first differing byte at offset "
+                f"{_first_difference(pa, pb)}, sha256 {da[rel][:12]}… vs {db[rel][:12]}…")
+    return verdicts

--- a/src/model/mlx_backend.py
+++ b/src/model/mlx_backend.py
@@ -947,12 +947,22 @@ class MLXMambaModel(ModelInterface, nn.Module):
         for i, (layer, layer_fn) in enumerate(zip(self.layers, self._layer_fns)):
             # Materialize `h` before forking it into two independent consumers
             # (`layer.mixing_matrix(h)` below and `layer_fn(h)`'s own advance). Without
-            # this barrier, this MLX build (0.32.0) has been observed to silently corrupt
-            # a LATER, unrelated call — `prefill(..., last_only=True)` on this same model
-            # two-process-later — even though every value read back from THIS function
-            # is itself correct. Reproduced in isolation and confirmed to disappear with
-            # this barrier; not a tolerance issue, so it is fixed here rather than
-            # loosened at any gate.
+            # this barrier, MLX has been observed to silently corrupt a LATER, unrelated
+            # call — `prefill(..., last_only=True)` on this same model — even though every
+            # value read back from THIS function is itself correct. Not a tolerance issue,
+            # so it is mitigated here rather than loosened at any gate.
+            #
+            # #298 CORRECTION: this barrier REDUCES but does NOT eliminate the corruption.
+            # Measured 2026-08-19 by `scripts/probe_mlx_buffer_reuse.py --pattern mixing
+            # --barrier --trials 40`: still 18/40 corrupt trials on toy.yaml and 20/40 on
+            # toy-moe.yaml (0/40 on toy-hybrid.yaml). The mitigation that actually holds is
+            # `set_cache_limit(0)` ON TOP of this barrier — 0/40 on all three configs, and
+            # on mlx 0.31.2/0.32.0/0.32.1 alike. Every path that writes a checked-in oracle
+            # runs under both (see `scripts/export_parity_fixture.py`'s
+            # `disable_buffer_cache`), but a caller invoking `mixing_matrices` outside the
+            # exporter and its four test modules is NOT protected by this barrier alone.
+            # The defect is upstream and unfixed; see
+            # `docs/design/14-inference-engine.md` §"MLX 0.32.0 buffer reuse (#298)".
             mx.eval(h)
             if not self.config.is_attention_layer(i) and not self.config.is_moe_layer(i):
                 m = layer.mixing_matrix(h).mean(axis=1)    # head-average -> (B,L,L)

--- a/swift/engine/Fixtures/README.md
+++ b/swift/engine/Fixtures/README.md
@@ -361,6 +361,28 @@ clip boundary differs from Python's unconditional `min(1.0, clip/(norm+eps))`).
 
 ## Regenerating
 
+**The exporter double-exports by default (#298).** Every command below runs `build_fixture`
+twice — the second time in a **fresh subprocess** — and compares the two trees byte-for-byte
+before leaving anything at `--out`. On agreement you get `double-export: N files identical`
+and `--out` is kept. On disagreement **nothing is left at `--out`**: both trees are preserved
+as `--out.mismatch-1` and `--out.mismatch-2`, the per-file verdicts print, and the command
+exits 2. That is deliberate — a mismatch means one of the two exports is silently corrupt and
+there is no way to tell which, so neither may be committed. Treat it as a #298 sighting, not a
+flake to rerun past.
+
+**Scope: intra-machine determinism, not cross-machine.** The check is two processes on ONE
+host, which is exactly what #298's per-process corruption requires to be caught. It does *not*
+claim a fixture regenerates byte-identically on a different machine, and that is known to be
+false: CI's `train-fixture-oracle`/`train-fixture-verify` pair measures ~1e-8 drift in
+`train.safetensors` between runner instances. The cross-runner form of this check is the
+`poc-fixture-oracle`/`poc-parity` manifest `diff` (see §poc below), which compares sha256
+manifests across two runners rather than raw bytes.
+
+`--no-double-export` opts out. Use it for the **poc** fixture, where that CI pair already
+performs the cross-runner check and a local repeat would double a ~571 MB, multi-minute
+export. (It is also set automatically on the child process, which is what bounds the
+recursion to exactly one extra export.)
+
 ```bash
 .venv/bin/python scripts/export_parity_fixture.py --config config/toy.yaml \
     --out swift/engine/Fixtures/toy --batch 2 --seq 129 --train-steps 3 \

--- a/tests/test_fixture_digest.py
+++ b/tests/test_fixture_digest.py
@@ -1,0 +1,140 @@
+"""The #298 double-export comparison detects corruption — and refuses to be BLIND.
+
+`src/conformance/fixture_digest.py` is the half of the #298 guard that decides whether two
+fixture exports agree. A guard that cannot fail is not a guard, so the load-bearing cases
+here are the negative ones: a single flipped byte, a dropped file, and — the one that
+matters most — two empty trees, which must RAISE rather than report agreement.
+
+Portable: hashlib/pathlib only, no MLX, so this runs on the Linux `portable` CI job where
+no fixture can be produced at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.conformance.fixture_digest import compare_trees, digest_tree
+
+
+def _tree(root, files):
+    root.mkdir(parents=True, exist_ok=True)
+    for name, payload in files.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+    return root
+
+
+# A stand-in for a fixture tree: a large-ish binary blob (crosses the 1 MiB streaming
+# chunk, so the chunked `_sha256`/`_first_difference` loops are actually exercised rather
+# than short-circuited on a single read) plus the small sidecars a real fixture carries.
+_BIG = bytes(range(256)) * 8192          # 2 MiB
+_FILES = {
+    "reference.safetensors": _BIG,
+    "weights.safetensors": b"\x01\x02\x03\x04" * 64,
+    "meta.json": b'{"forward_step_max_abs_diff": 1.43e-06}\n',
+}
+
+
+def test_identical_trees_agree(tmp_path):
+    a = _tree(tmp_path / "a", _FILES)
+    b = _tree(tmp_path / "b", _FILES)
+    assert compare_trees(a, b) == []
+    assert digest_tree(a) == digest_tree(b)
+    assert set(digest_tree(a)) == set(_FILES)
+
+
+def test_flipped_byte_is_reported(tmp_path):
+    """The negative control the whole guard rests on: one corrupted byte in the middle of
+    a multi-megabyte oracle — the shape #298's silent corruption would take."""
+    a = _tree(tmp_path / "a", _FILES)
+    corrupt = dict(_FILES)
+    offset = 1_000_000
+    blob = bytearray(_BIG)
+    blob[offset] ^= 0x01
+    corrupt["reference.safetensors"] = bytes(blob)
+    b = _tree(tmp_path / "b", corrupt)
+
+    verdicts = compare_trees(a, b)
+    assert len(verdicts) == 1, verdicts
+    assert "reference.safetensors" in verdicts[0]
+    assert f"offset {offset}" in verdicts[0], verdicts[0]
+    # Same-size corruption must NOT be reported as a size mismatch.
+    assert "size mismatch" not in verdicts[0]
+
+
+def test_missing_file_is_reported_from_both_sides(tmp_path):
+    """A DROPPED oracle key is the same class of failure as a drifted one (the same
+    reasoning `tests/test_parity_fixture_export.py` applies to safetensors keys), and it
+    has to be caught whichever side lost it."""
+    a = _tree(tmp_path / "a", _FILES)
+    fewer = {k: v for k, v in _FILES.items() if k != "meta.json"}
+    b = _tree(tmp_path / "b", fewer)
+
+    forward = compare_trees(a, b)
+    assert len(forward) == 1 and "meta.json" in forward[0]
+    assert "missing from" in forward[0]
+
+    reverse = compare_trees(b, a)
+    assert len(reverse) == 1 and "meta.json" in reverse[0]
+    assert "missing from" in reverse[0]
+
+
+def test_size_mismatch_is_reported_as_such(tmp_path):
+    a = _tree(tmp_path / "a", _FILES)
+    truncated = dict(_FILES, **{"reference.safetensors": _BIG[:-4096]})
+    b = _tree(tmp_path / "b", truncated)
+
+    verdicts = compare_trees(a, b)
+    assert len(verdicts) == 1
+    assert "size mismatch" in verdicts[0], verdicts[0]
+
+
+def test_nested_files_are_compared(tmp_path):
+    """Fixture trees are not flat forever; a corruption one directory down must not be
+    invisible to the guard."""
+    a = _tree(tmp_path / "a", dict(_FILES, **{"sub/extra.bin": b"abc"}))
+    b = _tree(tmp_path / "b", dict(_FILES, **{"sub/extra.bin": b"abd"}))
+    verdicts = compare_trees(a, b)
+    assert len(verdicts) == 1 and verdicts[0].startswith("sub/extra.bin")
+
+
+def test_empty_trees_are_blind_not_clean(tmp_path):
+    """THE anti-blind case. Two empty directories must never compare 'identical' — a
+    check that cannot observe its target reports that it could not, and an export that
+    wrote nothing at all is exactly the situation where a false 'clean' would let a
+    missing oracle through."""
+    a = (tmp_path / "a")
+    b = (tmp_path / "b")
+    a.mkdir()
+    b.mkdir()
+    with pytest.raises(ValueError, match="no files"):
+        digest_tree(a)
+    with pytest.raises(ValueError, match="no files"):
+        compare_trees(a, b)
+
+
+def test_missing_tree_raises(tmp_path):
+    a = _tree(tmp_path / "a", _FILES)
+    with pytest.raises(FileNotFoundError):
+        digest_tree(tmp_path / "nope")
+    with pytest.raises(FileNotFoundError):
+        compare_trees(a, tmp_path / "nope")
+    with pytest.raises(FileNotFoundError):
+        compare_trees(tmp_path / "nope", a)
+
+
+def test_a_file_where_a_tree_was_expected_raises(tmp_path):
+    """`--out` pointing at a regular file is unreadable-as-a-tree, i.e. BLIND."""
+    f = tmp_path / "not-a-dir"
+    f.write_bytes(b"x")
+    with pytest.raises(FileNotFoundError):
+        digest_tree(f)
+
+
+def test_empty_files_still_count_as_files(tmp_path):
+    """A zero-byte file is *present*; only a tree with no files at all is BLIND."""
+    a = _tree(tmp_path / "a", {"empty.bin": b""})
+    b = _tree(tmp_path / "b", {"empty.bin": b""})
+    assert compare_trees(a, b) == []
+    assert list(digest_tree(a)) == ["empty.bin"]

--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -116,6 +116,7 @@ PORTABLE_MODULES = [
     "src.conformance.prefill_decode_parity",
     "src.conformance.quant_parity",
     "src.conformance.tolerances",
+    "src.conformance.fixture_digest",
     "src.serve.sessions",
     "src.serve.rewind",
     "src.serve.sampling",

--- a/tests/test_lowp_parity_band.py
+++ b/tests/test_lowp_parity_band.py
@@ -44,9 +44,12 @@ def _build_model_and_tokens(config_name: str, precision: str, seed: int = 0):
     import mlx.core as mx
 
     # #298 mitigation (buffer-cache reuse corrupting an unrelated later computation) —
-    # same as scripts/export_parity_fixture.py and tests/test_parity_fixture_export.py.
-    mx.clear_cache()
-    mx.set_cache_limit(0)
+    # the one shared helper, imported LOCALLY so this module still imports with no MLX at
+    # all (T5 runs on the portable Linux job). Unscoped on purpose: the models this helper
+    # returns are used by the caller long after it returns.
+    from scripts.export_parity_fixture import disable_buffer_cache_for_process
+
+    disable_buffer_cache_for_process()
 
     from src.model.blocks import load_config
     from src.model.mlx_backend import MLXMambaModel

--- a/tests/test_mlx_mixing_matrix.py
+++ b/tests/test_mlx_mixing_matrix.py
@@ -24,7 +24,8 @@ mx = pytest.importorskip("mlx.core")
 # within one process — exactly what this file's tests do. One shared mitigation, whose
 # rationale and loud-failure contract live on the helper (see
 # `scripts/export_parity_fixture.py`); the confinement is checkable with
-# `git grep set_cache_limit -- src scripts tests`, which must name that file alone.
+# `git grep set_cache_limit -- src scripts tests`, which must show no CALL site outside
+# that file (the remaining hits here are prose and the fail-loud test's monkeypatch stubs).
 from scripts.export_parity_fixture import disable_buffer_cache_for_process  # noqa: E402
 
 disable_buffer_cache_for_process()

--- a/tests/test_mlx_mixing_matrix.py
+++ b/tests/test_mlx_mixing_matrix.py
@@ -19,14 +19,15 @@ import numpy as np
 import pytest
 
 mx = pytest.importorskip("mlx.core")
-# See scripts/export_parity_fixture.py's matching comment: this local MLX build (0.32.0)
-# has been observed to silently corrupt results when many independently-constructed
-# models allocate/free buffers of the same size class within one process — exactly what
-# this file's three tests do. Disabling the buffer-cache pool (proven in isolation to
-# take the observed failure rate to 0/10) trades allocator throughput, irrelevant here,
-# for correctness.
-mx.clear_cache()
-mx.set_cache_limit(0)
+# #264/#298: this local MLX build (0.32.0) has been observed to silently corrupt results
+# when many independently-constructed models allocate/free buffers of the same size class
+# within one process — exactly what this file's tests do. One shared mitigation, whose
+# rationale and loud-failure contract live on the helper (see
+# `scripts/export_parity_fixture.py`); the confinement is checkable with
+# `git grep set_cache_limit -- src scripts tests`, which must name that file alone.
+from scripts.export_parity_fixture import disable_buffer_cache_for_process  # noqa: E402
+
+disable_buffer_cache_for_process()
 
 from src.model.blocks import MambaConfig
 from src.model.mlx_backend import MLXMambaModel, MambaBlock, _linear, _DTYPES
@@ -131,3 +132,58 @@ def test_mixing_matrices_skips_attention_and_moe_layers():
         arr = np.array(m)
         assert np.isfinite(arr).all()
         assert arr.shape == (2, 16, 16)
+
+
+def test_disable_buffer_cache_fails_loudly_if_the_limit_does_not_take(monkeypatch):
+    """#298 edge case 1: an MLX version bump that changes `set_cache_limit`'s semantics
+    must make the mitigation RAISE, never degrade to a silent no-op.
+
+    A mitigation that has quietly stopped applying is indistinguishable from a working one
+    right up until it bakes a corrupted oracle into the Swift gate — which is the exact
+    failure #298's guard exists to prevent, so the check has to be on the fail-loud side.
+    MLX 0.32.0 has no `get_cache_limit`, so the helper confirms via a second
+    `set_cache_limit(0)` (which returns the limit then in force) plus `get_cache_memory()`;
+    both observations are falsified here.
+    """
+    from scripts.export_parity_fixture import disable_buffer_cache
+
+    # (a) the limit never takes: every set_cache_limit reports a non-zero prior limit.
+    monkeypatch.setattr(mx, "set_cache_limit", lambda n: 1 << 20)
+    with pytest.raises(RuntimeError, match="did not take effect"):
+        with disable_buffer_cache():
+            raise AssertionError("the context body must never be reached")
+
+    # ...and the message names the MLX version, so a report says WHICH build changed.
+    monkeypatch.setattr(mx, "__version__", "9.9.9-probe")
+    with pytest.raises(RuntimeError, match="9.9.9-probe"):
+        disable_buffer_cache_for_process()
+
+    # (b) the limit reads back as 0 but the pool is still populated — the subtler
+    # regression, where the setter is honoured for reporting but stops freeing.
+    monkeypatch.setattr(mx, "set_cache_limit", lambda n: 0)
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 4096)
+    with pytest.raises(RuntimeError, match="still holds"):
+        disable_buffer_cache_for_process()
+
+
+def test_disable_buffer_cache_restores_the_previous_limit(monkeypatch):
+    """The scoped form is scoped: `build_fixture` must not leave the process-wide limit
+    changed for whatever runs next in the same interpreter (a pytest session runs ~19 other
+    MLX modules after this one). Checked against a recording stub rather than the live
+    allocator, because this module disables the cache process-wide at import."""
+    from scripts.export_parity_fixture import disable_buffer_cache
+
+    calls = []
+    state = {"limit": 1 << 24}
+
+    def fake_set(n):
+        calls.append(n)
+        prev, state["limit"] = state["limit"], n
+        return prev
+
+    monkeypatch.setattr(mx, "set_cache_limit", fake_set)
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 0)
+    with disable_buffer_cache():
+        assert state["limit"] == 0
+    assert state["limit"] == 1 << 24
+    assert calls == [0, 0, 1 << 24]

--- a/tests/test_parity_fixture_export.py
+++ b/tests/test_parity_fixture_export.py
@@ -25,10 +25,10 @@ mx = pytest.importorskip("mlx.core")
 # when many independently-constructed models allocate/free buffers of the same size class
 # within one process — exactly what `build_fixture` (re-invoked below) and the fresh
 # `MLXMambaModel` construction in the route-bias test do inside an already-populated
-# pytest process. Same mitigation as `scripts/export_parity_fixture.py` and
-# `tests/test_mlx_mixing_matrix.py`: disable the buffer-cache pool for this module.
-mx.clear_cache()
-mx.set_cache_limit(0)
+# pytest process. One shared mitigation, defined in `scripts/export_parity_fixture.py`.
+from scripts.export_parity_fixture import disable_buffer_cache_for_process  # noqa: E402
+
+disable_buffer_cache_for_process()
 
 from safetensors.numpy import load_file            # noqa: E402
 

--- a/tests/test_train_parity_fixture_export.py
+++ b/tests/test_train_parity_fixture_export.py
@@ -23,10 +23,10 @@ mx = pytest.importorskip("mlx.core")
 # when many independently-constructed models allocate/free buffers of the same size class
 # within one process — exactly what `build_fixture` (re-invoked below, with `--train-steps`
 # constructing multiple MLX models in-process) does inside an already-populated pytest
-# process. Same mitigation as `tests/test_parity_fixture_export.py` and
-# `tests/test_mlx_mixing_matrix.py`: disable the buffer-cache pool for this module.
-mx.clear_cache()
-mx.set_cache_limit(0)
+# process. One shared mitigation, defined in `scripts/export_parity_fixture.py`.
+from scripts.export_parity_fixture import disable_buffer_cache_for_process  # noqa: E402
+
+disable_buffer_cache_for_process()
 
 from safetensors.numpy import load_file            # noqa: E402
 


### PR DESCRIPTION
Refs #298 — **deliberately not `Closes`.** This PR ships the guard and the written
answers; the underlying MLX defect is upstream and unfixed in 0.31.2, 0.32.0 and 0.32.1
(measured: 35/40, 16/40, 14/40). Per `docs/design/14-inference-engine.md`, #298 stays open
as an upstream-tracking item.

## Summary

#298 is closed by a **guard plus written answers, not a cure**. The defect is upstream in MLX and cannot be proven fixed from this repository; nothing here claims otherwise, and #298 should stay open as an upstream-tracking item.

**The guard.** `scripts/export_parity_fixture.py` now exports twice — the second time in a **fresh subprocess** — and compares the trees byte-for-byte before leaving anything at `--out`. Agreement keeps `--out`; disagreement leaves **nothing** there, preserves both trees as `--out.mismatch-1`/`-2`, prints per-file verdicts, and exits 2. The corruption is deterministic *per process*, so two interpreters would have to corrupt identically to agree — which is why the second export lives in `main()` rather than `build_fixture` (an in-process repeat would prove nothing).

**The comparison** is `src/conformance/fixture_digest.py`: portable (hashlib/pathlib only, above the seam, in `PORTABLE_MODULES`), so its logic is unit-tested on Linux where no MLX exists. `digest_tree` **raises** on a missing or empty tree — two empty trees comparing "identical" is the BLIND failure the guard exists to prevent.

**Confinement, now checkable.** #264's mitigation is consolidated into one `disable_buffer_cache()` helper that **fails loudly** (naming `mx.__version__`) if the limit stops taking effect. The issue said two call sites and the plan said three; the tree actually had **five** — it had been copy-pasted into `test_train_parity_fixture_export.py` and `test_lowp_parity_band.py` too. All five now route through the helper, and no call site remains outside that one file.

## The measured answers (`scripts/probe_mlx_buffer_reuse.py`, new)

The probe reports `BLIND` and exits non-zero when its own positive control fails to reproduce, and compares against an **accessor-free reference** rather than trial 0 — trial 0 is itself corrupt about half the time, so a trial-0 reference reports the *clean* trials as the failures.

- **Version question — answered.** mlx **0.31.2, 0.32.0 and 0.32.1 are all affected** at the same order (35/40, 30/40, 27/40 on `toy.yaml`). Downgrading is not a remedy and neither is upgrading. Upstream search (issues/PRs for buffer-cache corruption, `set_cache_limit`, allocator reuse, hazard tracking, silent wrong results; plus v0.32.0/v0.32.1 release notes) found **no matching issue** — a documented negative.
- **Hot-path question — answered: keep it off.** 0/30 on all three toy configs with the cache on, while the *same instrument on the same host* sees 11–30/40 in the `mixing` pattern. Structural argument recorded too (`mixing_matrices` forks a lazy `h` into two consumers; `forward`/`step`/`prefill` do not). Cost of doing otherwise, measured: **+13%** (toy) to **+30%** (toy-moe).
- **`mixing.N` escalation — resolved by measurement, nothing loosened.** `src/conformance/tolerances.py` is untouched; no logit/id tolerance moved.
- **Two claims already in the tree are corrected in place**, both falsified by measurement rather than by opinion: #264's `mx.eval(h)` barrier alone is **not** sufficient (still 18/40 and 20/40 corrupt), and the confinement grep wording now says what the grep actually returns.

## Found while verifying — the CI flake, reproduced

The exporter in isolation is clean (0 drift over 20 fresh `build_fixture` runs), but run `test_parity_fixture_export.py` **after** `test_mlx_mixing_matrix.py` in the same process and it corrupts at **3/12** — versus **0/12** for the export module alone. Measured on `main`, so this **pre-dates** this branch.

The failing assertion is not `mixing.N` and not a tolerance: it is `greedy_ids`, exact ints, **16/16 wrong by 222**. That is D4's third branch — a live recurrence of the upstream defect — so it is recorded with its exact repro command and **nothing is loosened**. It also shows `set_cache_limit(0)` does **not** compose across pytest modules. Making the suite robust needs process isolation for the MLX fixture modules; parked, not done here.

## Testing

- [x] Tests added/updated — `tests/test_fixture_digest.py` (9 portable cases incl. empty-tree-is-BLIND), plus fail-loud/scoping cases in `tests/test_mlx_mixing_matrix.py`
- [x] All tests passing — `pytest -q -rs`: **1656 passed, 12 skipped** (all pre-existing env gates)
- [x] Smoke gate — `scripts/smoke_test.py --backend mlx` on a freshly-built toy split: **PASSED**
- [x] Manual — V3 positive (`8 files identical across two fresh processes`) and **V4 negative control**: a deliberately corrupted oracle exits **2**, leaves nothing at `--out`, leaves `.mismatch-1`/`-2`
- [ ] **`monica-parity` NOT run locally** — this host has Command Line Tools only, and mlx-swift's `default.metallib` is an Xcode-only build product, so `swift run monica-parity` cannot work (`.github/workflows/ci.yml:446-487` documents this and uses `xcodebuild`). No Swift source and no fixture bytes changed on this branch — only `swift/engine/Fixtures/README.md` — so the gate's inputs are unchanged, but **CI is what actually proves it.**

## Docs

`docs/design/14-inference-engine.md` gains a `## MLX 0.32.0 buffer reuse (#298)` section carrying all five answers; `swift/engine/Fixtures/README.md` records the regeneration change and states the guard's **intra-machine-only** scope; `docs/feature-matrix.md` and `docs/test-plan.md` gain **ENGINE-10**. Six findings parked in `docs/parked-findings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ur4BdaFTqnwqSUAx5TrX8
