### PR TITLE
feat: [M12] SERVE-3: make session rewind reachable — RewindTree has no caller

### DIFF
--- a/docs/design/01-architecture-seam.md
+++ b/docs/design/01-architecture-seam.md
@@ -67,7 +67,11 @@ From `src/model/interface.py`:
 (`serve/sessions`, `serve/rewind`) holds many states at once and snapshots them at turn
 boundaries. On an immutable-array backend (MLX) a structural copy suffices; a backend whose
 `step` mutates buffers in place **must** deep-copy here, or a retained snapshot silently
-aliases a later step.
+aliases a later step. The two modules are joined by `SessionHistory`
+(`src/serve/sessions.py`, #305) — the composition point where a turn boundary is snapshotted
+into `RewindTree` and restored back through `SessionStore.set_state` — and driven from
+`scripts/generate.py --interactive`, the rewindable continuation REPL. Both stay above the seam:
+they pass the opaque `State` through and never inspect it.
 
 The two compute paths (`forward` and `step`) are separate implementations that must
 produce identical logits — enforced by [conformance](03-conformance.md).

--- a/docs/design/14-inference-engine.md
+++ b/docs/design/14-inference-engine.md
@@ -111,7 +111,13 @@ RoPE'd K/V produced by the sequence forward; MoE layers contribute the stateless
 > **The constant-size state is what makes all four levers cheap.** No paged attention, no radix
 > cache, and turn-boundary snapshot/undo rides the same opaque blob — `RewindTree`
 > (`src/serve/rewind.py:42`) snapshots a **fixed-size** `State`, not a cache that grows with the
-> conversation.
+> conversation. **Composition point and entry point (#305):** `SessionHistory`
+> (`src/serve/sessions.py`) joins `SessionStore` to `RewindTree` — `commit_turn` is
+> `tree.commit(store.get_state(...))`, `rewind_to` is `store.set_state(..., tree.rewind(...))` —
+> and `scripts/generate.py --interactive` is the stateful continuation REPL a person types
+> (`/rewind`, `/tree`, `/help`, sized by `--rewind-depth`). Turns after the first, and every turn
+> after a rewind, call `serve.generate.generate(..., prefill=False)`, because `SessionStore.prefill`
+> is fresh-session-only and a restored snapshot's position is unknowable above the seam.
 
 ## Quantization (#168)
 

--- a/docs/feature-matrix.md
+++ b/docs/feature-matrix.md
@@ -86,7 +86,7 @@ Last audited 2026-08-18 (`/closure-audit`, whole repo).
 |----|-----------|----------|-----|------|-------|--------|-------|--------|
 | SERVE-1 | A person can generate text from a checkpoint | done | done | done | done | Shipped | — | design/14 |
 | SERVE-2 | A person can control sampling (temp/top-p/repetition) | done | done | done | done | Shipped | — | design/14 |
-| SERVE-3 | A person can rewind a session to a turn boundary and branch | none | none | none | none | Planned | #305 | design/14 |
+| SERVE-3 | A person can rewind a session to a turn boundary and branch | done | done | none | none | Shipped | #305 | design/14 |
 | SERVE-4 | A person can constrain decoding to an allowed id set | done | done | done | done | Shipped | #226 | design/12 |
 | SERVE-5 | A person can decode speculatively | done | done | n/a | none | In progress | #172 | design/14 |
 

--- a/docs/parked-findings.md
+++ b/docs/parked-findings.md
@@ -177,3 +177,10 @@ Format: date, `file:line`, what was seen, what task surfaced it, rough severity.
   identical on `main`, so it predates #304, but it means those suites are not actually
   decontaminated against. Found while checking the #304 fixture rewrite lost no texts. Severity:
   contamination risk, non-blocking.
+
+- [2026-08-20] `src/serve/rewind.py:49`, `RewindTree` exposes `__contains__`/`__len__` but no
+  public way to enumerate its retained node ids — `_nodes` is the only source. `SessionHistory`
+  (#305) therefore keeps its own commit-order list and filters it through `__contains__`, which
+  works but duplicates bookkeeping the tree already has and would silently drift if anything ever
+  committed to the tree without going through `SessionHistory`. Found while wiring the rewind
+  entry point for #305. Severity: minor API gap, non-blocking.

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -86,7 +86,7 @@ Last audited 2026-08-18 (`/closure-audit`, whole repo: 81 capabilities × 131 te
 |----|------|-------------|-----|--------------------|------|
 | SERVE-1 | `test_generate.py` | `test_generate.py` | `scripts/smoke_test.py`, CI `swift-engine` `monica-generate` steps | EOS handling, max tokens | none |
 | SERVE-2 | `test_repetition_penalty.py`, `test_generate.py`, `test_constrained_sampling.py` | same | `scripts/smoke_test.py` | temp 0, top-p renormalization, all-non-finite fallback | none |
-| SERVE-3 | `test_serve.py` | `test_serve.py` | none | snapshot/restore of the recurrent state | no CLI or serving entry point reaches `RewindTree` — unit-tested only |
+| SERVE-3 | `test_serve.py` (`RewindTree` + `SessionHistory`) | `test_rewind_entry_point.py` (whole REPL, portable), `test_serve.py` `test_mlx_rewind_restores_the_opaque_state_and_the_continuation` (mlx-gated, toy scale) | none | over-deep rewind, uncommitted session, root rewind, `/rewind 0/-1/abc/#unknown`, unknown command, double branch + rewind across the branch point, LRU eviction, `--rewind-depth 0`, negative `--rewind-depth` | no CI job drives the CLI REPL itself — the mlx-gated integration test is the closest surface; CUDA and Swift are uncovered (the path is backend-agnostic but exercised on neither) |
 | SERVE-4 | `test_constrained_sampling.py`, `test_masked_decode.py`, `test_completion_mask.py` | CI `swift-macos` mask-set parity (Python vs Swift `VocabTrie`) | CI `swift-engine` `monica-generate --lsp-mask` | empty/all-out-of-range/duplicate-bearing `allowed_ids` | none |
 | SERVE-5 | `test_spec_decode.py` (mlx-gated) | none | none | greedy-equivalence assertion | Swift side has only the `verifyBlock` prerequisite; full spec decode not built (#172) |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -256,12 +256,12 @@ $ printf 'the cat\n/tree\nsat down\n/rewind 1\nran away\n/tree\n/rewind 99\n/fro
         --interactive --temperature 0 --max-new-tokens 20 --rewind-depth 8
 
 rewind: up to 8 retained turn boundaries, at most 155648 bytes (8 x 19456 B/snapshot).
->>> the cat        -> tttttttttttttttttttt      [committed #1; depth 2, 2 retained]
+>>> the cat        -> tttttttttttttttttttt      [committed #1; depth 2, 2/8 retained]
 >>> /tree            #0 parent=None children=[1]   '(start)'
                    * #1 parent=0    children=[]    'the cattttttttttttttttttttt'
->>> sat down       -> nnnnnnnnnnnnnnnnnnnn      [committed #2; depth 3, 3 retained]
+>>> sat down       -> nnnnnnnnnnnnnnnnnnnn      [committed #2; depth 3, 3/8 retained]
 >>> /rewind 1      rewound to #1 (depth 2)      <- back to the boundary after "the cat"
->>> ran away       -> yyyyyyyyyyyyyyyyyyyy      [committed #3]  <- a DIFFERENT continuation
+>>> ran away       -> yyyyyyyyyyyyyyyyyyyy      [committed #3; depth 3, 4/8 retained]  <- a DIFFERENT continuation
 >>> /tree            #1 parent=0 children=[2, 3]   <- the branch point now has two children
 >>> /rewind 99     error: cannot rewind 99 turn(s): session 'repl' retains 3 boundary/
                    boundaries including the current one, so at most 2 rewind hop(s) are
@@ -279,8 +279,11 @@ arithmetic: `--rewind-depth x per_session_state_bytes(config)`, printed at start
 scale that is `8 x 19456 B = 152 KiB`; at `config/poc.yaml` one snapshot is
 `n_layers x ((d_conv-1) x d_inner + n_heads x head_dim x d_state) x 4 B`
 (fp32-charged, the conservative direction), and the default depth 32 caps the tree at 32 of
-them. Nothing grows with conversation length — that is the whole point of an SSM state, and why
-`RewindTree` needs no paged-attention or radix-cache machinery.
+them. The retained **state snapshots** are flat in conversation length — that is the whole point
+of an SSM state, and why `RewindTree` needs no paged-attention or radix-cache machinery. The REPL
+also keeps a small amount of its own bookkeeping alongside the state (transcript text for `/tree`,
+committed-id order) — LRU-pruned to the same retained set on every commit, so it stays bounded by
+`--rewind-depth` too, but it is not literally nothing.
 
 **Rewinds count *retained* boundaries, not wall-clock turns.** When the LRU cap evicts a node,
 its children are reparented onto its grandparent so deeper branches survive, which means one

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -199,8 +199,9 @@ by our own model) can be produced with
 
 ## 4. Serve & chat
 
-[`scripts/generate.py`](../scripts/generate.py) is the CLI front-end (completion + interactive
-chat). It needs trained `--weights`; without them it random-inits and emits gibberish.
+[`scripts/generate.py`](../scripts/generate.py) is the CLI front-end: completion, an
+instruction-template chat REPL, and a **stateful, rewindable** continuation REPL. It needs
+trained `--weights`; without them it random-inits and emits gibberish.
 
 **Completion** — continue a prompt (streams token-by-token):
 
@@ -222,11 +223,76 @@ Each chat line is wrapped in the **same instruction template the model was train
 ([`src/data/instruct_format.py`](../src/data/instruct_format.py)), and generation stops at the
 next `### Instruction:` marker or end-of-text.
 
+`--chat` is **stateless by construction** — a fresh session per turn, whole transcript
+re-rendered — so it has no rewind. For that, use `--interactive` below.
+
+**Interactive** — one stateful session for the whole run, with rewind and branching (#305):
+
+```bash
+.venv/bin/python scripts/generate.py \
+    --config config/poc.yaml --weights runs/poc/weights.safetensors \
+    --interactive --temperature 0 --rewind-depth 8
+```
+
+Each line you type **extends the live session** (no re-prefill of the transcript — the prompt
+goes through `step`, because `SessionStore.prefill` is fresh-session-only), and every completed
+exchange is committed to a
+[`RewindTree`](../src/serve/rewind.py) as a turn boundary. In-REPL commands:
+
+| Command | Effect |
+|---|---|
+| `<text>` | Continue the session; the turn is committed as a rewind boundary |
+| `/rewind [n]` | Rewind `n` retained boundaries (default 1) and branch there |
+| `/rewind #<id>` | Rewind to an absolute node id, as printed by `/tree` |
+| `/tree` | Retained boundaries: id, parent, children, `*` marks the current node |
+| `/help`, `/quit` | Command list; leave (Ctrl-D works too) |
+
+An annotated transcript — commit, branch, rewind, and a *different* continuation from the same
+prefix (toy scale, greedy, no weights, so the text itself is gibberish):
+
+```
+$ printf 'the cat\n/tree\nsat down\n/rewind 1\nran away\n/tree\n/rewind 99\n/frobnicate\n/quit\n' \
+    | .venv/bin/python scripts/generate.py --config config/toy.yaml --byte-fallback \
+        --interactive --temperature 0 --max-new-tokens 20 --rewind-depth 8
+
+rewind: up to 8 retained turn boundaries, at most 155648 bytes (8 x 19456 B/snapshot).
+>>> the cat        -> tttttttttttttttttttt      [committed #1; depth 2, 2 retained]
+>>> /tree            #0 parent=None children=[1]   '(start)'
+                   * #1 parent=0    children=[]    'the cattttttttttttttttttttt'
+>>> sat down       -> nnnnnnnnnnnnnnnnnnnn      [committed #2; depth 3, 3 retained]
+>>> /rewind 1      rewound to #1 (depth 2)      <- back to the boundary after "the cat"
+>>> ran away       -> yyyyyyyyyyyyyyyyyyyy      [committed #3]  <- a DIFFERENT continuation
+>>> /tree            #1 parent=0 children=[2, 3]   <- the branch point now has two children
+>>> /rewind 99     error: cannot rewind 99 turn(s): session 'repl' retains 3 boundary/
+                   boundaries including the current one, so at most 2 rewind hop(s) are
+                   possible (retained ids: [0, 1, 2, 3])
+>>> /frobnicate    error: unknown command '/frobnicate' — /help lists the commands. It was
+                   NOT sent to the model.
+```
+
+Rewinding to the same boundary and re-typing the *same* line reproduces that continuation
+byte-for-byte under `--temperature 0`; that identity is what
+`tests/test_rewind_entry_point.py::test_rewound_branch_matches_direct_generation` asserts.
+
+**Memory.** Snapshots are the fixed-size recurrent state, so the tree's ceiling is flat
+arithmetic: `--rewind-depth x per_session_state_bytes(config)`, printed at startup. At toy
+scale that is `8 x 19456 B = 152 KiB`; at `config/poc.yaml` one snapshot is
+`n_layers x ((d_conv-1) x d_inner + n_heads x head_dim x d_state) x 4 B`
+(fp32-charged, the conservative direction), and the default depth 32 caps the tree at 32 of
+them. Nothing grows with conversation length — that is the whole point of an SSM state, and why
+`RewindTree` needs no paged-attention or radix-cache machinery.
+
+**Rewinds count *retained* boundaries, not wall-clock turns.** When the LRU cap evicts a node,
+its children are reparented onto its grandparent so deeper branches survive, which means one
+"parent hop" can skip a turn that no longer exists. Asking for more hops than exist is an error
+naming the available depth — it never clamps to the root.
+
 | Flag | Default | Meaning |
 |---|---|---|
 | `--config` | `config/poc.yaml` | Model config (must match the weights) |
 | `--weights` | — (random init) | Path to a `.safetensors` checkpoint |
-| `--prompt "…"` / `--chat` | — | Completion prompt **or** chat REPL (one required) |
+| `--prompt "…"` / `--chat` / `--interactive` | — | Completion prompt, chat REPL, **or** stateful rewindable REPL (exactly one required) |
+| `--rewind-depth` | 32 | `--interactive` only: retained turn boundaries (LRU-capped); `0` disables rewind, negative is an error |
 | `--max-new-tokens` | 100 | Max tokens to generate |
 | `--temperature` | 0.8 | 0 = greedy/deterministic; higher = more random |
 | `--top-k` / `--top-p` | none | Top-k / nucleus filtering (e.g. `--top-p 0.9`) |
@@ -270,10 +336,26 @@ out = generate(store, "user1", ids,
 print(tok.decode(out))
 ```
 
-`SessionStore` holds each conversation's recurrent state with bounded memory; `RewindTree`
-([`src/serve/rewind.py`](../src/serve/rewind.py)) snapshots/undoes turns and branches history —
-the "experimental snapshotting" the SSM's small fixed-size state makes cheap. Both are portable,
-so the same code runs unchanged on the CUDA backend.
+`SessionStore` holds each conversation's recurrent state with bounded memory;
+`SessionHistory` ([`src/serve/sessions.py`](../src/serve/sessions.py)) composes it with
+`RewindTree` ([`src/serve/rewind.py`](../src/serve/rewind.py)) to snapshot/undo turns and branch
+history — the "experimental snapshotting" the SSM's small fixed-size state makes cheap. That
+composition is exactly what `--interactive` drives:
+
+```python
+from src.serve.sessions import SessionHistory
+
+history = SessionHistory(store, "user1", max_depth=32)
+history.commit_turn()                  # snapshot this turn boundary (get_state -> tree)
+out = generate(store, "user1", ids, ..., prefill=False)   # extend the LIVE session
+history.commit_turn()
+history.rewind_turns(1)                # tree -> set_state: back to the previous boundary
+```
+
+`prefill=False` is required for turns after the first and after every rewind: `store.prefill`
+seeds attention RoPE from position 0 and refuses a session that has consumed tokens or been
+restored from a snapshot. All three modules are portable, so the same code runs unchanged on the
+CUDA backend.
 
 ---
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,21 +1,29 @@
 """Generate text from a trained Mamba-2/SSD checkpoint (MLX backend).
 
 Wires the seam to the shared generation core: tokenizer encode -> SessionStore.step
--> sampler -> tokenizer decode, streaming tokens to stdout. Two modes:
+-> sampler -> tokenizer decode, streaming tokens to stdout. Three modes:
 
   * completion (``--prompt "..."``): continue the raw prompt verbatim.
   * chat (``--chat``): a REPL that wraps each line in the SAME instruction template
     Dolly was formatted with at train time (``src.data.instruct_format``), so the
     model is prompted in the shape it learned. Generation stops at the next
-    ``### Instruction:`` marker or EOS.
+    ``### Instruction:`` marker or EOS. Stateless by construction — a fresh session
+    per turn, whole transcript re-rendered.
+  * interactive (``--interactive``): a **stateful** continuation REPL. ONE session
+    lives for the whole run; each line extends it and each completed exchange is
+    committed to a ``RewindTree`` as a turn boundary, so ``/rewind`` restores the
+    fixed-size recurrent state and branches history (#305).
 
 mlx is imported inside ``main`` (local backend import, like ``scripts/smoke_test.py``)
-so the file stays runnable to parse on non-Mac hosts.
+so the file stays runnable to parse on non-Mac hosts — and so ``interactive_repl``
+below is importable, and testable, without a backend.
 
     .venv/bin/python scripts/generate.py --config config/poc.yaml \\
         --weights runs/poc/weights.safetensors --prompt "The history of"
     .venv/bin/python scripts/generate.py --config config/poc.yaml \\
         --weights runs/poc/weights.safetensors --chat
+    .venv/bin/python scripts/generate.py --config config/poc.yaml \\
+        --weights runs/poc/weights.safetensors --interactive --temperature 0
 """
 
 from __future__ import annotations
@@ -24,23 +32,193 @@ import argparse
 import sys
 from functools import partial
 from pathlib import Path
+from typing import Callable, Optional
 
 import numpy as np
 
 from src.data.instruct_format import INSTRUCTION_MARKER, render
 from src.serve import sampling
 from src.serve.generate import generate
-from src.serve.sessions import SessionStore
+from src.serve.sessions import SessionHistory, SessionStore
+
+REPL_EPILOG = """\
+interactive mode (--interactive) — one stateful session, rewindable:
+
+  <text>          continue the session with <text> (the turn is committed as a
+                  rewind boundary once its continuation is produced)
+  /rewind [n]     rewind n retained turn boundaries (default 1) and branch there
+  /rewind #<id>   rewind to an absolute node id, as printed by /tree
+  /tree           list retained boundaries: id, parent, children, * = current
+  /help           this list
+  /quit           leave (Ctrl-D works too)
+
+Retained boundaries are LRU-capped at --rewind-depth (default 32); the ceiling on
+what they cost is depth x per_session_state_bytes(config), printed at startup.
+--rewind-depth 0 disables rewind entirely (no tree is built).
+
+Rewinds count RETAINED boundaries, not wall-clock turns: eviction reparents a node's
+children onto its grandparent, so after the cap is hit one hop may skip a turn that
+no longer exists.
+"""
+
+
+def _nonnegative_int(text: str) -> int:
+    """argparse type for --rewind-depth: reject negatives loudly rather than clamp."""
+    value = int(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError(
+            f"must be >= 0 (0 disables rewind); got {value}")
+    return value
+
+
+def _parse_rewind_arg(arg: str) -> tuple[int, bool]:
+    """`"2" -> (2, False)`, `"#7" -> (7, True)`. Raises ValueError on anything else."""
+    body = arg[1:] if arg.startswith("#") else arg
+    try:
+        return int(body), arg.startswith("#")
+    except ValueError:
+        raise ValueError(
+            "/rewind takes a turn count (e.g. `/rewind 2`) or an absolute node id "
+            f"(e.g. `/rewind #3`); got {arg!r}") from None
+
+
+def _path_to_root(nodes, node_id: int) -> list[int]:
+    """Root-first ancestry of `node_id`, from a `SessionHistory.nodes()` listing."""
+    parent_of = {nid: parent for nid, parent, _ in nodes}
+    path: list[int] = []
+    cursor: Optional[int] = node_id
+    while cursor is not None and cursor in parent_of:
+        path.append(cursor)
+        cursor = parent_of[cursor]
+    return list(reversed(path))
+
+
+def interactive_repl(
+    store,
+    session_id: str,
+    history: Optional[SessionHistory],
+    *,
+    run_turn: Callable[..., str],
+    read_line: Callable[[], Optional[str]],
+    emit: Callable[[str], None],
+    rewind_enabled: bool = True,
+) -> None:
+    """Drive a stateful continuation session until `read_line()` returns None.
+
+    Module-level and fully injected so a test can script stdin/stdout without a pty and
+    without a backend: `run_turn(text, prefill=...) -> continuation` owns the tokenizer,
+    sampler and `serve.generate.generate` call; `read_line()` yields the next input line
+    (None at EOF); `emit(line)` writes one line of REPL chrome.
+
+    The session is prefilled ONLY while it is genuinely fresh. After the first turn it has
+    consumed tokens, and after a rewind its position is unknowable above the seam, so both
+    cases fall back to `prefill=False` — `SessionStore.prefill` refuses them by design.
+
+    The displayed transcript (`node id -> text`) lives here, not in `SessionHistory`: the
+    tree holds opaque `State` blobs and text is a presentation concern.
+    """
+    transcript: dict[int, str] = {}
+    if rewind_enabled:
+        if history is None:
+            raise ValueError("rewind_enabled=True requires a SessionHistory")
+        root = history.commit_turn()          # turn 0: the empty, freshly-created state
+        transcript[root] = "(start)"
+        emit(f"rewind: up to {history.max_depth} retained turn boundaries, at most "
+             f"{history.budget_bytes()} bytes "
+             f"({history.max_depth} x {history.per_node_bytes()} B/snapshot).")
+    else:
+        emit("rewind: DISABLED (--rewind-depth 0); no tree is built.")
+    emit("interactive mode — type text to continue the session; /help for commands.")
+
+    fresh = True
+    while True:
+        line = read_line()
+        if line is None:
+            break
+        text = line.strip()
+        if not text:
+            continue
+
+        if not text.startswith("/"):
+            out = run_turn(text, prefill=fresh)
+            fresh = False
+            if rewind_enabled:
+                node_id = history.commit_turn()
+                transcript[node_id] = text + out
+                emit(f"[committed #{node_id}; depth {history.depth()}, "
+                     f"{len(history)}/{history.max_depth} retained]")
+            continue
+
+        parts = text.split()
+        command, command_args = parts[0], parts[1:]
+
+        if command in ("/quit", "/exit"):
+            break
+
+        if command == "/help":
+            for help_line in REPL_EPILOG.splitlines():
+                emit(help_line)
+            continue
+
+        if command == "/tree":
+            if not rewind_enabled:
+                emit("error: rewind is disabled (--rewind-depth 0); there is no tree.")
+                continue
+            emit(f"{len(history)}/{history.max_depth} retained boundaries, "
+                 f"current depth {history.depth()}:")
+            for node_id, parent, children in history.nodes():
+                mark = "*" if node_id == history.current() else " "
+                emit(f"{mark} #{node_id}  parent={parent}  children={children}  "
+                     f"{transcript.get(node_id, '')!r}")
+            continue
+
+        if command == "/rewind":
+            if not rewind_enabled:
+                emit("error: rewind is disabled (--rewind-depth 0); rerun with "
+                     "--rewind-depth N (N >= 1) to enable it.")
+                continue
+            if len(command_args) > 1:
+                emit(f"error: /rewind takes at most one argument; got {command_args}")
+                continue
+            try:
+                count, absolute = _parse_rewind_arg(
+                    command_args[0] if command_args else "1")
+                if absolute:
+                    target = history.rewind_to(count)
+                elif count >= 1 and history.depth() <= 1:
+                    # DoD 6b: nothing committed beyond the root. Restore the root (a real
+                    # set_state, not a no-op) and say why there is nothing to rewind past.
+                    target = history.rewind_to(history.current())
+                    emit("session is empty — you are at the root (turn 0); there is no "
+                         "earlier boundary to rewind past. Restored the root state.")
+                else:
+                    target = history.rewind_turns(count)
+            except (ValueError, LookupError) as exc:
+                emit(f"error: {exc}")          # no traceback; the session is untouched
+                continue
+            fresh = False                      # a restored session cannot be prefilled
+            emit(f"rewound to #{target} (depth {history.depth()}); transcript:")
+            for node_id in _path_to_root(history.nodes(), target):
+                emit(f"  #{node_id}: {transcript.get(node_id, '')!r}")
+            continue
+
+        emit(f"error: unknown command {command!r} — /help lists the commands. It was "
+             "NOT sent to the model.")
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description=__doc__,
+    ap = argparse.ArgumentParser(description=__doc__, epilog=REPL_EPILOG,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--config", type=Path, default=Path("config/poc-qwen.yaml"))
     ap.add_argument("--weights", type=Path, default=None,
                     help="portable .safetensors checkpoint; RANDOM INIT if omitted")
     ap.add_argument("--prompt", default=None, help="completion-mode prompt")
     ap.add_argument("--chat", action="store_true", help="instruction-template REPL")
+    ap.add_argument("--interactive", action="store_true",
+                    help="stateful continuation REPL with /rewind, /tree, /help (#305)")
+    ap.add_argument("--rewind-depth", type=_nonnegative_int, default=32,
+                    help="retained turn boundaries in --interactive mode (LRU-capped; "
+                         "0 disables rewind, negative is an error)")
     ap.add_argument("--max-new-tokens", type=int, default=100)
     ap.add_argument("--temperature", type=float, default=0.8)
     ap.add_argument("--top-k", type=int, default=None)
@@ -58,8 +236,11 @@ def main() -> None:
     ap.add_argument("--byte-fallback", action="store_true",
                     help="offline ByteTokenizer (toy config only; not OLMo/Qwen-compatible)")
     args = ap.parse_args()
-    if not args.chat and args.prompt is None:
-        ap.error("provide --prompt for completion mode, or --chat for the REPL")
+    if args.chat and args.interactive:
+        ap.error("--chat and --interactive are different REPLs; pick one")
+    if not args.chat and not args.interactive and args.prompt is None:
+        ap.error("provide --prompt for completion mode, --chat for the instruction "
+                 "REPL, or --interactive for the stateful continuation REPL")
 
     try:
         import mlx.core as mx  # noqa: F401  (seeded below; import proves availability)
@@ -155,7 +336,46 @@ def main() -> None:
         print()
         return produced
 
-    if args.chat:
+    def encode(text: str) -> list[int]:
+        # add_special_tokens=False for the same reason `run` uses it; ByteTokenizer.encode
+        # takes no kwargs, hence the fallback.
+        try:
+            return tok.encode(text, add_special_tokens=False)
+        except TypeError:
+            return tok.encode(text)
+
+    if args.interactive:
+        sid = "repl"
+        store.create(sid)
+        history = (SessionHistory(store, sid, max_depth=args.rewind_depth)
+                   if args.rewind_depth > 0 else None)
+
+        def run_turn(text: str, *, prefill: bool = True) -> str:
+            """Extend the live session with `text` and stream its continuation."""
+            ids = encode(text)
+            if not ids:
+                return ""
+            out_ids = generate(
+                store, sid, ids, sampler=sampler, to_numpy=to_numpy,
+                max_new_tokens=args.max_new_tokens, eos_id=eos_id,
+                pass_context=True, prefill=prefill,
+                on_token=lambda t: (sys.stdout.write(tok.decode([t])),
+                                    sys.stdout.flush()),
+            )
+            print()
+            return tok.decode(out_ids)
+
+        def read_line() -> str | None:
+            try:
+                return input(">>> ")
+            except (EOFError, KeyboardInterrupt):
+                print(file=sys.stderr)
+                return None
+
+        interactive_repl(store, sid, history, run_turn=run_turn, read_line=read_line,
+                         emit=lambda s: print(s, file=sys.stderr),
+                         rewind_enabled=args.rewind_depth > 0)
+    elif args.chat:
         print("chat mode — type a message (Ctrl-D / Ctrl-C to exit).", file=sys.stderr)
         messages: list[dict] = []
         while True:

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -115,9 +115,18 @@ def interactive_repl(
     cases fall back to `prefill=False` — `SessionStore.prefill` refuses them by design.
 
     The displayed transcript (`node id -> text`) lives here, not in `SessionHistory`: the
-    tree holds opaque `State` blobs and text is a presentation concern.
+    tree holds opaque `State` blobs and text is a presentation concern. It is pruned to the
+    tree's own retained ids on every commit so it stays bounded by `--rewind-depth` too —
+    `RewindTree` evicts nodes but never tells this dict, so without pruning `transcript` would
+    grow without bound over a long-lived session even though the state it describes does not.
     """
     transcript: dict[int, str] = {}
+
+    def _prune_transcript() -> None:
+        retained = set(history.retained_ids())
+        for stale in [node_id for node_id in transcript if node_id not in retained]:
+            del transcript[stale]
+
     if rewind_enabled:
         if history is None:
             raise ValueError("rewind_enabled=True requires a SessionHistory")
@@ -145,6 +154,7 @@ def interactive_repl(
             if rewind_enabled:
                 node_id = history.commit_turn()
                 transcript[node_id] = text + out
+                _prune_transcript()
                 emit(f"[committed #{node_id}; depth {history.depth()}, "
                      f"{len(history)}/{history.max_depth} retained]")
             continue
@@ -185,9 +195,15 @@ def interactive_repl(
                     command_args[0] if command_args else "1")
                 if absolute:
                     target = history.rewind_to(count)
-                elif count >= 1 and history.depth() <= 1:
-                    # DoD 6b: nothing committed beyond the root. Restore the root (a real
-                    # set_state, not a no-op) and say why there is nothing to rewind past.
+                elif count == 1 and history.depth() <= 1:
+                    # DoD 6b: nothing committed beyond the root, and the default `/rewind`
+                    # (count 1) asked for exactly the one hop that doesn't exist. Restore the
+                    # root (a real set_state, not a no-op) and say why there is nothing to
+                    # rewind past. A larger count (e.g. `/rewind 2` at the root) falls through
+                    # to `rewind_turns` below instead, so it gets the precise "cannot rewind N
+                    # turn(s) ... at most 0 rewind hop(s) are possible" error rather than being
+                    # collapsed into this same message regardless of how far past the root it
+                    # asked to go.
                     target = history.rewind_to(history.current())
                     emit("session is empty — you are at the root (turn 0); there is no "
                          "earlier boundary to rewind past. Restored the root state.")

--- a/src/serve/generate.py
+++ b/src/serve/generate.py
@@ -5,7 +5,9 @@ decoded tokens to a user, and the lm-eval adapter (`src/eval/olmes_adapter.py`)
 collects them for generative tasks. It drives the model through two `SessionStore`
 primitives only — `prefill(session_id, prompt_ids)` for the prompt (#165) and
 `step(session_id, token)` for each decoded token — so it adds no state handling of its
-own.
+own. `prefill=False` routes the prompt through `step` instead, which is how the stateful
+REPL (`scripts/generate.py --interactive`, #305) extends a live or rewound session that
+`SessionStore.prefill` refuses.
 
 Above the seam: only numpy + the `SessionStore` API. Backend logits are converted to
 numpy via the injected `to_numpy` (as in `src/eval/val_loss.py`); the `sampler`
@@ -32,6 +34,7 @@ def generate(
     stop_fn: Optional[Callable[[List[int]], bool]] = None,
     on_token: Optional[Callable[[int], None]] = None,
     pass_context: bool = False,
+    prefill: bool = True,
 ) -> List[int]:
     """Generate up to `max_new_tokens` continuation ids for `session_id`.
 
@@ -45,6 +48,17 @@ def generate(
     `stop_fn(generated)` is True. `prompt_ids` must be non-empty (the recurrence needs a
     token to advance on). Returns only the generated ids (not the prompt).
 
+    `prefill=False` seeds the loop by `step`-ing each prompt id instead. The two paths are
+    equivalent by construction — same state, same final logits, gated by
+    `src/conformance/prefill_decode_parity.py` — so the default is byte-identical to the
+    single-scan path and no existing caller changes behavior. The option exists because a
+    **live** session cannot be prefilled: `SessionStore.prefill` is fresh-session-only
+    (`src/serve/sessions.py:111`), and a session restored from a rewind snapshot has an
+    unknowable token position above the seam (`set_state` marks it `None`), so prefill
+    refuses it rather than mis-seeding attention RoPE from position 0. The stateful
+    continuation REPL (`scripts/generate.py --interactive`) uses `prefill=False` for every
+    turn after the first and after every rewind.
+
     `pass_context=True` calls `sampler(logits, previous_tokens=prompt + generated)` so a
     repetition-aware sampler can penalize already-emitted tokens; the default keeps the
     bare `sampler(logits)` contract the lm-eval adapter relies on.
@@ -53,7 +67,11 @@ def generate(
         raise ValueError("prompt_ids must be non-empty")
 
     prompt = [int(t) for t in prompt_ids]
-    logits = store.prefill(session_id, prompt)
+    if prefill:
+        logits = store.prefill(session_id, prompt)
+    else:
+        for tok_id in prompt:
+            logits = store.step(session_id, tok_id)
 
     generated: List[int] = []
     for _ in range(max_new_tokens):

--- a/src/serve/sessions.py
+++ b/src/serve/sessions.py
@@ -18,7 +18,14 @@ Usage::
     store.create("s1")
     logits = store.prefill("s1", prompt_ids)   # whole prompt in ONE parallel scan
     logits = store.step("s1", next_id)         # then one token at a time
-    snapshot = store.get_state("s1")     # hand to serve.rewind.RewindTree.commit(...)
+
+    history = SessionHistory(store, "s1")      # composes the store with serve.rewind
+    history.commit_turn()                      # snapshot this turn boundary into the tree
+    history.rewind_turns(1)                    # ... and restore it later, in place
+
+`SessionHistory` (below) is the composition point between this module and
+`serve.rewind.RewindTree`; `scripts/generate.py --interactive` is the entry point that
+drives it (#305).
 """
 
 from __future__ import annotations
@@ -30,6 +37,7 @@ import numpy as np
 
 from ..model.blocks import MambaConfig
 from ..model.interface import Array, ModelInterface, State
+from .rewind import RewindTree
 
 # Bytes per state element by declared precision. Note the conservative default below:
 # the MLX backend keeps the SSM state in fp32 even when precision is fp16, so a naive
@@ -153,7 +161,11 @@ class SessionStore:
 
     # --- snapshot / restore (the bridge to serve.rewind) ---
     def get_state(self, session_id: str) -> State:
-        """An independent snapshot of a session's state, safe to retain (cloned)."""
+        """An independent snapshot of a session's state, safe to retain (cloned).
+
+        `SessionHistory.commit_turn` (below) is the caller: it hands the clone straight to
+        `RewindTree.commit`, which retains it as a turn-boundary node.
+        """
         return self.model.clone_state(self._states[session_id])
 
     def set_state(self, session_id: str, state: State) -> None:
@@ -163,6 +175,9 @@ class SessionStore:
         independent copy. Without this, installing a `RewindTree.rewind(...)` result
         (which aliases the tree node) lets a subsequent in-place `step` mutation on a
         numpy/CUDA state silently corrupt the retained snapshot.
+
+        `SessionHistory.rewind_to` (below) is the caller: it pairs `RewindTree.rewind`
+        with this method, which is the whole of the rewind operation.
         """
         self._states[session_id] = self.model.clone_state(state)
         self._states.move_to_end(session_id)
@@ -191,3 +206,127 @@ class SessionStore:
             self._positions.pop(sid, None)
             evicted.append(sid)
         return evicted
+
+
+class SessionHistory:
+    """Turn-boundary history for ONE session: the composition of `SessionStore` and
+    `serve.rewind.RewindTree`.
+
+    `SessionStore` owns the live state and `RewindTree` owns the retained snapshots;
+    neither knows about the other. This class is the join: `commit_turn` snapshots the
+    live session (`store.get_state`, which clones at the seam) into the tree, and
+    `rewind_to` pulls a snapshot back out (`tree.rewind`) and reinstalls it
+    (`store.set_state`). It never touches the model and never inspects a `State` — above
+    the seam `State` is opaque, so the blob is only ever passed through.
+
+    **Rewinds count RETAINED boundaries, not wall-clock turns.** The tree is LRU-capped at
+    `max_depth`, and `RewindTree._detach` reparents an evicted node's children onto its
+    grandparent so deeper branches outlive the cap. One "parent hop" therefore skips any
+    turn that has already been evicted. `rewind_turns(n)` walks `n` retained parents; if
+    the run is long enough for eviction, that is not the same as "n turns ago", and the
+    caller is told the retained depth when it asks for more than exists.
+
+    Guards **reject**; none clamps and none silently no-ops. Asking to rewind further than
+    the retained history raises rather than landing on the root, because a rewind that
+    quietly lands somewhere else is indistinguishable from one that worked.
+    """
+
+    def __init__(self, store: SessionStore, session_id: str, max_depth: int = 32) -> None:
+        if session_id not in store:
+            raise KeyError(
+                f"session {session_id!r} does not exist in the store; create it before "
+                "attaching a SessionHistory")
+        self.store = store
+        self.session_id = session_id
+        self.tree = RewindTree(max_depth=max_depth)   # raises if max_depth < 1
+        # Ids in commit order. The tree evicts, so this is a superset of what is retained;
+        # `retained_ids` filters it through the tree's own membership test rather than
+        # reaching into `RewindTree._nodes`.
+        self._committed: list[int] = []
+
+    # --- the composition ---
+    def commit_turn(self) -> int:
+        """Snapshot the live session as a turn boundary. Returns the new node id."""
+        node_id = self.tree.commit(self.store.get_state(self.session_id))
+        self._committed.append(node_id)
+        return node_id
+
+    def rewind_turns(self, n: int) -> int:
+        """Walk `n` retained parents from the current node and restore that snapshot.
+
+        Returns the node id landed on. Raises `ValueError` — without touching the session
+        — if `n < 1`, if nothing has been committed, or if fewer than `n` retained
+        ancestors exist (the message names both `n` and the available depth).
+        """
+        if n < 1:
+            raise ValueError(f"n must be >= 1 (got {n})")
+        current = self.tree.current()
+        if current is None:
+            raise ValueError(
+                f"session {self.session_id!r} has no committed turn boundaries; "
+                "call commit_turn() before rewinding")
+        target = current
+        for _ in range(n):
+            parent = self.tree.parent(target)
+            if parent is None:
+                available = self.depth() - 1
+                raise ValueError(
+                    f"cannot rewind {n} turn(s): session {self.session_id!r} retains "
+                    f"{self.depth()} boundary/boundaries including the current one, so at "
+                    f"most {available} rewind hop(s) are possible "
+                    f"(retained ids: {self.retained_ids()})")
+            target = parent
+        return self.rewind_to(target)
+
+    def rewind_to(self, node_id: int) -> int:
+        """Restore an absolute node id. Raises `LookupError` if it is unknown or evicted."""
+        try:
+            state = self.tree.rewind(node_id)
+        except KeyError:
+            raise LookupError(
+                f"node {node_id} is not retained by session {self.session_id!r}'s rewind "
+                f"tree (retained ids: {self.retained_ids()})") from None
+        self.store.set_state(self.session_id, state)
+        return node_id
+
+    # --- introspection ---
+    def current(self) -> Optional[int]:
+        return self.tree.current()
+
+    def __len__(self) -> int:
+        """Retained nodes, as the tree itself counts them (the LRU cap's own view)."""
+        return len(self.tree)
+
+    def retained_ids(self) -> list[int]:
+        """Committed ids that survived eviction, in commit order."""
+        return [i for i in self._committed if i in self.tree]
+
+    def depth(self) -> int:
+        """Retained ancestors of the current node, inclusive. 0 if nothing is committed."""
+        node = self.tree.current()
+        n = 0
+        while node is not None:
+            n += 1
+            node = self.tree.parent(node)
+        return n
+
+    def nodes(self) -> list[tuple[int, Optional[int], list[int]]]:
+        """`(id, parent_id, children)` for every retained node, in commit order."""
+        return [(i, self.tree.parent(i), self.tree.children(i)) for i in self.retained_ids()]
+
+    @property
+    def max_depth(self) -> int:
+        return self.tree.max_depth
+
+    def per_node_bytes(self) -> int:
+        """Conservative bytes for ONE retained snapshot — pure config arithmetic."""
+        return per_session_state_bytes(self.store.model.config)
+
+    def budget_bytes(self) -> int:
+        """Ceiling on what the retained tree can cost: `max_depth x per_node_bytes()`.
+
+        Conservative (fp32-charged) and exact in shape: snapshots are uniform because the
+        recurrent state is fixed-size, which is what makes a flat node count the right
+        budget in the first place.
+        """
+        return self.max_depth * self.per_node_bytes()

--- a/src/serve/sessions.py
+++ b/src/serve/sessions.py
@@ -248,6 +248,12 @@ class SessionHistory:
     def commit_turn(self) -> int:
         """Snapshot the live session as a turn boundary. Returns the new node id."""
         node_id = self.tree.commit(self.store.get_state(self.session_id))
+        # Drop ids the tree has already evicted before appending the new one, so `_committed`
+        # stays bounded by `max_depth` too. The tree is LRU-capped; without this the id list
+        # would grow without bound over a long-lived session even though the tree itself
+        # never does — `retained_ids()` masked the leak by filtering on every read, but never
+        # freed the stale entries themselves.
+        self._committed = self.retained_ids()
         self._committed.append(node_id)
         return node_id
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -188,3 +188,48 @@ def test_default_uses_bare_sampler_contract():
 
     out = generate(store, "s", [0], sampler=bare_sampler, max_new_tokens=2)
     assert out == [1, 2]
+
+
+# --- prefill=False: the live/rewound-session path (#305) -----------------------------
+
+def _greedy(logits):
+    return int(np.argmax(logits))
+
+
+def test_prefill_false_matches_prefill_true_on_a_fresh_session():
+    """The two prompt paths are equivalent by construction; assert it on both ids and state.
+
+    `prefill=True` runs the whole prompt through one parallel scan, `prefill=False` steps
+    it token by token. `src/conformance/prefill_decode_parity.py` gates that equivalence on
+    the real backends; here it is checked through `generate` itself, which is what lets the
+    stateful REPL extend a session `SessionStore.prefill` refuses.
+    """
+    prompt = [2, 5, 9]
+    scanned = _store()
+    stepped = SessionStore(CounterModel())
+    stepped.create("s")
+
+    out_scan = generate(scanned, "s", prompt, sampler=_greedy, max_new_tokens=5)
+    out_step = generate(stepped, "s", prompt, sampler=_greedy, max_new_tokens=5,
+                        prefill=False)
+
+    assert out_step == out_scan
+    assert np.array_equal(np.asarray(scanned.get_state("s")),
+                          np.asarray(stepped.get_state("s")))
+
+
+def test_prefill_false_extends_a_live_session_that_prefill_would_refuse():
+    """After one generation the session is at a non-zero position: prefill must refuse it
+    and `prefill=False` must continue it (the second-turn case in the REPL)."""
+    store = _store()
+    generate(store, "s", [1, 2], sampler=_greedy, max_new_tokens=3)
+    with pytest.raises(ValueError, match="fresh-session"):
+        generate(store, "s", [4], sampler=_greedy, max_new_tokens=3)
+    assert generate(store, "s", [4], sampler=_greedy, max_new_tokens=3,
+                    prefill=False) == [5, 6, 7]
+
+
+def test_prefill_false_still_rejects_an_empty_prompt():
+    store = _store()
+    with pytest.raises(ValueError, match="prompt_ids must be non-empty"):
+        generate(store, "s", [], sampler=_greedy, prefill=False)

--- a/tests/test_rewind_entry_point.py
+++ b/tests/test_rewind_entry_point.py
@@ -1,0 +1,286 @@
+"""End-to-end tests for the session-rewind entry point (`scripts/generate.py`, #305).
+
+Portable — no backend, so these run in the Linux `portable` CI job. Every assertion goes
+through `scripts.generate.interactive_repl` with scripted input lines, because the defect
+this issue closes was a rewind layer with no caller: a test that reached the tree directly
+would re-create that defect in a new costume.
+
+**The model matters more than the plumbing.** `tests/test_serve.py`'s `FakeModel` returns
+`eye(V)[token % V]` — logits that depend only on the last token fed, never on the
+recurrent state — so a rewind test written against it passes with state restoration
+completely broken. `StatefulFakeModel` below keys its logits off a rolling hash of every
+token the session has consumed, which is what makes the identity assertion load-bearing.
+`test_state_independent_model_makes_the_identity_vacuous` pins that reasoning in place by
+running the same script against the state-independent model and watching the "differs from
+the discarded branch" half fail.
+"""
+
+from __future__ import annotations
+
+import sys
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.serve import sampling
+from src.serve.generate import generate
+from src.serve.sessions import SessionHistory, SessionStore
+from scripts.generate import _nonnegative_int, interactive_repl, main
+from tests.test_serve import FakeModel
+
+VOCAB = 16
+
+
+class StatefulFakeModel(FakeModel):
+    """A `FakeModel` whose logits are a function of the STATE, not just the last token.
+
+    State is a rolling hash of every token consumed, and the logits one-hot at
+    `state % vocab`, so any two distinct token histories almost surely decode to different
+    continuations — a wrong restored state provably yields a wrong continuation.
+
+    A plain running sum (the obvious choice) is *not* good enough here: greedy decoding on
+    `logits = eye(V)[sum % V]` has absorbing fixed points, so distinct prefixes converge to
+    the same repeated token within a few steps and the "differs from the discarded branch"
+    assertion goes vacuous again. The hash has no such traps.
+    """
+
+    def step(self, token, state):
+        new_state = (state * 131 + np.asarray(token) + 7) % 1_000_003
+        logits = np.eye(self.config.vocab_size)[new_state % self.config.vocab_size]
+        return logits, new_state
+
+
+def _encode(text: str) -> list[int]:
+    return [ord(ch) % VOCAB for ch in text]
+
+
+def _decode(ids) -> str:
+    return "".join(chr(ord("A") + int(i)) for i in ids)
+
+
+class ScriptedRepl:
+    """Drives `interactive_repl` with a fixed list of input lines and records everything.
+
+    `run_turn` is the real thing — `src.serve.generate.generate` against a `SessionStore` —
+    with a trivial character tokenizer standing in for the CLI's. Only stdin/stdout are
+    faked, so the state handling under test is exactly the CLI's.
+    """
+
+    def __init__(self, lines, *, model=None, rewind_depth: int = 8,
+                 max_new_tokens: int = 6):
+        self.model = model if model is not None else StatefulFakeModel(vocab_size=VOCAB)
+        self.store = SessionStore(self.model, max_concurrent=1)
+        self.sid = "repl"
+        self.store.create(self.sid)
+        self.history = (SessionHistory(self.store, self.sid, max_depth=rewind_depth)
+                        if rewind_depth > 0 else None)
+        self.sampler = partial(sampling.sample, temperature=0.0,
+                               rng=np.random.default_rng(0))
+        self.max_new_tokens = max_new_tokens
+        self._lines = list(lines)
+        self.emitted: list[str] = []
+        self.turns: list[tuple[str, str]] = []     # (input text, continuation)
+        self.boundary_states: list = []            # store state at each turn boundary
+
+    # --- the three injected seams ---
+    def run_turn(self, text: str, *, prefill: bool = True) -> str:
+        ids = _encode(text)
+        out_ids = generate(self.store, self.sid, ids, sampler=self.sampler,
+                           to_numpy=np.asarray, max_new_tokens=self.max_new_tokens,
+                           pass_context=True, prefill=prefill)
+        continuation = _decode(out_ids)
+        self.turns.append((text, continuation))
+        self.boundary_states.append(self.store.get_state(self.sid))
+        return continuation
+
+    def read_line(self):
+        return self._lines.pop(0) if self._lines else None
+
+    def emit(self, line: str) -> None:
+        self.emitted.append(line)
+
+    # --- helpers ---
+    def run(self) -> "ScriptedRepl":
+        interactive_repl(self.store, self.sid, self.history, run_turn=self.run_turn,
+                         read_line=self.read_line, emit=self.emit,
+                         rewind_enabled=self.history is not None)
+        return self
+
+    @property
+    def chrome(self) -> str:
+        return "\n".join(self.emitted)
+
+    def continuation(self, index: int) -> str:
+        return self.turns[index][1]
+
+
+# The three lines that make the branch test sharp. `X` and `B` end with the SAME character
+# but differ earlier, so a model that only looks at the last token cannot tell them apart
+# (see test_state_independent_model_makes_the_identity_vacuous) while a state-dependent one
+# must.
+LINE_A, LINE_X, LINE_B = "hi", "ab", "cb"
+
+
+# --- criterion 3: rewinding restores the recurrent state, proven by output ---------------
+
+def test_rewound_branch_matches_direct_generation():
+    """A -> B directly == A -> X -> rewind -> B, and != the discarded X continuation."""
+    direct = ScriptedRepl([LINE_A, LINE_B]).run()
+    rewound = ScriptedRepl([LINE_A, LINE_X, "/rewind 1", LINE_B]).run()
+
+    out_b = direct.continuation(1)
+    out_x = rewound.continuation(1)
+    out_b_prime = rewound.continuation(2)
+
+    assert out_b, "the fake model must actually produce a continuation"
+    # State restored: the rewound branch regenerates B's continuation byte-for-byte.
+    assert out_b_prime == out_b
+    # A real branch, not a replay of the discarded one, and not a vacuous identity.
+    assert out_b_prime != out_x
+
+
+def test_state_independent_model_makes_the_identity_vacuous():
+    """Why `StatefulFakeModel` exists: the base `FakeModel` cannot prove anything.
+
+    With logits keyed off the last token alone, the discarded branch and the rewound one
+    decode identically (both lines end in the same character), so the "differs from the
+    discarded branch" half of the criterion FAILS — which is exactly the signal that a
+    state-independent model would have let a broken rewind through.
+    """
+    rewound = ScriptedRepl([LINE_A, LINE_X, "/rewind 1", LINE_B],
+                           model=FakeModel(vocab_size=VOCAB)).run()
+    assert rewound.continuation(2) == rewound.continuation(1)
+
+
+def test_restored_state_equals_the_snapshot():
+    """The direct check: the store's state after `/rewind` == the boundary snapshot."""
+    repl = ScriptedRepl([LINE_A, LINE_X, "/rewind 1"]).run()
+    at_boundary = repl.boundary_states[0]           # state right after LINE_A
+    after_rewind = repl.store.get_state(repl.sid)
+    assert np.array_equal(np.asarray(at_boundary), np.asarray(after_rewind))
+    # And it genuinely moved: the discarded branch's state differs.
+    assert not np.array_equal(np.asarray(repl.boundary_states[1]),
+                              np.asarray(after_rewind))
+
+
+# --- criterion 6: every guard is watched rejecting ---------------------------------------
+
+def test_over_deep_rewind_errors_and_leaves_the_session_untouched():
+    repl = ScriptedRepl([LINE_A, "/rewind 5"]).run()
+    before = np.asarray(repl.boundary_states[0])
+    assert "cannot rewind 5 turn(s)" in repl.chrome
+    assert "at most 1 rewind hop(s) are possible" in repl.chrome
+    assert np.array_equal(before, np.asarray(repl.store.get_state(repl.sid)))
+
+
+def test_rewind_with_nothing_committed_restores_the_root_and_says_so():
+    repl = ScriptedRepl(["/rewind"]).run()
+    assert "session is empty" in repl.chrome
+    assert "Restored the root state." in repl.chrome
+    # The root is the freshly-created (zero) state, and it really was reinstalled.
+    assert np.array_equal(np.asarray(repl.store.get_state(repl.sid)),
+                          np.asarray(repl.model.init_state(1)))
+
+
+@pytest.mark.parametrize("argument", ["0", "-1"])
+def test_rewind_non_positive_count_is_rejected(argument):
+    repl = ScriptedRepl([LINE_A, LINE_X, f"/rewind {argument}"]).run()
+    assert f"error: n must be >= 1 (got {argument})" in repl.chrome
+
+
+def test_rewind_non_numeric_argument_is_rejected():
+    repl = ScriptedRepl([LINE_A, "/rewind abc"]).run()
+    assert "/rewind takes a turn count" in repl.chrome
+    assert "got 'abc'" in repl.chrome
+
+
+def test_rewind_too_many_arguments_is_rejected():
+    repl = ScriptedRepl([LINE_A, "/rewind 1 2"]).run()
+    assert "takes at most one argument" in repl.chrome
+
+
+def test_rewind_to_unknown_node_id_names_the_retained_ids():
+    repl = ScriptedRepl([LINE_A, "/rewind #999"]).run()
+    assert "node 999 is not retained" in repl.chrome
+    assert "retained ids: [0, 1]" in repl.chrome
+
+
+def test_unknown_command_is_rejected_and_never_reaches_the_model():
+    repl = ScriptedRepl(["/frobnicate"]).run()
+    assert "unknown command '/frobnicate'" in repl.chrome
+    assert "NOT sent to the model" in repl.chrome
+    assert repl.turns == []          # the typo was never fed as prompt text
+
+
+def test_rewind_depth_zero_disables_rewind_without_building_a_tree():
+    repl = ScriptedRepl([LINE_A, "/rewind", "/tree"], rewind_depth=0).run()
+    assert repl.history is None
+    assert "rewind: DISABLED (--rewind-depth 0); no tree is built." in repl.chrome
+    assert repl.chrome.count("rewind is disabled") == 2      # /rewind and /tree both say so
+    assert len(repl.turns) == 1                              # the turn itself still works
+
+
+def test_negative_rewind_depth_is_an_argparse_error(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv",
+                        ["generate.py", "--interactive", "--rewind-depth", "-1"])
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2
+    assert "must be >= 0" in capsys.readouterr().err
+
+
+def test_nonnegative_int_accepts_zero_and_rejects_negatives():
+    assert _nonnegative_int("0") == 0
+    with pytest.raises(Exception, match="must be >= 0"):
+        _nonnegative_int("-3")
+
+
+# --- criterion 6e / 6h: branching and eviction --------------------------------------------
+
+def test_branch_twice_then_rewind_across_the_branch_point():
+    """Two children off one boundary, reached by absolute id, with matching continuations."""
+    repl = ScriptedRepl([LINE_A, LINE_X, "/rewind 1", LINE_B, "/tree"]).run()
+    # Nodes: 0 root, 1 = after A, 2 = after X, 3 = after B (both children of 1).
+    branch_point = [n for n in repl.history.nodes() if n[0] == 1][0]
+    assert sorted(branch_point[2]) == [2, 3]
+    assert "* #3" in repl.chrome
+
+    # Rewind across the branch point to the discarded child and continue it: the
+    # continuation must match what that branch produced the first time.
+    resumed = ScriptedRepl([LINE_A, LINE_X, "/rewind 1", LINE_B, "/rewind #2", LINE_B]).run()
+    from_branch_x = ScriptedRepl([LINE_A, LINE_X, LINE_B]).run()
+    assert resumed.continuation(3) == from_branch_x.continuation(2)
+    assert resumed.continuation(3) != resumed.continuation(2)   # the other branch differs
+
+
+def test_eviction_bounds_the_tree_and_a_deeper_rewind_errors():
+    lines = ["aa", "bb", "cc", "dd", "ee", "/rewind 4"]
+    repl = ScriptedRepl(lines, rewind_depth=3).run()
+    assert len(repl.history) == 3 == len(repl.history.tree)
+    assert len(repl.history.retained_ids()) == 3
+    assert "cannot rewind 4 turn(s)" in repl.chrome
+    assert "at most 2 rewind hop(s) are possible" in repl.chrome
+
+
+# --- criterion 7: the memory bound is stated ----------------------------------------------
+
+def test_startup_states_the_retained_node_budget():
+    repl = ScriptedRepl([], rewind_depth=4).run()
+    per_node = repl.history.per_node_bytes()
+    assert f"at most {4 * per_node} bytes" in repl.chrome
+    assert f"4 x {per_node} B/snapshot" in repl.chrome
+
+
+def test_help_lists_every_command():
+    repl = ScriptedRepl(["/help"]).run()
+    for command in ("/rewind [n]", "/rewind #<id>", "/tree", "/help", "/quit"):
+        assert command in repl.chrome
+
+
+def test_quit_stops_the_loop_before_later_lines():
+    repl = ScriptedRepl([LINE_A, "/quit", LINE_B]).run()
+    assert len(repl.turns) == 1

--- a/tests/test_rewind_entry_point.py
+++ b/tests/test_rewind_entry_point.py
@@ -186,6 +186,23 @@ def test_rewind_with_nothing_committed_restores_the_root_and_says_so():
                           np.asarray(repl.model.init_state(1)))
 
 
+def test_rewind_multiple_at_root_reports_over_deep_not_empty():
+    """`/rewind 2` at the root asks for a specific hop count that doesn't exist.
+
+    It must get the precise "cannot rewind 2 turn(s) ... at most 0 rewind hop(s)" error
+    (matching `test_over_deep_rewind_errors_and_leaves_the_session_untouched`'s pattern), not
+    be collapsed into the generic "session is empty" message that only the bare `/rewind`
+    (count 1) default gets.
+    """
+    repl = ScriptedRepl(["/rewind 2"]).run()
+    assert "session is empty" not in repl.chrome
+    assert "cannot rewind 2 turn(s)" in repl.chrome
+    assert "at most 0 rewind hop(s) are possible" in repl.chrome
+    # A rejected rewind must leave the session untouched, same as any other over-deep rewind.
+    assert np.array_equal(np.asarray(repl.store.get_state(repl.sid)),
+                          np.asarray(repl.model.init_state(1)))
+
+
 @pytest.mark.parametrize("argument", ["0", "-1"])
 def test_rewind_non_positive_count_is_rejected(argument):
     repl = ScriptedRepl([LINE_A, LINE_X, f"/rewind {argument}"]).run()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -399,6 +399,25 @@ def test_retained_ids_and_depth_follow_eviction():
         history.rewind_turns(3)
 
 
+def test_committed_bookkeeping_does_not_outgrow_the_evicted_tree():
+    """`_committed` must stay pruned to what the tree retains, not just filtered on read.
+
+    The tree is LRU-capped at `max_depth`, so a long-lived session commits far more turns
+    than it retains. `retained_ids()` has always filtered `_committed` through tree
+    membership, which makes the *symptom* invisible — but `_committed` itself grew by one
+    entry per commit forever unless it is pruned on write, too.
+    """
+    store, history = _history(max_depth=3)
+    for token in range(50):
+        store.step("s1", token + 1)
+        history.commit_turn()
+    assert len(history) == 3
+    # The private list backing retained_ids() must itself be bounded, not just its filtered
+    # view — otherwise 50 commits leaves 50 stale ids sitting in memory forever.
+    assert len(history._committed) == 3
+    assert history._committed == history.retained_ids()
+
+
 def test_budget_bytes_is_max_depth_times_the_per_session_state():
     store, history = _history(max_depth=6)
     assert history.per_node_bytes() == per_session_state_bytes(store.model.config)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -18,6 +18,7 @@ import pytest
 from src.model.blocks import MambaConfig
 from src.serve.rewind import RewindTree
 from src.serve.sessions import (
+    SessionHistory,
     SessionStore,
     per_session_state_bytes,
     per_session_state_floats,
@@ -295,3 +296,175 @@ def test_eviction_reparents_children_onto_grandparent():
     assert tree.parent(n2) == n0      # n2 reparented onto the grandparent
     assert n2 in tree.children(n0)
     assert tree.parent(n3) == n2 and tree.current() == n3
+
+
+# --- SessionHistory: the SessionStore x RewindTree composition (#305) ----------------
+
+def _history(max_depth: int = 32, vocab_size: int = 8):
+    store = SessionStore(FakeModel(vocab_size=vocab_size), max_concurrent=1)
+    store.create("s1")
+    return store, SessionHistory(store, "s1", max_depth=max_depth)
+
+
+def test_session_history_requires_an_existing_session():
+    store = SessionStore(FakeModel())
+    with pytest.raises(KeyError, match="does not exist"):
+        SessionHistory(store, "nope")
+
+
+def test_session_history_rejects_a_zero_max_depth():
+    store = SessionStore(FakeModel())
+    store.create("s1")
+    with pytest.raises(ValueError, match="max_depth must be >= 1"):
+        SessionHistory(store, "s1", max_depth=0)
+
+
+def test_commit_turn_snapshots_the_live_state_and_depth_tracks_it():
+    store, history = _history()
+    assert history.depth() == 0 and history.current() is None
+    root = history.commit_turn()
+    store.step("s1", 5)
+    second = history.commit_turn()
+    assert history.depth() == 2
+    assert history.retained_ids() == [root, second]
+    assert history.nodes() == [(root, None, [second]), (second, root, [])]
+
+
+def test_rewind_turns_restores_the_earlier_snapshot():
+    store, history = _history()
+    store.step("s1", 4)
+    boundary = history.commit_turn()          # state = 4
+    store.step("s1", 7)
+    history.commit_turn()                     # state = 11
+    assert int(store.get_state("s1")[0]) == 11
+    assert history.rewind_turns(1) == boundary
+    assert int(store.get_state("s1")[0]) == 4
+
+
+def test_commit_after_rewind_forks_history():
+    store, history = _history()
+    store.step("s1", 4)
+    boundary = history.commit_turn()
+    store.step("s1", 7)
+    first_branch = history.commit_turn()
+    history.rewind_turns(1)
+    store.step("s1", 2)
+    second_branch = history.commit_turn()
+    children = dict((nid, kids) for nid, _, kids in history.nodes())
+    assert sorted(children[boundary]) == sorted([first_branch, second_branch])
+
+
+def test_rewind_turns_rejects_non_positive_n():
+    _, history = _history()
+    history.commit_turn()
+    with pytest.raises(ValueError, match="n must be >= 1"):
+        history.rewind_turns(0)
+
+
+def test_rewind_turns_rejects_an_uncommitted_session():
+    _, history = _history()
+    with pytest.raises(ValueError, match="no committed turn boundaries"):
+        history.rewind_turns(1)
+
+
+def test_rewind_turns_rejects_going_deeper_than_the_retained_history():
+    store, history = _history()
+    history.commit_turn()
+    store.step("s1", 3)
+    history.commit_turn()
+    before = int(store.get_state("s1")[0])
+    with pytest.raises(ValueError, match=r"cannot rewind 4 turn\(s\).*at most 1 rewind"):
+        history.rewind_turns(4)
+    assert int(store.get_state("s1")[0]) == before   # a rejected rewind changes nothing
+
+
+def test_rewind_to_unknown_node_raises_lookup_error_naming_the_retained_ids():
+    _, history = _history()
+    history.commit_turn()
+    with pytest.raises(LookupError, match=r"node 42 is not retained.*retained ids: \[0\]"):
+        history.rewind_to(42)
+
+
+def test_retained_ids_and_depth_follow_eviction():
+    store, history = _history(max_depth=3)
+    for token in range(5):
+        store.step("s1", token + 1)
+        history.commit_turn()
+    assert len(history) == 3 == len(history.tree)
+    assert len(history.retained_ids()) == 3
+    # Eviction reparents onto the grandparent, so the retained chain is 3 deep and
+    # `rewind_turns` counts RETAINED boundaries, not the five turns actually taken.
+    assert history.depth() == 3
+    with pytest.raises(ValueError, match="at most 2 rewind"):
+        history.rewind_turns(3)
+
+
+def test_budget_bytes_is_max_depth_times_the_per_session_state():
+    store, history = _history(max_depth=6)
+    assert history.per_node_bytes() == per_session_state_bytes(store.model.config)
+    assert history.budget_bytes() == 6 * history.per_node_bytes()
+    assert history.max_depth == 6
+
+
+def test_rewound_snapshot_is_independent_of_later_steps():
+    """`get_state`/`set_state` both clone, so a retained node cannot be aliased."""
+    store, history = _history()
+    store.step("s1", 9)
+    boundary = history.commit_turn()
+    store.step("s1", 1)
+    history.commit_turn()
+    history.rewind_to(boundary)
+    store.step("s1", 100)                     # mutate the live session hard
+    history.rewind_to(boundary)               # the retained node must be untouched
+    assert int(store.get_state("s1")[0]) == 9
+
+
+# --- the real opaque state, on the real backend (mlx-gated, toy scale) ---------------
+
+def test_mlx_rewind_restores_the_opaque_state_and_the_continuation():
+    """Toy-scale MLX check that rewind restores the *actual* opaque `State`.
+
+    Everything above is numpy arithmetic through a FakeModel; this is the one place the
+    real per-layer `(conv_state, ssm_state)` tuples and the real `clone_state` semantics
+    are exercised. Greedy (`temperature=0`) so the continuation identity needs no RNG
+    bookkeeping.
+    """
+    mx = pytest.importorskip("mlx.core")
+    from functools import partial
+
+    from src.model.blocks import load_config
+    from src.model.mlx_backend import MLXMambaModel
+    from src.serve import sampling
+    from src.serve.generate import generate
+
+    cfg = load_config("config/toy.yaml")
+    mx.random.seed(0)
+    model = MLXMambaModel(cfg)
+    store = SessionStore(model, max_concurrent=1)
+    store.create("s")
+    history = SessionHistory(store, "s", max_depth=8)
+
+    greedy = partial(sampling.sample, temperature=0.0)
+    decode = dict(sampler=greedy, to_numpy=lambda a: np.array(a), max_new_tokens=6)
+
+    generate(store, "s", [3, 14, 15, 92], **decode)          # turn A (fresh -> prefill)
+    boundary = history.commit_turn()
+    snapshot = store.get_state("s")
+
+    out_b = generate(store, "s", [65, 35, 89], prefill=False, **decode)
+    history.commit_turn()
+
+    history.rewind_to(boundary)
+    restored = store.get_state("s")
+    assert len(restored) == cfg.n_layers
+    for layer, ((snap_a, snap_b), (rest_a, rest_b)) in enumerate(zip(snapshot, restored)):
+        assert np.array_equal(np.array(snap_a), np.array(rest_a)), f"layer {layer} conv"
+        assert np.array_equal(np.array(snap_b), np.array(rest_b)), f"layer {layer} ssm"
+
+    out_x = generate(store, "s", [7, 7, 7], prefill=False, **decode)   # discarded branch
+    history.commit_turn()
+    history.rewind_to(boundary)
+    out_b_again = generate(store, "s", [65, 35, 89], prefill=False, **decode)
+
+    assert out_b_again == out_b        # state restored -> byte-identical continuation
+    assert out_b_again != out_x        # ... and a real branch, not a replay


### PR DESCRIPTION
Closes #305

## Summary

`RewindTree` was built, unit-tested and described in three design documents, but had **zero
non-test importers** in `src/` or `scripts/`. The layer closed; the capability never reached a
person. This wires it end to end through one entry point.

- **`src/serve/sessions.py` — `SessionHistory`, the composition point.** `commit_turn` is
  `tree.commit(store.get_state(sid))`; `rewind_to` is `store.set_state(sid, tree.rewind(id))`.
  Portable, numpy-free, opaque `State` only. Guards **reject and name the available depth** —
  none clamps to the root, none silently no-ops. The docstring states that rewinds count
  **retained** boundaries, not wall-clock turns, because `RewindTree._detach` reparents an
  evicted node's children onto its grandparent.
- **`scripts/generate.py --interactive` — the entry point.** A third mode alongside `--prompt`
  and `--chat`: one stateful session for the whole run, `/rewind [n|#id]`, `/tree`, `/help`,
  `/quit`, sized by `--rewind-depth` (default 32; `0` disables rewind and builds no tree;
  negative is an argparse error). The loop is extracted to a module-level `interactive_repl(...)`
  with `run_turn` / `read_line` / `emit` injected, so tests drive it without a pty and without a
  backend. `--help` documents every command via an `epilog`.
- **`src/serve/generate.py` — additive `prefill: bool = True`.** The one net-new line of library
  work: `SessionStore.prefill` is fresh-session-only, and a session restored from a snapshot has
  an unknowable position above the seam, so turns after the first (and every turn after a rewind)
  step the prompt in instead. The default path is byte-identical to before.
- **`--chat` is deliberately left untouched.** It is stateless by construction — a fresh session
  per turn, whole transcript re-rendered — so bolting `/rewind` onto it would degenerate to
  popping a `messages` list: the same "no real caller" defect in a new costume.

## Criterion 3, proven by output — and watched failing first

The whole defect being fixed is a class with no caller, so "has a caller" is trivial to fake. The
proof is an **output identity** against a fake model whose logits depend on the recurrent state:

```
--- baseline: StatefulFakeModel, rewind intact
    out_B='MKGIMP'  out_X='GCFOLO'  out_B'='MKGIMP'
    half 1 (out_B' == out_B) : PASS      half 2 (out_B' != out_X) : PASS
--- MUTATION A: rewind_to never calls store.set_state
    out_B='MKGIMP'  out_X='GCFOLO'  out_B'='CLAAIJ'
    half 1 (out_B' == out_B) : FAIL      half 2 (out_B' != out_X) : PASS
--- MUTATION B: rewind_to restores a fresh zeroed state
    out_B='MKGIMP'  out_X='GCFOLO'  out_B'='HDBCLN'
    half 1 (out_B' == out_B) : FAIL      half 2 (out_B' != out_X) : PASS
--- MUTATION C: state-independent FakeModel, rewind intact
    out_B='CCCCCC'  out_X='CCCCCC'  out_B'='CCCCCC'
    half 1 (out_B' == out_B) : PASS      half 2 (out_B' != out_X) : FAIL
```

Read honestly: **half 1 is what catches an unrestored state** (mutations A and B). **Half 2 is
what catches a vacuous test** — it fails only under mutation C, where the model's logits do not
depend on the state, which is exactly the trap `tests/test_serve.py`'s existing `FakeModel`
(`logits = eye(V)[token % V]`) would have walked the test into. That case is pinned permanently as
`test_state_independent_model_makes_the_identity_vacuous`, so the reason the stateful model is
required cannot quietly rot.

`StatefulFakeModel` uses a rolling hash rather than the running sum the plan sketched: greedy
decoding on `eye(V)[sum % V]` has absorbing fixed points, so distinct prefixes converge to the
same repeated token within a few steps and half 2 goes vacuous again.

## The over-deep guard, watched rejecting by hand

Verification step 5, real CLI, `config/toy.yaml`, random init, greedy — exact stdout:

```
rewind: up to 8 retained turn boundaries, at most 155648 bytes (8 x 19456 B/snapshot).
interactive mode — type text to continue the session; /help for commands.
>>> tttttttttttttttttttt[committed #1; depth 2, 2/8 retained]
>>>   #0  parent=None  children=[1]  '(start)'
* #1  parent=0  children=[]  'the cattttttttttttttttttttt'
>>> nnnnnnnnnnnnnnnnnnnn[committed #2; depth 3, 3/8 retained]
>>> rewound to #1 (depth 2); transcript:
  #0: '(start)'
  #1: 'the cattttttttttttttttttttt'
>>> yyyyyyyyyyyyyyyyyyyy[committed #3; depth 3, 4/8 retained]
>>>   #0  parent=None  children=[1]  '(start)'
  #1  parent=0  children=[2, 3]  'the cattttttttttttttttttttt'
  #2  parent=1  children=[]  'sat downnnnnnnnnnnnnnnnnnnnn'
* #3  parent=1  children=[]  'ran awayyyyyyyyyyyyyyyyyyyyy'
>>> error: cannot rewind 99 turn(s): session 'repl' retains 3 boundary/boundaries including the current one, so at most 2 rewind hop(s) are possible (retained ids: [0, 1, 2, 3])
>>> error: unknown command '/frobnicate' — /help lists the commands. It was NOT sent to the model.
```

The post-rewind continuation (`yyy…`) differs from the discarded one (`nnn…`); `/tree` shows node
`#1` with two children; `/rewind 99` prints the available depth with **no traceback and no change
to the session**; `/frobnicate` is rejected rather than fed to the model.

## No dead paths (DoD 10)

Every `RewindTree` member, and whether the entry point reaches it. Backed by
`grep -nF "self.tree." src/serve/sessions.py`:

| Member | Reachable from `--interactive`? | Where |
|---|---|---|
| `commit` | yes | `SessionHistory.commit_turn` (`sessions.py:250`) ← REPL startup + every turn |
| `rewind` | yes | `SessionHistory.rewind_to` (`:284`) ← `/rewind` |
| `current` | yes | `:263`, `:294`, `:302` ← `/tree`'s `*` marker, `depth()` |
| `parent` | yes | `:270`, `:306`, `:311` ← `rewind_turns` hops, `depth()`, `/tree` |
| `children` | yes | `:311` ← `/tree` |
| `__contains__` | yes | `:298` (`retained_ids`) ← `/tree`, every guard message |
| `__len__` | yes | `SessionHistory.__len__` (`:294`) ← the `[committed …]` and `/tree` status lines |
| `max_depth` | yes | `:315` ← startup budget line, `/tree` header |
| `_evict`, `_pick_victim`, `_detach` | **no — internal only** | called by `commit` when the LRU cap is exceeded. They are reached *through* the entry point at `--rewind-depth k` once k+1 turns are committed (covered by `test_eviction_bounds_the_tree_and_a_deeper_rewind_errors`), but never called by name outside `rewind.py` and its unit tests. That is correct: they are the cap's implementation, not API. |

Nothing in `src/serve/rewind.py` is now unreachable.

## Feature-matrix convention note

`SERVE-3` is written `done | done | none | none | Shipped`. CUDA is `none` because the path is
backend-agnostic but is exercised on no CUDA host and by no CUDA test; Swift is `none` (out of
scope, and the engine exists, so not `n/a`). **Shipped-with-`none` precedent checked and found:**
`LSP-10` (`docs/feature-matrix.md:123`, #279) is `Shipped` with `none` in the Swift column. The
convention is not invented here.

## Testing

- [x] Tests added/updated — `tests/test_rewind_entry_point.py` (19 new, portable, every assertion
      through `interactive_repl`; `grep -c RewindTree` = **0**), `tests/test_serve.py` (+14
      `SessionHistory` unit tests and 1 mlx-gated toy-scale opaque-state test),
      `tests/test_generate.py` (+3 `prefill=False` equivalence tests)
- [x] All tests passing — `.venv/bin/python -m pytest -q -rs` → **1722 passed, 22 skipped** in
      378.86 s
- [x] Untouched gates pass **unedited** — `tests/test_import_guard.py` and
      `tests/test_workflow_triggers.py`, 12 passed (no CI job added, no new portable module)
- [x] Smoke gate green on a **fresh** toy split — `SMOKE TEST PASSED ✅ resume is exact and eval runs.`
- [x] Manual testing completed — verification step 5 above, plus `--help` printing all three
      commands and both flags

**macOS CI cost (#315 constraint).** The one mlx-gated addition is toy-scale and measured:
`pytest tests/test_serve.py -q -k "mlx and rewind"` → **1 passed in 0.13 s** (0.45 s wall
including interpreter startup). Well under the 10 s bound; nothing slow was added to the macOS PR
path. `tests/test_rewind_entry_point.py` is backend-free and runs in the Linux `portable` job
(19 tests in 0.08 s).

## Parked

1 finding appended to `docs/parked-findings.md` (`RewindTree` has no public retained-id
enumeration, so `SessionHistory` duplicates the bookkeeping). Not acted on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ur4BdaFTqnwqSUAx5TrX8
